### PR TITLE
Include test and CI code in pylint precommit check

### DIFF
--- a/continuous_integration/check_help_in_readme.py
+++ b/continuous_integration/check_help_in_readme.py
@@ -95,15 +95,15 @@ def capture_output_lines(command: str) -> List[str]:
         ) from exception
 
     assert proc is not None
+    with proc:
+        output, err = proc.communicate()
+        if err:
+            raise RuntimeError(
+                f"The command {command!r} failed with exit code {proc.returncode} and "
+                f"stderr:\n{err}"
+            )
 
-    output, err = proc.communicate()
-    if err:
-        raise RuntimeError(
-            f"The command {command!r} failed with exit code {proc.returncode} and "
-            f"stderr:\n{err}"
-        )
-
-    return output.splitlines()
+        return output.splitlines()
 
 
 def output_lines_to_code_block(output_lines: List[str]) -> List[str]:

--- a/continuous_integration/check_init_and_setup_coincide.py
+++ b/continuous_integration/check_init_and_setup_coincide.py
@@ -88,7 +88,7 @@ def main() -> int:
 
     classifiers = (
         subprocess.check_output(
-            [sys.executable, str(setup_py_pth), f"--classifiers"], encoding="utf-8"
+            [sys.executable, str(setup_py_pth), "--classifiers"], encoding="utf-8"
         )
         .strip()
         .splitlines()
@@ -102,8 +102,8 @@ def main() -> int:
 
     if status_classifier is None:
         print(
-            f"Expected a status classifier in setup.py "
-            f"(e.g., 'Development Status :: 3 - Alpha'), but found none.",
+            "Expected a status classifier in setup.py "
+            "(e.g., 'Development Status :: 3 - Alpha'), but found none.",
             file=sys.stderr,
         )
         success = False

--- a/continuous_integration/precommit.py
+++ b/continuous_integration/precommit.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+
 """Run pre-commit checks on the repository."""
 import argparse
 import enum
@@ -9,8 +10,12 @@ import subprocess
 import sys
 from typing import Optional, Mapping, Sequence
 
+# pylint: disable=unnecessary-comprehension
+
 
 class Step(enum.Enum):
+    """Enumerate different pre-commit steps."""
+
     REFORMAT = "reformat"
     MYPY = "mypy"
     PYLINT = "pylint"
@@ -123,7 +128,7 @@ def main() -> int:
 
         exit_code = call_and_report(
             verb="mypy",
-            cmd=["mypy", "--strict", f"--config-file", str(config_file)] + mypy_targets,
+            cmd=["mypy", "--strict", "--config-file", str(config_file)] + mypy_targets,
             cwd=repo_root,
         )
         if exit_code != 0:
@@ -133,7 +138,7 @@ def main() -> int:
 
     if Step.PYLINT in selects and Step.PYLINT not in skips:
         print("Pylint'ing...")
-        pylint_targets = ["aas_core_codegen"]
+        pylint_targets = ["aas_core_codegen", "tests", "continuous_integration"]
         rcfile = pathlib.Path("continuous_integration") / "pylint.rc"
 
         exit_code = call_and_report(

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,17 +1,14 @@
 """Provide common functionality across different tests."""
-import os
-import pathlib
 from typing import List, Tuple, Optional, Union, Sequence
 
 import asttokens
 from icontract import ensure
 
 from aas_core_codegen import parse, intermediate
-from aas_core_codegen.intermediate import (
-    construction as intermediate_construction,
-    _hierarchy as intermediate_hierarchy,
-)
 from aas_core_codegen.common import Error
+
+
+# pylint: disable=missing-function-docstring
 
 
 def most_underlying_messages(error_or_errors: Union[Error, Sequence[Error]]) -> str:
@@ -69,7 +66,7 @@ def parse_source(source: str) -> Tuple[Optional[parse.SymbolTable], Optional[Err
     """Parse the given source text into a symbol table."""
     atok, parse_exception = parse.source_to_atok(source=source)
     if parse_exception:
-        raise parse_exception
+        raise parse_exception  # pylint: disable=raising-bad-type
 
     assert atok is not None
 
@@ -82,7 +79,7 @@ def translate_source_to_intermediate(
 ) -> Tuple[Optional[intermediate.SymbolTable], Optional[Error]]:
     atok, parse_exception = parse.source_to_atok(source=source)
     if parse_exception:
-        raise parse_exception
+        raise parse_exception  # pylint: disable=raising-bad-type
 
     assert atok is not None
 

--- a/tests/csharp/live_test_main.py
+++ b/tests/csharp/live_test_main.py
@@ -17,13 +17,13 @@ import aas_core_codegen.main
 def main() -> int:
     """Execute the main routine."""
     print("Running dotnet --version to check that dotnet is available...")
-    run = subprocess.run(
+    exit_code = subprocess.call(
         ["dotnet", "--version"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
     )
-    if run.returncode != 0:
+    if exit_code != 0:
         print(
             f"Failed to execute ``dotnet --version`` "
-            f"with the exit code {run.returncode}. Is dotnet installed?",
+            f"with the exit code {exit_code}. Is dotnet installed?",
             file=sys.stderr,
         )
         return 1
@@ -87,11 +87,11 @@ def main() -> int:
                         <Platforms>AnyCPU</Platforms>
                         <LangVersion>8</LangVersion>
                     </PropertyGroup>
-                    
+
                     <ItemGroup>
-                        <!-- 
-                            You can exclude this dependency if you are compiling 
-                            for net5.0 or netcore3.1. 
+                        <!--
+                            You can exclude this dependency if you are compiling
+                            for net5.0 or netcore3.1.
                         -->
                         <PackageReference Include="System.Text.Json" Version="5.*" />
                     </ItemGroup>
@@ -102,10 +102,14 @@ def main() -> int:
             )
 
             print("Calling dotnet build...")
-            run = subprocess.run(["dotnet", "build", "."], cwd=str(output_dir))
-            assert (
-                run.returncode == 0
-            ), f"Expected the build to succeed, but got exit code: {run.returncode}"
+            exit_code = subprocess.call(["dotnet", "build", "."], cwd=str(output_dir))
+            if exit_code != 0:
+                print(
+                    f"ERROR: Expected the build to succeed, "
+                    f"but got exit code: {exit_code}",
+                    file=sys.stderr,
+                )
+                return 1
 
     return 0
 

--- a/tests/csharp/test_common.py
+++ b/tests/csharp/test_common.py
@@ -1,3 +1,5 @@
+# pylint: disable=missing-docstring
+
 import unittest
 
 import aas_core_codegen.csharp.common as csharp_common

--- a/tests/csharp/test_description.py
+++ b/tests/csharp/test_description.py
@@ -1,3 +1,5 @@
+# pylint: disable=missing-docstring
+
 import textwrap
 import unittest.mock
 
@@ -38,10 +40,10 @@ class TestDescription(unittest.TestCase):
                 '''\
                 class Some_class:
                     """"""  # Intentionally left empty
-                
+
                 class Reference:
                     pass
-                    
+
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
                 associate_ref_with(Reference)
@@ -57,10 +59,10 @@ class TestDescription(unittest.TestCase):
                 '''\
                 class Some_class:
                     """Do & drink something."""
-                
+
                 class Reference:
                     pass
-                    
+
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
                 associate_ref_with(Reference)
@@ -84,10 +86,10 @@ class TestDescription(unittest.TestCase):
                 '''\
                 class Some_class:
                     """Do & drink :class:`.Some_class`."""
-                    
+
                 class Reference:
                     pass
-                    
+
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
                 associate_ref_with(Reference)
@@ -112,10 +114,10 @@ class TestDescription(unittest.TestCase):
                 @abstract
                 class Some_class:
                     """Do & drink :class:`.Some_class`."""
-                    
+
                 class Reference:
                     pass
-                    
+
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
                 associate_ref_with(Reference)
@@ -139,10 +141,10 @@ class TestDescription(unittest.TestCase):
                 '''\
                 class Some_class(Enum):
                     """Do & drink :class:`.Some_class`."""
-                    
+
                 class Reference:
                     pass
-                    
+
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
                 associate_ref_with(Reference)
@@ -172,10 +174,10 @@ class TestDescription(unittest.TestCase):
 
                     Second & remark.
                     """
-                    
+
                 class Reference:
                     pass
-                    
+
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
                 associate_ref_with(Reference)
@@ -216,10 +218,10 @@ class TestDescription(unittest.TestCase):
                         text
                     :returns: some result
                     """
-                    
+
                 class Reference:
                     pass
-                    
+
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
                 associate_ref_with(Reference)

--- a/tests/csharp/test_main.py
+++ b/tests/csharp/test_main.py
@@ -1,3 +1,5 @@
+# pylint: disable=missing-docstring
+
 import contextlib
 import io
 import os
@@ -39,7 +41,9 @@ class Test_against_recorded(unittest.TestCase):
                         expected_output_dir.exists() and expected_output_dir.is_dir()
                     ), expected_output_dir
 
-                    tmp_dir = tempfile.TemporaryDirectory()
+                    tmp_dir = (
+                        tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
+                    )
                     exit_stack.push(tmp_dir)
                     output_dir = pathlib.Path(tmp_dir.name)
 

--- a/tests/infer_for_schema/test_len_on_properties.py
+++ b/tests/infer_for_schema/test_len_on_properties.py
@@ -1,3 +1,5 @@
+# pylint: disable=missing-docstring
+
 import textwrap
 import unittest
 from typing import Tuple, Optional, MutableMapping, List
@@ -61,7 +63,7 @@ class Test_expected(unittest.TestCase):
     def test_min_value_constant_left(self) -> None:
         source = textwrap.dedent(
             """\
-            @invariant(lambda self: 10 < len(self.some_property)) 
+            @invariant(lambda self: 10 < len(self.some_property))
             class Something:
                 some_property: str
 
@@ -102,7 +104,7 @@ class Test_expected(unittest.TestCase):
     def test_min_value_constant_right(self) -> None:
         source = textwrap.dedent(
             """\
-            @invariant(lambda self: len(self.some_property) > 10) 
+            @invariant(lambda self: len(self.some_property) > 10)
             class Something:
                 some_property: str
 
@@ -143,7 +145,7 @@ class Test_expected(unittest.TestCase):
     def test_max_value_constant_right(self) -> None:
         source = textwrap.dedent(
             """\
-            @invariant(lambda self: len(self.some_property) < 10) 
+            @invariant(lambda self: len(self.some_property) < 10)
             class Something:
                 some_property: str
 
@@ -184,7 +186,7 @@ class Test_expected(unittest.TestCase):
     def test_max_value_constant_left(self) -> None:
         source = textwrap.dedent(
             """\
-            @invariant(lambda self: 10 > len(self.some_property)) 
+            @invariant(lambda self: 10 > len(self.some_property))
             class Something:
                 some_property: str
 
@@ -225,7 +227,7 @@ class Test_expected(unittest.TestCase):
     def test_exact_value_constant_left(self) -> None:
         source = textwrap.dedent(
             """\
-            @invariant(lambda self: 10 == len(self.some_property)) 
+            @invariant(lambda self: 10 == len(self.some_property))
             class Something:
                 some_property: str
 
@@ -266,7 +268,7 @@ class Test_expected(unittest.TestCase):
     def test_exact_value_constant_right(self) -> None:
         source = textwrap.dedent(
             """\
-            @invariant(lambda self: len(self.some_property) == 10) 
+            @invariant(lambda self: len(self.some_property) == 10)
             class Something:
                 some_property: str
 
@@ -308,10 +310,10 @@ class Test_expected(unittest.TestCase):
         source = textwrap.dedent(
             """\
             @invariant(
-                lambda self: 
+                lambda self:
                 not (self.some_property is not None)
                 or len(self.some_property) == 10
-            ) 
+            )
             class Something:
                 some_property: Optional[str]
 
@@ -359,14 +361,14 @@ class Test_expected(unittest.TestCase):
                 def __init__(self, some_property: str) -> None:
                     self.some_property = some_property
 
-                
-            @invariant(lambda self: len(self.some_property) > 5) 
+
+            @invariant(lambda self: len(self.some_property) > 5)
             class Something(Parent):
                 def __init__(self, some_property: str) -> None:
                     Parent.__init__(
                         self,
                         some_property=some_property
-                    ) 
+                    )
 
 
             class Reference:
@@ -410,7 +412,7 @@ class Test_unexpected(unittest.TestCase):
         source = textwrap.dedent(
             """\
             @invariant(lambda self: len(self.some_property) > 10)
-            @invariant(lambda self: len(self.some_property) < 3) 
+            @invariant(lambda self: len(self.some_property) < 3)
             class Something:
                 some_property: str
 
@@ -440,7 +442,7 @@ class Test_unexpected(unittest.TestCase):
         source = textwrap.dedent(
             """\
             @invariant(lambda self: len(self.some_property) > 10)
-            @invariant(lambda self: len(self.some_property) == 3) 
+            @invariant(lambda self: len(self.some_property) == 3)
             class Something:
                 some_property: str
 
@@ -470,7 +472,7 @@ class Test_unexpected(unittest.TestCase):
         source = textwrap.dedent(
             """\
             @invariant(lambda self: len(self.some_property) < 10)
-            @invariant(lambda self: len(self.some_property) == 30) 
+            @invariant(lambda self: len(self.some_property) == 30)
             class Something:
                 some_property: str
 

--- a/tests/infer_for_schema/test_len_on_self.py
+++ b/tests/infer_for_schema/test_len_on_self.py
@@ -1,3 +1,5 @@
+# pylint: disable=missing-docstring
+
 import textwrap
 import unittest
 from typing import Tuple, Optional, MutableMapping, List
@@ -257,9 +259,9 @@ class Test_expected(unittest.TestCase):
                 pass
 
 
-            @invariant(lambda self: len(self) > 5) 
+            @invariant(lambda self: len(self) > 5)
             class Something(Parent):
-                pass 
+                pass
 
 
             class Reference:
@@ -298,7 +300,7 @@ class Test_unexpected(unittest.TestCase):
         source = textwrap.dedent(
             """\
             @invariant(lambda self: len(self) > 10)
-            @invariant(lambda self: len(self) < 3) 
+            @invariant(lambda self: len(self) < 3)
             class Something(str):
                 pass
 
@@ -325,7 +327,7 @@ class Test_unexpected(unittest.TestCase):
         source = textwrap.dedent(
             """\
             @invariant(lambda self: len(self) > 10)
-            @invariant(lambda self: len(self) == 3) 
+            @invariant(lambda self: len(self) == 3)
             class Something(str):
                 pass
 
@@ -352,7 +354,7 @@ class Test_unexpected(unittest.TestCase):
         source = textwrap.dedent(
             """\
             @invariant(lambda self: len(self) < 10)
-            @invariant(lambda self: len(self) == 30) 
+            @invariant(lambda self: len(self) == 30)
             class Something(str):
                 pass
 

--- a/tests/infer_for_schema/test_patterns_on_properties.py
+++ b/tests/infer_for_schema/test_patterns_on_properties.py
@@ -1,3 +1,5 @@
+# pylint: disable=missing-docstring
+
 import textwrap
 import unittest
 from typing import MutableMapping, List
@@ -61,7 +63,7 @@ class Test_expected(unittest.TestCase):
                 prefix = "something"
                 return match(f"{prefix}-[a-zA-Z]+", text) is not None
 
-            
+
             @invariant(lambda self: is_something(self.some_property))
             class Something:
                 some_property: str
@@ -157,13 +159,13 @@ class Test_expected(unittest.TestCase):
                 return match("something-[a-zA-Z]+", text) is not None
 
             @invariant(
-                lambda self: 
-                not (self.some_property is not None) 
+                lambda self:
+                not (self.some_property is not None)
                 or  is_something(self.some_property)
             )
             class Something:
                 some_property: Optional[str]
-            
+
                 def __init__(self, some_property: Optional[str] = None) -> None:
                     self.some_property = some_property
 

--- a/tests/infer_for_schema/test_patterns_on_self.py
+++ b/tests/infer_for_schema/test_patterns_on_self.py
@@ -1,3 +1,5 @@
+# pylint: disable=missing-docstring
+
 import textwrap
 import unittest
 from typing import MutableMapping, List

--- a/tests/intermediate/test_constructor.py
+++ b/tests/intermediate/test_constructor.py
@@ -1,3 +1,5 @@
+# pylint: disable=missing-docstring
+
 import re
 import textwrap
 import unittest
@@ -55,10 +57,10 @@ class Test_empty_ok(unittest.TestCase):
             """\
             class Something:
                 pass
-                
+
             class Reference:
                 pass
-            
+
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             associate_ref_with(Reference)
@@ -85,10 +87,10 @@ class Test_empty_ok(unittest.TestCase):
             class Something:
                 def __init__(self) -> None:
                     pass
-            
+
             class Reference:
                 pass
-            
+
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             associate_ref_with(Reference)
@@ -120,10 +122,10 @@ class Test_call_to_super_constructor_ok(unittest.TestCase):
             class Something(Parent):
                 def __init__(self) -> None:
                     Parent.__init__(self)
-                    
+
             class Reference:
                 pass
-            
+
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             associate_ref_with(Reference)
@@ -158,10 +160,10 @@ class Test_call_to_super_constructor_ok(unittest.TestCase):
             class Something(Parent):
                 def __init__(self, a: int, b: int) -> None:
                     Parent.__init__(self, a, b)
-                    
+
             class Reference:
                 pass
-            
+
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             associate_ref_with(Reference)
@@ -191,10 +193,10 @@ class Test_assign_property_ok(unittest.TestCase):
 
                 def __init__(self, x: int) -> None:
                     self.x = x
-            
+
             class Reference:
                 pass
-            
+
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             associate_ref_with(Reference)
@@ -223,10 +225,10 @@ class Test_assign_fail(unittest.TestCase):
 
                 def __init__(self, a: int) -> None:
                     self.a = self.b = a
-                    
+
             class Reference:
                 pass
-            
+
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             associate_ref_with(Reference)
@@ -250,10 +252,10 @@ class Test_assign_fail(unittest.TestCase):
 
                 def __init__(self, a: int, b: int) -> None:
                     self.a, self.b = a, b
-                    
+
             class Reference:
                 pass
-            
+
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             associate_ref_with(Reference)
@@ -278,10 +280,10 @@ class Test_assign_fail(unittest.TestCase):
 
                 def __init__(self, a: int, b: int) -> None:
                     x = a
-                    
+
             class Reference:
                 pass
-            
+
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             associate_ref_with(Reference)
@@ -302,10 +304,10 @@ class Test_assign_fail(unittest.TestCase):
             class Something:
                 def __init__(self, a: int) -> None:
                     self.a = a
-            
+
             class Reference:
                 pass
-            
+
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             associate_ref_with(Reference)
@@ -328,10 +330,10 @@ class Test_assign_fail(unittest.TestCase):
 
                 def __init__(self, a: int) -> None:
                     self.a = a + 100
-                    
+
             class Reference:
                 pass
-            
+
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             associate_ref_with(Reference)
@@ -362,7 +364,7 @@ class Test_assign_fail(unittest.TestCase):
 
             class Reference:
                 pass
-            
+
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             associate_ref_with(Reference)
@@ -396,14 +398,14 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
                     self.b = b
 
             class Something(Parent):
-                """Represent something concrete.""" 
+                """Represent something concrete."""
 
                 def __init__(self, a: int, b: int) -> None:
                     super().__init__(self, a, b)
-                    
+
             class Reference:
                 pass
-            
+
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             associate_ref_with(Reference)
@@ -435,14 +437,14 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
                     self.b = b
 
             class Something(DBC, Parent):
-                """Represent something concrete.""" 
+                """Represent something concrete."""
 
                 def __init__(self, a: int, b: int) -> None:
                     Parent.__init__(self, **{'a': a, 'b': b})
-                    
+
             class Reference:
                 pass
-            
+
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             associate_ref_with(Reference)
@@ -472,10 +474,10 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
             class Something:
                 def __init__(self, a: int, b: int) -> None:
                     Unrelated.__init__(self, a=a, b=b)
-                    
+
             class Reference:
                 pass
-            
+
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             associate_ref_with(Reference)
@@ -498,14 +500,14 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
             class Parent:
                 pass
 
-            class Something(Parent): 
+            class Something(Parent):
 
                 def __init__(self, a: int, b: int) -> None:
                     Parent.__init__(self)
-                    
+
             class Reference:
                 pass
-            
+
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             associate_ref_with(Reference)
@@ -533,10 +535,10 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
             class Something(DBC, Parent):
                 def __init__(self, a: int) -> None:
                     Parent.__init__(self, a + 100)
-                    
+
             class Reference:
                 pass
-            
+
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             associate_ref_with(Reference)
@@ -565,10 +567,10 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
             class Something(DBC, Parent):
                 def __init__(self, a: int) -> None:
                     Parent.__init__(self, a=a + 100)
-                    
+
             class Reference:
                 pass
-            
+
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             associate_ref_with(Reference)
@@ -599,10 +601,10 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
             class Something(Parent):
                 def __init__(self, a: int, b: int, c: int) -> None:
                     Parent.__init__(self, a, b, c)
-                    
+
             class Reference:
                 pass
-            
+
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             associate_ref_with(Reference)
@@ -633,10 +635,10 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
             class Something(DBC, Parent):
                 def __init__(self, a: int, b: int, c: int) -> None:
                     Parent.__init__(self, a=a, b=b, c=c)
-                    
+
             class Reference:
                 pass
-            
+
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             associate_ref_with(Reference)
@@ -668,10 +670,10 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
             class Something(Parent):
                 def __init__(self, a: int) -> None:
                     Parent.__init__(self, a, b)
-            
+
             class Reference:
                 pass
-            
+
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             associate_ref_with(Reference)
@@ -703,10 +705,10 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
             class Something(DBC, Parent):
                 def __init__(self, a: int, y: int) -> None:
                     Parent.__init__(self, a, b=y)
-                    
+
             class Reference:
                 pass
-            
+
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             associate_ref_with(Reference)
@@ -739,10 +741,10 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
             class Something(Parent):
                 def __init__(self, a: int) -> None:
                     Parent.__init__(self, a)
-                    
+
             class Reference:
                 pass
-            
+
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             associate_ref_with(Reference)
@@ -767,10 +769,10 @@ class Test_unexpected_statements(unittest.TestCase):
 
                 def __init__(self, a: int) -> None:
                     print("something")
-                    
+
             class Reference:
                 pass
-            
+
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             associate_ref_with(Reference)
@@ -794,10 +796,10 @@ class Test_unexpected_statements(unittest.TestCase):
 
                 def __init__(self, a: int) -> None:
                     1 + 2
-                    
+
             class Reference:
                 pass
-            
+
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             associate_ref_with(Reference)

--- a/tests/intermediate/test_hierarchy.py
+++ b/tests/intermediate/test_hierarchy.py
@@ -1,9 +1,12 @@
+# pylint: disable=missing-docstring
+
 import textwrap
 import unittest
 
-import aas_core_codegen.intermediate._hierarchy as _hierarchy
-import tests.common
+from aas_core_codegen.intermediate import _hierarchy as intermediate_hierarchy
 from aas_core_codegen.common import Identifier
+
+import tests.common
 
 
 class Test_ontology_ok(unittest.TestCase):
@@ -13,10 +16,10 @@ class Test_ontology_ok(unittest.TestCase):
                 """\
                 class Something:
                     pass
-                    
+
                 class Reference:
                     pass
-                
+
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
                 associate_ref_with(Reference)
@@ -27,7 +30,9 @@ class Test_ontology_ok(unittest.TestCase):
         assert error is None, tests.common.most_underlying_messages(error)
         assert symbol_table is not None
 
-        ontology, errors = _hierarchy.map_symbol_table_to_ontology(symbol_table)
+        ontology, errors = intermediate_hierarchy.map_symbol_table_to_ontology(
+            symbol_table
+        )
         assert errors is None, f"{errors=}"
         assert ontology is not None
 
@@ -60,10 +65,10 @@ class Test_ontology_ok(unittest.TestCase):
 
                 class Something(Parent, Another_parent):
                     pass
-                    
+
                 class Reference:
                     pass
-                
+
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
                 associate_ref_with(Reference)
@@ -71,9 +76,12 @@ class Test_ontology_ok(unittest.TestCase):
             )
         )
 
+        assert error is None, tests.common.most_underlying_messages(error)
         assert symbol_table is not None
 
-        ontology, errors = _hierarchy.map_symbol_table_to_ontology(symbol_table)
+        ontology, errors = intermediate_hierarchy.map_symbol_table_to_ontology(
+            symbol_table
+        )
         assert errors is None, f"{errors=}"
         assert ontology is not None
 
@@ -108,10 +116,10 @@ class Test_ontology_fail(unittest.TestCase):
                 @abstract
                 class Something(Abstract):
                     x: int
-                    
+
                 class Reference:
                     pass
-                
+
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
                 associate_ref_with(Reference)
@@ -121,7 +129,7 @@ class Test_ontology_fail(unittest.TestCase):
         assert error is None, tests.common.most_underlying_messages(error)
         assert symbol_table is not None
 
-        ontology, errors = _hierarchy.map_symbol_table_to_ontology(symbol_table)
+        _, errors = intermediate_hierarchy.map_symbol_table_to_ontology(symbol_table)
         assert errors is not None and len(errors) == 1
 
         self.assertEqual(
@@ -143,10 +151,10 @@ class Test_ontology_fail(unittest.TestCase):
                 class Something(Abstract):
                     def do_something(self) -> None:
                         pass
-                        
+
                 class Reference:
                     pass
-                
+
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
                 associate_ref_with(Reference)
@@ -156,7 +164,7 @@ class Test_ontology_fail(unittest.TestCase):
         assert error is None, tests.common.most_underlying_messages(error)
         assert symbol_table is not None
 
-        ontology, errors = _hierarchy.map_symbol_table_to_ontology(symbol_table)
+        _, errors = intermediate_hierarchy.map_symbol_table_to_ontology(symbol_table)
         assert errors is not None and len(errors) == 1
 
         self.assertEqual(
@@ -176,10 +184,10 @@ class Test_ontology_fail(unittest.TestCase):
 
                 class Something(Abstract):
                     pass
-                    
+
                 class Reference:
                     pass
-                
+
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
                 associate_ref_with(Reference)
@@ -189,7 +197,7 @@ class Test_ontology_fail(unittest.TestCase):
         assert error is None, tests.common.most_underlying_messages(error)
         assert symbol_table is not None
 
-        ontology, errors = _hierarchy.map_symbol_table_to_ontology(symbol_table)
+        _, errors = intermediate_hierarchy.map_symbol_table_to_ontology(symbol_table)
         assert errors is not None and len(errors) == 1
 
         self.assertEqual(
@@ -210,10 +218,10 @@ class Test_ontology_fail(unittest.TestCase):
                 @abstract
                 class Something(Cycle):
                     pass
-                    
+
                 class Reference:
                     pass
-                
+
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
                 associate_ref_with(Reference)
@@ -223,7 +231,7 @@ class Test_ontology_fail(unittest.TestCase):
         assert error is None, tests.common.most_underlying_messages(error)
         assert symbol_table is not None
 
-        ontology, errors = _hierarchy.map_symbol_table_to_ontology(symbol_table)
+        _, errors = intermediate_hierarchy.map_symbol_table_to_ontology(symbol_table)
         assert errors is not None and len(errors) == 1
 
         self.assertEqual(

--- a/tests/intermediate/test_translate.py
+++ b/tests/intermediate/test_translate.py
@@ -1,3 +1,5 @@
+# pylint: disable=missing-docstring
+
 import os
 import pathlib
 import textwrap
@@ -17,28 +19,28 @@ class Test_in_lining_of_constructor_statements(unittest.TestCase):
             @abstract
             class VeryAbstract:
                 some_property: int
-            
+
                 @require(lambda some_property: some_property > 0)
                 def __init__(self, some_property: int) -> None:
                     self.some_property = some_property
-            
-            
+
+
             @abstract
             class Abstract(VeryAbstract):
                 another_property: int
-            
+
                 @require(lambda another_property: another_property > 0)
                 def __init__(self, some_property: int, another_property: int) -> None:
                     VeryAbstract.__init__(self, some_property)
                     self.another_property = another_property
-                    
+
             class Concrete(Abstract):
                 yet_another_property: int
-            
+
                 @require(lambda yet_another_property: yet_another_property > 0)
                 def __init__(
-                        self, 
-                        some_property: int, 
+                        self,
+                        some_property: int,
                         another_property: int,
                         yet_another_property: int
                 ) -> None:
@@ -48,7 +50,7 @@ class Test_in_lining_of_constructor_statements(unittest.TestCase):
 
             class Reference:
                 pass
-                
+
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             associate_ref_with(Reference)
@@ -81,10 +83,10 @@ class Test_parsing_docstrings(unittest.TestCase):
 
                  * Nested reference :class:`.Some_class`
                  """
-            
+
             class Reference:
                 pass
-                
+
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             associate_ref_with(Reference)
@@ -116,7 +118,7 @@ class Test_parsing_docstrings(unittest.TestCase):
 class Test_against_recorded(unittest.TestCase):
     # Set this variable to True if you want to re-record the test data,
     # without any checks
-    RERECORD = True  # TODO: undo
+    RERECORD = False
 
     def test_cases(self) -> None:
         this_dir = pathlib.Path(os.path.realpath(__file__)).parent

--- a/tests/jsonschema/test_main.py
+++ b/tests/jsonschema/test_main.py
@@ -1,3 +1,5 @@
+# pylint: disable=missing-docstring
+
 import contextlib
 import io
 import os
@@ -11,7 +13,7 @@ import aas_core_codegen.main
 class Test_against_recorded(unittest.TestCase):
     # Set this variable to True if you want to re-record the test data,
     # without any checks
-    RERECORD = True  # TODO: undo
+    RERECORD = False
 
     def test_cases(self) -> None:
         repo_dir = pathlib.Path(os.path.realpath(__file__)).parent.parent.parent
@@ -39,7 +41,9 @@ class Test_against_recorded(unittest.TestCase):
                         expected_output_dir.exists() and expected_output_dir.is_dir()
                     ), expected_output_dir
 
-                    tmp_dir = tempfile.TemporaryDirectory()
+                    tmp_dir = (
+                        tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
+                    )
                     exit_stack.push(tmp_dir)
                     output_dir = pathlib.Path(tmp_dir.name)
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,8 +1,12 @@
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-class-docstring
+# pylint: disable=missing-function-docstring
+# pylint: disable=no-self-use
+
 import ast
 import os
 import pathlib
 import re
-import sys
 import textwrap
 import unittest
 from typing import Optional, Tuple, List
@@ -35,7 +39,7 @@ class Test_parsing_AST(unittest.TestCase):
             """
         )
 
-        atok, error = parse.source_to_atok(source=source)
+        _, error = parse.source_to_atok(source=source)
         assert error is not None
         assert isinstance(error, SyntaxError)
         self.assertEqual(1, error.lineno)
@@ -60,6 +64,7 @@ class Test_checking_imports(unittest.TestCase):
         )
 
         atok, error = parse.source_to_atok(source=source)
+        assert error is None, f"{error=}"
         assert atok is not None
 
         errors = parse.check_expected_imports(atok=atok)
@@ -80,6 +85,7 @@ class Test_checking_imports(unittest.TestCase):
         )
 
         atok, error = parse.source_to_atok(source=source)
+        assert error is None, f"{error=}"
         assert atok is not None
 
         # NOTE (mristin, 2022-01-22):
@@ -155,10 +161,10 @@ class Test_parsing_docstring(unittest.TestCase):
             '''\
             class Some_class:
                 """"""
-                
+
             class Reference:
                 pass
-                
+
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             associate_ref_with(Reference)
@@ -174,10 +180,10 @@ class Test_parsing_docstring(unittest.TestCase):
             '''\
             class Some_class:
                 """This is some documentation."""
-                
+
             class Reference:
                 pass
-                
+
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             associate_ref_with(Reference)
@@ -198,10 +204,10 @@ class Test_parsing_docstring(unittest.TestCase):
 
                 Another paragraph.
                 """
-            
+
             class Reference:
                 pass
-                
+
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             associate_ref_with(Reference)
@@ -222,7 +228,7 @@ class Test_unexpected_class_definitions(unittest.TestCase):
         assert parse_exception is None, f"{parse_exception=}"
         assert atok is not None
 
-        symbol_table, error = parse.atok_to_symbol_table(atok=atok)
+        _, error = parse.atok_to_symbol_table(atok=atok)
         return error
 
 
@@ -292,7 +298,7 @@ class Test_parse_type_annotation_fail(unittest.TestCase):
             "x: Mapping[str, ...]"
         )
 
-        type_annotation, error = parse._translate._type_annotation(node=anno, atok=atok)
+        _, error = parse._translate._type_annotation(node=anno, atok=atok)
         assert error is not None
 
         self.assertEqual(
@@ -306,7 +312,7 @@ class Test_parse_type_annotation_fail(unittest.TestCase):
             "x: (int if True else str)"
         )
 
-        type_annotation, error = parse._translate._type_annotation(node=anno, atok=atok)
+        _, error = parse._translate._type_annotation(node=anno, atok=atok)
         assert error is not None
 
         # NOTE (mristin, 2022-01-22):
@@ -325,7 +331,7 @@ class Test_parse_type_annotation_fail(unittest.TestCase):
             "x: Optional[str:int]"
         )
 
-        type_annotation, error = parse._translate._type_annotation(node=anno, atok=atok)
+        _, error = parse._translate._type_annotation(node=anno, atok=atok)
         assert error is not None
 
         self.assertEqual(
@@ -339,7 +345,7 @@ class Test_parse_type_annotation_fail(unittest.TestCase):
             "x: Optional[1:2, 3]"
         )
 
-        type_annotation, error = parse._translate._type_annotation(node=anno, atok=atok)
+        _, error = parse._translate._type_annotation(node=anno, atok=atok)
         assert error is not None
 
         self.assertEqual(
@@ -353,7 +359,7 @@ class Test_parse_type_annotation_fail(unittest.TestCase):
             "x: Optional[str if True else int]"
         )
 
-        type_annotation, error = parse._translate._type_annotation(node=anno, atok=atok)
+        _, error = parse._translate._type_annotation(node=anno, atok=atok)
         assert error is not None
 
         self.assertEqual(


### PR DESCRIPTION
We excluded the test and continuous integration code from pylint checks
since we did not really care about most of the rules. However, if
there is a ``TODO`` in the tests, there is no check to actually detect
it. There were already multiple cases where we checked in ``TODO`` code
inadvertently.

Therefore we add the test code in pylint check in this patch.

This patch also includes all the fixes which were necessary to make
pylint happy.