### PR TITLE
Put `object` on the list of reserved words

### DIFF
--- a/aas_core_codegen/parse/_translate.py
+++ b/aas_core_codegen/parse/_translate.py
@@ -1888,6 +1888,7 @@ def _verify_symbol_table(
         "boolean",
         "bytes",
         "bytearray",
+        "object",
     }
 
     reserved_symbol_names = builtin_types_in_many_implementations.union(


### PR DESCRIPTION
The word `object` is reserved in C# and Java so we check that it does
not appear either as a class name or as a property.