### PR TITLE
Approximate naming and `allOf` to aas-specs JSON

### DIFF
--- a/aas_core_codegen/jsonschema/main.py
+++ b/aas_core_codegen/jsonschema/main.py
@@ -435,7 +435,12 @@ def _define_for_class(
     model_type = naming.json_model_type(cls.name)
 
     result = collections.OrderedDict()  # type: MutableMapping[str, Any]
-    result[model_type] = {"allOf": all_of} if len(all_of) > 0 else {"type": "object"}
+    if len(all_of) == 0:
+        result[model_type] = {"type": "object"}
+    elif len(all_of) == 1:
+        result[model_type] = all_of[0]
+    else:
+        result[model_type] = {"allOf": all_of}
 
     # region Define the abstract part
 

--- a/aas_core_codegen/naming.py
+++ b/aas_core_codegen/naming.py
@@ -16,7 +16,13 @@ def json_property(identifier: Identifier) -> Identifier:
     'something'
 
     >>> json_property(Identifier("something_to_URL"))
-    'somethingToURL'
+    'somethingToUrl'
+
+    >>> json_property(Identifier("global_asset_ID"))
+    'globalAssetId'
+
+    >>> json_property(Identifier("specific_asset_IDs"))
+    'specificAssetIds'
     """
     parts = identifier.split("_")
 
@@ -25,10 +31,7 @@ def json_property(identifier: Identifier) -> Identifier:
 
     cased_parts = [parts[0].lower()]  # type: List[str]
     for part in parts[1:]:
-        if part.upper() in UPPERCASE_ABBREVIATION_SET:
-            cased_parts.append(part.upper())
-        else:
-            cased_parts.append(part.capitalize())
+        cased_parts.append(part.capitalize())
 
     return Identifier("".join(cased_parts))
 

--- a/test_data/csharp/test_main/v3rc2/expected_output/jsonization.cs
+++ b/test_data/csharp/test_main/v3rc2/expected_output/jsonization.cs
@@ -423,7 +423,7 @@ namespace AasCore.Aas3
 
                             switch (propertyName)
                             {
-                                case "semanticID":
+                                case "semanticId":
                                     theSemanticId =  (
                                         Json.JsonSerializer.Deserialize<IReference>(
                                             ref reader));
@@ -482,7 +482,7 @@ namespace AasCore.Aas3
 
                 if (that.SemanticId != null)
                 {
-                    writer.WritePropertyName("semanticID");
+                    writer.WritePropertyName("semanticId");
                     Json.JsonSerializer.Serialize(
                         writer, that.SemanticId);
                 }
@@ -2628,7 +2628,7 @@ namespace AasCore.Aas3
 
                             switch (propertyName)
                             {
-                                case "semanticID":
+                                case "semanticId":
                                     theSemanticId =  (
                                         Json.JsonSerializer.Deserialize<IReference>(
                                             ref reader));
@@ -2648,7 +2648,7 @@ namespace AasCore.Aas3
                                         Json.JsonSerializer.Deserialize<string>(
                                             ref reader));
                                     break;
-                                case "valueID":
+                                case "valueId":
                                     theValueId =  (
                                         Json.JsonSerializer.Deserialize<IReference>(
                                             ref reader));
@@ -2694,7 +2694,7 @@ namespace AasCore.Aas3
 
                 if (that.SemanticId != null)
                 {
-                    writer.WritePropertyName("semanticID");
+                    writer.WritePropertyName("semanticId");
                     Json.JsonSerializer.Serialize(
                         writer, that.SemanticId);
                 }
@@ -2716,7 +2716,7 @@ namespace AasCore.Aas3
 
                 if (that.ValueId != null)
                 {
-                    writer.WritePropertyName("valueID");
+                    writer.WritePropertyName("valueId");
                     Json.JsonSerializer.Serialize(
                         writer, that.ValueId);
                 }
@@ -3065,12 +3065,12 @@ namespace AasCore.Aas3
                                         Json.JsonSerializer.Deserialize<AssetKind>(
                                             ref reader));
                                     break;
-                                case "globalAssetID":
+                                case "globalAssetId":
                                     theGlobalAssetId =  (
                                         Json.JsonSerializer.Deserialize<IReference>(
                                             ref reader));
                                     break;
-                                case "specificAssetID":
+                                case "specificAssetId":
                                     theSpecificAssetId =  (
                                         Json.JsonSerializer.Deserialize<IdentifierKeyValuePair>(
                                             ref reader));
@@ -3118,14 +3118,14 @@ namespace AasCore.Aas3
 
                 if (that.GlobalAssetId != null)
                 {
-                    writer.WritePropertyName("globalAssetID");
+                    writer.WritePropertyName("globalAssetId");
                     Json.JsonSerializer.Serialize(
                         writer, that.GlobalAssetId);
                 }
 
                 if (that.SpecificAssetId != null)
                 {
-                    writer.WritePropertyName("specificAssetID");
+                    writer.WritePropertyName("specificAssetId");
                     Json.JsonSerializer.Serialize(
                         writer, that.SpecificAssetId);
                 }
@@ -3221,7 +3221,7 @@ namespace AasCore.Aas3
 
                             switch (propertyName)
                             {
-                                case "semanticID":
+                                case "semanticId":
                                     theSemanticId =  (
                                         Json.JsonSerializer.Deserialize<IReference>(
                                             ref reader));
@@ -3236,7 +3236,7 @@ namespace AasCore.Aas3
                                         Json.JsonSerializer.Deserialize<string>(
                                             ref reader));
                                     break;
-                                case "externalSubjectID":
+                                case "externalSubjectId":
                                     theExternalSubjectId =  (
                                         Json.JsonSerializer.Deserialize<IReference>(
                                             ref reader));
@@ -3275,7 +3275,7 @@ namespace AasCore.Aas3
 
                 if (that.SemanticId != null)
                 {
-                    writer.WritePropertyName("semanticID");
+                    writer.WritePropertyName("semanticId");
                     Json.JsonSerializer.Serialize(
                         writer, that.SemanticId);
                 }
@@ -3290,7 +3290,7 @@ namespace AasCore.Aas3
 
                 if (that.ExternalSubjectId != null)
                 {
-                    writer.WritePropertyName("externalSubjectID");
+                    writer.WritePropertyName("externalSubjectId");
                     Json.JsonSerializer.Serialize(
                         writer, that.ExternalSubjectId);
                 }
@@ -3364,7 +3364,7 @@ namespace AasCore.Aas3
                                         Json.JsonSerializer.Deserialize<ModelingKind>(
                                             ref reader));
                                     break;
-                                case "semanticID":
+                                case "semanticId":
                                     theSemanticId =  (
                                         Json.JsonSerializer.Deserialize<IReference>(
                                             ref reader));
@@ -3466,7 +3466,7 @@ namespace AasCore.Aas3
 
                 if (that.SemanticId != null)
                 {
-                    writer.WritePropertyName("semanticID");
+                    writer.WritePropertyName("semanticId");
                     Json.JsonSerializer.Serialize(
                         writer, that.SemanticId);
                 }
@@ -4013,7 +4013,7 @@ namespace AasCore.Aas3
                                         Json.JsonSerializer.Deserialize<ModelingKind>(
                                             ref reader));
                                     break;
-                                case "semanticID":
+                                case "semanticId":
                                     theSemanticId =  (
                                         Json.JsonSerializer.Deserialize<IReference>(
                                             ref reader));
@@ -4033,7 +4033,7 @@ namespace AasCore.Aas3
                                         Json.JsonSerializer.Deserialize<List<ISubmodelElement>>(
                                             ref reader));
                                     break;
-                                case "semanticIDValues":
+                                case "semanticIdValues":
                                     theSemanticIdValues =  (
                                         Json.JsonSerializer.Deserialize<IReference>(
                                             ref reader));
@@ -4127,7 +4127,7 @@ namespace AasCore.Aas3
 
                 if (that.SemanticId != null)
                 {
-                    writer.WritePropertyName("semanticID");
+                    writer.WritePropertyName("semanticId");
                     Json.JsonSerializer.Serialize(
                         writer, that.SemanticId);
                 }
@@ -4146,7 +4146,7 @@ namespace AasCore.Aas3
 
                 if (that.SemanticIdValues != null)
                 {
-                    writer.WritePropertyName("semanticIDValues");
+                    writer.WritePropertyName("semanticIdValues");
                     Json.JsonSerializer.Serialize(
                         writer, that.SemanticIdValues);
                 }
@@ -4246,7 +4246,7 @@ namespace AasCore.Aas3
                                         Json.JsonSerializer.Deserialize<ModelingKind>(
                                             ref reader));
                                     break;
-                                case "semanticID":
+                                case "semanticId":
                                     theSemanticId =  (
                                         Json.JsonSerializer.Deserialize<IReference>(
                                             ref reader));
@@ -4345,7 +4345,7 @@ namespace AasCore.Aas3
 
                 if (that.SemanticId != null)
                 {
-                    writer.WritePropertyName("semanticID");
+                    writer.WritePropertyName("semanticId");
                     Json.JsonSerializer.Serialize(
                         writer, that.SemanticId);
                 }
@@ -4635,7 +4635,7 @@ namespace AasCore.Aas3
                                         Json.JsonSerializer.Deserialize<ModelingKind>(
                                             ref reader));
                                     break;
-                                case "semanticID":
+                                case "semanticId":
                                     theSemanticId =  (
                                         Json.JsonSerializer.Deserialize<IReference>(
                                             ref reader));
@@ -4655,7 +4655,7 @@ namespace AasCore.Aas3
                                         Json.JsonSerializer.Deserialize<string>(
                                             ref reader));
                                     break;
-                                case "valueID":
+                                case "valueId":
                                     theValueId =  (
                                         Json.JsonSerializer.Deserialize<IReference>(
                                             ref reader));
@@ -4744,7 +4744,7 @@ namespace AasCore.Aas3
 
                 if (that.SemanticId != null)
                 {
-                    writer.WritePropertyName("semanticID");
+                    writer.WritePropertyName("semanticId");
                     Json.JsonSerializer.Serialize(
                         writer, that.SemanticId);
                 }
@@ -4766,7 +4766,7 @@ namespace AasCore.Aas3
 
                 if (that.ValueId != null)
                 {
-                    writer.WritePropertyName("valueID");
+                    writer.WritePropertyName("valueId");
                     Json.JsonSerializer.Serialize(
                         writer, that.ValueId);
                 }
@@ -4861,7 +4861,7 @@ namespace AasCore.Aas3
                                         Json.JsonSerializer.Deserialize<ModelingKind>(
                                             ref reader));
                                     break;
-                                case "semanticID":
+                                case "semanticId":
                                     theSemanticId =  (
                                         Json.JsonSerializer.Deserialize<IReference>(
                                             ref reader));
@@ -4876,7 +4876,7 @@ namespace AasCore.Aas3
                                         Json.JsonSerializer.Deserialize<LangStringSet>(
                                             ref reader));
                                     break;
-                                case "valueID":
+                                case "valueId":
                                     theValueId =  (
                                         Json.JsonSerializer.Deserialize<IReference>(
                                             ref reader));
@@ -4965,7 +4965,7 @@ namespace AasCore.Aas3
 
                 if (that.SemanticId != null)
                 {
-                    writer.WritePropertyName("semanticID");
+                    writer.WritePropertyName("semanticId");
                     Json.JsonSerializer.Serialize(
                         writer, that.SemanticId);
                 }
@@ -4983,7 +4983,7 @@ namespace AasCore.Aas3
 
                 if (that.ValueId != null)
                 {
-                    writer.WritePropertyName("valueID");
+                    writer.WritePropertyName("valueId");
                     Json.JsonSerializer.Serialize(
                         writer, that.ValueId);
                 }
@@ -5082,7 +5082,7 @@ namespace AasCore.Aas3
                                         Json.JsonSerializer.Deserialize<ModelingKind>(
                                             ref reader));
                                     break;
-                                case "semanticID":
+                                case "semanticId":
                                     theSemanticId =  (
                                         Json.JsonSerializer.Deserialize<IReference>(
                                             ref reader));
@@ -5191,7 +5191,7 @@ namespace AasCore.Aas3
 
                 if (that.SemanticId != null)
                 {
-                    writer.WritePropertyName("semanticID");
+                    writer.WritePropertyName("semanticId");
                     Json.JsonSerializer.Serialize(
                         writer, that.SemanticId);
                 }
@@ -5307,7 +5307,7 @@ namespace AasCore.Aas3
                                         Json.JsonSerializer.Deserialize<ModelingKind>(
                                             ref reader));
                                     break;
-                                case "semanticID":
+                                case "semanticId":
                                     theSemanticId =  (
                                         Json.JsonSerializer.Deserialize<IReference>(
                                             ref reader));
@@ -5406,7 +5406,7 @@ namespace AasCore.Aas3
 
                 if (that.SemanticId != null)
                 {
-                    writer.WritePropertyName("semanticID");
+                    writer.WritePropertyName("semanticId");
                     Json.JsonSerializer.Serialize(
                         writer, that.SemanticId);
                 }
@@ -5514,7 +5514,7 @@ namespace AasCore.Aas3
                                         Json.JsonSerializer.Deserialize<ModelingKind>(
                                             ref reader));
                                     break;
-                                case "semanticID":
+                                case "semanticId":
                                     theSemanticId =  (
                                         Json.JsonSerializer.Deserialize<IReference>(
                                             ref reader));
@@ -5618,7 +5618,7 @@ namespace AasCore.Aas3
 
                 if (that.SemanticId != null)
                 {
-                    writer.WritePropertyName("semanticID");
+                    writer.WritePropertyName("semanticId");
                     Json.JsonSerializer.Serialize(
                         writer, that.SemanticId);
                 }
@@ -5730,7 +5730,7 @@ namespace AasCore.Aas3
                                         Json.JsonSerializer.Deserialize<ModelingKind>(
                                             ref reader));
                                     break;
-                                case "semanticID":
+                                case "semanticId":
                                     theSemanticId =  (
                                         Json.JsonSerializer.Deserialize<IReference>(
                                             ref reader));
@@ -5834,7 +5834,7 @@ namespace AasCore.Aas3
 
                 if (that.SemanticId != null)
                 {
-                    writer.WritePropertyName("semanticID");
+                    writer.WritePropertyName("semanticId");
                     Json.JsonSerializer.Serialize(
                         writer, that.SemanticId);
                 }
@@ -5948,7 +5948,7 @@ namespace AasCore.Aas3
                                         Json.JsonSerializer.Deserialize<ModelingKind>(
                                             ref reader));
                                     break;
-                                case "semanticID":
+                                case "semanticId":
                                     theSemanticId =  (
                                         Json.JsonSerializer.Deserialize<IReference>(
                                             ref reader));
@@ -6057,7 +6057,7 @@ namespace AasCore.Aas3
 
                 if (that.SemanticId != null)
                 {
-                    writer.WritePropertyName("semanticID");
+                    writer.WritePropertyName("semanticId");
                     Json.JsonSerializer.Serialize(
                         writer, that.SemanticId);
                 }
@@ -6214,7 +6214,7 @@ namespace AasCore.Aas3
                                         Json.JsonSerializer.Deserialize<ModelingKind>(
                                             ref reader));
                                     break;
-                                case "semanticID":
+                                case "semanticId":
                                     theSemanticId =  (
                                         Json.JsonSerializer.Deserialize<IReference>(
                                             ref reader));
@@ -6234,12 +6234,12 @@ namespace AasCore.Aas3
                                         Json.JsonSerializer.Deserialize<List<ISubmodelElement>>(
                                             ref reader));
                                     break;
-                                case "globalAssetID":
+                                case "globalAssetId":
                                     theGlobalAssetId =  (
                                         Json.JsonSerializer.Deserialize<IReference>(
                                             ref reader));
                                     break;
-                                case "specificAssetID":
+                                case "specificAssetId":
                                     theSpecificAssetId =  (
                                         Json.JsonSerializer.Deserialize<IdentifierKeyValuePair>(
                                             ref reader));
@@ -6328,7 +6328,7 @@ namespace AasCore.Aas3
 
                 if (that.SemanticId != null)
                 {
-                    writer.WritePropertyName("semanticID");
+                    writer.WritePropertyName("semanticId");
                     Json.JsonSerializer.Serialize(
                         writer, that.SemanticId);
                 }
@@ -6347,14 +6347,14 @@ namespace AasCore.Aas3
 
                 if (that.GlobalAssetId != null)
                 {
-                    writer.WritePropertyName("globalAssetID");
+                    writer.WritePropertyName("globalAssetId");
                     Json.JsonSerializer.Serialize(
                         writer, that.GlobalAssetId);
                 }
 
                 if (that.SpecificAssetId != null)
                 {
-                    writer.WritePropertyName("specificAssetID");
+                    writer.WritePropertyName("specificAssetId");
                     Json.JsonSerializer.Serialize(
                         writer, that.SpecificAssetId);
                 }
@@ -6557,7 +6557,7 @@ namespace AasCore.Aas3
                                         Json.JsonSerializer.Deserialize<ModelingKind>(
                                             ref reader));
                                     break;
-                                case "semanticID":
+                                case "semanticId":
                                     theSemanticId =  (
                                         Json.JsonSerializer.Deserialize<IReference>(
                                             ref reader));
@@ -6656,7 +6656,7 @@ namespace AasCore.Aas3
 
                 if (that.SemanticId != null)
                 {
-                    writer.WritePropertyName("semanticID");
+                    writer.WritePropertyName("semanticId");
                     Json.JsonSerializer.Serialize(
                         writer, that.SemanticId);
                 }
@@ -6761,7 +6761,7 @@ namespace AasCore.Aas3
                                         Json.JsonSerializer.Deserialize<ModelingKind>(
                                             ref reader));
                                     break;
-                                case "semanticID":
+                                case "semanticId":
                                     theSemanticId =  (
                                         Json.JsonSerializer.Deserialize<IReference>(
                                             ref reader));
@@ -6870,7 +6870,7 @@ namespace AasCore.Aas3
 
                 if (that.SemanticId != null)
                 {
-                    writer.WritePropertyName("semanticID");
+                    writer.WritePropertyName("semanticId");
                     Json.JsonSerializer.Serialize(
                         writer, that.SemanticId);
                 }
@@ -7054,7 +7054,7 @@ namespace AasCore.Aas3
                                         Json.JsonSerializer.Deserialize<ModelingKind>(
                                             ref reader));
                                     break;
-                                case "semanticID":
+                                case "semanticId":
                                     theSemanticId =  (
                                         Json.JsonSerializer.Deserialize<IReference>(
                                             ref reader));
@@ -7148,7 +7148,7 @@ namespace AasCore.Aas3
 
                 if (that.SemanticId != null)
                 {
-                    writer.WritePropertyName("semanticID");
+                    writer.WritePropertyName("semanticId");
                     Json.JsonSerializer.Serialize(
                         writer, that.SemanticId);
                 }
@@ -7424,7 +7424,7 @@ namespace AasCore.Aas3
                                         Json.JsonSerializer.Deserialize<LangStringSet>(
                                             ref reader));
                                     break;
-                                case "semanticID":
+                                case "semanticId":
                                     theSemanticId =  (
                                         Json.JsonSerializer.Deserialize<IReference>(
                                             ref reader));
@@ -7511,7 +7511,7 @@ namespace AasCore.Aas3
 
                 if (that.SemanticId != null)
                 {
-                    writer.WritePropertyName("semanticID");
+                    writer.WritePropertyName("semanticId");
                     Json.JsonSerializer.Serialize(
                         writer, that.SemanticId);
                 }
@@ -7770,7 +7770,7 @@ namespace AasCore.Aas3
                                         Json.JsonSerializer.Deserialize<List<Key>>(
                                             ref reader));
                                     break;
-                                case "referredSemanticID":
+                                case "referredSemanticId":
                                     theReferredSemanticId =  (
                                         Json.JsonSerializer.Deserialize<IReference>(
                                             ref reader));
@@ -7820,7 +7820,7 @@ namespace AasCore.Aas3
 
                 if (that.ReferredSemanticId != null)
                 {
-                    writer.WritePropertyName("referredSemanticID");
+                    writer.WritePropertyName("referredSemanticId");
                     Json.JsonSerializer.Serialize(
                         writer, that.ReferredSemanticId);
                 }
@@ -8579,7 +8579,7 @@ namespace AasCore.Aas3
                                 theValue ?? throw new Json.JsonException(
                                     "Required property is missing: value"),
                                 theValueId ?? throw new Json.JsonException(
-                                    "Required property is missing: valueID"));
+                                    "Required property is missing: valueId"));
 
                         case Json.JsonTokenType.PropertyName:
                             string propertyName = reader.GetString()
@@ -8593,7 +8593,7 @@ namespace AasCore.Aas3
                                         Json.JsonSerializer.Deserialize<string>(
                                             ref reader));
                                     break;
-                                case "valueID":
+                                case "valueId":
                                     theValueId =  (
                                         Json.JsonSerializer.Deserialize<IReference>(
                                             ref reader));
@@ -8634,7 +8634,7 @@ namespace AasCore.Aas3
                 Json.JsonSerializer.Serialize(
                     writer, that.Value);
 
-                writer.WritePropertyName("valueID");
+                writer.WritePropertyName("valueId");
                 Json.JsonSerializer.Serialize(
                     writer, that.ValueId);
 
@@ -8788,7 +8788,7 @@ namespace AasCore.Aas3
                                         Json.JsonSerializer.Deserialize<string>(
                                             ref reader));
                                     break;
-                                case "unitID":
+                                case "unitId":
                                     theUnitId =  (
                                         Json.JsonSerializer.Deserialize<IReference>(
                                             ref reader));
@@ -8828,7 +8828,7 @@ namespace AasCore.Aas3
                                         Json.JsonSerializer.Deserialize<string>(
                                             ref reader));
                                     break;
-                                case "valueID":
+                                case "valueId":
                                     theValueId =  (
                                         Json.JsonSerializer.Deserialize<IReference>(
                                             ref reader));
@@ -8893,7 +8893,7 @@ namespace AasCore.Aas3
 
                 if (that.UnitId != null)
                 {
-                    writer.WritePropertyName("unitID");
+                    writer.WritePropertyName("unitId");
                     Json.JsonSerializer.Serialize(
                         writer, that.UnitId);
                 }
@@ -8949,7 +8949,7 @@ namespace AasCore.Aas3
 
                 if (that.ValueId != null)
                 {
-                    writer.WritePropertyName("valueID");
+                    writer.WritePropertyName("valueId");
                     Json.JsonSerializer.Serialize(
                         writer, that.ValueId);
                 }
@@ -9068,7 +9068,7 @@ namespace AasCore.Aas3
                                         Json.JsonSerializer.Deserialize<string>(
                                             ref reader));
                                     break;
-                                case "registrationAuthorityID":
+                                case "registrationAuthorityId":
                                     theRegistrationAuthorityId =  (
                                         Json.JsonSerializer.Deserialize<string>(
                                             ref reader));
@@ -9182,7 +9182,7 @@ namespace AasCore.Aas3
 
                 if (that.RegistrationAuthorityId != null)
                 {
-                    writer.WritePropertyName("registrationAuthorityID");
+                    writer.WritePropertyName("registrationAuthorityId");
                     Json.JsonSerializer.Serialize(
                         writer, that.RegistrationAuthorityId);
                 }

--- a/test_data/jsonschema/test_main/v3rc1/expected_output/schema.json
+++ b/test_data/jsonschema/test_main/v3rc1/expected_output/schema.json
@@ -25,16 +25,12 @@
       ]
     },
     "HasSemantics": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "semanticID": {
-              "$ref": "#/definitions/Reference"
-            }
-          }
+      "type": "object",
+      "properties": {
+        "semanticId": {
+          "$ref": "#/definitions/Reference"
         }
-      ]
+      }
     },
     "Extension": {
       "allOf": [
@@ -64,16 +60,12 @@
       ]
     },
     "HasExtensions": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "extension": {
-              "$ref": "#/definitions/Extension"
-            }
-          }
+      "type": "object",
+      "properties": {
+        "extension": {
+          "$ref": "#/definitions/Extension"
         }
-      ]
+      }
     },
     "Referable": {
       "allOf": [
@@ -125,22 +117,18 @@
       ]
     },
     "Identifier": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "idType": {
-              "$ref": "#/definitions/IdentifierType"
-            },
-            "id": {
-              "$ref": "#/definitions/NonEmptyString"
-            }
-          },
-          "required": [
-            "idType",
-            "id"
-          ]
+      "type": "object",
+      "properties": {
+        "idType": {
+          "$ref": "#/definitions/IdentifierType"
+        },
+        "id": {
+          "$ref": "#/definitions/NonEmptyString"
         }
+      },
+      "required": [
+        "idType",
+        "id"
       ]
     },
     "IdentifierType": {
@@ -159,31 +147,23 @@
       ]
     },
     "HasKind": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "kind": {
-              "$ref": "#/definitions/ModelingKind"
-            }
-          }
+      "type": "object",
+      "properties": {
+        "kind": {
+          "$ref": "#/definitions/ModelingKind"
         }
-      ]
+      }
     },
     "HasDataSpecification": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "dataSpecifications": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Reference"
-              }
-            }
+      "type": "object",
+      "properties": {
+        "dataSpecifications": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Reference"
           }
         }
-      ]
+      }
     },
     "AdministrativeInformation": {
       "allOf": [
@@ -204,19 +184,15 @@
       ]
     },
     "Qualifiable": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "qualifiers": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Constraint_abstract"
-              }
-            }
+      "type": "object",
+      "properties": {
+        "qualifiers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Constraint_abstract"
           }
         }
-      ]
+      }
     },
     "Constraint": {
       "type": "object"
@@ -251,7 +227,7 @@
             "value": {
               "type": "string"
             },
-            "valueID": {
+            "valueId": {
               "$ref": "#/definitions/Reference"
             }
           },
@@ -330,33 +306,29 @@
       ]
     },
     "AssetInformation": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "assetKind": {
-              "$ref": "#/definitions/AssetKind"
-            },
-            "globalAssetID": {
-              "$ref": "#/definitions/Reference"
-            },
-            "specificAssetIds": {
-              "$ref": "#/definitions/IdentifierKeyValuePair"
-            },
-            "billOfMaterial": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Reference"
-              }
-            },
-            "defaultThumbnail": {
-              "$ref": "#/definitions/File"
-            }
-          },
-          "required": [
-            "assetKind"
-          ]
+      "type": "object",
+      "properties": {
+        "assetKind": {
+          "$ref": "#/definitions/AssetKind"
+        },
+        "globalAssetId": {
+          "$ref": "#/definitions/Reference"
+        },
+        "specificAssetIds": {
+          "$ref": "#/definitions/IdentifierKeyValuePair"
+        },
+        "billOfMaterial": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Reference"
+          }
+        },
+        "defaultThumbnail": {
+          "$ref": "#/definitions/File"
         }
+      },
+      "required": [
+        "assetKind"
       ]
     },
     "AssetKind": {
@@ -380,7 +352,7 @@
             "value": {
               "type": "string"
             },
-            "externalSubjectID": {
+            "externalSubjectId": {
               "$ref": "#/definitions/Reference"
             }
           },
@@ -526,11 +498,7 @@
       ]
     },
     "DataElement": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/SubmodelElement"
-        }
-      ]
+      "$ref": "#/definitions/SubmodelElement"
     },
     "DataElement_abstract": {
       "anyOf": [
@@ -568,7 +536,7 @@
             "value": {
               "type": "string"
             },
-            "valueID": {
+            "valueId": {
               "$ref": "#/definitions/Reference"
             }
           },
@@ -589,7 +557,7 @@
             "value": {
               "$ref": "#/definitions/LangStringSet"
             },
-            "valueID": {
+            "valueId": {
               "$ref": "#/definitions/Reference"
             }
           }
@@ -719,7 +687,7 @@
                 "$ref": "#/definitions/SubmodelElement_abstract"
               }
             },
-            "globalAssetID": {
+            "globalAssetId": {
               "$ref": "#/definitions/Reference"
             },
             "specificAssetIds": {
@@ -736,11 +704,7 @@
       ]
     },
     "Event": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/SubmodelElement"
-        }
-      ]
+      "$ref": "#/definitions/SubmodelElement"
     },
     "BasicEvent": {
       "allOf": [
@@ -791,26 +755,18 @@
       ]
     },
     "OperationVariable": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "value": {
-              "$ref": "#/definitions/SubmodelElement_abstract"
-            }
-          },
-          "required": [
-            "value"
-          ]
+      "type": "object",
+      "properties": {
+        "value": {
+          "$ref": "#/definitions/SubmodelElement_abstract"
         }
+      },
+      "required": [
+        "value"
       ]
     },
     "Capability": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/SubmodelElement"
-        }
-      ]
+      "$ref": "#/definitions/SubmodelElement"
     },
     "ConceptDescription": {
       "allOf": [
@@ -858,45 +814,37 @@
       ]
     },
     "Reference": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "keys": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Key"
-              },
-              "minItems": 1
-            }
+      "type": "object",
+      "properties": {
+        "keys": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Key"
           },
-          "required": [
-            "keys"
-          ]
+          "minItems": 1
         }
+      },
+      "required": [
+        "keys"
       ]
     },
     "Key": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "$ref": "#/definitions/KeyElements"
-            },
-            "value": {
-              "type": "string"
-            },
-            "idType": {
-              "$ref": "#/definitions/KeyType"
-            }
-          },
-          "required": [
-            "type",
-            "value",
-            "idType"
-          ]
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/KeyElements"
+        },
+        "value": {
+          "type": "string"
+        },
+        "idType": {
+          "$ref": "#/definitions/KeyType"
         }
+      },
+      "required": [
+        "type",
+        "value",
+        "idType"
       ]
     },
     "IdentifiableElements": {
@@ -1095,38 +1043,30 @@
       ]
     },
     "ValueReferencePair": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "value": {
-              "type": "string"
-            },
-            "valueID": {
-              "$ref": "#/definitions/Reference"
-            }
-          },
-          "required": [
-            "value",
-            "valueID"
-          ]
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "valueId": {
+          "$ref": "#/definitions/Reference"
         }
+      },
+      "required": [
+        "value",
+        "valueId"
       ]
     },
     "ValueList": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "valueReferencePairTypes": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/ValueReferencePair"
-              }
-            }
+      "type": "object",
+      "properties": {
+        "valueReferencePairTypes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ValueReferencePair"
           }
         }
-      ]
+      }
     },
     "DataSpecificationIEC61360": {
       "allOf": [
@@ -1145,7 +1085,7 @@
             "unit": {
               "$ref": "#/definitions/NonEmptyString"
             },
-            "unitID": {
+            "unitId": {
               "$ref": "#/definitions/Reference"
             },
             "sourceOfDefinition": {
@@ -1169,7 +1109,7 @@
             "value": {
               "type": "string"
             },
-            "valueID": {
+            "valueId": {
               "$ref": "#/definitions/Reference"
             },
             "levelType": {
@@ -1217,7 +1157,7 @@
             "conversionFactor": {
               "$ref": "#/definitions/NonEmptyString"
             },
-            "registrationAuthorityID": {
+            "registrationAuthorityId": {
               "$ref": "#/definitions/NonEmptyString"
             },
             "supplier": {
@@ -1228,18 +1168,14 @@
       ]
     },
     "Certificate": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "policyAdministrationPoint": {
-              "$ref": "#/definitions/PolicyAdministrationPoint"
-            }
-          },
-          "required": [
-            "policyAdministrationPoint"
-          ]
+      "type": "object",
+      "properties": {
+        "policyAdministrationPoint": {
+          "$ref": "#/definitions/PolicyAdministrationPoint"
         }
+      },
+      "required": [
+        "policyAdministrationPoint"
       ]
     },
     "Certificate_abstract": {
@@ -1278,83 +1214,67 @@
       ]
     },
     "ObjectAttributes": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "objectAttributes": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Reference"
-              },
-              "minItems": 1
-            }
+      "type": "object",
+      "properties": {
+        "objectAttributes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Reference"
           },
-          "required": [
-            "objectAttributes"
-          ]
+          "minItems": 1
         }
+      },
+      "required": [
+        "objectAttributes"
       ]
     },
     "Permission": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "permission": {
-              "$ref": "#/definitions/Reference"
-            },
-            "kindOfPermission": {
-              "$ref": "#/definitions/PermissionKind"
-            }
-          },
-          "required": [
-            "permission",
-            "kindOfPermission"
-          ]
+      "type": "object",
+      "properties": {
+        "permission": {
+          "$ref": "#/definitions/Reference"
+        },
+        "kindOfPermission": {
+          "$ref": "#/definitions/PermissionKind"
         }
+      },
+      "required": [
+        "permission",
+        "kindOfPermission"
       ]
     },
     "SubjectAttributes": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "subjectAttributes": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/DataElement_abstract"
-              }
-            }
-          },
-          "required": [
-            "subjectAttributes"
-          ]
+      "type": "object",
+      "properties": {
+        "subjectAttributes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DataElement_abstract"
+          }
         }
+      },
+      "required": [
+        "subjectAttributes"
       ]
     },
     "PermissionsPerObject": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "object": {
-              "$ref": "#/definitions/Reference"
-            },
-            "targetObjectAttributes": {
-              "$ref": "#/definitions/ObjectAttributes"
-            },
-            "permissions": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Permission"
-              }
-            }
-          },
-          "required": [
-            "object"
-          ]
+      "type": "object",
+      "properties": {
+        "object": {
+          "$ref": "#/definitions/Reference"
+        },
+        "targetObjectAttributes": {
+          "$ref": "#/definitions/ObjectAttributes"
+        },
+        "permissions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Permission"
+          }
         }
+      },
+      "required": [
+        "object"
       ]
     },
     "AccessPermissionRule": {
@@ -1385,163 +1305,135 @@
       ]
     },
     "AccessControl": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "accessPermissionRules": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/AccessPermissionRule"
-              }
-            },
-            "selectableSubjectAttributes": {
-              "$ref": "#/definitions/Reference"
-            },
-            "defaultSubjectAttributes": {
-              "$ref": "#/definitions/Reference"
-            },
-            "selectablePermissions": {
-              "$ref": "#/definitions/Reference"
-            },
-            "defaultPermissions": {
-              "$ref": "#/definitions/Reference"
-            },
-            "selectableEnvironmentAttributes": {
-              "$ref": "#/definitions/Reference"
-            },
-            "defaultEnvironmentAttributes": {
-              "$ref": "#/definitions/Reference"
-            }
-          },
-          "required": [
-            "defaultSubjectAttributes",
-            "selectablePermissions",
-            "defaultPermissions"
-          ]
+      "type": "object",
+      "properties": {
+        "accessPermissionRules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AccessPermissionRule"
+          }
+        },
+        "selectableSubjectAttributes": {
+          "$ref": "#/definitions/Reference"
+        },
+        "defaultSubjectAttributes": {
+          "$ref": "#/definitions/Reference"
+        },
+        "selectablePermissions": {
+          "$ref": "#/definitions/Reference"
+        },
+        "defaultPermissions": {
+          "$ref": "#/definitions/Reference"
+        },
+        "selectableEnvironmentAttributes": {
+          "$ref": "#/definitions/Reference"
+        },
+        "defaultEnvironmentAttributes": {
+          "$ref": "#/definitions/Reference"
         }
+      },
+      "required": [
+        "defaultSubjectAttributes",
+        "selectablePermissions",
+        "defaultPermissions"
       ]
     },
     "PolicyAdministrationPoint": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "externalAccessControl": {
-              "type": "boolean"
-            },
-            "localAccessControl": {
-              "$ref": "#/definitions/AccessControl"
-            }
-          },
-          "required": [
-            "externalAccessControl"
-          ]
+      "type": "object",
+      "properties": {
+        "externalAccessControl": {
+          "type": "boolean"
+        },
+        "localAccessControl": {
+          "$ref": "#/definitions/AccessControl"
         }
+      },
+      "required": [
+        "externalAccessControl"
       ]
     },
     "PolicyInformationPoints": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "externalInformationPoints": {
-              "type": "boolean"
-            },
-            "internalInformationPoints": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Reference"
-              }
-            }
-          },
-          "required": [
-            "externalInformationPoints"
-          ]
+      "type": "object",
+      "properties": {
+        "externalInformationPoints": {
+          "type": "boolean"
+        },
+        "internalInformationPoints": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Reference"
+          }
         }
+      },
+      "required": [
+        "externalInformationPoints"
       ]
     },
     "PolicyEnforcementPoints": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "externalPolicyEnforcementPoint": {
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "externalPolicyEnforcementPoint"
-          ]
+      "type": "object",
+      "properties": {
+        "externalPolicyEnforcementPoint": {
+          "type": "boolean"
         }
+      },
+      "required": [
+        "externalPolicyEnforcementPoint"
       ]
     },
     "PolicyDecisionPoint": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "externalPolicyDecisionPoints": {
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "externalPolicyDecisionPoints"
-          ]
+      "type": "object",
+      "properties": {
+        "externalPolicyDecisionPoints": {
+          "type": "boolean"
         }
+      },
+      "required": [
+        "externalPolicyDecisionPoints"
       ]
     },
     "AccessControlPolicyPoints": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "policyAdministrationPoint": {
-              "$ref": "#/definitions/PolicyAdministrationPoint"
-            },
-            "policyDecisionPoint": {
-              "$ref": "#/definitions/PolicyDecisionPoint"
-            },
-            "policyEnforcementPoints": {
-              "$ref": "#/definitions/PolicyEnforcementPoints"
-            },
-            "policyInformationPoints": {
-              "$ref": "#/definitions/PolicyInformationPoints"
-            }
-          },
-          "required": [
-            "policyAdministrationPoint",
-            "policyDecisionPoint",
-            "policyEnforcementPoints"
-          ]
+      "type": "object",
+      "properties": {
+        "policyAdministrationPoint": {
+          "$ref": "#/definitions/PolicyAdministrationPoint"
+        },
+        "policyDecisionPoint": {
+          "$ref": "#/definitions/PolicyDecisionPoint"
+        },
+        "policyEnforcementPoints": {
+          "$ref": "#/definitions/PolicyEnforcementPoints"
+        },
+        "policyInformationPoints": {
+          "$ref": "#/definitions/PolicyInformationPoints"
         }
+      },
+      "required": [
+        "policyAdministrationPoint",
+        "policyDecisionPoint",
+        "policyEnforcementPoints"
       ]
     },
     "Security": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "accessControlPolicyPoints": {
-              "$ref": "#/definitions/AccessControlPolicyPoints"
-            },
-            "certificates": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Certificate_abstract"
-              }
-            },
-            "requiredCertificatesExtension": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Reference"
-              }
-            }
-          },
-          "required": [
-            "accessControlPolicyPoints"
-          ]
+      "type": "object",
+      "properties": {
+        "accessControlPolicyPoints": {
+          "$ref": "#/definitions/AccessControlPolicyPoints"
+        },
+        "certificates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Certificate_abstract"
+          }
+        },
+        "requiredCertificatesExtension": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Reference"
+          }
         }
+      },
+      "required": [
+        "accessControlPolicyPoints"
       ]
     },
     "PermissionKind": {
@@ -1554,42 +1446,38 @@
       ]
     },
     "Environment": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "assetAdministrationShells": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/AssetAdministrationShell"
-              }
-            },
-            "assets": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Asset"
-              }
-            },
-            "submodels": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Submodel"
-              }
-            },
-            "conceptDescriptions": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/ConceptDescription"
-              }
-            }
-          },
-          "required": [
-            "assetAdministrationShells",
-            "assets",
-            "submodels",
-            "conceptDescriptions"
-          ]
+      "type": "object",
+      "properties": {
+        "assetAdministrationShells": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AssetAdministrationShell"
+          }
+        },
+        "assets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Asset"
+          }
+        },
+        "submodels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Submodel"
+          }
+        },
+        "conceptDescriptions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ConceptDescription"
+          }
         }
+      },
+      "required": [
+        "assetAdministrationShells",
+        "assets",
+        "submodels",
+        "conceptDescriptions"
       ]
     }
   }

--- a/test_data/jsonschema/test_main/v3rc2/expected_output/schema.json
+++ b/test_data/jsonschema/test_main/v3rc2/expected_output/schema.json
@@ -25,16 +25,12 @@
       ]
     },
     "HasSemantics": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "semanticID": {
-              "$ref": "#/definitions/Reference_abstract"
-            }
-          }
+      "type": "object",
+      "properties": {
+        "semanticId": {
+          "$ref": "#/definitions/Reference_abstract"
         }
-      ]
+      }
     },
     "Extension": {
       "allOf": [
@@ -64,21 +60,17 @@
       ]
     },
     "HasExtensions": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "extensions": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Extension"
-              }
-            }
-          },
-          "required": [
-            "extensions"
-          ]
+      "type": "object",
+      "properties": {
+        "extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Extension"
+          }
         }
+      },
+      "required": [
+        "extensions"
       ]
     },
     "Referable": {
@@ -134,33 +126,25 @@
       ]
     },
     "HasKind": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "kind": {
-              "$ref": "#/definitions/ModelingKind"
-            }
-          }
+      "type": "object",
+      "properties": {
+        "kind": {
+          "$ref": "#/definitions/ModelingKind"
         }
-      ]
+      }
     },
     "HasDataSpecification": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "dataSpecifications": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Reference_abstract"
-              }
-            }
-          },
-          "required": [
-            "dataSpecifications"
-          ]
+      "type": "object",
+      "properties": {
+        "dataSpecifications": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Reference_abstract"
+          }
         }
+      },
+      "required": [
+        "dataSpecifications"
       ]
     },
     "AdministrativeInformation": {
@@ -195,21 +179,17 @@
       ]
     },
     "Qualifiable": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "qualifiers": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Constraint_abstract"
-              }
-            }
-          },
-          "required": [
-            "qualifiers"
-          ]
+      "type": "object",
+      "properties": {
+        "qualifiers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Constraint_abstract"
+          }
         }
+      },
+      "required": [
+        "qualifiers"
       ]
     },
     "Qualifier": {
@@ -232,7 +212,7 @@
             "value": {
               "$ref": "#/definitions/NonEmptyString"
             },
-            "valueID": {
+            "valueId": {
               "$ref": "#/definitions/Reference_abstract"
             }
           },
@@ -296,27 +276,23 @@
       ]
     },
     "AssetInformation": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "assetKind": {
-              "$ref": "#/definitions/AssetKind"
-            },
-            "globalAssetID": {
-              "$ref": "#/definitions/Reference_abstract"
-            },
-            "specificAssetID": {
-              "$ref": "#/definitions/IdentifierKeyValuePair"
-            },
-            "defaultThumbnail": {
-              "$ref": "#/definitions/File"
-            }
-          },
-          "required": [
-            "assetKind"
-          ]
+      "type": "object",
+      "properties": {
+        "assetKind": {
+          "$ref": "#/definitions/AssetKind"
+        },
+        "globalAssetId": {
+          "$ref": "#/definitions/Reference_abstract"
+        },
+        "specificAssetId": {
+          "$ref": "#/definitions/IdentifierKeyValuePair"
+        },
+        "defaultThumbnail": {
+          "$ref": "#/definitions/File"
         }
+      },
+      "required": [
+        "assetKind"
       ]
     },
     "AssetKind": {
@@ -340,7 +316,7 @@
             "value": {
               "$ref": "#/definitions/NonEmptyString"
             },
-            "externalSubjectID": {
+            "externalSubjectId": {
               "$ref": "#/definitions/Reference_abstract"
             }
           },
@@ -485,7 +461,7 @@
                 "$ref": "#/definitions/SubmodelElement_abstract"
               }
             },
-            "semanticIDValues": {
+            "semanticIdValues": {
               "$ref": "#/definitions/Reference_abstract"
             },
             "valueTypeValues": {
@@ -521,11 +497,7 @@
       ]
     },
     "DataElement": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/SubmodelElement"
-        }
-      ]
+      "$ref": "#/definitions/SubmodelElement"
     },
     "DataElement_abstract": {
       "anyOf": [
@@ -563,7 +535,7 @@
             "value": {
               "$ref": "#/definitions/NonEmptyString"
             },
-            "valueID": {
+            "valueId": {
               "$ref": "#/definitions/Reference_abstract"
             }
           },
@@ -584,7 +556,7 @@
             "translatable": {
               "$ref": "#/definitions/LangStringSet"
             },
-            "valueID": {
+            "valueId": {
               "$ref": "#/definitions/Reference_abstract"
             }
           }
@@ -719,10 +691,10 @@
                 "$ref": "#/definitions/SubmodelElement_abstract"
               }
             },
-            "globalAssetID": {
+            "globalAssetId": {
               "$ref": "#/definitions/Reference_abstract"
             },
-            "specificAssetID": {
+            "specificAssetId": {
               "$ref": "#/definitions/IdentifierKeyValuePair"
             }
           },
@@ -734,11 +706,7 @@
       ]
     },
     "Event": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/SubmodelElement"
-        }
-      ]
+      "$ref": "#/definitions/SubmodelElement"
     },
     "BasicEvent": {
       "allOf": [
@@ -794,26 +762,18 @@
       ]
     },
     "OperationVariable": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "value": {
-              "$ref": "#/definitions/SubmodelElement_abstract"
-            }
-          },
-          "required": [
-            "value"
-          ]
+      "type": "object",
+      "properties": {
+        "value": {
+          "$ref": "#/definitions/SubmodelElement_abstract"
         }
+      },
+      "required": [
+        "value"
       ]
     },
     "Capability": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/SubmodelElement"
-        }
-      ]
+      "$ref": "#/definitions/SubmodelElement"
     },
     "ConceptDescription": {
       "allOf": [
@@ -916,7 +876,7 @@
               },
               "minItems": 1
             },
-            "referredSemanticID": {
+            "referredSemanticId": {
               "$ref": "#/definitions/Reference_abstract"
             }
           },
@@ -927,22 +887,18 @@
       ]
     },
     "Key": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "$ref": "#/definitions/KeyElements"
-            },
-            "value": {
-              "$ref": "#/definitions/NonEmptyString"
-            }
-          },
-          "required": [
-            "type",
-            "value"
-          ]
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/KeyElements"
+        },
+        "value": {
+          "$ref": "#/definitions/NonEmptyString"
         }
+      },
+      "required": [
+        "type",
+        "value"
       ]
     },
     "IdentifiableElements": {
@@ -1218,40 +1174,32 @@
       ]
     },
     "ValueReferencePair": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "value": {
-              "$ref": "#/definitions/NonEmptyString"
-            },
-            "valueID": {
-              "$ref": "#/definitions/Reference_abstract"
-            }
-          },
-          "required": [
-            "value",
-            "valueID"
-          ]
+      "type": "object",
+      "properties": {
+        "value": {
+          "$ref": "#/definitions/NonEmptyString"
+        },
+        "valueId": {
+          "$ref": "#/definitions/Reference_abstract"
         }
+      },
+      "required": [
+        "value",
+        "valueId"
       ]
     },
     "ValueList": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "valueReferencePairs": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/ValueReferencePair"
-              }
-            }
-          },
-          "required": [
-            "valueReferencePairs"
-          ]
+      "type": "object",
+      "properties": {
+        "valueReferencePairs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ValueReferencePair"
+          }
         }
+      },
+      "required": [
+        "valueReferencePairs"
       ]
     },
     "DataSpecificationIec61360": {
@@ -1271,7 +1219,7 @@
             "unit": {
               "$ref": "#/definitions/NonEmptyString"
             },
-            "unitID": {
+            "unitId": {
               "$ref": "#/definitions/Reference_abstract"
             },
             "sourceOfDefinition": {
@@ -1295,7 +1243,7 @@
             "value": {
               "$ref": "#/definitions/NonEmptyString"
             },
-            "valueID": {
+            "valueId": {
               "$ref": "#/definitions/Reference_abstract"
             },
             "levelType": {
@@ -1343,7 +1291,7 @@
             "conversionFactor": {
               "$ref": "#/definitions/NonEmptyString"
             },
-            "registrationAuthorityID": {
+            "registrationAuthorityId": {
               "$ref": "#/definitions/NonEmptyString"
             },
             "supplier": {
@@ -1354,35 +1302,31 @@
       ]
     },
     "Environment": {
-      "allOf": [
-        {
-          "type": "object",
-          "properties": {
-            "assetAdministrationShells": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/AssetAdministrationShell"
-              }
-            },
-            "submodels": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Submodel"
-              }
-            },
-            "conceptDescriptions": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/ConceptDescription"
-              }
-            }
-          },
-          "required": [
-            "assetAdministrationShells",
-            "submodels",
-            "conceptDescriptions"
-          ]
+      "type": "object",
+      "properties": {
+        "assetAdministrationShells": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AssetAdministrationShell"
+          }
+        },
+        "submodels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Submodel"
+          }
+        },
+        "conceptDescriptions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ConceptDescription"
+          }
         }
+      },
+      "required": [
+        "assetAdministrationShells",
+        "submodels",
+        "conceptDescriptions"
       ]
     }
   }

--- a/tests/jsonschema/test_main.py
+++ b/tests/jsonschema/test_main.py
@@ -13,7 +13,7 @@ import aas_core_codegen.main
 class Test_against_recorded(unittest.TestCase):
     # Set this variable to True if you want to re-record the test data,
     # without any checks
-    RERECORD = True
+    RERECORD = False
 
     def test_cases(self) -> None:
         repo_dir = pathlib.Path(os.path.realpath(__file__)).parent.parent.parent


### PR DESCRIPTION
We always introduced an `allOf` even though there is a single
definition. With this patch, we check for the number of possible
definitions and, if there is only one, write the properties directly in
the definition.

Additionally, we fix the naming to coincide more with the official JSON
schema in the http://github.com/admin-shell-io/aas-specs.