### PR TITLE
Fix GitHub workflow CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
   Finish-Coveralls:
     name: Finish Coveralls
-    needs: Execute
+    needs: Execute-continuous-integration
     runs-on: ubuntu-latest
     container: python:3-slim
     steps:


### PR DESCRIPTION
This patch fixes a minor mistake in the script where the jobs were
renamed, but not updated in references appropriately.