### PR TITLE
Remove redundant `type` property in JSON schema

### DIFF
--- a/aas_core_codegen/jsonschema/main.py
+++ b/aas_core_codegen/jsonschema/main.py
@@ -420,10 +420,12 @@ def _define_for_class(
     assert properties is not None
     assert required is not None
 
+    definition = collections.OrderedDict()  # type: MutableMapping[str, Any]
+    if len(cls.inheritances) == 0:
+        definition["type"] = "object"
+
     if len(properties) > 0:
-        definition = collections.OrderedDict(
-            [("type", "object"), ("properties", properties)]
-        )
+        definition["properties"] = properties
 
         if len(required) > 0:
             definition["required"] = required

--- a/test_data/jsonschema/test_main/v3rc1/expected_output/schema.json
+++ b/test_data/jsonschema/test_main/v3rc1/expected_output/schema.json
@@ -38,7 +38,6 @@
           "$ref": "#/definitions/HasSemantics"
         },
         {
-          "type": "object",
           "properties": {
             "name": {
               "$ref": "#/definitions/NonEmptyString"
@@ -73,7 +72,6 @@
           "$ref": "#/definitions/HasExtensions"
         },
         {
-          "type": "object",
           "properties": {
             "idShort": {
               "$ref": "#/definitions/NonEmptyString",
@@ -101,7 +99,6 @@
           "$ref": "#/definitions/Referable"
         },
         {
-          "type": "object",
           "properties": {
             "administration": {
               "$ref": "#/definitions/AdministrativeInformation"
@@ -171,7 +168,6 @@
           "$ref": "#/definitions/HasDataSpecification"
         },
         {
-          "type": "object",
           "properties": {
             "version": {
               "$ref": "#/definitions/NonEmptyString"
@@ -216,7 +212,6 @@
           "$ref": "#/definitions/HasSemantics"
         },
         {
-          "type": "object",
           "properties": {
             "type": {
               "$ref": "#/definitions/NonEmptyString"
@@ -244,7 +239,6 @@
           "$ref": "#/definitions/Constraint"
         },
         {
-          "type": "object",
           "properties": {
             "dependsOn": {
               "type": "array",
@@ -265,7 +259,6 @@
           "$ref": "#/definitions/HasDataSpecification"
         },
         {
-          "type": "object",
           "properties": {
             "derivedFrom": {
               "$ref": "#/definitions/Reference"
@@ -344,7 +337,6 @@
           "$ref": "#/definitions/HasSemantics"
         },
         {
-          "type": "object",
           "properties": {
             "key": {
               "$ref": "#/definitions/NonEmptyString"
@@ -380,7 +372,6 @@
           "$ref": "#/definitions/HasDataSpecification"
         },
         {
-          "type": "object",
           "properties": {
             "submodelElements": {
               "type": "array",
@@ -457,7 +448,6 @@
           "$ref": "#/definitions/SubmodelElement"
         },
         {
-          "type": "object",
           "properties": {
             "first": {
               "$ref": "#/definitions/Reference"
@@ -479,7 +469,6 @@
           "$ref": "#/definitions/SubmodelElement"
         },
         {
-          "type": "object",
           "properties": {
             "values": {
               "type": "array",
@@ -528,7 +517,6 @@
           "$ref": "#/definitions/DataElement"
         },
         {
-          "type": "object",
           "properties": {
             "valueType": {
               "$ref": "#/definitions/DataTypeDef"
@@ -552,7 +540,6 @@
           "$ref": "#/definitions/DataElement"
         },
         {
-          "type": "object",
           "properties": {
             "value": {
               "$ref": "#/definitions/LangStringSet"
@@ -570,7 +557,6 @@
           "$ref": "#/definitions/DataElement"
         },
         {
-          "type": "object",
           "properties": {
             "valueType": {
               "$ref": "#/definitions/DataTypeDef"
@@ -594,7 +580,6 @@
           "$ref": "#/definitions/DataElement"
         },
         {
-          "type": "object",
           "properties": {
             "value": {
               "$ref": "#/definitions/Reference"
@@ -609,7 +594,6 @@
           "$ref": "#/definitions/DataElement"
         },
         {
-          "type": "object",
           "properties": {
             "mimeType": {
               "$ref": "#/definitions/MimeTyped"
@@ -630,7 +614,6 @@
           "$ref": "#/definitions/DataElement"
         },
         {
-          "type": "object",
           "properties": {
             "mimeType": {
               "$ref": "#/definitions/MimeTyped"
@@ -651,7 +634,6 @@
           "$ref": "#/definitions/RelationshipElement"
         },
         {
-          "type": "object",
           "properties": {
             "annotation": {
               "type": "array",
@@ -676,7 +658,6 @@
           "$ref": "#/definitions/SubmodelElement"
         },
         {
-          "type": "object",
           "properties": {
             "entityType": {
               "$ref": "#/definitions/EntityType"
@@ -712,7 +693,6 @@
           "$ref": "#/definitions/Event"
         },
         {
-          "type": "object",
           "properties": {
             "observed": {
               "$ref": "#/definitions/Reference"
@@ -730,7 +710,6 @@
           "$ref": "#/definitions/SubmodelElement"
         },
         {
-          "type": "object",
           "properties": {
             "inputVariables": {
               "type": "array",
@@ -777,7 +756,6 @@
           "$ref": "#/definitions/HasDataSpecification"
         },
         {
-          "type": "object",
           "properties": {
             "isCaseOf": {
               "type": "array",
@@ -801,7 +779,6 @@
           "$ref": "#/definitions/HasDataSpecification"
         },
         {
-          "type": "object",
           "properties": {
             "containedElements": {
               "type": "array",
@@ -1074,7 +1051,6 @@
           "$ref": "#/definitions/DataSpecificationContent"
         },
         {
-          "type": "object",
           "properties": {
             "preferredName": {
               "$ref": "#/definitions/LangStringSet"
@@ -1125,7 +1101,6 @@
           "$ref": "#/definitions/DataSpecificationContent"
         },
         {
-          "type": "object",
           "properties": {
             "unitName": {
               "$ref": "#/definitions/NonEmptyString"
@@ -1191,7 +1166,6 @@
           "$ref": "#/definitions/Certificate"
         },
         {
-          "type": "object",
           "properties": {
             "blobCertificate": {
               "$ref": "#/definitions/Blob"
@@ -1286,7 +1260,6 @@
           "$ref": "#/definitions/Qualifiable"
         },
         {
-          "type": "object",
           "properties": {
             "targetSubjectAttributes": {
               "$ref": "#/definitions/SubjectAttributes"

--- a/test_data/jsonschema/test_main/v3rc2/expected_output/schema.json
+++ b/test_data/jsonschema/test_main/v3rc2/expected_output/schema.json
@@ -38,7 +38,6 @@
           "$ref": "#/definitions/HasSemantics"
         },
         {
-          "type": "object",
           "properties": {
             "name": {
               "$ref": "#/definitions/NonEmptyString"
@@ -79,7 +78,6 @@
           "$ref": "#/definitions/HasExtensions"
         },
         {
-          "type": "object",
           "properties": {
             "idShort": {
               "$ref": "#/definitions/NonEmptyString"
@@ -103,7 +101,6 @@
           "$ref": "#/definitions/Referable"
         },
         {
-          "type": "object",
           "properties": {
             "id": {
               "$ref": "#/definitions/NonEmptyString"
@@ -153,7 +150,6 @@
           "$ref": "#/definitions/HasDataSpecification"
         },
         {
-          "type": "object",
           "properties": {
             "version": {
               "$ref": "#/definitions/NonEmptyString"
@@ -201,7 +197,6 @@
           "$ref": "#/definitions/HasSemantics"
         },
         {
-          "type": "object",
           "properties": {
             "type": {
               "$ref": "#/definitions/NonEmptyString"
@@ -229,7 +224,6 @@
           "$ref": "#/definitions/Constraint"
         },
         {
-          "type": "object",
           "properties": {
             "dependsOn": {
               "type": "array",
@@ -253,7 +247,6 @@
           "$ref": "#/definitions/HasDataSpecification"
         },
         {
-          "type": "object",
           "properties": {
             "derivedFrom": {
               "$ref": "#/definitions/Reference_abstract"
@@ -308,7 +301,6 @@
           "$ref": "#/definitions/HasSemantics"
         },
         {
-          "type": "object",
           "properties": {
             "key": {
               "$ref": "#/definitions/NonEmptyString"
@@ -345,7 +337,6 @@
           "$ref": "#/definitions/HasDataSpecification"
         },
         {
-          "type": "object",
           "properties": {
             "submodelElements": {
               "type": "array",
@@ -428,7 +419,6 @@
           "$ref": "#/definitions/SubmodelElement"
         },
         {
-          "type": "object",
           "properties": {
             "first": {
               "$ref": "#/definitions/Reference_abstract"
@@ -450,7 +440,6 @@
           "$ref": "#/definitions/SubmodelElement"
         },
         {
-          "type": "object",
           "properties": {
             "submodelElementTypeValues": {
               "$ref": "#/definitions/SubmodelElements"
@@ -481,7 +470,6 @@
           "$ref": "#/definitions/SubmodelElement"
         },
         {
-          "type": "object",
           "properties": {
             "values": {
               "type": "array",
@@ -527,7 +515,6 @@
           "$ref": "#/definitions/DataElement"
         },
         {
-          "type": "object",
           "properties": {
             "valueType": {
               "$ref": "#/definitions/DataTypeDef"
@@ -551,7 +538,6 @@
           "$ref": "#/definitions/DataElement"
         },
         {
-          "type": "object",
           "properties": {
             "translatable": {
               "$ref": "#/definitions/LangStringSet"
@@ -569,7 +555,6 @@
           "$ref": "#/definitions/DataElement"
         },
         {
-          "type": "object",
           "properties": {
             "valueType": {
               "$ref": "#/definitions/DataTypeDef"
@@ -593,7 +578,6 @@
           "$ref": "#/definitions/DataElement"
         },
         {
-          "type": "object",
           "properties": {
             "reference": {
               "$ref": "#/definitions/Reference_abstract"
@@ -608,7 +592,6 @@
           "$ref": "#/definitions/DataElement"
         },
         {
-          "type": "object",
           "properties": {
             "mimeType": {
               "$ref": "#/definitions/MimeTyped",
@@ -630,7 +613,6 @@
           "$ref": "#/definitions/DataElement"
         },
         {
-          "type": "object",
           "properties": {
             "mimeType": {
               "$ref": "#/definitions/MimeTyped",
@@ -652,7 +634,6 @@
           "$ref": "#/definitions/RelationshipElement"
         },
         {
-          "type": "object",
           "properties": {
             "annotation": {
               "type": "array",
@@ -680,7 +661,6 @@
           "$ref": "#/definitions/SubmodelElement"
         },
         {
-          "type": "object",
           "properties": {
             "entityType": {
               "$ref": "#/definitions/EntityType"
@@ -714,7 +694,6 @@
           "$ref": "#/definitions/Event"
         },
         {
-          "type": "object",
           "properties": {
             "observed": {
               "$ref": "#/definitions/Reference_abstract"
@@ -732,7 +711,6 @@
           "$ref": "#/definitions/SubmodelElement"
         },
         {
-          "type": "object",
           "properties": {
             "inputVariables": {
               "type": "array",
@@ -784,7 +762,6 @@
           "$ref": "#/definitions/HasDataSpecification"
         },
         {
-          "type": "object",
           "properties": {
             "isCaseOf": {
               "type": "array",
@@ -811,7 +788,6 @@
           "$ref": "#/definitions/HasDataSpecification"
         },
         {
-          "type": "object",
           "properties": {
             "containedElements": {
               "type": "array",
@@ -845,7 +821,6 @@
           "$ref": "#/definitions/Reference"
         },
         {
-          "type": "object",
           "properties": {
             "values": {
               "type": "array",
@@ -867,7 +842,6 @@
           "$ref": "#/definitions/Reference"
         },
         {
-          "type": "object",
           "properties": {
             "keys": {
               "type": "array",
@@ -1208,7 +1182,6 @@
           "$ref": "#/definitions/DataSpecificationContent"
         },
         {
-          "type": "object",
           "properties": {
             "preferredName": {
               "$ref": "#/definitions/LangStringSet"
@@ -1259,7 +1232,6 @@
           "$ref": "#/definitions/DataSpecificationContent"
         },
         {
-          "type": "object",
           "properties": {
             "unitName": {
               "$ref": "#/definitions/NonEmptyString"


### PR DESCRIPTION
Currently we always include the `type` property even though a definition
"inherits" from another definition through `allOf`.

With this patch, the `type` property is only defined if there are no
ancestor definitions.