### PR TITLE
Use `oneOf` instead of `anyOf` in JSON schema

### DIFF
--- a/aas_core_codegen/jsonschema/main.py
+++ b/aas_core_codegen/jsonschema/main.py
@@ -460,12 +460,12 @@ def _define_for_class(
     if len(cls.concrete_descendants) > 0 and id(cls) in ids_of_classes_in_properties:
         model_type_abstract = f"{model_type}_abstract"
 
-        any_of = [
+        one_of = [
             {"$ref": f"#/definitions/{naming.json_model_type(descendant.name)}"}
             for descendant in cls.concrete_descendants
         ]  # type: List[MutableMapping[str, Any]]
 
-        result[model_type_abstract] = {"anyOf": any_of}
+        result[model_type_abstract] = {"oneOf": one_of}
 
     # endregion
 

--- a/test_data/jsonschema/test_main/v3rc1/expected_output/schema.json
+++ b/test_data/jsonschema/test_main/v3rc1/expected_output/schema.json
@@ -206,7 +206,7 @@
       ]
     },
     "Constraint_abstract": {
-      "anyOf": [
+      "oneOf": [
         {
           "$ref": "#/definitions/Formula"
         },
@@ -415,7 +415,7 @@
       ]
     },
     "SubmodelElement_abstract": {
-      "anyOf": [
+      "oneOf": [
         {
           "$ref": "#/definitions/RelationshipElement"
         },
@@ -508,7 +508,7 @@
       "$ref": "#/definitions/SubmodelElement"
     },
     "DataElement_abstract": {
-      "anyOf": [
+      "oneOf": [
         {
           "$ref": "#/definitions/Blob"
         },
@@ -1176,7 +1176,7 @@
       ]
     },
     "Certificate_abstract": {
-      "anyOf": [
+      "oneOf": [
         {
           "$ref": "#/definitions/BlobCertificate"
         }

--- a/test_data/jsonschema/test_main/v3rc2/expected_output/schema.json
+++ b/test_data/jsonschema/test_main/v3rc2/expected_output/schema.json
@@ -179,7 +179,7 @@
       ]
     },
     "Constraint_abstract": {
-      "anyOf": [
+      "oneOf": [
         {
           "$ref": "#/definitions/Formula"
         },
@@ -389,7 +389,7 @@
       ]
     },
     "SubmodelElement_abstract": {
-      "anyOf": [
+      "oneOf": [
         {
           "$ref": "#/definitions/AnnotatedRelationshipElement"
         },
@@ -506,7 +506,7 @@
       "$ref": "#/definitions/SubmodelElement"
     },
     "DataElement_abstract": {
-      "anyOf": [
+      "oneOf": [
         {
           "$ref": "#/definitions/Blob"
         },
@@ -832,7 +832,7 @@
       ]
     },
     "Reference_abstract": {
-      "anyOf": [
+      "oneOf": [
         {
           "$ref": "#/definitions/GlobalReference"
         },


### PR DESCRIPTION
The qualifier `anyOf` is too restrictive for abstract classes since we
want to reject overlapping properties.