### PR TITLE
Release 0.0.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,14 @@
     Please keep this file at 72 line width so that we can copy-paste
     the release logs directly into commit messages.
 
+0.0.3 (2022-01-22)
+==================
+
+* Add support for Python 3.10 (#27)
+* Add support for Python 3.9 (#26)
+* Remove ``ExpressionWithDeclarations`` from our tree (#25)
+* Revert lost `--version` command flag (#23)
+
 0.0.2 (2022-01-15)
 ==================
 

--- a/aas_core_codegen/__init__.py
+++ b/aas_core_codegen/__init__.py
@@ -1,6 +1,6 @@
 """Generate different implementations and schemas based on an AAS meta-model."""
 
-__version__ = "0.0.2"
+__version__ = "0.0.3"
 __author__ = "Marko Ristin, Nico Braunisch, Robert Lehmann"
 __license__ = "License :: OSI Approved :: MIT License"
 __status__ = "Production/Stable"

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open(os.path.join(here, "requirements.txt"), encoding="utf-8") as fid:
 
 setup(
     name="aas-core-codegen",
-    version="0.0.2",
+    version="0.0.3",
     description="Generate different implementations and schemas based on an AAS meta-model.",
     long_description=long_description,
     url="https://github.com/aas-core-works/aas-core-codegen",


### PR DESCRIPTION
* Add support for Python 3.10 (#27)
* Add support for Python 3.9 (#26)
* Remove ``ExpressionWithDeclarations`` from our tree (#25)
* Revert lost `--version` command flag (#23)