### PR TITLE
Add `--version` flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -152,6 +152,7 @@ Call the generator with the appropriate target:
 
     usage: aas-core-codegen [-h] --model_path MODEL_PATH --snippets_dir
                             SNIPPETS_DIR --output_dir OUTPUT_DIR --target {csharp}
+                            [--version]
 
     Generate different implementations and schemas based on an AAS meta-model.
 
@@ -165,6 +166,7 @@ Call the generator with the appropriate target:
       --output_dir OUTPUT_DIR
                             path to the generated code
       --target {csharp}     target language or schema
+      --version             show the current version and exit
 
 .. Help ends: aas-core-codegen --help
 

--- a/aas_core_codegen/main.py
+++ b/aas_core_codegen/main.py
@@ -204,6 +204,17 @@ def main(prog: str) -> int:
         required=True,
         choices=[literal.value for literal in Target],
     )
+    parser.add_argument(
+        "--version", help="show the current version and exit", action="store_true"
+    )
+
+    # NOTE (mristin, 2022-01-14):
+    # The module ``argparse`` is not flexible enough to understand special options such
+    # as ``--version`` so we manually hard-wire.
+    if "--version" in sys.argv and "--help" not in sys.argv:
+        print(aas_core_codegen.__version__)
+        return 1
+
     args = parser.parse_args()
 
     target_to_str = {literal.value: literal for literal in Target}


### PR DESCRIPTION
This patch adds the `--version` flag to the main program so that we can
track the versions when reporting issues.