### PR TITLE
Add scripts for propagation from aas-core-meta

### DIFF
--- a/continuous_integration/precommit.py
+++ b/continuous_integration/precommit.py
@@ -103,6 +103,7 @@ def main() -> int:
         reformat_targets = [
             "aas_core_codegen",
             "continuous_integration",
+            "dev_scripts",
             "tests",
             "setup.py",
         ]
@@ -126,7 +127,12 @@ def main() -> int:
 
     if Step.MYPY in selects and Step.MYPY not in skips:
         print("Mypy'ing...")
-        mypy_targets = ["aas_core_codegen", "tests", "continuous_integration"]
+        mypy_targets = [
+            "aas_core_codegen",
+            "tests",
+            "continuous_integration",
+            "dev_scripts",
+        ]
         config_file = pathlib.Path("continuous_integration") / "mypy.ini"
 
         exit_code = call_and_report(
@@ -141,7 +147,12 @@ def main() -> int:
 
     if Step.PYLINT in selects and Step.PYLINT not in skips:
         print("Pylint'ing...")
-        pylint_targets = ["aas_core_codegen", "tests", "continuous_integration"]
+        pylint_targets = [
+            "aas_core_codegen",
+            "tests",
+            "continuous_integration",
+            "dev_scripts",
+        ]
         rcfile = pathlib.Path("continuous_integration") / "pylint.rc"
 
         exit_code = call_and_report(

--- a/dev_scripts/__init__.py
+++ b/dev_scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Provide scripts which are manually invoked during the development."""

--- a/dev_scripts/fetch_meta_models_from_aas_core_meta.py
+++ b/dev_scripts/fetch_meta_models_from_aas_core_meta.py
@@ -1,0 +1,58 @@
+"""Fetch meta-models from aas-core-meta repository."""
+
+import argparse
+import os
+import pathlib
+import sys
+import urllib.request
+
+
+def main() -> int:
+    """Execute the main routine."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.parse_args()
+
+    this_path = pathlib.Path(os.path.realpath(__file__))
+    repo_root = this_path.parent.parent
+
+    raw_aas_core_meta_url = (
+        "https://raw.githubusercontent.com/aas-core-works/aas-core-meta/main"
+    )
+
+    sources_targets = [
+        (
+            f"{raw_aas_core_meta_url}/aas_core_meta/v3rc1.py",
+            repo_root / "test_data/jsonschema/test_main/v3rc1/input/meta_model.py",
+        ),
+        (
+            f"{raw_aas_core_meta_url}/aas_core_meta/v3rc1.py",
+            repo_root / "test_data/rdf_shacl/test_main/v3rc1/input/meta_model.py",
+        ),
+        (
+            f"{raw_aas_core_meta_url}/aas_core_meta/v3rc2.py",
+            repo_root / "test_data/csharp/test_main/v3rc2/input/meta_model.py",
+        ),
+        (
+            f"{raw_aas_core_meta_url}/aas_core_meta/v3rc2.py",
+            repo_root
+            / "test_data/intermediate/expected/real_meta_models/v3rc2/meta_model.py",
+        ),
+        (
+            f"{raw_aas_core_meta_url}/aas_core_meta/v3rc2.py",
+            repo_root / "test_data/jsonschema/test_main/v3rc2/input/meta_model.py",
+        ),
+        (
+            f"{raw_aas_core_meta_url}/aas_core_meta/v3rc2.py",
+            repo_root / "test_data/parse/expected/real_meta_models/v3rc2/meta_model.py",
+        ),
+    ]
+
+    for url, tgt_pth in sources_targets:
+        print(f"Downloading {url} to {tgt_pth.relative_to(repo_root)}...")
+        urllib.request.urlretrieve(url=url, filename=str(tgt_pth))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dev_scripts/run_tests_with_rerecord.py
+++ b/dev_scripts/run_tests_with_rerecord.py
@@ -1,0 +1,44 @@
+"""Run all the tests with the environment variable ``AAS_CORE_CODEGEN_RERECORD`` set."""
+
+import argparse
+import os
+import pathlib
+import subprocess
+import sys
+import shlex
+
+
+def main() -> int:
+    """Execute the main routine."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.parse_args()
+
+    this_path = pathlib.Path(os.path.realpath(__file__))
+    repo_root = this_path.parent.parent
+
+    env = os.environ.copy()
+    env["AAS_CORE_CODEGEN_RERECORD"] = "1"
+
+    tests_to_run = [
+        "tests.csharp.test_main.Test_against_recorded",
+        "tests.intermediate.test_translate.Test_against_recorded",
+        "tests.jsonschema.test_main.Test_against_recorded",
+        "tests.rdf_shacl.test_main.Test_against_recorded",
+        "tests.test_parse.Test_against_recorded",
+    ]
+
+    for qualified_test_name in tests_to_run:
+        cmd = [sys.executable, "-m", "unittest", "-v", qualified_test_name]
+
+        print(f"Executing {qualified_test_name}...")
+        exit_code = subprocess.call(cmd, cwd=str(repo_root), env=env)
+        if exit_code != 0:
+            cmd_str = " ".join(shlex.quote(part) for part in cmd)
+            print(f"Failed to execute the test: {cmd_str}")
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     ],
     license="License :: OSI Approved :: MIT License",
     keywords="asset administration shell code generation industry 4.0 industrie i4.0",
-    packages=find_packages(exclude=["tests", "continuous_integration"]),
+    packages=find_packages(exclude=["tests", "continuous_integration", "dev_scripts"]),
     install_requires=install_requires,
     # fmt: off
     extras_require={

--- a/tests/csharp/test_main.py
+++ b/tests/csharp/test_main.py
@@ -11,9 +11,11 @@ import aas_core_codegen.main
 
 
 class Test_against_recorded(unittest.TestCase):
-    # Set this variable to True if you want to re-record the test data,
-    # without any checks
-    RERECORD = False
+    RERECORD = os.environ.get("AAS_CORE_CODEGEN_RERECORD", "").lower() in (
+        "1",
+        "true",
+        "on",
+    )
 
     def test_cases(self) -> None:
         repo_dir = pathlib.Path(os.path.realpath(__file__)).parent.parent.parent

--- a/tests/intermediate/test_translate.py
+++ b/tests/intermediate/test_translate.py
@@ -146,9 +146,11 @@ class Test_parsing_docstrings(unittest.TestCase):
 
 
 class Test_against_recorded(unittest.TestCase):
-    # Set this variable to True if you want to re-record the test data,
-    # without any checks
-    RERECORD = False
+    RERECORD = os.environ.get("AAS_CORE_CODEGEN_RERECORD", "").lower() in (
+        "1",
+        "true",
+        "on",
+    )
 
     def test_cases(self) -> None:
         this_dir = pathlib.Path(os.path.realpath(__file__)).parent

--- a/tests/jsonschema/test_main.py
+++ b/tests/jsonschema/test_main.py
@@ -11,9 +11,11 @@ import aas_core_codegen.main
 
 
 class Test_against_recorded(unittest.TestCase):
-    # Set this variable to True if you want to re-record the test data,
-    # without any checks
-    RERECORD = False
+    RERECORD = os.environ.get("AAS_CORE_CODEGEN_RERECORD", "").lower() in (
+        "1",
+        "true",
+        "on",
+    )
 
     def test_cases(self) -> None:
         repo_dir = pathlib.Path(os.path.realpath(__file__)).parent.parent.parent

--- a/tests/rdf_shacl/test_main.py
+++ b/tests/rdf_shacl/test_main.py
@@ -11,9 +11,11 @@ import aas_core_codegen.main
 
 
 class Test_against_recorded(unittest.TestCase):
-    # Set this variable to True if you want to re-record the test data,
-    # without any checks
-    RERECORD = False
+    RERECORD = os.environ.get("AAS_CORE_CODEGEN_RERECORD", "").lower() in (
+        "1",
+        "true",
+        "on",
+    )
 
     def test_cases(self) -> None:
         repo_dir = pathlib.Path(os.path.realpath(__file__)).parent.parent.parent

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -358,9 +358,11 @@ class Test_parse_type_annotation_fail(unittest.TestCase):
 
 
 class Test_against_recorded(unittest.TestCase):
-    # Set this variable to True if you want to re-record the test data,
-    # without any checks
-    RERECORD = False
+    RERECORD = os.environ.get("AAS_CORE_CODEGEN_RERECORD", "").lower() in (
+        "1",
+        "true",
+        "on",
+    )
 
     def test_cases(self) -> None:
         this_dir = pathlib.Path(os.path.realpath(__file__)).parent


### PR DESCRIPTION
We write multiple scripts to facilitate back-propagation of changes from
the aas-core-meta repository to our test data.