### PR TITLE
Remove `ExpressionWithDeclarations` from our tree

### DIFF
--- a/aas_core_codegen/csharp/verification/_generate.py
+++ b/aas_core_codegen/csharp/verification/_generate.py
@@ -1139,20 +1139,6 @@ class _InvariantTranspiler(
         #  add heuristic for breaking the lines
         return Stripped(" || ".join(values)), None
 
-    def transform_declaration(
-        self, node: parse_tree.Declaration
-    ) -> Tuple[Optional[Stripped], Optional[Error]]:
-        # BEFORE-RELEASE (mristin, 2021-12-13):
-        #  implement once we got to end-to-end with serialization
-        raise NotImplementedError()
-
-    def transform_expression_with_declarations(
-        self, node: parse_tree.ExpressionWithDeclarations
-    ) -> Tuple[Optional[Stripped], Optional[Error]]:
-        # BEFORE-RELEASE (mristin, 2021-12-13):
-        #  implement once we got to end-to-end with serialization
-        raise NotImplementedError()
-
     def transform_joined_str(
         self, node: parse_tree.JoinedStr
     ) -> Tuple[Optional[Stripped], Optional[Error]]:


### PR DESCRIPTION
Since we do not have a clear use case yet for
`ExpressionWithDeclarations` (and consequently for `Declaration`), we
remove these two classes from *our* internal abstract syntax tree.

Additionally, there were breaking changes between Python 3.8 and 3.9
which have repercussions on parsing indices (and hence how we get to
`ExpressionWithDeclarations`). At this moment, we decide not to support
the concept and avoid the additional implementation complexity.

Once and if we have a clear use case, we will add these two classes
back into the parse tree.