### PR TITLE
Release 0.0.1rc1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,6 @@
+0.0.1rc1 (2021-12-27)
+=====================
+
+* The initial release candidate.
+  This is actually an alpha release!
+  Since the UAG Verwaltungsschale still needs to decide on fundamentals of the meta-model (such as basic primitive types) yet, this release is only meant for first experimental usage.

--- a/README.rst
+++ b/README.rst
@@ -165,6 +165,11 @@ Versioning
 We are still not clear about how to version the generator.
 For the moment, we use a lax incremental versioning with ``0.0`` prefix (``0.0.1``, 0.0.2``) *etc.*
 
+The changelog is available in `CHANGELOG.rst`.
+
+.. _CHANGELOG.rst: https://github.com/aas-core-works/aas-core-codegen/blob/main/CHANGELOG.rst
+
+
 Contributing
 ============
 


### PR DESCRIPTION
* The initial release candidate.
  This is actually an alpha release!
  Since the UAG Verwaltungsschale still needs to decide on fundamentals
  of the meta-model (such as basic primitive types) yet, this release
  is only meant for first experimental usage.