### PR TITLE
In-line constrained primitives in JSON Schema

### DIFF
--- a/aas_core_codegen/infer_for_schema/__init__.py
+++ b/aas_core_codegen/infer_for_schema/__init__.py
@@ -1,18 +1,13 @@
 """Infer constraints representable in common schemas such as JSON Schema or XSD."""
 
-from aas_core_codegen.infer_for_schema import _len, _pattern, _stringify
+from aas_core_codegen.infer_for_schema import _len, _pattern, _inline, _stringify
 
 LenConstraint = _len.LenConstraint
-infer_len_constraints_by_class_properties = (
-    _len.infer_len_constraints_by_class_properties
-)
-infer_len_constraint_of_self = _len.infer_len_constraint_of_self
 
 PatternConstraint = _pattern.PatternConstraint
-infer_patterns_by_class_properties = _pattern.infer_patterns_by_class_properties
-infer_patterns_on_self = _pattern.infer_patterns_on_self
-PatternVerificationsByName = _pattern.PatternVerificationsByName
-map_pattern_verifications_by_name = _pattern.map_pattern_verifications_by_name
+
+ConstraintsByProperty = _inline.ConstraintsByProperty
+infer_constraints_by_class = _inline.infer_constraints_by_class
 
 dump = _stringify.dump
 dump_len_constraints_by_properties = _stringify.dump_len_constraints_by_properties

--- a/aas_core_codegen/infer_for_schema/_inline.py
+++ b/aas_core_codegen/infer_for_schema/_inline.py
@@ -1,0 +1,363 @@
+"""Merge constrained primitives as property constraints."""
+
+from typing import Tuple, Optional, List, Mapping, MutableMapping, Sequence
+
+from icontract import ensure
+
+from aas_core_codegen import intermediate
+from aas_core_codegen.common import Error
+from aas_core_codegen.infer_for_schema import (
+    _len as infer_for_schema_len,
+    _pattern as infer_for_schema_pattern,
+)
+
+
+@ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
+def _infer_len_constraints_by_constrained_primitive(
+    symbol_table: intermediate.SymbolTable,
+) -> Tuple[
+    Optional[
+        MutableMapping[
+            intermediate.ConstrainedPrimitive, infer_for_schema_len.LenConstraint
+        ]
+    ],
+    Optional[List[Error]],
+]:
+    """Infer the constraints on ``len(.)`` of the constrained primitives."""
+
+    # NOTE (mristin, 2022-02-11):
+    # We do this inference in two passes. In the first pass, we only infer
+    # the constraints defined for the constrained primitive and ignore the ancestors.
+    # In the second pass, we stack the constraints of the ancestors as well.
+
+    errors = []  # type: List[Error]
+
+    first_pass: MutableMapping[
+        intermediate.ConstrainedPrimitive, infer_for_schema_len.LenConstraint
+    ] = dict()
+
+    for symbol in symbol_table.symbols:
+        if isinstance(symbol, intermediate.ConstrainedPrimitive):
+            (
+                len_constraint,
+                len_constraint_errors,
+            ) = infer_for_schema_len.infer_len_constraint_of_self(
+                constrained_primitive=symbol
+            )
+
+            if len_constraint_errors is not None:
+                errors.extend(len_constraint_errors)
+            else:
+                assert len_constraint is not None
+
+                first_pass[symbol] = len_constraint
+
+    if len(errors) > 0:
+        return None, errors
+
+    second_pass: MutableMapping[
+        intermediate.ConstrainedPrimitive, infer_for_schema_len.LenConstraint
+    ] = dict()
+
+    for symbol in symbol_table.symbols_topologically_sorted:
+        if isinstance(symbol, intermediate.ConstrainedPrimitive):
+            # NOTE (mristin, 2022-02-11):
+            # We make the copy in order to avoid bugs when we start processing
+            # the inheritances.
+            len_constraint = first_pass[symbol].copy()
+
+            for inheritance in symbol.inheritances:
+                inherited_len_constraint = second_pass.get(inheritance, None)
+                assert (
+                    inherited_len_constraint is not None
+                ), "Expected topological order"
+
+                if inherited_len_constraint.min_value is not None:
+                    len_constraint.min_value = (
+                        max(
+                            len_constraint.min_value, inherited_len_constraint.min_value
+                        )
+                        if len_constraint.min_value is not None
+                        else inherited_len_constraint.min_value
+                    )
+
+                if inherited_len_constraint.max_value is not None:
+                    len_constraint.max_value = (
+                        min(
+                            len_constraint.max_value, inherited_len_constraint.max_value
+                        )
+                        if len_constraint.max_value is not None
+                        else inherited_len_constraint.max_value
+                    )
+
+            second_pass[symbol] = len_constraint
+
+    assert len(errors) == 0
+    return second_pass, None
+
+
+def _infer_pattern_constraints_by_constrained_primitive(
+    symbol_table: intermediate.SymbolTable,
+    pattern_verifications_by_name: infer_for_schema_pattern.PatternVerificationsByName,
+) -> MutableMapping[
+    intermediate.ConstrainedPrimitive, List[infer_for_schema_pattern.PatternConstraint]
+]:
+    """Infer the pattern constraints of the constrained strings."""
+
+    # NOTE (mristin, 2022-02-11):
+    # We do this inference in two passes. In the first pass, we only infer
+    # the constraints defined for the constrained primitive and ignore the ancestors.
+    # In the second pass, we stack the constraints of the ancestors as well.
+
+    first_pass: MutableMapping[
+        intermediate.ConstrainedPrimitive,
+        List[infer_for_schema_pattern.PatternConstraint],
+    ] = dict()
+
+    for symbol in symbol_table.symbols:
+        if isinstance(symbol, intermediate.ConstrainedPrimitive):
+            pattern_constraints = infer_for_schema_pattern.infer_patterns_on_self(
+                constrained_primitive=symbol,
+                pattern_verifications_by_name=pattern_verifications_by_name,
+            )
+
+            first_pass[symbol] = pattern_constraints
+
+    second_pass: MutableMapping[
+        intermediate.ConstrainedPrimitive,
+        List[infer_for_schema_pattern.PatternConstraint],
+    ] = dict()
+
+    for symbol in symbol_table.symbols_topologically_sorted:
+        if isinstance(symbol, intermediate.ConstrainedPrimitive):
+            # NOTE (mristin, 2022-02-11):
+            # We make the copy in order to avoid bugs when we start processing
+            # the inheritances.
+            pattern_constraints = first_pass[symbol][:]
+
+            for inheritance in symbol.inheritances:
+                inherited_pattern_constraints = second_pass.get(inheritance, None)
+                assert (
+                    inherited_pattern_constraints is not None
+                ), "Expected topological order"
+
+                pattern_constraints = (
+                    inherited_pattern_constraints + pattern_constraints
+                )
+
+            second_pass[symbol] = pattern_constraints
+
+    return second_pass
+
+
+class ConstraintsByProperty:
+    """
+    Represent all the inferred property constraints of a symbol.
+
+    The constraints coming from the constrained primitives are in-lined and hence also
+    included in this representation.
+    """
+
+    def __init__(
+        self,
+        len_constraints_by_property: Mapping[
+            intermediate.Property, infer_for_schema_len.LenConstraint
+        ],
+        patterns_by_property: Mapping[
+            intermediate.Property, Sequence[infer_for_schema_pattern.PatternConstraint]
+        ],
+    ) -> None:
+        """Initialize with the given values."""
+        self.len_constraints_by_property = len_constraints_by_property
+        self.patterns_by_property = patterns_by_property
+
+
+@ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
+def infer_constraints_by_class(
+    symbol_table: intermediate.SymbolTable,
+) -> Tuple[
+    Optional[MutableMapping[intermediate.ClassUnion, ConstraintsByProperty]],
+    Optional[List[Error]],
+]:
+    """Infer the constraints from the invariants and constrained primitives."""
+    errors = []  # type: List[Error]
+
+    pattern_verifications_by_name = (
+        infer_for_schema_pattern.map_pattern_verifications_by_name(
+            verifications=symbol_table.verification_functions
+        )
+    )
+
+    (
+        len_constraints_by_constrained_primitive,
+        some_errors,
+    ) = _infer_len_constraints_by_constrained_primitive(symbol_table=symbol_table)
+    if some_errors is not None:
+        errors.extend(some_errors)
+
+    if len(errors) > 0:
+        return None, errors
+
+    assert len_constraints_by_constrained_primitive is not None
+
+    patterns_by_constrained_primitive = (
+        _infer_pattern_constraints_by_constrained_primitive(
+            symbol_table=symbol_table,
+            pattern_verifications_by_name=pattern_verifications_by_name,
+        )
+    )
+
+    result: MutableMapping[intermediate.ClassUnion, ConstraintsByProperty] = dict()
+
+    for symbol in symbol_table.symbols:
+        if not isinstance(
+            symbol, (intermediate.AbstractClass, intermediate.ConcreteClass)
+        ):
+            continue
+
+        # region Infer constraints on ``len(.)``
+
+        len_constraints_by_property: MutableMapping[
+            intermediate.Property, infer_for_schema_len.LenConstraint
+        ] = dict()
+
+        (
+            len_constraints_from_invariants,
+            len_constraints_errors,
+        ) = infer_for_schema_len.len_constraints_from_invariants(cls=symbol)
+
+        if len_constraints_errors is not None:
+            errors.extend(len_constraints_errors)
+            continue
+
+        assert len_constraints_from_invariants is not None
+
+        patterns_by_property: MutableMapping[
+            intermediate.Property, List[infer_for_schema_pattern.PatternConstraint]
+        ] = dict()
+
+        patterns_from_invariants_by_property = (
+            infer_for_schema_pattern.patterns_from_invariants(
+                cls=symbol, pattern_verifications_by_name=pattern_verifications_by_name
+            )
+        )
+
+        for prop in symbol.properties:
+            # NOTE (mristin, 2022-03-3):
+            # We need to go beneath ``Optional`` as the constraints are applied even
+            # if a property is optional. In cases where cardinality is affected by
+            # ``Optional``, the client code needs to cover them separately.
+            type_anno = intermediate.beneath_optional(prop.type_annotation)
+
+            len_constraint_from_type: Optional[
+                infer_for_schema_len.LenConstraint
+            ] = None
+
+            len_constraint_from_invariants = len_constraints_from_invariants.get(
+                prop, None
+            )
+
+            if isinstance(type_anno, intermediate.OurTypeAnnotation) and isinstance(
+                type_anno.symbol, intermediate.ConstrainedPrimitive
+            ):
+                len_constraint_from_type = len_constraints_by_constrained_primitive.get(
+                    type_anno.symbol, None
+                )
+
+            # Merge the constraint from the type and from the invariants
+
+            if (
+                len_constraint_from_type is None
+                and len_constraint_from_invariants is None
+            ):
+                continue
+
+            elif (
+                len_constraint_from_type is not None
+                and len_constraint_from_invariants is None
+            ):
+                len_constraints_by_property[prop] = len_constraint_from_type
+
+            elif (
+                len_constraint_from_type is None
+                and len_constraint_from_invariants is not None
+            ):
+                len_constraints_by_property[prop] = len_constraint_from_invariants
+
+            elif (
+                len_constraint_from_type is not None
+                and len_constraint_from_invariants is not None
+            ):
+                # NOTE (mristin, 2022-03-2):
+                # We have to make the bounds *stricter* since both
+                # the type constraints and the invariant(s) need to be satisfied.
+
+                min_value = infer_for_schema_len.max_with_none(
+                    len_constraint_from_type.min_value,
+                    len_constraint_from_invariants.min_value,
+                )
+
+                max_value = infer_for_schema_len.min_with_none(
+                    len_constraint_from_type.max_value,
+                    len_constraint_from_invariants.max_value,
+                )
+
+                if (
+                    min_value is not None
+                    and max_value is not None
+                    and min_value > max_value
+                ):
+                    errors.append(
+                        Error(
+                            symbol.parsed.node,
+                            f"The inferred minimum and maximum value on len(.) "
+                            f"is contradictory: "
+                            f"minimum = {min_value}, maximum = {max_value}; "
+                            f"please check the invariants and "
+                            f"any involved constrained primitives",
+                        )
+                    )
+                    continue
+
+                len_constraints_by_property[prop] = infer_for_schema_len.LenConstraint(
+                    min_value=min_value, max_value=max_value
+                )
+
+            else:
+                raise AssertionError(
+                    f"Unhandled case: "
+                    f"{len_constraint_from_type=}, {len_constraint_from_invariants}"
+                )
+
+            # endregion
+
+            # region Infer constraints on string patterns
+
+            patterns_from_type: List[infer_for_schema_pattern.PatternConstraint] = []
+            patterns_from_invariants = patterns_from_invariants_by_property.get(
+                prop, []
+            )
+
+            if isinstance(type_anno, intermediate.OurTypeAnnotation) and isinstance(
+                type_anno.symbol, intermediate.ConstrainedPrimitive
+            ):
+                patterns_from_type = patterns_by_constrained_primitive.get(
+                    type_anno.symbol, []
+                )
+
+            merged = patterns_from_type + patterns_from_invariants
+
+            if len(merged) > 0:
+                patterns_by_property[prop] = merged
+
+        # endregion
+
+        if len(errors) > 0:
+            return None, errors
+
+        result[symbol] = ConstraintsByProperty(
+            len_constraints_by_property=len_constraints_by_property,
+            patterns_by_property=patterns_by_property,
+        )
+
+    return result, None

--- a/aas_core_codegen/infer_for_schema/_pattern.py
+++ b/aas_core_codegen/infer_for_schema/_pattern.py
@@ -112,7 +112,7 @@ def _match_constraint_on_property(
     )
 
 
-def infer_patterns_by_class_properties(
+def patterns_from_invariants(
     cls: intermediate.Class,
     pattern_verifications_by_name: PatternVerificationsByName,
 ) -> MutableMapping[intermediate.Property, List[PatternConstraint]]:

--- a/aas_core_codegen/intermediate/__init__.py
+++ b/aas_core_codegen/intermediate/__init__.py
@@ -40,6 +40,7 @@ Signature = _types.Signature
 Interface = _types.Interface
 SymbolTable = _types.SymbolTable
 
+beneath_optional = _types.beneath_optional
 map_descendability = _types.map_descendability
 collect_ids_of_symbols_in_properties = _types.collect_ids_of_symbols_in_properties
 

--- a/aas_core_codegen/intermediate/_types.py
+++ b/aas_core_codegen/intermediate/_types.py
@@ -131,8 +131,22 @@ TypeAnnotationUnion = Union[
     OptionalTypeAnnotation,
 ]
 
+
 assert_union_of_descendants_exhaustive(
     union=TypeAnnotationUnion, base_class=TypeAnnotation
+)
+
+
+TypeAnnotationExceptOptional = Union[
+    PrimitiveTypeAnnotation,
+    OurTypeAnnotation,
+    ListTypeAnnotation,
+]
+
+assert_union_without_excluded(
+    original_union=TypeAnnotationUnion,
+    subset_union=TypeAnnotationExceptOptional,
+    excluded=[OptionalTypeAnnotation],
 )
 
 
@@ -167,6 +181,19 @@ def type_annotations_equal(
         assert_never(that)
 
     raise AssertionError("Should not have gotten here")
+
+
+def beneath_optional(
+    type_annotation: TypeAnnotationUnion,
+) -> TypeAnnotationExceptOptional:
+    """Descend below ``Optional[...]`` to the underlying type."""
+    type_anno = type_annotation
+    while isinstance(type_anno, OptionalTypeAnnotation):
+        type_anno = type_anno.value
+
+    assert not isinstance(type_anno, OptionalTypeAnnotation)
+
+    return type_anno
 
 
 class Description:

--- a/aas_core_codegen/rdf_shacl/common.py
+++ b/aas_core_codegen/rdf_shacl/common.py
@@ -1,16 +1,15 @@
 """Provide common functions for both RDF and SHACL generators."""
-from typing import MutableMapping, Tuple, Optional, List, Union
+from typing import MutableMapping, Tuple, Optional, List
 
 from icontract import ensure
 
 from aas_core_codegen import intermediate, specific_implementations
-from aas_core_codegen.rdf_shacl import naming as rdf_shacl_naming
 from aas_core_codegen.common import (
     Stripped,
     Error,
-    assert_union_without_excluded,
     assert_never,
 )
+from aas_core_codegen.rdf_shacl import naming as rdf_shacl_naming
 
 INDENT = "    "
 INDENT2 = INDENT * 2
@@ -127,28 +126,3 @@ PRIMITIVE_MAP = {
     intermediate.PrimitiveType.BYTEARRAY: "xsd:byte",
 }
 assert all(literal in PRIMITIVE_MAP for literal in intermediate.PrimitiveType)
-
-TypeAnnotationExceptOptional = Union[
-    intermediate.PrimitiveTypeAnnotation,
-    intermediate.OurTypeAnnotation,
-    intermediate.ListTypeAnnotation,
-]
-
-assert_union_without_excluded(
-    original_union=intermediate.TypeAnnotationUnion,
-    subset_union=TypeAnnotationExceptOptional,
-    excluded=[intermediate.OptionalTypeAnnotation],
-)
-
-
-def beneath_optional(
-    type_annotation: intermediate.TypeAnnotationUnion,
-) -> TypeAnnotationExceptOptional:
-    """Descend below ``Optional[...]`` to the underlying type."""
-    type_anno = type_annotation
-    while isinstance(type_anno, intermediate.OptionalTypeAnnotation):
-        type_anno = type_anno.value
-
-    assert not isinstance(type_anno, intermediate.OptionalTypeAnnotation)
-
-    return type_anno

--- a/aas_core_codegen/rdf_shacl/rdf.py
+++ b/aas_core_codegen/rdf_shacl/rdf.py
@@ -177,7 +177,7 @@ def _define_property(
     class_to_rdfs_range: rdf_shacl_common.ClassToRdfsRange,
 ) -> Tuple[Optional[Stripped], Optional[Error]]:
     """Generate the definition of a property ``prop`` of the intermediate ``symbol``."""
-    type_anno = rdf_shacl_common.beneath_optional(prop.type_annotation)
+    type_anno = intermediate.beneath_optional(prop.type_annotation)
 
     cls_name = rdf_shacl_naming.class_name(cls.name)
     rdfs_domain = f"aas:{cls_name}"
@@ -205,7 +205,7 @@ def _define_property(
         rdf_type = "owl:DatatypeProperty"
 
     elif isinstance(type_anno, intermediate.ListTypeAnnotation):
-        type_anno_items = rdf_shacl_common.beneath_optional(type_anno.items)
+        type_anno_items = intermediate.beneath_optional(type_anno.items)
 
         if isinstance(type_anno_items, intermediate.OurTypeAnnotation):
             rdf_type = "owl:ObjectProperty"

--- a/test_data/jsonschema/test_main/v3rc1/expected_output/schema.json
+++ b/test_data/jsonschema/test_main/v3rc1/expected_output/schema.json
@@ -9,21 +9,6 @@
     }
   ],
   "definitions": {
-    "NonEmptyString": {
-      "type": "string",
-      "minLength": 1
-    },
-    "MimeTyped": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/NonEmptyString"
-        },
-        {
-          "type": "string",
-          "pattern": "([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+/([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+([ \t]*;[ \t]*([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+=(([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+|\"(([\t !#-\\[\\]-~]|[\\x80-\\xff])|\\\\([\t !-~]|[\\x80-\\xff]))*\"))*"
-        }
-      ]
-    },
     "HasSemantics": {
       "type": "object",
       "properties": {
@@ -40,7 +25,8 @@
         {
           "properties": {
             "name": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "valueType": {
               "$ref": "#/definitions/DataTypeDef"
@@ -77,20 +63,16 @@
         {
           "properties": {
             "idShort": {
-              "allOf": [
-                {
-                  "$ref": "#/definitions/NonEmptyString"
-                },
-                {
-                  "pattern": "^[a-zA-Z][a-zA-Z_0-9]*$"
-                }
-              ]
+              "type": "string",
+              "minLength": 1,
+              "pattern": "^[a-zA-Z][a-zA-Z_0-9]*$"
             },
             "displayName": {
               "$ref": "#/definitions/LangStringSet"
             },
             "category": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "description": {
               "$ref": "#/definitions/LangStringSet"
@@ -133,7 +115,8 @@
           "$ref": "#/definitions/IdentifierType"
         },
         "id": {
-          "$ref": "#/definitions/NonEmptyString"
+          "type": "string",
+          "minLength": 1
         }
       },
       "required": [
@@ -183,10 +166,12 @@
         {
           "properties": {
             "version": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "revision": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             }
           }
         }
@@ -235,7 +220,8 @@
         {
           "properties": {
             "type": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "valueType": {
               "$ref": "#/definitions/DataTypeDef"
@@ -363,10 +349,12 @@
         {
           "properties": {
             "key": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "value": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "externalSubjectId": {
               "$ref": "#/definitions/Reference"
@@ -603,7 +591,9 @@
         {
           "properties": {
             "mimeType": {
-              "$ref": "#/definitions/MimeTyped"
+              "type": "string",
+              "minLength": 1,
+              "pattern": "([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+/([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+([ \t]*;[ \t]*([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+=(([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+|\"(([\t !#-\\[\\]-~]|[\\x80-\\xff])|\\\\([\t !-~]|[\\x80-\\xff]))*\"))*"
             },
             "value": {
               "type": "string"
@@ -623,7 +613,9 @@
         {
           "properties": {
             "mimeType": {
-              "$ref": "#/definitions/MimeTyped"
+              "type": "string",
+              "minLength": 1,
+              "pattern": "([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+/([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+([ \t]*;[ \t]*([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+=(([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+|\"(([\t !#-\\[\\]-~]|[\\x80-\\xff])|\\\\([\t !-~]|[\\x80-\\xff]))*\"))*"
             },
             "value": {
               "type": "string"
@@ -816,7 +808,8 @@
           "$ref": "#/definitions/KeyElements"
         },
         "value": {
-          "$ref": "#/definitions/NonEmptyString"
+          "type": "string",
+          "minLength": 1
         },
         "idType": {
           "$ref": "#/definitions/KeyType"
@@ -1015,16 +1008,19 @@
               "$ref": "#/definitions/LangStringSet"
             },
             "unit": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "unitId": {
               "$ref": "#/definitions/Reference"
             },
             "sourceOfDefinition": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "symbol": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "dataType": {
               "$ref": "#/definitions/DataTypeIEC61360"
@@ -1033,7 +1029,8 @@
               "$ref": "#/definitions/LangStringSet"
             },
             "valueFormat": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "valueList": {
               "$ref": "#/definitions/ValueList"
@@ -1059,40 +1056,51 @@
         {
           "properties": {
             "unitName": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "unitSymbol": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "definition": {
               "$ref": "#/definitions/LangStringSet"
             },
             "siNotation": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "dinNotation": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "eceName": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "eceCode": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "nistName": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "sourceOfDefinition": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "conversionFactor": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "registrationAuthorityId": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "supplier": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             }
           }
         }

--- a/test_data/jsonschema/test_main/v3rc2/expected_output/schema.json
+++ b/test_data/jsonschema/test_main/v3rc2/expected_output/schema.json
@@ -9,21 +9,6 @@
     }
   ],
   "definitions": {
-    "NonEmptyString": {
-      "type": "string",
-      "minLength": 1
-    },
-    "MimeTyped": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/NonEmptyString"
-        },
-        {
-          "type": "string",
-          "pattern": "([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+/([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+([ \t]*;[ \t]*([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+=(([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+|\"(([\t !#-\\[\\]-~]|[\\x80-\\xff])|\\\\([\t !-~]|[\\x80-\\xff]))*\"))*"
-        }
-      ]
-    },
     "HasSemantics": {
       "type": "object",
       "properties": {
@@ -40,13 +25,15 @@
         {
           "properties": {
             "name": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "valueType": {
               "$ref": "#/definitions/DataTypeDef"
             },
             "value": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "refersTo": {
               "$ref": "#/definitions/Reference_abstract"
@@ -80,13 +67,15 @@
         {
           "properties": {
             "idShort": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "displayName": {
               "$ref": "#/definitions/LangStringSet"
             },
             "category": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "description": {
               "$ref": "#/definitions/LangStringSet"
@@ -109,7 +98,8 @@
         {
           "properties": {
             "id": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "administration": {
               "$ref": "#/definitions/AdministrativeInformation"
@@ -158,10 +148,12 @@
         {
           "properties": {
             "version": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "revision": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             }
           }
         }
@@ -217,13 +209,15 @@
         {
           "properties": {
             "type": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "valueType": {
               "$ref": "#/definitions/DataTypeDef"
             },
             "value": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "valueId": {
               "$ref": "#/definitions/Reference_abstract"
@@ -321,10 +315,12 @@
         {
           "properties": {
             "key": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "value": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "externalSubjectId": {
               "$ref": "#/definitions/Reference_abstract"
@@ -538,7 +534,8 @@
               "$ref": "#/definitions/DataTypeDef"
             },
             "value": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "valueId": {
               "$ref": "#/definitions/Reference_abstract"
@@ -578,10 +575,12 @@
               "$ref": "#/definitions/DataTypeDef"
             },
             "min": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "max": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             }
           },
           "required": [
@@ -614,7 +613,11 @@
             "mimeType": {
               "allOf": [
                 {
-                  "$ref": "#/definitions/MimeTyped"
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "pattern": "([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+/([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+([ \t]*;[ \t]*([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+=(([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+|\"(([\t !#-\\[\\]-~]|[\\x80-\\xff])|\\\\([\t !-~]|[\\x80-\\xff]))*\"))*"
                 },
                 {
                   "pattern": "([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+/([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+([ \t]*;[ \t]*([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+=(([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+|\"(([\t !#-\\[\\]-~]|[\\x80-\\xff])|\\\\([\t !-~]|[\\x80-\\xff]))*\"))*"
@@ -641,7 +644,11 @@
             "mimeType": {
               "allOf": [
                 {
-                  "$ref": "#/definitions/MimeTyped"
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "pattern": "([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+/([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+([ \t]*;[ \t]*([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+=(([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+|\"(([\t !#-\\[\\]-~]|[\\x80-\\xff])|\\\\([\t !-~]|[\\x80-\\xff]))*\"))*"
                 },
                 {
                   "pattern": "([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+/([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+([ \t]*;[ \t]*([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+=(([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+|\"(([\t !#-\\[\\]-~]|[\\x80-\\xff])|\\\\([\t !-~]|[\\x80-\\xff]))*\"))*"
@@ -649,7 +656,8 @@
               ]
             },
             "value": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             }
           },
           "required": [
@@ -863,7 +871,7 @@
             "values": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/NonEmptyString"
+                "type": "string"
               },
               "minItems": 1
             }
@@ -905,7 +913,8 @@
           "$ref": "#/definitions/KeyElements"
         },
         "value": {
-          "$ref": "#/definitions/NonEmptyString"
+          "type": "string",
+          "minLength": 1
         }
       },
       "required": [
@@ -1086,7 +1095,8 @@
       "type": "object",
       "properties": {
         "value": {
-          "$ref": "#/definitions/NonEmptyString"
+          "type": "string",
+          "minLength": 1
         },
         "valueId": {
           "$ref": "#/definitions/Reference_abstract"
@@ -1125,16 +1135,19 @@
               "$ref": "#/definitions/LangStringSet"
             },
             "unit": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "unitId": {
               "$ref": "#/definitions/Reference_abstract"
             },
             "sourceOfDefinition": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "symbol": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "dataType": {
               "$ref": "#/definitions/DataTypeIec61360"
@@ -1143,13 +1156,15 @@
               "$ref": "#/definitions/LangStringSet"
             },
             "valueFormat": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "valueList": {
               "$ref": "#/definitions/ValueList"
             },
             "value": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "valueId": {
               "$ref": "#/definitions/Reference_abstract"
@@ -1169,40 +1184,51 @@
         {
           "properties": {
             "unitName": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "unitSymbol": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "definition": {
               "$ref": "#/definitions/LangStringSet"
             },
             "siNotation": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "dinNotation": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "eceName": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "eceCode": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "nistName": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "sourceOfDefinition": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "conversionFactor": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "registrationAuthorityId": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             },
             "supplier": {
-              "$ref": "#/definitions/NonEmptyString"
+              "type": "string",
+              "minLength": 1
             }
           }
         }

--- a/tests/infer_for_schema/test_len_on_properties.py
+++ b/tests/infer_for_schema/test_len_on_properties.py
@@ -8,6 +8,7 @@ from icontract import ensure
 
 import tests.common
 from aas_core_codegen import intermediate, infer_for_schema
+from aas_core_codegen.infer_for_schema import _len as infer_for_schema_len
 from aas_core_codegen.common import Identifier, Error
 
 
@@ -15,7 +16,7 @@ from aas_core_codegen.common import Identifier, Error
 def infer_constraints_by_properties_of_class_something(
     source: str,
 ) -> Tuple[
-    Optional[MutableMapping[intermediate.Property, infer_for_schema.LenConstraint]],
+    Optional[MutableMapping[intermediate.Property, infer_for_schema_len.LenConstraint]],
     Optional[List[Error]],
 ]:
     """Translate the ``source`` into inferred constraints of the class ``Something``."""
@@ -25,7 +26,7 @@ def infer_constraints_by_properties_of_class_something(
     symbol = symbol_table.must_find(Identifier("Something"))
     assert isinstance(symbol, intermediate.Class)
 
-    result = infer_for_schema.infer_len_constraints_by_class_properties(cls=symbol)
+    result = infer_for_schema_len.len_constraints_from_invariants(cls=symbol)
 
     return result
 

--- a/tests/infer_for_schema/test_len_on_self.py
+++ b/tests/infer_for_schema/test_len_on_self.py
@@ -8,13 +8,14 @@ from icontract import ensure
 
 import tests.common
 from aas_core_codegen import intermediate, infer_for_schema
+from aas_core_codegen.infer_for_schema import _len as infer_for_schema_len
 from aas_core_codegen.common import Identifier, Error
 
 
 @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
 def infer_constraints_on_self_of_class_something(
     source: str,
-) -> Tuple[Optional[infer_for_schema.LenConstraint], Optional[List[Error]]]:
+) -> Tuple[Optional[infer_for_schema_len.LenConstraint], Optional[List[Error]]]:
     """Translate the ``source`` into inferred constraints on the class ``Something``."""
     symbol_table, error = tests.common.translate_source_to_intermediate(source=source)
     assert error is None, tests.common.most_underlying_messages(error)
@@ -22,7 +23,9 @@ def infer_constraints_on_self_of_class_something(
     symbol = symbol_table.must_find(Identifier("Something"))
     assert isinstance(symbol, intermediate.ConstrainedPrimitive)
 
-    result = infer_for_schema.infer_len_constraint_of_self(constrained_primitive=symbol)
+    result = infer_for_schema_len.infer_len_constraint_of_self(
+        constrained_primitive=symbol
+    )
 
     return result
 

--- a/tests/infer_for_schema/test_patterns_on_properties.py
+++ b/tests/infer_for_schema/test_patterns_on_properties.py
@@ -6,12 +6,15 @@ from typing import MutableMapping, List
 
 import tests.common
 from aas_core_codegen import intermediate, infer_for_schema
+from aas_core_codegen.infer_for_schema import _pattern as infer_for_schema_pattern
 from aas_core_codegen.common import Identifier
 
 
 def infer_patterns_by_properties_of_class_something(
     source: str,
-) -> MutableMapping[intermediate.Property, List[infer_for_schema.PatternConstraint]]:
+) -> MutableMapping[
+    intermediate.Property, List[infer_for_schema_pattern.PatternConstraint]
+]:
     """Translate the ``source`` into inferred constraints of the class ``Something``."""
     symbol_table, error = tests.common.translate_source_to_intermediate(source=source)
     assert error is None, tests.common.most_underlying_messages(error)
@@ -19,11 +22,13 @@ def infer_patterns_by_properties_of_class_something(
     symbol = symbol_table.must_find(Identifier("Something"))
     assert isinstance(symbol, intermediate.Class)
 
-    pattern_verifications_by_name = infer_for_schema.map_pattern_verifications_by_name(
-        verifications=symbol_table.verification_functions
+    pattern_verifications_by_name = (
+        infer_for_schema_pattern.map_pattern_verifications_by_name(
+            verifications=symbol_table.verification_functions
+        )
     )
 
-    return infer_for_schema.infer_patterns_by_class_properties(
+    return infer_for_schema_pattern.patterns_from_invariants(
         cls=symbol, pattern_verifications_by_name=pattern_verifications_by_name
     )
 

--- a/tests/infer_for_schema/test_patterns_on_self.py
+++ b/tests/infer_for_schema/test_patterns_on_self.py
@@ -6,12 +6,13 @@ from typing import MutableMapping, List
 
 import tests.common
 from aas_core_codegen import intermediate, infer_for_schema
+from aas_core_codegen.infer_for_schema import _pattern as infer_for_schema_pattern
 from aas_core_codegen.common import Identifier
 
 
 def infer_patterns_on_self_of_class_something(
     source: str,
-) -> List[infer_for_schema.PatternConstraint]:
+) -> List[infer_for_schema_pattern.PatternConstraint]:
     """Translate the ``source`` into inferred constraints of the class ``Something``."""
     symbol_table, error = tests.common.translate_source_to_intermediate(source=source)
     assert error is None, tests.common.most_underlying_messages(error)
@@ -19,11 +20,13 @@ def infer_patterns_on_self_of_class_something(
     symbol = symbol_table.must_find(Identifier("Something"))
     assert isinstance(symbol, intermediate.ConstrainedPrimitive)
 
-    pattern_verifications_by_name = infer_for_schema.map_pattern_verifications_by_name(
-        verifications=symbol_table.verification_functions
+    pattern_verifications_by_name = (
+        infer_for_schema_pattern.map_pattern_verifications_by_name(
+            verifications=symbol_table.verification_functions
+        )
     )
 
-    return infer_for_schema.infer_patterns_on_self(
+    return infer_for_schema_pattern.infer_patterns_on_self(
         constrained_primitive=symbol,
         pattern_verifications_by_name=pattern_verifications_by_name,
     )


### PR DESCRIPTION
Since the JSON schema is going to be also used for OpenAPI 3 schema, we
should not introduce additional definitions. Therefore we in-line the
constraints of constrained primitives in the actual properties of the
objects.

This change also had repercussions on SHACL generation as we in-line
the constrained primitives there as well.