### PR TITLE
Document `dev_scripts`

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -98,3 +98,11 @@ We follow Chris Beams' `guidelines on commit messages`_:
 7) Use the body to explain *what* and *why* vs. *how*
 
 .. _guidelines on commit messages: https://chris.beams.io/posts/git-commit/
+
+Development Scripts
+===================
+We need to frequently back-propagate test data from https://github.com/aas-core-works/aas-core-meta/ repository.
+To facilitate fetching and re-recording test output whenever the meta-models change, we wrote a couple of scripts in [`dev_scripts/`](https://github.com/aas-core-works/aas-core-codegen/tree/main/dev_scripts).
+
+The scripts are hopefully self-explaining.
+Please let us know if you need more information so that we can improve this documentation accordingly.


### PR DESCRIPTION
We mention `dev_scripts` in `CONTRIBUTING.rst` so that other developers
are aware of their existence.