### PR TITLE
Add `:constraintref:` to all meta-models

### DIFF
--- a/test_data/csharp/test_main/v3rc2/expected_output/types.cs
+++ b/test_data/csharp/test_main/v3rc2/expected_output/types.cs
@@ -2589,8 +2589,8 @@ namespace AasCore.Aas3
         /// The value of the property instance.
         /// </summary>
         /// <remarks>
-        /// See Constraint AASd-065
-        /// See Constraint AASd-007
+        /// See Constraint AASd-065
+        /// See Constraint AASd-007
         /// </remarks>
         public string? Value { get; set; }
 
@@ -2598,8 +2598,8 @@ namespace AasCore.Aas3
         /// Reference to the global unique id of a coded value.
         /// </summary>
         /// <remarks>
-        /// See Constraint AASd-065
-        /// See Constraint AASd-007
+        /// See Constraint AASd-065
+        /// See Constraint AASd-007
         /// </remarks>
         public IReference? ValueId { get; set; }
 
@@ -2922,15 +2922,15 @@ namespace AasCore.Aas3
 
         /// <summary>
         /// The value of the property instance.
-        /// See Constraint AASd-012
-        /// See Constraint AASd-065"
+        /// See Constraint AASd-012
+        /// See Constraint AASd-065
         /// </summary>
         public LangStringSet? Value { get; set; }
 
         /// <summary>
         /// Reference to the global unique id of a coded value.
-        /// See Constraint AASd-012
-        /// See Constraint AASd-065"
+        /// See Constraint AASd-012
+        /// See Constraint AASd-065
         /// </summary>
         public IReference? ValueId { get; set; }
 

--- a/test_data/csharp/test_main/v3rc2/input/meta_model.py
+++ b/test_data/csharp/test_main/v3rc2/input/meta_model.py
@@ -1064,16 +1064,16 @@ class Property(Data_element):
     """
     The value of the property instance.
 
-    See Constraint AASd-065
-    See Constraint AASd-007
+    See :constraintref:`AASd-065`
+    See :constraintref:`AASd-007`
     """
 
     value_ID: Optional["Reference"]
     """
     Reference to the global unique id of a coded value.
 
-    See Constraint AASd-065
-    See Constraint AASd-007
+    See :constraintref:`AASd-065`
+    See :constraintref:`AASd-007`
     """
 
     def __init__(
@@ -1135,15 +1135,15 @@ class Multi_language_property(Data_element):
     value: Optional["Lang_string_set"]
     """
     The value of the property instance.
-    See Constraint AASd-012
-    See Constraint AASd-065"
+    See :constraintref:`AASd-012`
+    See :constraintref:`AASd-065`
     """
 
     value_ID: Optional["Reference"]
     """
     Reference to the global unique id of a coded value.
-    See Constraint AASd-012
-    See Constraint AASd-065"
+    See :constraintref:`AASd-012`
+    See :constraintref:`AASd-065`
     """
 
     def __init__(

--- a/test_data/intermediate/expected/real_meta_models/v3rc2/meta_model.py
+++ b/test_data/intermediate/expected/real_meta_models/v3rc2/meta_model.py
@@ -1064,16 +1064,16 @@ class Property(Data_element):
     """
     The value of the property instance.
 
-    See Constraint AASd-065
-    See Constraint AASd-007
+    See :constraintref:`AASd-065`
+    See :constraintref:`AASd-007`
     """
 
     value_ID: Optional["Reference"]
     """
     Reference to the global unique id of a coded value.
 
-    See Constraint AASd-065
-    See Constraint AASd-007
+    See :constraintref:`AASd-065`
+    See :constraintref:`AASd-007`
     """
 
     def __init__(
@@ -1135,15 +1135,15 @@ class Multi_language_property(Data_element):
     value: Optional["Lang_string_set"]
     """
     The value of the property instance.
-    See Constraint AASd-012
-    See Constraint AASd-065"
+    See :constraintref:`AASd-012`
+    See :constraintref:`AASd-065`
     """
 
     value_ID: Optional["Reference"]
     """
     Reference to the global unique id of a coded value.
-    See Constraint AASd-012
-    See Constraint AASd-065"
+    See :constraintref:`AASd-012`
+    See :constraintref:`AASd-065`
     """
 
     def __init__(

--- a/test_data/jsonschema/test_main/v3rc1/input/meta_model.py
+++ b/test_data/jsonschema/test_main/v3rc1/input/meta_model.py
@@ -1235,16 +1235,16 @@ class Property(Data_element):
     """
     The value of the property instance.
 
-    See Constraint AASd-065
-    See Constraint AASd-007
+    See :constraintref:`AASd-065`
+    See :constraintref:`AASd-007`
     """
 
     value_ID: Optional["Reference"]
     """
     Reference to the global unique id of a coded value.
 
-    See Constraint AASd-065
-    See Constraint AASd-007
+    See :constraintref:`AASd-065`
+    See :constraintref:`AASd-007`
     """
 
     def __init__(
@@ -1298,21 +1298,21 @@ class Multi_language_property(Data_element):
     ConceptDescription then DataSpecificationIEC61360/dataType shall be
     STRING_TRANSLATABLE.
 
-    See Constraint AASd-065
+    See :constraintref:`AASd-065`
     """
 
     value: Optional["Lang_string_set"]
     """
     The value of the property instance.
-    See Constraint AASd-012
-    See Constraint AASd-065"
+    See :constraintref:`AASd-012`
+    See :constraintref:`AASd-065`
     """
 
     value_ID: Optional["Reference"]
     """
     Reference to the global unique id of a coded value.
-    See Constraint AASd-012
-    See Constraint AASd-065"
+    See :constraintref:`AASd-012`
+    See :constraintref:`AASd-065`
     """
 
     def __init__(
@@ -1525,7 +1525,7 @@ class File(Data_element):
     A File is a data element that represents an address to a file.
     The value is an URI that can represent an absolute or relative path.
 
-    See Constraint AASd-057
+    See :constraintref:`AASd-057`
     """
 
     MIME_type: MIME_typed
@@ -1688,7 +1688,7 @@ class Entity(Submodel_element):
     """
     Reference to an identifier key value pair representing a specific identifier
     of the asset represented by the asset administration shell.
-    See Constraint AASd-014
+    See :constraintref:`AASd-014`
     """
 
     def __init__(

--- a/test_data/jsonschema/test_main/v3rc2/input/meta_model.py
+++ b/test_data/jsonschema/test_main/v3rc2/input/meta_model.py
@@ -1064,16 +1064,16 @@ class Property(Data_element):
     """
     The value of the property instance.
 
-    See Constraint AASd-065
-    See Constraint AASd-007
+    See :constraintref:`AASd-065`
+    See :constraintref:`AASd-007`
     """
 
     value_ID: Optional["Reference"]
     """
     Reference to the global unique id of a coded value.
 
-    See Constraint AASd-065
-    See Constraint AASd-007
+    See :constraintref:`AASd-065`
+    See :constraintref:`AASd-007`
     """
 
     def __init__(
@@ -1135,15 +1135,15 @@ class Multi_language_property(Data_element):
     value: Optional["Lang_string_set"]
     """
     The value of the property instance.
-    See Constraint AASd-012
-    See Constraint AASd-065"
+    See :constraintref:`AASd-012`
+    See :constraintref:`AASd-065`
     """
 
     value_ID: Optional["Reference"]
     """
     Reference to the global unique id of a coded value.
-    See Constraint AASd-012
-    See Constraint AASd-065"
+    See :constraintref:`AASd-012`
+    See :constraintref:`AASd-065`
     """
 
     def __init__(

--- a/test_data/parse/expected/real_meta_models/v3rc2/meta_model.py
+++ b/test_data/parse/expected/real_meta_models/v3rc2/meta_model.py
@@ -1064,16 +1064,16 @@ class Property(Data_element):
     """
     The value of the property instance.
 
-    See Constraint AASd-065
-    See Constraint AASd-007
+    See :constraintref:`AASd-065`
+    See :constraintref:`AASd-007`
     """
 
     value_ID: Optional["Reference"]
     """
     Reference to the global unique id of a coded value.
 
-    See Constraint AASd-065
-    See Constraint AASd-007
+    See :constraintref:`AASd-065`
+    See :constraintref:`AASd-007`
     """
 
     def __init__(
@@ -1135,15 +1135,15 @@ class Multi_language_property(Data_element):
     value: Optional["Lang_string_set"]
     """
     The value of the property instance.
-    See Constraint AASd-012
-    See Constraint AASd-065"
+    See :constraintref:`AASd-012`
+    See :constraintref:`AASd-065`
     """
 
     value_ID: Optional["Reference"]
     """
     Reference to the global unique id of a coded value.
-    See Constraint AASd-012
-    See Constraint AASd-065"
+    See :constraintref:`AASd-012`
+    See :constraintref:`AASd-065`
     """
 
     def __init__(

--- a/test_data/rdf_shacl/test_main/v3rc1/expected_output/rdf-ontology.ttl
+++ b/test_data/rdf_shacl/test_main/v3rc1/expected_output/rdf-ontology.ttl
@@ -1706,7 +1706,7 @@ aas:MultiLanguageProperty rdf:type owl:Class ;
     rdfs:label "has value"^^xsd:string ;
     rdfs:domain aas:MultiLanguageProperty ;
     rdfs:range rdf:langString ;
-    rdfs:comment "The value of the property instance. See Constraint AASd-012 See Constraint AASd-065\""@en ;
+    rdfs:comment "The value of the property instance. See Constraint AASd-012 See Constraint AASd-065"@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/MultiLanguageProperty/valueId
@@ -1714,7 +1714,7 @@ aas:MultiLanguageProperty rdf:type owl:Class ;
     rdfs:label "has value id"^^xsd:string ;
     rdfs:domain aas:MultiLanguageProperty ;
     rdfs:range aas:Reference ;
-    rdfs:comment "Reference to the global unique id of a coded value. See Constraint AASd-012 See Constraint AASd-065\""@en ;
+    rdfs:comment "Reference to the global unique id of a coded value. See Constraint AASd-012 See Constraint AASd-065"@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/ObjectAttributes
@@ -1956,7 +1956,7 @@ aas:Property rdf:type owl:Class ;
     rdfs:label "has value"^^xsd:string ;
     rdfs:domain aas:Property ;
     rdfs:range xsd:string ;
-    rdfs:comment "The value of the property instance.\n\nSee Constraint AASd-065 See Constraint AASd-007"@en ;
+    rdfs:comment "The value of the property instance.\n\nSee Constraint AASd-065 See Constraint AASd-007"@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/Property/valueId
@@ -1964,7 +1964,7 @@ aas:Property rdf:type owl:Class ;
     rdfs:label "has value id"^^xsd:string ;
     rdfs:domain aas:Property ;
     rdfs:range aas:Reference ;
-    rdfs:comment "Reference to the global unique id of a coded value.\n\nSee Constraint AASd-065 See Constraint AASd-007"@en ;
+    rdfs:comment "Reference to the global unique id of a coded value.\n\nSee Constraint AASd-065 See Constraint AASd-007"@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/Qualifiable

--- a/test_data/rdf_shacl/test_main/v3rc1/input/meta_model.py
+++ b/test_data/rdf_shacl/test_main/v3rc1/input/meta_model.py
@@ -1235,16 +1235,16 @@ class Property(Data_element):
     """
     The value of the property instance.
 
-    See Constraint AASd-065
-    See Constraint AASd-007
+    See :constraintref:`AASd-065`
+    See :constraintref:`AASd-007`
     """
 
     value_ID: Optional["Reference"]
     """
     Reference to the global unique id of a coded value.
 
-    See Constraint AASd-065
-    See Constraint AASd-007
+    See :constraintref:`AASd-065`
+    See :constraintref:`AASd-007`
     """
 
     def __init__(
@@ -1298,21 +1298,21 @@ class Multi_language_property(Data_element):
     ConceptDescription then DataSpecificationIEC61360/dataType shall be
     STRING_TRANSLATABLE.
 
-    See Constraint AASd-065
+    See :constraintref:`AASd-065`
     """
 
     value: Optional["Lang_string_set"]
     """
     The value of the property instance.
-    See Constraint AASd-012
-    See Constraint AASd-065"
+    See :constraintref:`AASd-012`
+    See :constraintref:`AASd-065`
     """
 
     value_ID: Optional["Reference"]
     """
     Reference to the global unique id of a coded value.
-    See Constraint AASd-012
-    See Constraint AASd-065"
+    See :constraintref:`AASd-012`
+    See :constraintref:`AASd-065`
     """
 
     def __init__(
@@ -1525,7 +1525,7 @@ class File(Data_element):
     A File is a data element that represents an address to a file.
     The value is an URI that can represent an absolute or relative path.
 
-    See Constraint AASd-057
+    See :constraintref:`AASd-057`
     """
 
     MIME_type: MIME_typed
@@ -1688,7 +1688,7 @@ class Entity(Submodel_element):
     """
     Reference to an identifier key value pair representing a specific identifier
     of the asset represented by the asset administration shell.
-    See Constraint AASd-014
+    See :constraintref:`AASd-014`
     """
 
     def __init__(


### PR DESCRIPTION
We sync with aas-core-meta and add `:constraintref:` to all test
meta-models to reflect the references to constraints.