### PR TITLE
Fix `ModelTypes` enumeration in JSON

### DIFF
--- a/aas_core_codegen/intermediate/_translate.py
+++ b/aas_core_codegen/intermediate/_translate.py
@@ -2251,6 +2251,27 @@ def _verify(symbol_table: SymbolTable, ontology: _hierarchy.Ontology) -> List[Er
     """Perform a battery of checks on the consistency of ``symbol_table``."""
     errors = []  # type: List[Error]
 
+    # region Check that there are no duplicate symbol names
+
+    observed_names = dict()  # type: MutableMapping[Identifier, Symbol]
+    for symbol in symbol_table.symbols:
+        other_symbol = observed_names.get(symbol.name, None)
+        if other_symbol is None:
+            observed_names[symbol.name] = symbol
+        else:
+            errors.append(
+                Error(
+                    symbol.parsed.node,
+                    f"The symbol with the name {symbol.name!r} conflicts with "
+                    f"other symbol with the same name.",
+                )
+            )
+
+    if len(errors) > 0:
+        return errors
+
+    # endregion
+
     # region Check ``with_model_type`` for classes with at least one concrete descendant
 
     symbols_in_properties = collect_ids_of_symbols_in_properties(

--- a/aas_core_codegen/jsonschema/main.py
+++ b/aas_core_codegen/jsonschema/main.py
@@ -504,19 +504,17 @@ def _generate(
     if len(errors) > 0:
         return None, errors
 
+    model_types = [
+        naming.json_model_type(symbol.name)
+        for symbol in symbol_table.symbols
+        if (
+            isinstance(symbol, intermediate.ConcreteClass)
+            and symbol.serialization.with_model_type
+        )
+    ]  # type: List[Identifier]
+
     definitions["ModelTypes"] = collections.OrderedDict(
-        [
-            ("type", "string"),
-            (
-                "enum",
-                [
-                    naming.json_model_type(symbol.name)
-                    for symbol in symbol_table.symbols
-                    if isinstance(symbol, intermediate.ConcreteClass)
-                    and len(symbol.inheritances) > 0
-                ],
-            ),
-        ]
+        [("type", "string"), ("enum", model_types)]
     )
 
     definitions["ModelType"] = collections.OrderedDict(

--- a/aas_core_codegen/parse/_translate.py
+++ b/aas_core_codegen/parse/_translate.py
@@ -6,7 +6,19 @@ import io
 import itertools
 import sys
 import textwrap
-from typing import List, Any, Optional, cast, Type, Tuple, Union, Mapping, Set, Sequence
+from typing import (
+    List,
+    Any,
+    Optional,
+    cast,
+    Type,
+    Tuple,
+    Union,
+    Mapping,
+    Set,
+    Sequence,
+    MutableMapping,
+)
 
 import asttokens
 import docutils.io
@@ -2135,6 +2147,27 @@ def _verify_symbol_table(
                     f"for the code generation: {func.name!r}",
                 )
             )
+
+    # endregion
+
+    # region Check that there are no duplicate symbol names
+
+    observed_names = dict()  # type: MutableMapping[Identifier, Symbol]
+    for symbol in symbol_table.symbols:
+        other_symbol = observed_names.get(symbol.name, None)
+        if other_symbol is None:
+            observed_names[symbol.name] = symbol
+        else:
+            errors.append(
+                Error(
+                    symbol.node,
+                    f"The symbol with the name {symbol.name!r} conflicts with "
+                    f"other symbol with the same name.",
+                )
+            )
+
+    if len(errors) > 0:
+        return None, errors
 
     # endregion
 

--- a/test_data/jsonschema/test_main/v3rc1/expected_output/schema.json
+++ b/test_data/jsonschema/test_main/v3rc1/expected_output/schema.json
@@ -1376,13 +1376,10 @@
     "ModelTypes": {
       "type": "string",
       "enum": [
-        "Extension",
-        "AdministrativeInformation",
         "Qualifier",
         "Formula",
         "AssetAdministrationShell",
         "Asset",
-        "IdentifierKeyValuePair",
         "Submodel",
         "RelationshipElement",
         "SubmodelElementCollection",
@@ -1399,8 +1396,6 @@
         "Capability",
         "ConceptDescription",
         "View",
-        "DataSpecificationIEC61360",
-        "DataSpecificationPhysicalUnit",
         "BlobCertificate",
         "AccessPermissionRule"
       ]

--- a/test_data/jsonschema/test_main/v3rc2/expected_output/schema.json
+++ b/test_data/jsonschema/test_main/v3rc2/expected_output/schema.json
@@ -1180,12 +1180,9 @@
     "ModelTypes": {
       "type": "string",
       "enum": [
-        "Extension",
-        "AdministrativeInformation",
         "Qualifier",
         "Formula",
         "AssetAdministrationShell",
-        "IdentifierKeyValuePair",
         "Submodel",
         "SubmodelElementList",
         "SubmodelElementStruct",
@@ -1203,9 +1200,7 @@
         "ConceptDescription",
         "View",
         "GlobalReference",
-        "ModelReference",
-        "DataSpecificationIec61360",
-        "DataSpecificationPhysicalUnit"
+        "ModelReference"
       ]
     },
     "ModelType": {


### PR DESCRIPTION
Instead of automatically inferring `modelType` in serialization, which
was error prone and succeptible to changes between meta-model versions,
we use serialization settings to determine the enumeration `ModelTypes`
in JSON schema.