### PR TITLE
Fix double curly brackets in C# verification

### DIFF
--- a/aas_core_codegen/csharp/verification/_generate.py
+++ b/aas_core_codegen/csharp/verification/_generate.py
@@ -1475,7 +1475,7 @@ def _generate_implementation_class(
             /// visitors.
             /// </remarks>
             private static class Implementation
-            {{
+            {
             """
         )
     )

--- a/test_data/csharp/test_main/v3rc2/expected_output/verification.cs
+++ b/test_data/csharp/test_main/v3rc2/expected_output/verification.cs
@@ -146,7 +146,7 @@ namespace AasCore.Aas3
         /// visitors.
         /// </remarks>
         private static class Implementation
-        {{
+        {
             /// <summary>
             /// Hash allowed enum values for efficient validation of enums.
             /// </summary>


### PR DESCRIPTION
There was a minor bug where double curly brackets were written in a code
block, but the string literal has not been interpolated.

The bug went unnoticed since we did not re-run live test on C#.