### PR TITLE
Upgrade docutils to 0.18.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 icontract>=2.5.2,<3
 asttokens>=2.0.5,<3
 sortedcontainers>=2.4.0,<3
-docutils>=0.17.1,<1
+docutils>=0.18.1,<1


### PR DESCRIPTION
We have to lift the minimum docutils version to 0.18.1 since we use some
of its novel features (*e.g.*, `findall`) which are not available in the
current docutils version 0.17.1.

The problem went unnoticed since we always installed the newest version
locally, and became only apparent when the lowest version had been
installed.

Fixes #42.