### PR TITLE
Release 0.0.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,20 @@
     Please keep this file at 72 line width so that we can copy-paste
     the release logs directly into commit messages.
 
+0.0.2 (2022-01-15)
+==================
+
+* Provide generator for JSON schema (#13)
+* Improve errors on unmatched verification functions (#21)
+* Note the origin of the invariants (#20)
+* Rename ``implemented_for`` to ``specified_for`` (#19)
+* Reverse the invariants (#18)
+* Ignore primitive types for origins in hierarchy (#17)
+* Fix second pass to resolve descendants correctly (#16)
+* Make ``indent_but_first_line`` ignore empty lines (#15)
+* Fix encoding to ``utf-8`` on file I/O (#14)
+* Add ``--version`` flag (#12)
+
 0.0.1rc1.post1 (2021-12-27)
 ===========================
 

--- a/aas_core_codegen/__init__.py
+++ b/aas_core_codegen/__init__.py
@@ -1,6 +1,6 @@
 """Generate different implementations and schemas based on an AAS meta-model."""
 
-__version__ = "0.0.1rc1.post1"
+__version__ = "0.0.2"
 __author__ = "Marko Ristin, Nico Braunisch, Robert Lehmann"
 __license__ = "License :: OSI Approved :: MIT License"
 __status__ = "Production/Stable"

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open(os.path.join(here, "requirements.txt"), encoding="utf-8") as fid:
 
 setup(
     name="aas-core-codegen",
-    version="0.0.1rc1.post1",
+    version="0.0.2",
     description="Generate different implementations and schemas based on an AAS meta-model.",
     long_description=long_description,
     url="https://github.com/aas-core-works/aas-core-codegen",


### PR DESCRIPTION
* Provide generator for JSON schema (#13)
* Improve errors on unmatched verification functions (#21)
* Note the origin of the invariants (#20)
* Rename ``implemented_for`` to ``specified_for`` (#19)
* Reverse the invariants (#18)
* Ignore primitive types for origins in hierarchy (#17)
* Fix second pass to resolve descendants correctly (#16)
* Make ``indent_but_first_line`` ignore empty lines (#15)
* Fix encoding to ``utf-8`` on file I/O (#14)
* Add ``--version`` flag (#12)