### PR TITLE
Skip unused symbols in JSON schema

### DIFF
--- a/aas_core_codegen/jsonschema/main.py
+++ b/aas_core_codegen/jsonschema/main.py
@@ -520,7 +520,7 @@ def _generate(
         verifications=symbol_table.verification_functions
     )
 
-    ids_of_classes_in_properties = intermediate.collect_ids_of_symbols_in_properties(
+    ids_of_symbols_in_properties = intermediate.collect_ids_of_symbols_in_properties(
         symbol_table=symbol_table
     )
 
@@ -569,9 +569,15 @@ def _generate(
                 continue
         else:
             if isinstance(symbol, intermediate.Enumeration):
+                if id(symbol) not in ids_of_symbols_in_properties:
+                    continue
+
                 extension = _define_for_enumeration(enumeration=symbol)
 
             elif isinstance(symbol, intermediate.ConstrainedPrimitive):
+                if id(symbol) not in ids_of_symbols_in_properties:
+                    continue
+
                 extension, definition_errors = _define_for_constrained_primitive(
                     constrained_primitive=symbol,
                     pattern_verifications_by_name=pattern_verifications_by_name,
@@ -584,7 +590,7 @@ def _generate(
             elif isinstance(symbol, intermediate.Class):
                 extension, definition_errors = _define_for_class(
                     cls=symbol,
-                    ids_of_classes_in_properties=ids_of_classes_in_properties,
+                    ids_of_classes_in_properties=ids_of_symbols_in_properties,
                     pattern_verifications_by_name=pattern_verifications_by_name,
                 )
 

--- a/test_data/jsonschema/test_main/v3rc1/expected_output/schema.json
+++ b/test_data/jsonschema/test_main/v3rc1/expected_output/schema.json
@@ -842,43 +842,6 @@
         "idType"
       ]
     },
-    "IdentifiableElements": {
-      "type": "string",
-      "enum": [
-        "Asset",
-        "AssetAdministrationShell",
-        "ConceptDescription",
-        "Submodel"
-      ]
-    },
-    "ReferableElements": {
-      "type": "string",
-      "enum": [
-        "AccessPermissionRule",
-        "AnnotatedRelationshipElement",
-        "Asset",
-        "AssetAdministrationShell",
-        "BasicEvent",
-        "Blob",
-        "Capability",
-        "ConceptDescription",
-        "ConceptDictionary",
-        "DataElement",
-        "Entity",
-        "Event",
-        "File",
-        "MultiLanguageProperty",
-        "Operation",
-        "Property",
-        "Range",
-        "ReferenceElement",
-        "RelationshipElement",
-        "Submodel",
-        "SubmodelElement",
-        "SubmodelElementCollection",
-        "View"
-      ]
-    },
     "KeyElements": {
       "type": "string",
       "enum": [
@@ -907,13 +870,6 @@
         "SubmodelElement",
         "SubmodelElementCollection",
         "View"
-      ]
-    },
-    "LocalKeyType": {
-      "type": "string",
-      "enum": [
-        "IdShort",
-        "FragmentId"
       ]
     },
     "KeyType": {

--- a/test_data/jsonschema/test_main/v3rc2/expected_output/schema.json
+++ b/test_data/jsonschema/test_main/v3rc2/expected_output/schema.json
@@ -901,41 +901,6 @@
         "value"
       ]
     },
-    "IdentifiableElements": {
-      "type": "string",
-      "enum": [
-        "AssetAdministrationShell",
-        "ConceptDescription",
-        "Submodel"
-      ]
-    },
-    "ReferableElements": {
-      "type": "string",
-      "enum": [
-        "AccessPermissionRule",
-        "AnnotatedRelationshipElement",
-        "Asset",
-        "AssetAdministrationShell",
-        "BasicEvent",
-        "Blob",
-        "Capability",
-        "ConceptDescription",
-        "DataElement",
-        "Entity",
-        "Event",
-        "File",
-        "MultiLanguageProperty",
-        "Operation",
-        "Property",
-        "Range",
-        "ReferenceElement",
-        "RelationshipElement",
-        "Submodel",
-        "SubmodelElement",
-        "SubmodelElementList",
-        "SubmodelElementStruct"
-      ]
-    },
     "KeyElements": {
       "type": "string",
       "enum": [
@@ -989,74 +954,6 @@
         "SubmodelElement",
         "SubmodelElementList",
         "SubmodelElementStruct"
-      ]
-    },
-    "BuildInListTypes": {
-      "type": "string",
-      "enum": [
-        "ENTITIES",
-        "IDREFS",
-        "NMTOKENS"
-      ]
-    },
-    "DecimalBuildInTypes": {
-      "type": "string",
-      "enum": [
-        "integer",
-        "long",
-        "int",
-        "short",
-        "byte",
-        "NonNegativeInteger",
-        "positiveInteger",
-        "unsignedInteger",
-        "unsignedLong",
-        "unsignedInt",
-        "unsignedShort",
-        "unsignedByte",
-        "nonPositiveInteger",
-        "negativeInteger"
-      ]
-    },
-    "DurationBuildInTypes": {
-      "type": "string",
-      "enum": [
-        "dayTimeDuration",
-        "yearMonthDuration"
-      ]
-    },
-    "PrimitiveTypes": {
-      "type": "string",
-      "enum": [
-        "anyURI",
-        "base64Binary",
-        "boolean",
-        "date",
-        "dateTime",
-        "decimal",
-        "double",
-        "duration",
-        "float",
-        "gDay",
-        "gMonth",
-        "gMonthDay",
-        "heyBinary",
-        "NOTATION",
-        "QName",
-        "string",
-        "time"
-      ]
-    },
-    "StringBuildInTypes": {
-      "type": "string",
-      "enum": [
-        "normalizedString",
-        "token",
-        "Language",
-        "NCName",
-        "ENTITY",
-        "ID",
-        "IDREF"
       ]
     },
     "DataTypeDef": {


### PR DESCRIPTION
With this patch, we omit to generate the code for all the symbols which
are not used in any of the properties of any of the classes.