### PR TITLE
Introduce `constraintref` role in the docs

### DIFF
--- a/aas_core_codegen/csharp/description.py
+++ b/aas_core_codegen/csharp/description.py
@@ -114,6 +114,11 @@ class _ElementRenderer(intermediate_rendering.DocutilsElementTransformer[str]):
         arg_name = csharp_naming.argument_name(Identifier(element.reference))
         return f"<paramref name={xml.sax.saxutils.quoteattr(arg_name)} />", None
 
+    def transform_constraint_reference_in_doc(
+        self, element: intermediate_doc.ConstraintReference
+    ) -> Tuple[Optional[str], Optional[str]]:
+        return f"Constraint {element.reference}", None
+
     def transform_literal(
         self, element: docutils.nodes.literal
     ) -> Tuple[Optional[str], Optional[str]]:

--- a/aas_core_codegen/intermediate/_translate.py
+++ b/aas_core_codegen/intermediate/_translate.py
@@ -193,6 +193,28 @@ def _argument_reference_role(  # type: ignore
     return [node], []
 
 
+# noinspection PyUnusedLocal
+def _constraint_reference_role(  # type: ignore
+    role, rawtext, text, lineno, inliner, options=None, content=None
+) -> Any:
+    """Create a reference in the documentation to a constraint."""
+    # See: https://docutils.sourceforge.io/docs/howto/rst-roles.html
+    if content is None:
+        content = []
+
+    if options is None:
+        options = {}
+
+    docutils.parsers.rst.roles.set_classes(options)
+
+    reference = text
+
+    node = doc.ConstraintReference(
+        reference, rawtext, docutils.utils.unescape(text), refuri=text, **options
+    )
+    return [node], []
+
+
 # pylint: enable=unused-argument
 
 # The global registration is unfortunate since it is unpredictable and might affect
@@ -202,6 +224,9 @@ def _argument_reference_role(  # type: ignore
 docutils.parsers.rst.roles.register_local_role("class", _symbol_reference_role)
 docutils.parsers.rst.roles.register_local_role("attr", _attribute_reference_role)
 docutils.parsers.rst.roles.register_local_role("paramref", _argument_reference_role)
+docutils.parsers.rst.roles.register_local_role(
+    "constraintref", _constraint_reference_role
+)
 
 
 def _parsed_description_to_description(parsed: parse.Description) -> Description:

--- a/aas_core_codegen/intermediate/doc.py
+++ b/aas_core_codegen/intermediate/doc.py
@@ -102,3 +102,23 @@ class ArgumentReference(
         docutils.nodes.TextElement.__init__(
             self, rawsource, text, *children, **attributes
         )
+
+
+class ConstraintReference(
+    docutils.nodes.Inline, docutils.nodes.TextElement  # type: ignore
+):
+    """Represent a reference in the documentation to a constraint."""
+
+    def __init__(  # type: ignore
+        self,
+        reference: str,
+        rawsource="",
+        text="",
+        *children,
+        **attributes,
+    ) -> None:
+        """Initialize with ``reference`` and propagate the rest to the parent."""
+        self.reference = reference
+        docutils.nodes.TextElement.__init__(
+            self, rawsource, text, *children, **attributes
+        )

--- a/aas_core_codegen/intermediate/rendering.py
+++ b/aas_core_codegen/intermediate/rendering.py
@@ -43,6 +43,9 @@ class DocutilsElementTransformer(Generic[T], DBC):
         elif isinstance(element, doc.ArgumentReference):
             return self.transform_argument_reference_in_doc(element)
 
+        elif isinstance(element, doc.ConstraintReference):
+            return self.transform_constraint_reference_in_doc(element)
+
         elif isinstance(element, docutils.nodes.literal):
             return self.transform_literal(element)
 
@@ -103,6 +106,14 @@ class DocutilsElementTransformer(Generic[T], DBC):
         self, element: doc.ArgumentReference
     ) -> Tuple[Optional[T], Optional[str]]:
         """Transform an argument reference into something."""
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
+    def transform_constraint_reference_in_doc(
+        self, element: doc.ConstraintReference
+    ) -> Tuple[Optional[T], Optional[str]]:
+        """Transform a reference to a constraint into something."""
         raise NotImplementedError()
 
     @abc.abstractmethod

--- a/aas_core_codegen/rdf_shacl/_description.py
+++ b/aas_core_codegen/rdf_shacl/_description.py
@@ -147,6 +147,11 @@ class Renderer(intermediate_rendering.DocutilsElementTransformer[List["TokenUnio
         # return them as-is.
         return [TokenText(element.reference)], None
 
+    def transform_constraint_reference_in_doc(
+        self, element: intermediate_doc.ConstraintReference
+    ) -> Tuple[Optional[List["TokenUnion"]], Optional[str]]:
+        return [TokenText(f"Constraint {element.reference}")], None
+
     def transform_literal(
         self, element: docutils.nodes.literal
     ) -> Tuple[Optional[List["TokenUnion"]], Optional[str]]:

--- a/test_data/csharp/test_main/v3rc2/input/meta_model.py
+++ b/test_data/csharp/test_main/v3rc2/input/meta_model.py
@@ -1127,9 +1127,9 @@ class Multi_language_property(Data_element):
     ConceptDescription then DataSpecificationIEC61360/dataType shall be
     STRING_TRANSLATABLE.
 
-    See Constraint AASd-065
+    See :constraintref:`AASd-065`
 
-    See Constraint AASd-066
+    See :constraintref:`AASd-066`
     """
 
     value: Optional["Lang_string_set"]
@@ -1365,7 +1365,7 @@ class File(Data_element):
     A File is a data element that represents an address to a file.
     The value is an URI that can represent an absolute or relative path.
 
-    See Constraint AASd-057
+    See :constraintref:`AASd-057`
 
     Constraint AASd-079: If the semanticId of a File references a
     ConceptDescription then DataSpecificationIEC61360/dataType shall be one of: FILE.
@@ -1420,7 +1420,7 @@ class Annotated_relationship_element(Relationship_element):
     An annotated relationship element is a relationship element that can be annotated
     with additional data elements.
 
-    See Constraint AASd-055
+    See :constraintref:`AASd-055`
     """
 
     annotation: List[Data_element]
@@ -1534,7 +1534,7 @@ class Entity(Submodel_element):
     Reference to an identifier key value pair representing a specific identifier
     of the asset represented by the asset administration shell.
 
-    See Constraint AASd-014
+    See :constraintref:`AASd-014`
     """
 
     def __init__(
@@ -2605,7 +2605,7 @@ class Data_specification_IEC61360(Data_specification_content):
     """
     List of allowed values
 
-    See Constraint AASd-102
+    See :constraintref:`AASd-102`
     """
 
     value: Optional[Non_empty_string]
@@ -2624,7 +2624,7 @@ class Data_specification_IEC61360(Data_specification_content):
     """
     Unique value id
 
-    See Constraint AASd-102
+    See :constraintref:`AASd-102`
     """
 
     level_type: Optional["Level_type"]

--- a/test_data/intermediate/expected/real_meta_models/v3rc2/meta_model.py
+++ b/test_data/intermediate/expected/real_meta_models/v3rc2/meta_model.py
@@ -1127,9 +1127,9 @@ class Multi_language_property(Data_element):
     ConceptDescription then DataSpecificationIEC61360/dataType shall be
     STRING_TRANSLATABLE.
 
-    See Constraint AASd-065
+    See :constraintref:`AASd-065`
 
-    See Constraint AASd-066
+    See :constraintref:`AASd-066`
     """
 
     value: Optional["Lang_string_set"]
@@ -1365,7 +1365,7 @@ class File(Data_element):
     A File is a data element that represents an address to a file.
     The value is an URI that can represent an absolute or relative path.
 
-    See Constraint AASd-057
+    See :constraintref:`AASd-057`
 
     Constraint AASd-079: If the semanticId of a File references a
     ConceptDescription then DataSpecificationIEC61360/dataType shall be one of: FILE.
@@ -1420,7 +1420,7 @@ class Annotated_relationship_element(Relationship_element):
     An annotated relationship element is a relationship element that can be annotated
     with additional data elements.
 
-    See Constraint AASd-055
+    See :constraintref:`AASd-055`
     """
 
     annotation: List[Data_element]
@@ -1534,7 +1534,7 @@ class Entity(Submodel_element):
     Reference to an identifier key value pair representing a specific identifier
     of the asset represented by the asset administration shell.
 
-    See Constraint AASd-014
+    See :constraintref:`AASd-014`
     """
 
     def __init__(
@@ -2605,7 +2605,7 @@ class Data_specification_IEC61360(Data_specification_content):
     """
     List of allowed values
 
-    See Constraint AASd-102
+    See :constraintref:`AASd-102`
     """
 
     value: Optional[Non_empty_string]
@@ -2624,7 +2624,7 @@ class Data_specification_IEC61360(Data_specification_content):
     """
     Unique value id
 
-    See Constraint AASd-102
+    See :constraintref:`AASd-102`
     """
 
     level_type: Optional["Level_type"]

--- a/test_data/jsonschema/test_main/v3rc2/input/meta_model.py
+++ b/test_data/jsonschema/test_main/v3rc2/input/meta_model.py
@@ -1127,9 +1127,9 @@ class Multi_language_property(Data_element):
     ConceptDescription then DataSpecificationIEC61360/dataType shall be
     STRING_TRANSLATABLE.
 
-    See Constraint AASd-065
+    See :constraintref:`AASd-065`
 
-    See Constraint AASd-066
+    See :constraintref:`AASd-066`
     """
 
     value: Optional["Lang_string_set"]
@@ -1365,7 +1365,7 @@ class File(Data_element):
     A File is a data element that represents an address to a file.
     The value is an URI that can represent an absolute or relative path.
 
-    See Constraint AASd-057
+    See :constraintref:`AASd-057`
 
     Constraint AASd-079: If the semanticId of a File references a
     ConceptDescription then DataSpecificationIEC61360/dataType shall be one of: FILE.
@@ -1420,7 +1420,7 @@ class Annotated_relationship_element(Relationship_element):
     An annotated relationship element is a relationship element that can be annotated
     with additional data elements.
 
-    See Constraint AASd-055
+    See :constraintref:`AASd-055`
     """
 
     annotation: List[Data_element]
@@ -1534,7 +1534,7 @@ class Entity(Submodel_element):
     Reference to an identifier key value pair representing a specific identifier
     of the asset represented by the asset administration shell.
 
-    See Constraint AASd-014
+    See :constraintref:`AASd-014`
     """
 
     def __init__(
@@ -2605,7 +2605,7 @@ class Data_specification_IEC61360(Data_specification_content):
     """
     List of allowed values
 
-    See Constraint AASd-102
+    See :constraintref:`AASd-102`
     """
 
     value: Optional[Non_empty_string]
@@ -2624,7 +2624,7 @@ class Data_specification_IEC61360(Data_specification_content):
     """
     Unique value id
 
-    See Constraint AASd-102
+    See :constraintref:`AASd-102`
     """
 
     level_type: Optional["Level_type"]

--- a/test_data/parse/expected/real_meta_models/v3rc2/meta_model.py
+++ b/test_data/parse/expected/real_meta_models/v3rc2/meta_model.py
@@ -1127,9 +1127,9 @@ class Multi_language_property(Data_element):
     ConceptDescription then DataSpecificationIEC61360/dataType shall be
     STRING_TRANSLATABLE.
 
-    See Constraint AASd-065
+    See :constraintref:`AASd-065`
 
-    See Constraint AASd-066
+    See :constraintref:`AASd-066`
     """
 
     value: Optional["Lang_string_set"]
@@ -1365,7 +1365,7 @@ class File(Data_element):
     A File is a data element that represents an address to a file.
     The value is an URI that can represent an absolute or relative path.
 
-    See Constraint AASd-057
+    See :constraintref:`AASd-057`
 
     Constraint AASd-079: If the semanticId of a File references a
     ConceptDescription then DataSpecificationIEC61360/dataType shall be one of: FILE.
@@ -1420,7 +1420,7 @@ class Annotated_relationship_element(Relationship_element):
     An annotated relationship element is a relationship element that can be annotated
     with additional data elements.
 
-    See Constraint AASd-055
+    See :constraintref:`AASd-055`
     """
 
     annotation: List[Data_element]
@@ -1534,7 +1534,7 @@ class Entity(Submodel_element):
     Reference to an identifier key value pair representing a specific identifier
     of the asset represented by the asset administration shell.
 
-    See Constraint AASd-014
+    See :constraintref:`AASd-014`
     """
 
     def __init__(
@@ -2605,7 +2605,7 @@ class Data_specification_IEC61360(Data_specification_content):
     """
     List of allowed values
 
-    See Constraint AASd-102
+    See :constraintref:`AASd-102`
     """
 
     value: Optional[Non_empty_string]
@@ -2624,7 +2624,7 @@ class Data_specification_IEC61360(Data_specification_content):
     """
     Unique value id
 
-    See Constraint AASd-102
+    See :constraintref:`AASd-102`
     """
 
     level_type: Optional["Level_type"]


### PR DESCRIPTION
We introduce a special role, `constraintref`, to indicate references to
constraints. In a future pull request, we will introduce handling of the
constraints as field lists.