### PR TITLE
Note the origin of the invariants

### DIFF
--- a/aas_core_codegen/intermediate/_stringify.py
+++ b/aas_core_codegen/intermediate/_stringify.py
@@ -223,6 +223,11 @@ def _stringify_invariant(
         properties=[
             stringify.Property("description", that.description),
             stringify.Property("body", parse_tree.dump(that.body)),
+            stringify.Property(
+                "specified_for",
+                f"Reference to {that.specified_for.__class__.__name__} "
+                f"{that.specified_for.name}",
+            ),
             stringify.PropertyEllipsis("parsed", that.parsed),
         ],
     )

--- a/aas_core_codegen/intermediate/_types.py
+++ b/aas_core_codegen/intermediate/_types.py
@@ -341,16 +341,27 @@ class Invariant:
     description: Final[Optional[str]]
 
     #: Understood body of the invariant
-    body: Final[parse_tree.Node]
+    body: Final[parse_tree.Expression]
+
+    #: The original symbol where this invariant is specified.
+    #: We stack all the invariants over the ancestors, so using ``specified_for``
+    #: you can distinguish between inherited invariants and genuine invariants of
+    #: a class or a constrained primitive.
+    specified_for: Final[Union["ConstrainedPrimitive", "Class"]]
 
     #: Relation to the parse stage
     parsed: Final[parse.Invariant]
 
     def __init__(
-        self, description: Optional[str], body: parse_tree.Node, parsed: parse.Invariant
+        self,
+        description: Optional[str],
+        body: parse_tree.Expression,
+        specified_for: Union["ConstrainedPrimitive", "Class"],
+        parsed: parse.Invariant,
     ) -> None:
         self.description = description
         self.body = body
+        self.specified_for = specified_for
         self.parsed = parsed
 
 

--- a/test_data/intermediate/expected/real_meta_models/v3rc2/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/real_meta_models/v3rc2/expected_symbol_table.txt
@@ -11,6 +11,7 @@ SymbolTable(
         Invariant(
           description=None,
           body="Comparison(\n  left=FunctionCall(\n    name='len',\n    args=[\n      Name(\n        identifier='self',\n        original_node=...)],\n    original_node=...),\n  op='GE',\n  right=Constant(\n    value=1,\n    original_node=...),\n  original_node=...)",
+          specified_for='Reference to ConstrainedPrimitive Non_empty_string',
           parsed=...)],
       invariant_id_set=...,
       description=Description(
@@ -29,10 +30,12 @@ SymbolTable(
         Invariant(
           description=None,
           body="Comparison(\n  left=FunctionCall(\n    name='len',\n    args=[\n      Name(\n        identifier='self',\n        original_node=...)],\n    original_node=...),\n  op='GE',\n  right=Constant(\n    value=1,\n    original_node=...),\n  original_node=...)",
+          specified_for='Reference to ConstrainedPrimitive Non_empty_string',
           parsed=...),
         Invariant(
           description=None,
           body="FunctionCall(\n  name='is_MIME_type',\n  args=[\n    Name(\n      identifier='self',\n      original_node=...)],\n  original_node=...)",
+          specified_for='Reference to ConstrainedPrimitive MIME_typed',
           parsed=...)],
       invariant_id_set=...,
       description=Description(
@@ -1344,6 +1347,7 @@ SymbolTable(
         Invariant(
           description='Constraint AASd-005',
           body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='revision',\n      original_node=...),\n    original_node=...),\n  consequent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='version',\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          specified_for='Reference to ConcreteClass Administrative_information',
           parsed=...)],
       serialization=Serialization(
         with_model_type=False),
@@ -5988,6 +5992,7 @@ SymbolTable(
         Invariant(
           description=None,
           body="FunctionCall(\n  name='is_MIME_type',\n  args=[\n    Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='MIME_type',\n      original_node=...)],\n  original_node=...)",
+          specified_for='Reference to ConcreteClass Blob',
           parsed=...)],
       serialization=Serialization(
         with_model_type=True),
@@ -6287,6 +6292,7 @@ SymbolTable(
         Invariant(
           description=None,
           body="FunctionCall(\n  name='is_MIME_type',\n  args=[\n    Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='MIME_type',\n      original_node=...)],\n  original_node=...)",
+          specified_for='Reference to ConcreteClass File',
           parsed=...)],
       serialization=Serialization(
         with_model_type=True),
@@ -8876,6 +8882,7 @@ SymbolTable(
         Invariant(
           description=None,
           body="Comparison(\n  left=FunctionCall(\n    name='len',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='values',\n        original_node=...)],\n    original_node=...),\n  op='GE',\n  right=Constant(\n    value=1,\n    original_node=...),\n  original_node=...)",
+          specified_for='Reference to ConcreteClass Global_reference',
           parsed=...)],
       serialization=Serialization(
         with_model_type=True),
@@ -8961,6 +8968,7 @@ SymbolTable(
         Invariant(
           description=None,
           body="Comparison(\n  left=FunctionCall(\n    name='len',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='keys',\n        original_node=...)],\n    original_node=...),\n  op='GE',\n  right=Constant(\n    value=1,\n    original_node=...),\n  original_node=...)",
+          specified_for='Reference to ConcreteClass Model_reference',
           parsed=...)],
       serialization=Serialization(
         with_model_type=True),


### PR DESCRIPTION
After this patch, we note down which classes and constrained
primitives the invariants are specified for. This allows us to consider
only the invariants specified for a particular class and ignore the
invariants inherited from the ancestors.

This will be useful when we generate schemas since invariants in the
schemas are inherited, unlike, say, C# code.