### PR TITLE
Revert lost `--version` command flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -152,7 +152,7 @@ Call the generator with the appropriate target:
 
     usage: aas-core-codegen [-h] --model_path MODEL_PATH --snippets_dir
                             SNIPPETS_DIR --output_dir OUTPUT_DIR --target
-                            {csharp,jsonschema}
+                            {csharp,jsonschema} [--version]
 
     Generate different implementations and schemas based on an AAS meta-model.
 
@@ -167,6 +167,7 @@ Call the generator with the appropriate target:
                             path to the generated code
       --target {csharp,jsonschema}
                             target language or schema
+      --version             show the current version and exit
 
 .. Help ends: aas-core-codegen --help
 

--- a/aas_core_codegen/main.py
+++ b/aas_core_codegen/main.py
@@ -211,6 +211,17 @@ def main(prog: str) -> int:
         required=True,
         choices=[literal.value for literal in Target],
     )
+    parser.add_argument(
+        "--version", help="show the current version and exit", action="store_true"
+    )
+
+    # NOTE (mristin, 2022-01-14):
+    # The module ``argparse`` is not flexible enough to understand special options such
+    # as ``--version`` so we manually hard-wire.
+    if "--version" in sys.argv and "--help" not in sys.argv:
+        print(aas_core_codegen.__version__)
+        return 1
+
     args = parser.parse_args()
 
     target_to_str = {literal.value: literal for literal in Target}


### PR DESCRIPTION
This patch reverts unintentional changes in the commit
360c9b14d2b25cb1b8c65ef3efc794883f345e7a. We cherry-picked from the
development branch and omitted to include the logic for `--version` in
the pull request.