### PR TITLE
Release 0.0.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,20 @@
     Please keep this file at 72 line width so that we can copy-paste
     the release logs directly into commit messages.
 
+0.0.4 (2022-02-17)
+==================
+
+* Approximate RDF to aas-specs (#49)
+* Fix RDF schema generation (#48)
+* Generte RDF and SHACL schemas (#46)
+* Introduce topologically sorted symbols in the table (#45)
+* Upgrade docutils to 0.18.1 (#43)
+* Remove ``RefTypeAnnotation`` from the IR (#39)
+* Make jsonization in C# two-pass (#37)
+* Fix double curly brackets in C# verification (#36)
+* Infer type of enumeration literals in invariants (#32)
+* Allow enumeration literals to be arbitrary strings (#31)
+
 0.0.3 (2022-01-22)
 ==================
 

--- a/aas_core_codegen/__init__.py
+++ b/aas_core_codegen/__init__.py
@@ -1,6 +1,6 @@
 """Generate different implementations and schemas based on an AAS meta-model."""
 
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 __author__ = "Marko Ristin, Nico Braunisch, Robert Lehmann"
 __license__ = "License :: OSI Approved :: MIT License"
 __status__ = "Production/Stable"

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open(os.path.join(here, "requirements.txt"), encoding="utf-8") as fid:
 
 setup(
     name="aas-core-codegen",
-    version="0.0.3",
+    version="0.0.4",
     description="Generate different implementations and schemas based on an AAS meta-model.",
     long_description=long_description,
     url="https://github.com/aas-core-works/aas-core-codegen",


### PR DESCRIPTION
* Approximate RDF to aas-specs (#49)
* Fix RDF schema generation (#48)
* Generte RDF and SHACL schemas (#46)
* Introduce topologically sorted symbols in the table (#45)
* Upgrade docutils to 0.18.1 (#43)
* Remove `RefTypeAnnotation` from the IR (#39)
* Make jsonization in C# two-pass (#37)
* Fix double curly brackets in C# verification (#36)
* Infer type of enumeration literals in invariants (#32)
* Allow enumeration literals to be arbitrary strings (#31)