### PR TITLE
Upgrade black to 22.1.0

### DIFF
--- a/continuous_integration/precommit.py
+++ b/continuous_integration/precommit.py
@@ -19,7 +19,7 @@ class Step(enum.Enum):
 
 
 def main() -> int:
-    """"Execute entry_point routine."""
+    """Execute entry_point routine."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--overwrite",

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     # fmt: off
     extras_require={
         "dev": [
-            "black==20.8b1",
+            "black==22.1.0",
             "mypy==0.930",
             "pylint==2.12.2",
             "pydocstyle>=2.1.1,<3",


### PR DESCRIPTION
This patch upgrade the black to the latest version since we faced
various black-related bugs. We hope that the new version will be able to
fix them.