### PR TITLE
Add `modelType` in JSON schema

### DIFF
--- a/test_data/jsonschema/test_main/v3rc1/expected_output/schema.json
+++ b/test_data/jsonschema/test_main/v3rc1/expected_output/schema.json
@@ -85,10 +85,14 @@
             },
             "description": {
               "$ref": "#/definitions/LangStringSet"
+            },
+            "modelType": {
+              "$ref": "#/definitions/ModelType"
             }
           },
           "required": [
-            "idShort"
+            "idShort",
+            "modelType"
           ]
         }
       ]
@@ -191,7 +195,15 @@
       }
     },
     "Constraint": {
-      "type": "object"
+      "type": "object",
+      "properties": {
+        "modelType": {
+          "$ref": "#/definitions/ModelType"
+        }
+      },
+      "required": [
+        "modelType"
+      ]
     },
     "Constraint_abstract": {
       "anyOf": [
@@ -405,7 +417,13 @@
     "SubmodelElement_abstract": {
       "anyOf": [
         {
+          "$ref": "#/definitions/RelationshipElement"
+        },
+        {
           "$ref": "#/definitions/AnnotatedRelationshipElement"
+        },
+        {
+          "$ref": "#/definitions/Event"
         },
         {
           "$ref": "#/definitions/BasicEvent"
@@ -1147,10 +1165,14 @@
       "properties": {
         "policyAdministrationPoint": {
           "$ref": "#/definitions/PolicyAdministrationPoint"
+        },
+        "modelType": {
+          "$ref": "#/definitions/ModelType"
         }
       },
       "required": [
-        "policyAdministrationPoint"
+        "policyAdministrationPoint",
+        "modelType"
       ]
     },
     "Certificate_abstract": {
@@ -1451,6 +1473,50 @@
         "assets",
         "submodels",
         "conceptDescriptions"
+      ]
+    },
+    "ModelTypes": {
+      "type": "string",
+      "enum": [
+        "Extension",
+        "AdministrativeInformation",
+        "Qualifier",
+        "Formula",
+        "AssetAdministrationShell",
+        "Asset",
+        "IdentifierKeyValuePair",
+        "Submodel",
+        "RelationshipElement",
+        "SubmodelElementCollection",
+        "Property",
+        "MultiLanguageProperty",
+        "Range",
+        "ReferenceElement",
+        "Blob",
+        "File",
+        "AnnotatedRelationshipElement",
+        "Entity",
+        "Event",
+        "BasicEvent",
+        "Operation",
+        "Capability",
+        "ConceptDescription",
+        "View",
+        "DataSpecificationIEC61360",
+        "DataSpecificationPhysicalUnit",
+        "BlobCertificate",
+        "AccessPermissionRule"
+      ]
+    },
+    "ModelType": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/ModelTypes"
+        }
+      },
+      "required": [
+        "name"
       ]
     }
   }

--- a/test_data/jsonschema/test_main/v3rc1/input/meta_model.py
+++ b/test_data/jsonschema/test_main/v3rc1/input/meta_model.py
@@ -997,7 +997,6 @@ class Submodel_element(
 #
 #  🠒 We really need to think hard how we resolve the references. Should this class be
 #  implementation-specific?
-@abstract
 @reference_in_the_book(section=(4, 7, 8, 14))
 class Relationship_element(Submodel_element):
     """
@@ -1708,7 +1707,6 @@ class Entity(Submodel_element):
         self.specific_asset_IDs = specific_asset_IDs
 
 
-@abstract
 @reference_in_the_book(section=(4, 7, 8, 7))
 class Event(Submodel_element):
     """

--- a/test_data/jsonschema/test_main/v3rc2/expected_output/schema.json
+++ b/test_data/jsonschema/test_main/v3rc2/expected_output/schema.json
@@ -90,8 +90,14 @@
             },
             "description": {
               "$ref": "#/definitions/LangStringSet"
+            },
+            "modelType": {
+              "$ref": "#/definitions/ModelType"
             }
-          }
+          },
+          "required": [
+            "modelType"
+          ]
         }
       ]
     },
@@ -162,7 +168,15 @@
       ]
     },
     "Constraint": {
-      "type": "object"
+      "type": "object",
+      "properties": {
+        "modelType": {
+          "$ref": "#/definitions/ModelType"
+        }
+      },
+      "required": [
+        "modelType"
+      ]
     },
     "Constraint_abstract": {
       "anyOf": [
@@ -182,10 +196,14 @@
           "items": {
             "$ref": "#/definitions/Constraint_abstract"
           }
+        },
+        "modelType": {
+          "$ref": "#/definitions/ModelType"
         }
       },
       "required": [
-        "qualifiers"
+        "qualifiers",
+        "modelType"
       ]
     },
     "Qualifier": {
@@ -803,7 +821,15 @@
       ]
     },
     "Reference": {
-      "type": "object"
+      "type": "object",
+      "properties": {
+        "modelType": {
+          "$ref": "#/definitions/ModelType"
+        }
+      },
+      "required": [
+        "modelType"
+      ]
     },
     "Reference_abstract": {
       "anyOf": [
@@ -1299,6 +1325,48 @@
         "assetAdministrationShells",
         "submodels",
         "conceptDescriptions"
+      ]
+    },
+    "ModelTypes": {
+      "type": "string",
+      "enum": [
+        "Extension",
+        "AdministrativeInformation",
+        "Qualifier",
+        "Formula",
+        "AssetAdministrationShell",
+        "IdentifierKeyValuePair",
+        "Submodel",
+        "SubmodelElementList",
+        "SubmodelElementStruct",
+        "Property",
+        "MultiLanguageProperty",
+        "Range",
+        "ReferenceElement",
+        "Blob",
+        "File",
+        "AnnotatedRelationshipElement",
+        "Entity",
+        "BasicEvent",
+        "Operation",
+        "Capability",
+        "ConceptDescription",
+        "View",
+        "GlobalReference",
+        "ModelReference",
+        "DataSpecificationIec61360",
+        "DataSpecificationPhysicalUnit"
+      ]
+    },
+    "ModelType": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/ModelTypes"
+        }
+      },
+      "required": [
+        "name"
       ]
     }
   }


### PR DESCRIPTION
We add the discrimantor property `modelType`, conforming to the official
specs in admin-shell-io aas-specs repository.