### PR TITLE
Fix naming for set of symbols used in properties

### DIFF
--- a/aas_core_codegen/intermediate/__init__.py
+++ b/aas_core_codegen/intermediate/__init__.py
@@ -40,7 +40,7 @@ Interface = _types.Interface
 SymbolTable = _types.SymbolTable
 
 map_descendability = _types.map_descendability
-collect_ids_of_classes_in_properties = _types.collect_ids_of_classes_in_properties
+collect_ids_of_symbols_in_properties = _types.collect_ids_of_symbols_in_properties
 
 translate = _translate.translate
 errors_if_contracts_for_functions_or_methods_defined = (

--- a/aas_core_codegen/intermediate/_translate.py
+++ b/aas_core_codegen/intermediate/_translate.py
@@ -77,7 +77,7 @@ from aas_core_codegen.intermediate._types import (
     ClassUnion,
     VerificationUnion,
     UnderstoodMethod,
-    collect_ids_of_classes_in_properties,
+    collect_ids_of_symbols_in_properties,
     SymbolExceptEnumeration,
 )
 from aas_core_codegen.parse import tree as parse_tree
@@ -2201,7 +2201,7 @@ def _verify(symbol_table: SymbolTable, ontology: _hierarchy.Ontology) -> List[Er
 
     # region Check ``with_model_type`` for classes with at least one concrete descendant
 
-    classes_in_properties = collect_ids_of_classes_in_properties(
+    symbols_in_properties = collect_ids_of_symbols_in_properties(
         symbol_table=symbol_table
     )
 
@@ -2209,7 +2209,7 @@ def _verify(symbol_table: SymbolTable, ontology: _hierarchy.Ontology) -> List[Er
         if not isinstance(symbol, Class):
             continue
 
-        if id(symbol) in classes_in_properties:
+        if id(symbol) in symbols_in_properties:
             if len(symbol.concrete_descendants) >= 1:
                 if not symbol.serialization.with_model_type:
                     descendants_str = ", ".join(

--- a/aas_core_codegen/intermediate/_types.py
+++ b/aas_core_codegen/intermediate/_types.py
@@ -1614,9 +1614,9 @@ class _ConstructorArgumentOfClass:
         self.cls = cls
 
 
-def collect_ids_of_classes_in_properties(symbol_table: SymbolTable) -> Set[int]:
+def collect_ids_of_symbols_in_properties(symbol_table: SymbolTable) -> Set[int]:
     """
-    Collect the IDs of the classes occurring in type annotations of the properties.
+    Collect the IDs of the symbols occurring in type annotations of the properties.
 
     The IDs refer to IDs of the Python objects in this context.
     """

--- a/aas_core_codegen/jsonschema/main.py
+++ b/aas_core_codegen/jsonschema/main.py
@@ -520,7 +520,7 @@ def _generate(
         verifications=symbol_table.verification_functions
     )
 
-    ids_of_classes_in_properties = intermediate.collect_ids_of_classes_in_properties(
+    ids_of_classes_in_properties = intermediate.collect_ids_of_symbols_in_properties(
         symbol_table=symbol_table
     )
 


### PR DESCRIPTION
We erroneously called the function
`collect_ids_of_classes_in_properties`, while we actually collected the
IDs of the symbols.