### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9']
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
       - uses: actions/checkout@master

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /deleteme/
 /venv/
 /venv39/
+/venv310/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.idea/aas-core-csharp-codegen.iml
+++ b/.idea/aas-core-csharp-codegen.iml
@@ -10,7 +10,7 @@
       <excludeFolder url="file://$MODULE_DIR$/venv" />
       <excludeFolder url="file://$MODULE_DIR$/venv39" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.8 (aas-core-codegen)" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 3.1 (aas-core-codegen)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.8 (aas-core-codegen)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.1 (aas-core-codegen)" project-jdk-type="Python SDK" />
 </project>

--- a/continuous_integration/precommit.py
+++ b/continuous_integration/precommit.py
@@ -182,19 +182,32 @@ def main() -> int:
             "setup.py coincide."
         )
 
-    if Step.CHECK_HELP_IN_README in selects and Step.CHECK_HELP_IN_README not in skips:
-        cmd = [sys.executable, "continuous_integration/check_help_in_readme.py"]
-        if overwrite:
-            cmd.append("--overwrite")
+    # NOTE (mristin, 2022-01-22):
+    # We need to check for the Python version since ``argparse`` output changes
+    # between the versions. Hence we pin it at the moment to Python 3.8.
 
-        if not overwrite:
-            print("Checking that --help's and the readme coincide...")
+    if sys.version_info < (3, 9):
+        if (
+            Step.CHECK_HELP_IN_README in selects
+            and Step.CHECK_HELP_IN_README not in skips
+        ):
+            cmd = [sys.executable, "continuous_integration/check_help_in_readme.py"]
+            if overwrite:
+                cmd.append("--overwrite")
+
+            if not overwrite:
+                print("Checking that --help's and the readme coincide...")
+            else:
+                print("Overwriting the --help's in the readme...")
+
+            subprocess.check_call(cmd, cwd=str(repo_root))
         else:
-            print("Overwriting the --help's in the readme...")
-
-        subprocess.check_call(cmd, cwd=str(repo_root))
+            print("Skipped checking that --help's and the doc coincide.")
     else:
-        print("Skipped checking that --help's and the doc coincide.")
+        print(
+            "Skipped checking that --help's and the doc coincide "
+            "since we pin it on Python version 3.8."
+        )
 
     return 0
 

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     license="License :: OSI Approved :: MIT License",
     keywords="asset administration shell code generation industry 4.0 industrie i4.0",

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -42,6 +42,16 @@ class Test_parsing_AST(unittest.TestCase):
 
 
 class Test_checking_imports(unittest.TestCase):
+    @staticmethod
+    def replace_column_number_with_x(errors: List[str]) -> List[str]:
+        """
+        Replace the column number with ``"X"``.
+
+        We need to remove the column number as it changes between Python versions
+        (notably, it is more precise from Python 3.10 on).
+        """
+        return [re.sub(r"column [0-9]+", "column X", error) for error in errors]
+
     def test_import_reported(self) -> None:
         source = textwrap.dedent(
             """\
@@ -55,11 +65,11 @@ class Test_checking_imports(unittest.TestCase):
         errors = parse.check_expected_imports(atok=atok)
         self.assertListEqual(
             [
-                "At line 1 and column 1: "
+                "At line 1 and column X: "
                 "Unexpected ``import ...``. "
                 "Only ``from ... import...`` statements are expected."
             ],
-            errors,
+            Test_checking_imports.replace_column_number_with_x(errors),
         )
 
     def test_from_import_as_reported(self) -> None:
@@ -72,13 +82,17 @@ class Test_checking_imports(unittest.TestCase):
         atok, error = parse.source_to_atok(source=source)
         assert atok is not None
 
+        # NOTE (mristin, 2022-01-22):
+        # We need to remove the column number as it changes between Python versions
+        # (notably, it is more precise from Python 3.10 on.)
+
         errors = parse.check_expected_imports(atok=atok)
         self.assertListEqual(
             [
-                "At line 1 and column 1: Unexpected ``from ... import ... as ...``. "
+                "At line 1 and column X: Unexpected ``from ... import ... as ...``. "
                 "Only ``from ... import...`` statements are expected."
             ],
-            errors,
+            Test_checking_imports.replace_column_number_with_x(errors),
         )
 
     def test_unexpected_name_from_module(self) -> None:
@@ -95,11 +109,11 @@ class Test_checking_imports(unittest.TestCase):
         errors = parse.check_expected_imports(atok=atok)
         self.assertListEqual(
             [
-                "At line 1 and column 1: "
+                "At line 1 and column X: "
                 "Expected to import 'List' from the module typing, "
                 "but it is imported from enum."
             ],
-            errors,
+            Test_checking_imports.replace_column_number_with_x(errors),
         )
 
     def test_unexpected_import_from_a_module(self) -> None:
@@ -115,7 +129,8 @@ class Test_checking_imports(unittest.TestCase):
 
         errors = parse.check_expected_imports(atok=atok)
         self.assertListEqual(
-            ["At line 1 and column 1: Unexpected import of a name 'Else'."], errors
+            ["At line 1 and column X: Unexpected import of a name 'Else'."],
+            Test_checking_imports.replace_column_number_with_x(errors),
         )
 
 


### PR DESCRIPTION
This patch comprises minor fixes necessary to support Python 3.10.
Notably, we only had to make changes in the continuous integration.