### PR TITLE
Refactor parsing of decorators for extensibility

### DIFF
--- a/test_data/parse/unexpected/class_decorators/non_name_decorator/expected_error.txt
+++ b/test_data/parse/unexpected/class_decorators/non_name_decorator/expected_error.txt
@@ -1,1 +1,1 @@
-Handling of a decorator has not been implemented: "Attribute(value=Name(id='some_module', ctx=Load()), attr='some_decorator', ctx=Load())"
+Handling of a non-name or a non-call class decorator has not been implemented: Attribute(value=Name(id='some_module', ctx=Load()), attr='some_decorator', ctx=Load())


### PR DESCRIPTION
We change the order of parsing functions and introduce a union to
abstract a general class decorators. To make parsing of novel decorators
easier, we additionally introduce a dispatch function so that there is a
single point of entry for class decorators.