### PR TITLE
Reverse the invariants

### DIFF
--- a/aas_core_codegen/parse/_translate.py
+++ b/aas_core_codegen/parse/_translate.py
@@ -1614,6 +1614,11 @@ def _classdef_to_symbol(
             ),
         )
 
+    # NOTE (mristin, 20222-01-02):
+    # We need to inverse the invariants as we collect them top-down, while
+    # the decorators are applied bottom-up.
+    invariants = list(reversed(invariants))
+
     # endregion
 
     if is_abstract and is_implementation_specific:


### PR DESCRIPTION
This patch fixes a bug related to the order of the invariants. Namely,
the invariants are specified as decorators in a top-down order, while we
need to interpret the decorators in the reversed order (bottom-up) as
they decorate the function one by one.