### PR TITLE
Ignore primitive types for origins in hierarchy

### DIFF
--- a/aas_core_codegen/intermediate/_hierarchy.py
+++ b/aas_core_codegen/intermediate/_hierarchy.py
@@ -69,7 +69,13 @@ class _UnverifiedOntology:
         first_not_in_topological_order(classes, parsed_symbol_table) is None
     )
     @require(
-        lambda classes: len(classes) == 0 or len(classes[0].inheritances) == 0,
+        lambda classes:
+        len(classes) == 0
+        or sum(
+            1
+            for inheritance in classes[0].inheritances
+            if inheritance not in parse.PRIMITIVE_TYPES
+        ) == 0,
         "Origins first",
     )
     @require(


### PR DESCRIPTION
The precondition in the hierarchy was wrong when determining the
origins. Namely, the constrained primitives *always* inherit from a
primitive type, but can be still considered as origins of the hierarchy
as long as they do not inherit from other constrained primitives.