### PR TITLE
Report underlying messages in unit tests

### DIFF
--- a/tests/csharp/test_description.py
+++ b/tests/csharp/test_description.py
@@ -19,14 +19,14 @@ class TestDescription(unittest.TestCase):
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
         )
-        assert error is None, f"{error=}"
+        assert error is None, tests.common.most_underlying_messages(error)
         assert symbol_table is not None
 
         some_class = symbol_table.must_find(Identifier("Some_class"))
         assert some_class.description is not None
 
         code, error = csharp_description.generate_comment(some_class.description)
-        assert error is None, f"{error=}"
+        assert error is None, tests.common.most_underlying_messages(error)
 
         assert code is not None
 

--- a/tests/intermediate/test_constructor.py
+++ b/tests/intermediate/test_constructor.py
@@ -66,7 +66,7 @@ class Test_empty_ok(unittest.TestCase):
         )
 
         constructor_table, error = understand_constructor_table(source=source)
-        assert error is None, f"{error=}"
+        assert error is None, tests.common.most_underlying_messages(error)
         assert constructor_table is not None
 
         self.assertEqual(2, len(constructor_table.entries()))
@@ -96,7 +96,7 @@ class Test_empty_ok(unittest.TestCase):
         )
 
         constructor_table, error = understand_constructor_table(source=source)
-        assert error is None, f"{error=}"
+        assert error is None, tests.common.most_underlying_messages(error)
         assert constructor_table is not None
 
         self.assertEqual(2, len(constructor_table.entries()))
@@ -131,7 +131,7 @@ class Test_call_to_super_constructor_ok(unittest.TestCase):
         )
 
         constructor_table, error = understand_constructor_table(source=source)
-        assert error is None, f"{error=}"
+        assert error is None, tests.common.most_underlying_messages(error)
         assert constructor_table is not None
 
         self.assertEqual(3, len(constructor_table.entries()))
@@ -169,7 +169,7 @@ class Test_call_to_super_constructor_ok(unittest.TestCase):
         )
 
         constructor_table, error = understand_constructor_table(source=source)
-        assert error is None, f"{error=}"
+        assert error is None, tests.common.most_underlying_messages(error)
         assert constructor_table is not None
 
         self.assertEqual(3, len(constructor_table.entries()))
@@ -202,7 +202,7 @@ class Test_assign_property_ok(unittest.TestCase):
         )
 
         constructor_table, error = understand_constructor_table(source=source)
-        assert error is None, f"{error=}"
+        assert error is None, tests.common.most_underlying_messages(error)
         assert constructor_table is not None
 
         _, statements = must_find_item_for(constructor_table, "Something")

--- a/tests/intermediate/test_hierarchy.py
+++ b/tests/intermediate/test_hierarchy.py
@@ -24,7 +24,7 @@ class Test_ontology_ok(unittest.TestCase):
             )
         )
 
-        assert error is None, f"{error=}"
+        assert error is None, tests.common.most_underlying_messages(error)
         assert symbol_table is not None
 
         ontology, errors = _hierarchy.map_symbol_table_to_ontology(symbol_table)
@@ -118,7 +118,7 @@ class Test_ontology_fail(unittest.TestCase):
                 """
             )
         )
-        assert error is None, f"{error=}"
+        assert error is None, tests.common.most_underlying_messages(error)
         assert symbol_table is not None
 
         ontology, errors = _hierarchy.map_symbol_table_to_ontology(symbol_table)
@@ -153,7 +153,7 @@ class Test_ontology_fail(unittest.TestCase):
                 """
             )
         )
-        assert error is None, f"{error=}"
+        assert error is None, tests.common.most_underlying_messages(error)
         assert symbol_table is not None
 
         ontology, errors = _hierarchy.map_symbol_table_to_ontology(symbol_table)
@@ -186,7 +186,7 @@ class Test_ontology_fail(unittest.TestCase):
                 """
             )
         )
-        assert error is None, f"{error=}"
+        assert error is None, tests.common.most_underlying_messages(error)
         assert symbol_table is not None
 
         ontology, errors = _hierarchy.map_symbol_table_to_ontology(symbol_table)
@@ -220,7 +220,7 @@ class Test_ontology_fail(unittest.TestCase):
                 """
             )
         )
-        assert error is None, f"{error=}"
+        assert error is None, tests.common.most_underlying_messages(error)
         assert symbol_table is not None
 
         ontology, errors = _hierarchy.map_symbol_table_to_ontology(symbol_table)

--- a/tests/intermediate/test_translate.py
+++ b/tests/intermediate/test_translate.py
@@ -58,7 +58,7 @@ class Test_in_lining_of_constructor_statements(unittest.TestCase):
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
         )
-        assert error is None, f"{error=}"
+        assert error is None, tests.common.most_underlying_messages(error)
 
         assert symbol_table is not None
 
@@ -94,7 +94,7 @@ class Test_parsing_docstrings(unittest.TestCase):
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
         )
-        assert error is None, f"{error=}"
+        assert error is None, tests.common.most_underlying_messages(error)
 
         assert symbol_table is not None
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -330,7 +330,7 @@ class Test_parse_type_annotation(unittest.TestCase):
         )
 
         type_annotation, error = parse._translate._type_annotation(node=anno, atok=atok)
-        assert error is None, f"{error=}"
+        assert error is None, tests.common.most_underlying_messages(error)
 
         self.assertEqual("int", str(type_annotation))
 
@@ -340,7 +340,7 @@ class Test_parse_type_annotation(unittest.TestCase):
         )
 
         type_annotation, error = parse._translate._type_annotation(node=anno, atok=atok)
-        assert error is None, f"{error=}"
+        assert error is None, tests.common.most_underlying_messages(error)
 
         self.assertEqual("Mapping[str, Optional[int]]", str(type_annotation))
 
@@ -350,7 +350,7 @@ class Test_parse_type_annotation(unittest.TestCase):
         )
 
         type_annotation, error = parse._translate._type_annotation(node=anno, atok=atok)
-        assert error is None, f"{error=}"
+        assert error is None, tests.common.most_underlying_messages(error)
 
         self.assertEqual("Optional[List[Reference]]", str(type_annotation))
 


### PR DESCRIPTION
Previously, in case of errrors in unit tests, we reported a string
representation of the error. This is unreadable and slows down the
debugging. In this patch, we report the most underlying errors formatted
as a string.