### PR TITLE
Optimize path handling in C# JSON deserialization

### DIFF
--- a/.idea/dictionaries/rist.xml
+++ b/.idea/dictionaries/rist.xml
@@ -16,6 +16,7 @@
       <w>csproj</w>
       <w>datatype</w>
       <w>dedented</w>
+      <w>dedention</w>
       <w>descendability</w>
       <w>descendable</w>
       <w>deserializing</w>

--- a/test_data/csharp/test_main/v3rc2/input/snippets/Jsonization/Lang_string_set_from.cs
+++ b/test_data/csharp/test_main/v3rc2/input/snippets/Jsonization/Lang_string_set_from.cs
@@ -1,6 +1,6 @@
 public static Aas.LangStringSet LangStringSetFrom(
     Nodes.JsonNode node,
-    string path)
+    out Jsonization.Error? error)
 {
     throw new System.NotImplementedException("TODO");
 }


### PR DESCRIPTION
Currently, we pass in the path on every call to a deserialization
method. This is problematic since this induces a time complexity
of `O(n^2)` with `n` being the maximum length of a path. We need to
append the suffix on each call and therefore make a complete copy of the
previous path (the strings are stored as blocks in memory akin to arrays
in C#).

With this patch, we use an intermediate structure (`Error`) which stores
the path as a linked list. We append to this linked list when we unwind
the calls so that the time complexity is brought down to `O(n)`.

Additionally, the suffixes are appended only in case of errors which
should yield even better performance assuming that the correct data is
usually much more probable than incorrect data.