### PR TITLE
Add `ValueDataType` in JSON schema test for V3RC01

### DIFF
--- a/test_data/jsonschema/test_main/v3rc1/expected_output/schema.json
+++ b/test_data/jsonschema/test_main/v3rc1/expected_output/schema.json
@@ -24,6 +24,9 @@
         }
       ]
     },
+    "ValueDataType": {
+      "type": "string"
+    },
     "HasSemantics": {
       "allOf": [
         {
@@ -51,7 +54,7 @@
               "$ref": "#/definitions/DataTypeDef"
             },
             "value": {
-              "type": "string"
+              "$ref": "#/definitions/ValueDataType"
             },
             "refersTo": {
               "$ref": "#/definitions/Reference"
@@ -249,7 +252,7 @@
               "$ref": "#/definitions/DataTypeDef"
             },
             "value": {
-              "type": "string"
+              "$ref": "#/definitions/ValueDataType"
             },
             "valueID": {
               "$ref": "#/definitions/Reference"
@@ -566,7 +569,7 @@
               "$ref": "#/definitions/DataTypeDef"
             },
             "value": {
-              "type": "string"
+              "$ref": "#/definitions/ValueDataType"
             },
             "valueID": {
               "$ref": "#/definitions/Reference"
@@ -608,10 +611,10 @@
               "$ref": "#/definitions/DataTypeDef"
             },
             "min": {
-              "type": "string"
+              "$ref": "#/definitions/ValueDataType"
             },
             "max": {
-              "type": "string"
+              "$ref": "#/definitions/ValueDataType"
             }
           },
           "required": [
@@ -1100,7 +1103,7 @@
           "type": "object",
           "properties": {
             "value": {
-              "type": "string"
+              "$ref": "#/definitions/ValueDataType"
             },
             "valueID": {
               "$ref": "#/definitions/Reference"
@@ -1167,7 +1170,7 @@
               "$ref": "#/definitions/ValueList"
             },
             "value": {
-              "type": "string"
+              "$ref": "#/definitions/ValueDataType"
             },
             "valueID": {
               "$ref": "#/definitions/Reference"

--- a/test_data/jsonschema/test_main/v3rc1/input/meta_model.py
+++ b/test_data/jsonschema/test_main/v3rc1/input/meta_model.py
@@ -148,6 +148,15 @@ def is_MIME_type(text: str) -> bool:
     return match(media_type, text) is not None
 
 
+@verification
+@implementation_specific
+def value_and_data_type_match(
+        value: "Value_data_type",
+        data_type: "Data_type_def"
+) -> bool:
+    """Check that the actual type of :paramref:`value` matches :paramref:`data_type`."""
+    raise NotImplementedError()
+
 # endregion
 
 # region Constrained primitive types
@@ -162,8 +171,12 @@ class Non_empty_string(str, DBC):
 class MIME_typed(Non_empty_string, DBC):
     """Represent a string that follows the pattern of a MIME type."""
 
-
 # endregion
+
+@implementation_specific
+class Value_data_type:
+    """Represent an XML primitive type."""
+
 
 @abstract
 @reference_in_the_book(section=(4, 7, 2, 7))
@@ -203,8 +216,7 @@ class Extension(Has_semantics):
     Default: xsd:string
     """
 
-    # TODO (Nico: Add ValueDataType)
-    value: Optional[str]
+    value: Optional["Value_data_type"]
     """
     Value of the extension
     """
@@ -219,7 +231,7 @@ class Extension(Has_semantics):
             name: Non_empty_string,
             semantic_ID: Optional["Reference"] = None,
             value_type: Optional["Data_type_def"] = None,
-            value: Optional[str] = None,
+            value: Optional["Value_data_type"] = None,
             refers_to: Optional["Reference"] = None,
     ) -> None:
         Has_semantics.__init__(self, semantic_ID=semantic_ID)
@@ -604,7 +616,7 @@ class Qualifier(Constraint, Has_semantics):
     Data type of the qualifier value.
     """
 
-    value: Optional[str]
+    value: Optional["Value_data_type"]
     """
     The qualifier value is the value of the qualifier.
     """
@@ -618,7 +630,7 @@ class Qualifier(Constraint, Has_semantics):
             self,
             type: Non_empty_string,
             value_type: "Data_type_def",
-            value: Optional[str] = None,
+            value: Optional["Value_data_type"] = None,
             value_ID: Optional["Reference"] = None,
             semantic_ID: Optional["Reference"] = None,
     ) -> None:
@@ -1202,7 +1214,7 @@ class Property(Data_element):
     Data type of the value
     """
 
-    value: Optional[str]
+    value: Optional["Value_data_type"]
     """
     The value of the property instance.
 
@@ -1230,7 +1242,7 @@ class Property(Data_element):
             semantic_ID: Optional["Reference"] = None,
             qualifiers: Optional[List[Constraint]] = None,
             data_specifications: Optional[List["Reference"]] = None,
-            value: Optional[str] = None,
+            value: Optional["Value_data_type"] = None,
             value_ID: Optional["Reference"] = None,
     ) -> None:
         Data_element.__init__(
@@ -1339,13 +1351,13 @@ class Range(Data_element):
     Data type of the min und max
     """
 
-    min: Optional[str]
+    min: Optional["Value_data_type"]
     """
     The minimum value of the range.
     If the min value is missing, then the value is assumed to be negative infinite.
     """
 
-    max: Optional[str]
+    max: Optional["Value_data_type"]
     """
     The maximum value of the range.
     If the max value is missing,  then the value is assumed to be positive infinite.
@@ -1363,8 +1375,8 @@ class Range(Data_element):
             semantic_ID: Optional["Reference"] = None,
             qualifiers: Optional[List[Constraint]] = None,
             data_specifications: Optional[List["Reference"]] = None,
-            min: Optional[str] = None,
-            max: Optional[str] = None,
+            min: Optional["Value_data_type"] = None,
+            max: Optional["Value_data_type"] = None,
     ) -> None:
         Data_element.__init__(
             self,
@@ -2333,7 +2345,7 @@ class Value_reference_pair(DBC):
     defining its semantic.
     """
 
-    value: str
+    value: "Value_data_type"
     """
     The value of the referenced concept definition of the value in valueId.
     """
@@ -2343,7 +2355,7 @@ class Value_reference_pair(DBC):
     Global unique id of the value.
     """
 
-    def __init__(self, value: str, value_ID: "Reference") -> None:
+    def __init__(self, value: "Value_data_type", value_ID: "Reference") -> None:
         self.value = value
         self.value_ID = value_ID
 
@@ -2464,7 +2476,7 @@ class Data_specification_IEC_61360(Data_specification_content):
     List of allowed values
     """
 
-    value: Optional[str]
+    value: Optional["Value_data_type"]
     """
     Value
     """
@@ -2491,7 +2503,7 @@ class Data_specification_IEC_61360(Data_specification_content):
             definition: Optional["Lang_string_set"] = None,
             value_format: Optional[Non_empty_string] = None,
             value_list: Optional["Value_list"] = None,
-            value: Optional[str] = None,
+            value: Optional["Value_data_type"] = None,
             value_ID: Optional["Reference"] = None,
             level_type: Optional["Level_type"] = None,
     ) -> None:

--- a/test_data/jsonschema/test_main/v3rc1/input/snippets/Value_data_type.json
+++ b/test_data/jsonschema/test_main/v3rc1/input/snippets/Value_data_type.json
@@ -1,0 +1,5 @@
+{
+  "ValueDataType": {
+    "type": "string"
+  }
+}


### PR DESCRIPTION
This patch introduces the `ValueDataType` into the test case of JSON
Schema based on the meta-model version V3RC01.