### PR TITLE
Remove `*_abstract` definitions from JSON

### DIFF
--- a/aas_core_codegen/jsonschema/main.py
+++ b/aas_core_codegen/jsonschema/main.py
@@ -141,9 +141,7 @@ def _define_type(
         elif isinstance(type_annotation.symbol, intermediate.Class):
             if type_annotation.symbol.interface is not None:
                 return (
-                    collections.OrderedDict(
-                        [("$ref", f"#/definitions/{model_type}_abstract")]
-                    ),
+                    collections.OrderedDict([("$ref", f"#/definitions/{model_type}")]),
                     None,
                 )
             else:
@@ -346,25 +344,6 @@ def _define_for_class(
         result[model_type] = all_of[0]
     else:
         result[model_type] = {"allOf": all_of}
-
-    # region Define the abstract part
-
-    # NOTE (mristin, 2022-01-02):
-    # We generate the "*_abstract" definition of a class only if it is used to specify
-    # the type of one or more properties in the meta-model. Otherwise, we can ignore
-    # the abstract definition as it wouldn't be used during the validation.
-
-    if len(cls.concrete_descendants) > 0 and id(cls) in ids_of_classes_in_properties:
-        model_type_abstract = f"{model_type}_abstract"
-
-        one_of = [
-            {"$ref": f"#/definitions/{naming.json_model_type(descendant.name)}"}
-            for descendant in cls.concrete_descendants
-        ]  # type: List[MutableMapping[str, Any]]
-
-        result[model_type_abstract] = {"oneOf": one_of}
-
-    # endregion
 
     return result, None
 

--- a/test_data/jsonschema/test_main/v3rc1/expected_output/schema.json
+++ b/test_data/jsonschema/test_main/v3rc1/expected_output/schema.json
@@ -183,7 +183,7 @@
         "qualifiers": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Constraint_abstract"
+            "$ref": "#/definitions/Constraint"
           }
         }
       }
@@ -197,16 +197,6 @@
       },
       "required": [
         "modelType"
-      ]
-    },
-    "Constraint_abstract": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/Formula"
-        },
-        {
-          "$ref": "#/definitions/Qualifier"
-        }
       ]
     },
     "Qualifier": {
@@ -390,7 +380,7 @@
             "submodelElements": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/SubmodelElement_abstract"
+                "$ref": "#/definitions/SubmodelElement"
               }
             }
           }
@@ -413,49 +403,6 @@
         },
         {
           "$ref": "#/definitions/HasDataSpecification"
-        }
-      ]
-    },
-    "SubmodelElement_abstract": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/RelationshipElement"
-        },
-        {
-          "$ref": "#/definitions/AnnotatedRelationshipElement"
-        },
-        {
-          "$ref": "#/definitions/BasicEvent"
-        },
-        {
-          "$ref": "#/definitions/Blob"
-        },
-        {
-          "$ref": "#/definitions/Capability"
-        },
-        {
-          "$ref": "#/definitions/Entity"
-        },
-        {
-          "$ref": "#/definitions/File"
-        },
-        {
-          "$ref": "#/definitions/MultiLanguageProperty"
-        },
-        {
-          "$ref": "#/definitions/Operation"
-        },
-        {
-          "$ref": "#/definitions/Property"
-        },
-        {
-          "$ref": "#/definitions/Range"
-        },
-        {
-          "$ref": "#/definitions/ReferenceElement"
-        },
-        {
-          "$ref": "#/definitions/SubmodelElementCollection"
         }
       ]
     },
@@ -490,7 +437,7 @@
             "value": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/SubmodelElement_abstract"
+                "$ref": "#/definitions/SubmodelElement"
               }
             },
             "ordered": {
@@ -664,7 +611,7 @@
             "statements": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/SubmodelElement_abstract"
+                "$ref": "#/definitions/SubmodelElement"
               }
             },
             "globalAssetId": {
@@ -733,7 +680,7 @@
       "type": "object",
       "properties": {
         "value": {
-          "$ref": "#/definitions/SubmodelElement_abstract"
+          "$ref": "#/definitions/SubmodelElement"
         }
       },
       "required": [
@@ -1121,13 +1068,6 @@
         "modelType"
       ]
     },
-    "Certificate_abstract": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/BlobCertificate"
-        }
-      ]
-    },
     "BlobCertificate": {
       "allOf": [
         {
@@ -1363,7 +1303,7 @@
         "certificates": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Certificate_abstract"
+            "$ref": "#/definitions/Certificate"
           }
         },
         "requiredCertificateExtensions": {

--- a/test_data/jsonschema/test_main/v3rc2/expected_output/schema.json
+++ b/test_data/jsonschema/test_main/v3rc2/expected_output/schema.json
@@ -13,7 +13,7 @@
       "type": "object",
       "properties": {
         "semanticId": {
-          "$ref": "#/definitions/Reference_abstract"
+          "$ref": "#/definitions/Reference"
         }
       }
     },
@@ -36,7 +36,7 @@
               "minLength": 1
             },
             "refersTo": {
-              "$ref": "#/definitions/Reference_abstract"
+              "$ref": "#/definitions/Reference"
             }
           },
           "required": [
@@ -132,7 +132,7 @@
         "dataSpecifications": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Reference_abstract"
+            "$ref": "#/definitions/Reference"
           }
         }
       },
@@ -170,23 +170,13 @@
         "modelType"
       ]
     },
-    "Constraint_abstract": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/Formula"
-        },
-        {
-          "$ref": "#/definitions/Qualifier"
-        }
-      ]
-    },
     "Qualifiable": {
       "type": "object",
       "properties": {
         "qualifiers": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Constraint_abstract"
+            "$ref": "#/definitions/Constraint"
           }
         },
         "modelType": {
@@ -220,7 +210,7 @@
               "minLength": 1
             },
             "valueId": {
-              "$ref": "#/definitions/Reference_abstract"
+              "$ref": "#/definitions/Reference"
             }
           },
           "required": [
@@ -240,7 +230,7 @@
             "dependsOn": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/Reference_abstract"
+                "$ref": "#/definitions/Reference"
               }
             }
           },
@@ -261,7 +251,7 @@
         {
           "properties": {
             "derivedFrom": {
-              "$ref": "#/definitions/Reference_abstract"
+              "$ref": "#/definitions/Reference"
             },
             "assetInformation": {
               "$ref": "#/definitions/AssetInformation"
@@ -269,7 +259,7 @@
             "submodels": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/Reference_abstract"
+                "$ref": "#/definitions/Reference"
               }
             }
           },
@@ -287,7 +277,7 @@
           "$ref": "#/definitions/AssetKind"
         },
         "globalAssetId": {
-          "$ref": "#/definitions/Reference_abstract"
+          "$ref": "#/definitions/Reference"
         },
         "specificAssetId": {
           "$ref": "#/definitions/IdentifierKeyValuePair"
@@ -323,7 +313,7 @@
               "minLength": 1
             },
             "externalSubjectId": {
-              "$ref": "#/definitions/Reference_abstract"
+              "$ref": "#/definitions/Reference"
             }
           },
           "required": [
@@ -355,7 +345,7 @@
             "submodelElements": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/SubmodelElement_abstract"
+                "$ref": "#/definitions/SubmodelElement"
               }
             }
           },
@@ -384,49 +374,6 @@
         }
       ]
     },
-    "SubmodelElement_abstract": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/AnnotatedRelationshipElement"
-        },
-        {
-          "$ref": "#/definitions/BasicEvent"
-        },
-        {
-          "$ref": "#/definitions/Blob"
-        },
-        {
-          "$ref": "#/definitions/Capability"
-        },
-        {
-          "$ref": "#/definitions/Entity"
-        },
-        {
-          "$ref": "#/definitions/File"
-        },
-        {
-          "$ref": "#/definitions/MultiLanguageProperty"
-        },
-        {
-          "$ref": "#/definitions/Operation"
-        },
-        {
-          "$ref": "#/definitions/Property"
-        },
-        {
-          "$ref": "#/definitions/Range"
-        },
-        {
-          "$ref": "#/definitions/ReferenceElement"
-        },
-        {
-          "$ref": "#/definitions/SubmodelElementList"
-        },
-        {
-          "$ref": "#/definitions/SubmodelElementStruct"
-        }
-      ]
-    },
     "RelationshipElement": {
       "allOf": [
         {
@@ -435,10 +382,10 @@
         {
           "properties": {
             "first": {
-              "$ref": "#/definitions/Reference_abstract"
+              "$ref": "#/definitions/Reference"
             },
             "second": {
-              "$ref": "#/definitions/Reference_abstract"
+              "$ref": "#/definitions/Reference"
             }
           },
           "required": [
@@ -461,11 +408,11 @@
             "values": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/SubmodelElement_abstract"
+                "$ref": "#/definitions/SubmodelElement"
               }
             },
             "semanticIdValues": {
-              "$ref": "#/definitions/Reference_abstract"
+              "$ref": "#/definitions/Reference"
             },
             "valueTypeValues": {
               "$ref": "#/definitions/DataTypeDef"
@@ -488,7 +435,7 @@
             "values": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/SubmodelElement_abstract"
+                "$ref": "#/definitions/SubmodelElement"
               }
             }
           },
@@ -500,28 +447,6 @@
     },
     "DataElement": {
       "$ref": "#/definitions/SubmodelElement"
-    },
-    "DataElement_abstract": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/Blob"
-        },
-        {
-          "$ref": "#/definitions/File"
-        },
-        {
-          "$ref": "#/definitions/MultiLanguageProperty"
-        },
-        {
-          "$ref": "#/definitions/Property"
-        },
-        {
-          "$ref": "#/definitions/Range"
-        },
-        {
-          "$ref": "#/definitions/ReferenceElement"
-        }
-      ]
     },
     "Property": {
       "allOf": [
@@ -538,7 +463,7 @@
               "minLength": 1
             },
             "valueId": {
-              "$ref": "#/definitions/Reference_abstract"
+              "$ref": "#/definitions/Reference"
             }
           },
           "required": [
@@ -558,7 +483,7 @@
               "$ref": "#/definitions/LangStringSet"
             },
             "valueId": {
-              "$ref": "#/definitions/Reference_abstract"
+              "$ref": "#/definitions/Reference"
             }
           }
         }
@@ -597,7 +522,7 @@
         {
           "properties": {
             "value": {
-              "$ref": "#/definitions/Reference_abstract"
+              "$ref": "#/definitions/Reference"
             }
           }
         }
@@ -676,7 +601,7 @@
             "annotation": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/DataElement_abstract"
+                "$ref": "#/definitions/DataElement"
               }
             }
           },
@@ -706,11 +631,11 @@
             "statements": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/SubmodelElement_abstract"
+                "$ref": "#/definitions/SubmodelElement"
               }
             },
             "globalAssetId": {
-              "$ref": "#/definitions/Reference_abstract"
+              "$ref": "#/definitions/Reference"
             },
             "specificAssetId": {
               "$ref": "#/definitions/IdentifierKeyValuePair"
@@ -734,7 +659,7 @@
         {
           "properties": {
             "observed": {
-              "$ref": "#/definitions/Reference_abstract"
+              "$ref": "#/definitions/Reference"
             }
           },
           "required": [
@@ -781,7 +706,7 @@
       "type": "object",
       "properties": {
         "value": {
-          "$ref": "#/definitions/SubmodelElement_abstract"
+          "$ref": "#/definitions/SubmodelElement"
         }
       },
       "required": [
@@ -804,7 +729,7 @@
             "isCaseOf": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/Reference_abstract"
+                "$ref": "#/definitions/Reference"
               }
             }
           },
@@ -830,7 +755,7 @@
             "containedElements": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/Reference_abstract"
+                "$ref": "#/definitions/Reference"
               }
             }
           },
@@ -849,16 +774,6 @@
       },
       "required": [
         "modelType"
-      ]
-    },
-    "Reference_abstract": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/GlobalReference"
-        },
-        {
-          "$ref": "#/definitions/ModelReference"
-        }
       ]
     },
     "GlobalReference": {
@@ -897,7 +812,7 @@
               "minItems": 1
             },
             "referredSemanticId": {
-              "$ref": "#/definitions/Reference_abstract"
+              "$ref": "#/definitions/Reference"
             }
           },
           "required": [
@@ -1099,7 +1014,7 @@
           "minLength": 1
         },
         "valueId": {
-          "$ref": "#/definitions/Reference_abstract"
+          "$ref": "#/definitions/Reference"
         }
       },
       "required": [
@@ -1139,7 +1054,7 @@
               "minLength": 1
             },
             "unitId": {
-              "$ref": "#/definitions/Reference_abstract"
+              "$ref": "#/definitions/Reference"
             },
             "sourceOfDefinition": {
               "type": "string",
@@ -1167,7 +1082,7 @@
               "minLength": 1
             },
             "valueId": {
-              "$ref": "#/definitions/Reference_abstract"
+              "$ref": "#/definitions/Reference"
             },
             "levelType": {
               "$ref": "#/definitions/LevelType"


### PR DESCRIPTION
We need to remove the `*_abstract` definitions which specified the
"closed world" with `oneOf` since the generated JSON schema is also used
for various downstream code generations (*e.g.*, in OpenAPI 3 schemas
and respective server generations).