### PR TITLE
Add support for Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8']
+        python-version: ['3.8', '3.9']
 
     steps:
       - uses: actions/checkout@master

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Our own ignores
 /deleteme/
+/venv/
+/venv39/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.idea/aas-core-csharp-codegen.iml
+++ b/.idea/aas-core-csharp-codegen.iml
@@ -8,6 +8,7 @@
       <excludeFolder url="file://$MODULE_DIR$/obsolete" />
       <excludeFolder url="file://$MODULE_DIR$/test_data" />
       <excludeFolder url="file://$MODULE_DIR$/venv" />
+      <excludeFolder url="file://$MODULE_DIR$/venv39" />
     </content>
     <orderEntry type="jdk" jdkName="Python 3.8 (aas-core-codegen)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     license="License :: OSI Approved :: MIT License",
     keywords="asset administration shell code generation industry 4.0 industrie i4.0",


### PR DESCRIPTION
Previously, we only supported Python 3.8. Since there were breaking
changes in the `ast` module of Python 3.9, we have to switch on the
Python version and adapt the parsing accordingly.