### PR TITLE
Document the bottleneck in C# verification

### DIFF
--- a/aas_core_codegen/csharp/verification/_generate.py
+++ b/aas_core_codegen/csharp/verification/_generate.py
@@ -1879,8 +1879,33 @@ def generate(
         return None, errors
 
     verification_writer = io.StringIO()
-    verification_writer.write(f"namespace {namespace}\n{{\n")
-    verification_writer.write(f"{I}public static class Verification\n" f"{I}{{\n")
+    verification_writer.write(
+        textwrap.dedent(
+            f"""\
+            namespace {namespace}
+            {{
+            {I}/// <summary>
+            {I}/// Verify that the instances of the meta-model satisfy the invariants.
+            {I}/// </summary>
+            {I}/// <remarks>
+            {I}/// Mind that we pass the paths to the functions in order
+            {I}/// to provide informative exceptions in case of invariant violations.
+            {I}/// However, this comes with a <strong>SUBSTANTIAL COST</strong>!
+            {I}/// For each call to a parsing function, we have to copy the previous
+            {I}/// prefix path and append the identifier of the element under
+            {I}/// verification. Thus this can run <c>O(n^2)</c> where <c>n</c> denotes
+            {I}/// the longest path to an element.
+            {I}///
+            {I}/// Please notify the developers if this becomes a bottleneck for
+            {I}/// you since there is a workaround, but we did not prioritize it at
+            {I}/// the moment (<em>e.g.</em>, we could back-track the path only upon
+            {I}/// exceptions).
+            {I}/// </remarks>
+            {I}public static class Verification
+            {I}{{
+            """
+        )
+    )
 
     for i, verification_block in enumerate(verification_blocks):
         if i > 0:

--- a/test_data/csharp/test_main/v3rc2/expected_output/verification.cs
+++ b/test_data/csharp/test_main/v3rc2/expected_output/verification.cs
@@ -13,6 +13,23 @@ using Visitation = AasCore.Aas3.Visitation;
 
 namespace AasCore.Aas3
 {
+    /// <summary>
+    /// Verify that the instances of the meta-model satisfy the invariants.
+    /// </summary>
+    /// <remarks>
+    /// Mind that we pass the paths to the functions in order
+    /// to provide informative exceptions in case of invariant violations.
+    /// However, this comes with a <strong>SUBSTANTIAL COST</strong>!
+    /// For each call to a parsing function, we have to copy the previous
+    /// prefix path and append the identifier of the element under
+    /// verification. Thus this can run <c>O(n^2)</c> where <c>n</c> denotes
+    /// the longest path to an element.
+    ///
+    /// Please notify the developers if this becomes a bottleneck for
+    /// you since there is a workaround, but we did not prioritize it at
+    /// the moment (<em>e.g.</em>, we could back-track the path only upon
+    /// exceptions).
+    /// </remarks>
     public static class Verification
     {
         /// <summary>


### PR DESCRIPTION
We add a remark to warn the users of the code that passing paths around
is expensive. Hopefully we will be notified when this becomes a problem.
Otherwise, if the time permits at the end we plan to come back and
optimize the error handling so that we avoid this cost.