### PR TITLE
Handle `all` in intermediate representation

### DIFF
--- a/aas_core_codegen/parse/_rules.py
+++ b/aas_core_codegen/parse/_rules.py
@@ -75,6 +75,93 @@ class _ParseComparison(_Parse):
         return tree.Comparison(left=left, op=op, right=right, original_node=node), None
 
 
+class _ParseAll(_Parse):
+    def matches(self, node: ast.AST) -> bool:
+        return (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "all"
+        )
+
+    def transform(self, node: ast.AST) -> Tuple[Optional[tree.Node], Optional[Error]]:
+        assert (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "all"
+        )
+
+        if len(node.keywords) > 0:
+            return None, Error(
+                node,
+                "Expected no keyword arguments in ``all``, "
+                f"but got {len(node.keywords)}",
+            )
+
+        if len(node.args) != 1:
+            return None, Error(
+                node,
+                "Expected exactly one argument in ``all``, "
+                f"but got {len(node.args)}",
+            )
+
+        if not isinstance(node.args[0], ast.GeneratorExp):
+            return None, Error(
+                node,
+                "Expected a generator expression in ``all``, "
+                f"but got: {ast.dump(node)}",
+            )
+
+        generator_exp = node.args[0]
+
+        condition, error = ast_node_to_our_node(generator_exp.elt)
+        if error is not None:
+            return None, error
+
+        assert isinstance(condition, tree.Expression), f"{condition=}"
+
+        if len(generator_exp.generators) != 1:
+            return None, Error(
+                node,
+                "Expected exactly one generator in ``all``, "
+                f"but got {len(generator_exp.generators)}",
+            )
+
+        generator = generator_exp.generators[0]
+        if not isinstance(generator, ast.comprehension):
+            return None, Error(
+                generator, f"Expected a comprehension, but got: {ast.dump(generator)}"
+            )
+
+        if not isinstance(generator.target, ast.Name):
+            return None, Error(
+                generator,
+                f"Expected the target of the generator to be a name, "
+                f"but got: {ast.dump(generator.target)}",
+            )
+
+        variable, error = ast_node_to_our_node(generator.target)
+        if error is not None:
+            return None, error
+        assert isinstance(variable, tree.Name), f"{variable=}"
+
+        an_iter, error = ast_node_to_our_node(generator.iter)
+        if error is not None:
+            return None, error
+
+        assert isinstance(an_iter, tree.Expression), f"{an_iter=}"
+
+        return (
+            tree.All(
+                for_each=tree.ForEach(
+                    variable=variable, iteration=an_iter, original_node=generator
+                ),
+                condition=condition,
+                original_node=node,
+            ),
+            None,
+        )
+
+
 class _ParseCall(_Parse):
     def matches(self, node: ast.AST) -> bool:
         return isinstance(node, ast.Call)
@@ -398,6 +485,7 @@ class _ParseReturn(_Parse):
 
 _CHAIN_OF_RULES = [
     _ParseComparison(),
+    _ParseAll(),
     _ParseCall(),
     _ParseConstant(),
     _ParseImplication(),

--- a/test_data/csharp/test_main/v3rc2/expected_output/jsonization.cs
+++ b/test_data/csharp/test_main/v3rc2/expected_output/jsonization.cs
@@ -1680,10 +1680,10 @@ namespace AasCore.Aas3
                 }
 
                 Nodes.JsonNode? nodeDerivedFrom = obj["derivedFrom"];
-                Aas.IReference? theDerivedFrom = null;
+                Aas.ModelReference? theDerivedFrom = null;
                 if (nodeDerivedFrom != null)
                 {
-                    theDerivedFrom = DeserializeImplementation.IReferenceFrom(
+                    theDerivedFrom = DeserializeImplementation.ModelReferenceFrom(
                         nodeDerivedFrom,
                         out error);
                     if (error != null)
@@ -1724,56 +1724,54 @@ namespace AasCore.Aas3
                 }
 
                 Nodes.JsonNode? nodeSubmodels = obj["submodels"];
-                if (nodeSubmodels == null)
+                List<ModelReference>? theSubmodels = null;
+                if (nodeSubmodels != null)
                 {
-                    error = new Reporting.Error(
-                        "Required property \"submodels\" is missing ");
-                    return null;
-                }
-                Nodes.JsonArray? arraySubmodels = nodeSubmodels as Nodes.JsonArray;
-                if (arraySubmodels == null)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a JsonArray, but got {nodeSubmodels.GetType()}");
-                    error._pathSegments.AddFirst(
-                        new Reporting.NameSegment(
-                            "submodels"));
-                    return null;
-                }
-                var theSubmodels = new List<IReference>(
-                    arraySubmodels.Count);
-                int indexSubmodels = 0;
-                foreach (Nodes.JsonNode? item in arraySubmodels)
-                {
-                    if (item == null)
+                    Nodes.JsonArray? arraySubmodels = nodeSubmodels as Nodes.JsonArray;
+                    if (arraySubmodels == null)
                     {
                         error = new Reporting.Error(
-                            "Expected a non-null item, but got a null");
-                        error._pathSegments.AddFirst(
-                            new Reporting.IndexSegment(
-                                indexSubmodels));
-                        error._pathSegments.AddFirst(
-                            new Reporting.NameSegment(
-                                "submodels"));
-                    }
-                    IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
-                        item ?? throw new System.InvalidOperationException(),
-                        out error);
-                    if (error != null)
-                    {
-                        error._pathSegments.AddFirst(
-                            new Reporting.IndexSegment(
-                                indexSubmodels));
+                            $"Expected a JsonArray, but got {nodeSubmodels.GetType()}");
                         error._pathSegments.AddFirst(
                             new Reporting.NameSegment(
                                 "submodels"));
                         return null;
                     }
-                    theSubmodels.Add(
-                        parsedItem
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected result null when error is null"));
-                    indexSubmodels++;
+                    theSubmodels = new List<ModelReference>(
+                        arraySubmodels.Count);
+                    int indexSubmodels = 0;
+                    foreach (Nodes.JsonNode? item in arraySubmodels)
+                    {
+                        if (item == null)
+                        {
+                            error = new Reporting.Error(
+                                "Expected a non-null item, but got a null");
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexSubmodels));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "submodels"));
+                        }
+                        ModelReference? parsedItem = DeserializeImplementation.ModelReferenceFrom(
+                            item ?? throw new System.InvalidOperationException(),
+                            out error);
+                        if (error != null)
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexSubmodels));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "submodels"));
+                            return null;
+                        }
+                        theSubmodels.Add(
+                            parsedItem
+                                ?? throw new System.InvalidOperationException(
+                                    "Unexpected result null when error is null"));
+                        indexSubmodels++;
+                    }
                 }
 
                 return new Aas.AssetAdministrationShell(
@@ -1793,9 +1791,7 @@ namespace AasCore.Aas3
                     theAdministration,
                     theDataSpecifications,
                     theDerivedFrom,
-                    theSubmodels
-                         ?? throw new System.InvalidOperationException(
-                            "Unexpected null, had to be handled before"));
+                    theSubmodels);
             }  // internal static AssetAdministrationShellFrom
 
             /// <summary>
@@ -11948,14 +11944,17 @@ namespace AasCore.Aas3
                 result["assetInformation"] = Transform(
                     that.AssetInformation);
 
-                var arraySubmodels = new Nodes.JsonArray();
-                foreach (IReference item in that.Submodels)
+                if (that.Submodels != null)
                 {
-                    arraySubmodels.Add(
-                        Transform(
-                            item));
+                    var arraySubmodels = new Nodes.JsonArray();
+                    foreach (ModelReference item in that.Submodels)
+                    {
+                        arraySubmodels.Add(
+                            Transform(
+                                item));
+                    }
+                    result["submodels"] = arraySubmodels;
                 }
-                result["submodels"] = arraySubmodels;
 
                 return result;
             }

--- a/test_data/csharp/test_main/v3rc2/expected_output/types.cs
+++ b/test_data/csharp/test_main/v3rc2/expected_output/types.cs
@@ -840,7 +840,7 @@ namespace AasCore.Aas3
         /// <summary>
         /// The reference to the AAS the AAS was derived from.
         /// </summary>
-        public IReference? DerivedFrom { get; set; }
+        public ModelReference? DerivedFrom { get; set; }
 
         /// <summary>
         /// Meta-information about the asset the AAS is representing.
@@ -855,7 +855,7 @@ namespace AasCore.Aas3
         /// The asset of an AAS is typically described by one or more submodels. Temporarily
         /// no submodel might be assigned to the AAS.
         /// </remarks>
-        public List<IReference> Submodels { get; set; }
+        public List<ModelReference>? Submodels { get; set; }
 
         /// <summary>
         /// Iterate over all the class instances referenced from this instance
@@ -898,9 +898,12 @@ namespace AasCore.Aas3
 
             yield return AssetInformation;
 
-            foreach (var anItem in Submodels)
+            if (Submodels != null)
             {
-                yield return anItem;
+                foreach (var anItem in Submodels)
+                {
+                    yield return anItem;
+                }
             }
         }
 
@@ -986,14 +989,17 @@ namespace AasCore.Aas3
                 yield return anItem;
             }
 
-            foreach (var anItem in Submodels)
+            if (Submodels != null)
             {
-                yield return anItem;
-
-                // Recurse
-                foreach (var anotherItem in anItem.Descend())
+                foreach (var anItem in Submodels)
                 {
-                    yield return anotherItem;
+                    yield return anItem;
+
+                    // Recurse
+                    foreach (var anotherItem in anItem.Descend())
+                    {
+                        yield return anotherItem;
+                    }
                 }
             }
         }
@@ -1045,8 +1051,8 @@ namespace AasCore.Aas3
             LangStringSet? description = null,
             AdministrativeInformation? administration = null,
             List<IReference>? dataSpecifications = null,
-            IReference? derivedFrom = null,
-            List<IReference>? submodels = null)
+            ModelReference? derivedFrom = null,
+            List<ModelReference>? submodels = null)
         {
             Extensions = (extensions != null)
                 ? extensions
@@ -1060,9 +1066,7 @@ namespace AasCore.Aas3
             DataSpecifications = dataSpecifications;
             DerivedFrom = derivedFrom;
             AssetInformation = assetInformation;
-            Submodels = (submodels != null)
-                ? submodels
-                : new List<IReference>();
+            Submodels = submodels;
         }
     }
 

--- a/test_data/csharp/test_main/v3rc2/input/snippets/Verification/is_model_reference_to.cs
+++ b/test_data/csharp/test_main/v3rc2/input/snippets/Verification/is_model_reference_to.cs
@@ -1,0 +1,7 @@
+public static bool IsModelReferenceTo(
+    Aas.ModelReference reference,
+    Aas.KeyElements expected_type
+)
+{
+    throw new System.NotImplementedException("TODO");
+}

--- a/test_data/intermediate/expected/real_meta_models/v3rc2/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/real_meta_models/v3rc2/expected_symbol_table.txt
@@ -1949,7 +1949,7 @@ SymbolTable(
           name='derived_from',
           type_annotation=OptionalTypeAnnotation(
             value=OurTypeAnnotation(
-              symbol='Reference to symbol Reference',
+              symbol='Reference to symbol Model_reference',
               parsed=...),
             parsed=...),
           description=Description(
@@ -1969,9 +1969,11 @@ SymbolTable(
           parsed=...),
         Property(
           name='submodels',
-          type_annotation=ListTypeAnnotation(
-            items=OurTypeAnnotation(
-              symbol='Reference to symbol Reference',
+          type_annotation=OptionalTypeAnnotation(
+            value=ListTypeAnnotation(
+              items=OurTypeAnnotation(
+                symbol='Reference to symbol Model_reference',
+                parsed=...),
               parsed=...),
             parsed=...),
           description=Description(
@@ -2082,7 +2084,7 @@ SymbolTable(
             name='derived_from',
             type_annotation=OptionalTypeAnnotation(
               value=OurTypeAnnotation(
-                symbol='Reference to symbol Reference',
+                symbol='Reference to symbol Model_reference',
                 parsed=...),
               parsed=...),
             default=DefaultConstant(
@@ -2094,7 +2096,7 @@ SymbolTable(
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
-                  symbol='Reference to symbol Reference',
+                  symbol='Reference to symbol Model_reference',
                   parsed=...),
                 parsed=...),
               parsed=...),
@@ -2122,8 +2124,18 @@ SymbolTable(
           "AssignArgument(\n  name='data_specifications',\n  argument='data_specifications',\n  default=None)",
           "AssignArgument(\n  name='derived_from',\n  argument='derived_from',\n  default=None)",
           "AssignArgument(\n  name='asset_information',\n  argument='asset_information',\n  default=None)",
-          "AssignArgument(\n  name='submodels',\n  argument='submodels',\n  default=EmptyList(\n    node=...))"]),
-      invariants=[],
+          "AssignArgument(\n  name='submodels',\n  argument='submodels',\n  default=None)"]),
+      invariants=[
+        Invariant(
+          description='derived_from points to an Asset Administration Shell',
+          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='derived_from',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='is_model_reference_to',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='derived_from',\n        original_node=...),\n      Member(\n        instance=Name(\n          identifier='Key_elements',\n          original_node=...),\n        name='Submodel',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          specified_for='Reference to ConcreteClass Asset_administration_shell',
+          parsed=...),
+        Invariant(
+          description='Submodel references point to a submodel',
+          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='submodels',\n      original_node=...),\n    original_node=...),\n  consequent=All(\n    for_each=ForEach(\n      variable=Name(\n        identifier='submodel',\n        original_node=...),\n      iteration=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='submodels',\n        original_node=...),\n      original_node=...),\n    condition=FunctionCall(\n      name='is_model_reference_to',\n      args=[\n        Name(\n          identifier='submodel',\n          original_node=...),\n        Member(\n          instance=Name(\n            identifier='Key_elements',\n            original_node=...),\n          name='Submodel',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          specified_for='Reference to ConcreteClass Asset_administration_shell',
+          parsed=...)],
       serialization=Serialization(
         with_model_type=True),
       reference_in_the_book=ReferenceInTheBook(
@@ -11781,7 +11793,36 @@ SymbolTable(
         postconditions=[]),
       parsed=...,
       arguments_by_name=...,
-      pattern='([!#$%&\'*+\\-.^_`|~0-9a-zA-Z])+/([!#$%&\'*+\\-.^_`|~0-9a-zA-Z])+([ \t]*;[ \t]*([!#$%&\'*+\\-.^_`|~0-9a-zA-Z])+=(([!#$%&\'*+\\-.^_`|~0-9a-zA-Z])+|"(([\t !#-\\[\\]-~]|[\\x80-\\xff])|\\\\([\t !-~]|[\\x80-\\xff]))*"))*')],
+      pattern='([!#$%&\'*+\\-.^_`|~0-9a-zA-Z])+/([!#$%&\'*+\\-.^_`|~0-9a-zA-Z])+([ \t]*;[ \t]*([!#$%&\'*+\\-.^_`|~0-9a-zA-Z])+=(([!#$%&\'*+\\-.^_`|~0-9a-zA-Z])+|"(([\t !#-\\[\\]-~]|[\\x80-\\xff])|\\\\([\t !-~]|[\\x80-\\xff]))*"))*'),
+    ImplementationSpecificVerification(
+      name='is_model_reference_to',
+      arguments=[
+        Argument(
+          name='reference',
+          type_annotation=OurTypeAnnotation(
+            symbol='Reference to symbol Model_reference',
+            parsed=...),
+          default=None,
+          parsed=...),
+        Argument(
+          name='expected_type',
+          type_annotation=OurTypeAnnotation(
+            symbol='Reference to symbol Key_elements',
+            parsed=...),
+          default=None,
+          parsed=...)],
+      returns=PrimitiveTypeAnnotation(
+        a_type='BOOL',
+        parsed=...),
+      description=Description(
+        document=...,
+        node=...),
+      contracts=Contracts(
+        preconditions=[],
+        snapshots=[],
+        postconditions=[]),
+      parsed=...,
+      arguments_by_name=...)],
   verification_functions_by_name=...,
   meta_model=MetaModel(
     description=Description(

--- a/test_data/jsonschema/test_main/v3rc2/expected_output/schema.json
+++ b/test_data/jsonschema/test_main/v3rc2/expected_output/schema.json
@@ -245,7 +245,7 @@
         {
           "properties": {
             "derivedFrom": {
-              "$ref": "#/definitions/Reference"
+              "$ref": "#/definitions/ModelReference"
             },
             "assetInformation": {
               "$ref": "#/definitions/AssetInformation"
@@ -253,13 +253,12 @@
             "submodels": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/Reference"
+                "$ref": "#/definitions/ModelReference"
               }
             }
           },
           "required": [
-            "assetInformation",
-            "submodels"
+            "assetInformation"
           ]
         }
       ]

--- a/test_data/parse/expected/real_meta_models/v3rc2/expected_symbol_table.txt
+++ b/test_data/parse/expected/real_meta_models/v3rc2/expected_symbol_table.txt
@@ -1219,7 +1219,7 @@ UnverifiedSymbolTable(
             identifier='Optional',
             subscripts=[
               AtomicTypeAnnotation(
-                identifier='Reference',
+                identifier='Model_reference',
                 node=...)],
             node=...),
           description=Description(
@@ -1238,10 +1238,14 @@ UnverifiedSymbolTable(
         Property(
           name='submodels',
           type_annotation=SubscriptedTypeAnnotation(
-            identifier='List',
+            identifier='Optional',
             subscripts=[
-              AtomicTypeAnnotation(
-                identifier='Reference',
+              SubscriptedTypeAnnotation(
+                identifier='List',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Model_reference',
+                    node=...)],
                 node=...)],
             node=...),
           description=Description(
@@ -1370,7 +1374,7 @@ UnverifiedSymbolTable(
                 identifier='Optional',
                 subscripts=[
                   AtomicTypeAnnotation(
-                    identifier='Reference',
+                    identifier='Model_reference',
                     node=...)],
                 node=...),
               default=Default(
@@ -1385,7 +1389,7 @@ UnverifiedSymbolTable(
                     identifier='List',
                     subscripts=[
                       AtomicTypeAnnotation(
-                        identifier='Reference',
+                        identifier='Model_reference',
                         node=...)],
                     node=...)],
                 node=...),
@@ -1401,7 +1405,15 @@ UnverifiedSymbolTable(
           node=...,
           arguments_by_name=...,
           body=...)],
-      invariants=[],
+      invariants=[
+        Invariant(
+          description='derived_from points to an Asset Administration Shell',
+          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='derived_from',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='is_model_reference_to',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='derived_from',\n        original_node=...),\n      Member(\n        instance=Name(\n          identifier='Key_elements',\n          original_node=...),\n        name='Submodel',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          node=...),
+        Invariant(
+          description='Submodel references point to a submodel',
+          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='submodels',\n      original_node=...),\n    original_node=...),\n  consequent=All(\n    for_each=ForEach(\n      variable=Name(\n        identifier='submodel',\n        original_node=...),\n      iteration=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='submodels',\n        original_node=...),\n      original_node=...),\n    condition=FunctionCall(\n      name='is_model_reference_to',\n      args=[\n        Name(\n          identifier='submodel',\n          original_node=...),\n        Member(\n          instance=Name(\n            identifier='Key_elements',\n            original_node=...),\n          name='Submodel',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          node=...)],
       serialization=Serialization(
         with_model_type=True),
       reference_in_the_book=ReferenceInTheBook(
@@ -8251,6 +8263,36 @@ UnverifiedSymbolTable(
         "Assignment(\n  target=Name(\n    identifier='parameter',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      FormattedValue(\n        value=Name(\n          identifier='token',\n          original_node=...),\n        original_node=...),\n      '=(',\n      FormattedValue(\n        value=Name(\n          identifier='token',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='quoted_string',\n          original_node=...),\n        original_node=...),\n      ')'],\n    original_node=...),\n  original_node=...)",
         "Assignment(\n  target=Name(\n    identifier='media_type',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      FormattedValue(\n        value=Name(\n          identifier='type',\n          original_node=...),\n        original_node=...),\n      '/',\n      FormattedValue(\n        value=Name(\n          identifier='subtype',\n          original_node=...),\n        original_node=...),\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='ows',\n          original_node=...),\n        original_node=...),\n      ';',\n      FormattedValue(\n        value=Name(\n          identifier='ows',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='parameter',\n          original_node=...),\n        original_node=...),\n      ')*'],\n    original_node=...),\n  original_node=...)",
         "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='media_type',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+      node=...,
+      arguments_by_name=...),
+    ImplementationSpecificMethod(
+      name='is_model_reference_to',
+      verification=True,
+      arguments=[
+        Argument(
+          name='reference',
+          type_annotation=AtomicTypeAnnotation(
+            identifier='Model_reference',
+            node=...),
+          default=None,
+          node=...),
+        Argument(
+          name='expected_type',
+          type_annotation=AtomicTypeAnnotation(
+            identifier='Key_elements',
+            node=...),
+          default=None,
+          node=...)],
+      returns=AtomicTypeAnnotation(
+        identifier='bool',
+        node=...),
+      description=Description(
+        document=...,
+        node=...),
+      contracts=Contracts(
+        preconditions=[],
+        snapshots=[],
+        postconditions=[]),
       node=...,
       arguments_by_name=...)],
   meta_model=MetaModel(


### PR DESCRIPTION
We add support for `all` built-in as well as simple generator
expressions in the intermediate representation.