### PR TITLE
Stack heritage in second passes

### DIFF
--- a/test_data/csharp/test_main/v3rc2/expected_output/jsonization.cs
+++ b/test_data/csharp/test_main/v3rc2/expected_output/jsonization.cs
@@ -1447,57 +1447,6 @@ namespace AasCore.Aas3
                     return null;
                 }
 
-                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
-                List<IReference>? theDataSpecifications = null;
-                if (nodeDataSpecifications != null)
-                {
-                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
-                    if (arrayDataSpecifications == null)
-                    {
-                        error = new Reporting.Error(
-                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
-                            new Reporting.NameSegment(
-                                "dataSpecifications"));
-                        return null;
-                    }
-                    theDataSpecifications = new List<IReference>(
-                        arrayDataSpecifications.Count);
-                    int indexDataSpecifications = 0;
-                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
-                    {
-                        if (item == null)
-                        {
-                            error = new Reporting.Error(
-                                "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                        }
-                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
-                            item ?? throw new System.InvalidOperationException(),
-                            out error);
-                        if (error != null)
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            return null;
-                        }
-                        theDataSpecifications.Add(
-                            parsedItem
-                                ?? throw new System.InvalidOperationException(
-                                    "Unexpected result null when error is null"));
-                        indexDataSpecifications++;
-                    }
-                }
-
                 Nodes.JsonNode? nodeExtensions = obj["extensions"];
                 if (nodeExtensions == null)
                 {
@@ -1676,6 +1625,57 @@ namespace AasCore.Aas3
                     {
                         throw new System.InvalidOperationException(
                             "Unexpected theAdministration null when error is also null");
+                    }
+                }
+
+                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
+                List<IReference>? theDataSpecifications = null;
+                if (nodeDataSpecifications != null)
+                {
+                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
+                    if (arrayDataSpecifications == null)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
+                        error._pathSegments.AddFirst(
+                            new Reporting.NameSegment(
+                                "dataSpecifications"));
+                        return null;
+                    }
+                    theDataSpecifications = new List<IReference>(
+                        arrayDataSpecifications.Count);
+                    int indexDataSpecifications = 0;
+                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                    {
+                        if (item == null)
+                        {
+                            error = new Reporting.Error(
+                                "Expected a non-null item, but got a null");
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                        }
+                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
+                            item ?? throw new System.InvalidOperationException(),
+                            out error);
+                        if (error != null)
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            return null;
+                        }
+                        theDataSpecifications.Add(
+                            parsedItem
+                                ?? throw new System.InvalidOperationException(
+                                    "Unexpected result null when error is null"));
+                        indexDataSpecifications++;
                     }
                 }
 
@@ -2075,152 +2075,6 @@ namespace AasCore.Aas3
                     return null;
                 }
 
-                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
-                List<IReference>? theDataSpecifications = null;
-                if (nodeDataSpecifications != null)
-                {
-                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
-                    if (arrayDataSpecifications == null)
-                    {
-                        error = new Reporting.Error(
-                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
-                            new Reporting.NameSegment(
-                                "dataSpecifications"));
-                        return null;
-                    }
-                    theDataSpecifications = new List<IReference>(
-                        arrayDataSpecifications.Count);
-                    int indexDataSpecifications = 0;
-                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
-                    {
-                        if (item == null)
-                        {
-                            error = new Reporting.Error(
-                                "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                        }
-                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
-                            item ?? throw new System.InvalidOperationException(),
-                            out error);
-                        if (error != null)
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            return null;
-                        }
-                        theDataSpecifications.Add(
-                            parsedItem
-                                ?? throw new System.InvalidOperationException(
-                                    "Unexpected result null when error is null"));
-                        indexDataSpecifications++;
-                    }
-                }
-
-                Nodes.JsonNode? nodeKind = obj["kind"];
-                Aas.ModelingKind? theKind = null;
-                if (nodeKind != null)
-                {
-                    theKind = DeserializeImplementation.ModelingKindFrom(
-                        nodeKind,
-                        out error);
-                    if (error != null)
-                    {
-                        error._pathSegments.AddFirst(
-                            new Reporting.NameSegment(
-                                "kind"));
-                        return null;
-                    }
-                    if (theKind == null)
-                    {
-                        throw new System.InvalidOperationException(
-                            "Unexpected theKind null when error is also null");
-                    }
-                }
-
-                Nodes.JsonNode? nodeSemanticId = obj["semanticId"];
-                Aas.IReference? theSemanticId = null;
-                if (nodeSemanticId != null)
-                {
-                    theSemanticId = DeserializeImplementation.IReferenceFrom(
-                        nodeSemanticId,
-                        out error);
-                    if (error != null)
-                    {
-                        error._pathSegments.AddFirst(
-                            new Reporting.NameSegment(
-                                "semanticId"));
-                        return null;
-                    }
-                    if (theSemanticId == null)
-                    {
-                        throw new System.InvalidOperationException(
-                            "Unexpected theSemanticId null when error is also null");
-                    }
-                }
-
-                Nodes.JsonNode? nodeQualifiers = obj["qualifiers"];
-                if (nodeQualifiers == null)
-                {
-                    error = new Reporting.Error(
-                        "Required property \"qualifiers\" is missing ");
-                    return null;
-                }
-                Nodes.JsonArray? arrayQualifiers = nodeQualifiers as Nodes.JsonArray;
-                if (arrayQualifiers == null)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a JsonArray, but got {nodeQualifiers.GetType()}");
-                    error._pathSegments.AddFirst(
-                        new Reporting.NameSegment(
-                            "qualifiers"));
-                    return null;
-                }
-                var theQualifiers = new List<IConstraint>(
-                    arrayQualifiers.Count);
-                int indexQualifiers = 0;
-                foreach (Nodes.JsonNode? item in arrayQualifiers)
-                {
-                    if (item == null)
-                    {
-                        error = new Reporting.Error(
-                            "Expected a non-null item, but got a null");
-                        error._pathSegments.AddFirst(
-                            new Reporting.IndexSegment(
-                                indexQualifiers));
-                        error._pathSegments.AddFirst(
-                            new Reporting.NameSegment(
-                                "qualifiers"));
-                    }
-                    IConstraint? parsedItem = DeserializeImplementation.IConstraintFrom(
-                        item ?? throw new System.InvalidOperationException(),
-                        out error);
-                    if (error != null)
-                    {
-                        error._pathSegments.AddFirst(
-                            new Reporting.IndexSegment(
-                                indexQualifiers));
-                        error._pathSegments.AddFirst(
-                            new Reporting.NameSegment(
-                                "qualifiers"));
-                        return null;
-                    }
-                    theQualifiers.Add(
-                        parsedItem
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected result null when error is null"));
-                    indexQualifiers++;
-                }
-
                 Nodes.JsonNode? nodeExtensions = obj["extensions"];
                 if (nodeExtensions == null)
                 {
@@ -2399,6 +2253,152 @@ namespace AasCore.Aas3
                     {
                         throw new System.InvalidOperationException(
                             "Unexpected theAdministration null when error is also null");
+                    }
+                }
+
+                Nodes.JsonNode? nodeKind = obj["kind"];
+                Aas.ModelingKind? theKind = null;
+                if (nodeKind != null)
+                {
+                    theKind = DeserializeImplementation.ModelingKindFrom(
+                        nodeKind,
+                        out error);
+                    if (error != null)
+                    {
+                        error._pathSegments.AddFirst(
+                            new Reporting.NameSegment(
+                                "kind"));
+                        return null;
+                    }
+                    if (theKind == null)
+                    {
+                        throw new System.InvalidOperationException(
+                            "Unexpected theKind null when error is also null");
+                    }
+                }
+
+                Nodes.JsonNode? nodeSemanticId = obj["semanticId"];
+                Aas.IReference? theSemanticId = null;
+                if (nodeSemanticId != null)
+                {
+                    theSemanticId = DeserializeImplementation.IReferenceFrom(
+                        nodeSemanticId,
+                        out error);
+                    if (error != null)
+                    {
+                        error._pathSegments.AddFirst(
+                            new Reporting.NameSegment(
+                                "semanticId"));
+                        return null;
+                    }
+                    if (theSemanticId == null)
+                    {
+                        throw new System.InvalidOperationException(
+                            "Unexpected theSemanticId null when error is also null");
+                    }
+                }
+
+                Nodes.JsonNode? nodeQualifiers = obj["qualifiers"];
+                if (nodeQualifiers == null)
+                {
+                    error = new Reporting.Error(
+                        "Required property \"qualifiers\" is missing ");
+                    return null;
+                }
+                Nodes.JsonArray? arrayQualifiers = nodeQualifiers as Nodes.JsonArray;
+                if (arrayQualifiers == null)
+                {
+                    error = new Reporting.Error(
+                        $"Expected a JsonArray, but got {nodeQualifiers.GetType()}");
+                    error._pathSegments.AddFirst(
+                        new Reporting.NameSegment(
+                            "qualifiers"));
+                    return null;
+                }
+                var theQualifiers = new List<IConstraint>(
+                    arrayQualifiers.Count);
+                int indexQualifiers = 0;
+                foreach (Nodes.JsonNode? item in arrayQualifiers)
+                {
+                    if (item == null)
+                    {
+                        error = new Reporting.Error(
+                            "Expected a non-null item, but got a null");
+                        error._pathSegments.AddFirst(
+                            new Reporting.IndexSegment(
+                                indexQualifiers));
+                        error._pathSegments.AddFirst(
+                            new Reporting.NameSegment(
+                                "qualifiers"));
+                    }
+                    IConstraint? parsedItem = DeserializeImplementation.IConstraintFrom(
+                        item ?? throw new System.InvalidOperationException(),
+                        out error);
+                    if (error != null)
+                    {
+                        error._pathSegments.AddFirst(
+                            new Reporting.IndexSegment(
+                                indexQualifiers));
+                        error._pathSegments.AddFirst(
+                            new Reporting.NameSegment(
+                                "qualifiers"));
+                        return null;
+                    }
+                    theQualifiers.Add(
+                        parsedItem
+                            ?? throw new System.InvalidOperationException(
+                                "Unexpected result null when error is null"));
+                    indexQualifiers++;
+                }
+
+                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
+                List<IReference>? theDataSpecifications = null;
+                if (nodeDataSpecifications != null)
+                {
+                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
+                    if (arrayDataSpecifications == null)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
+                        error._pathSegments.AddFirst(
+                            new Reporting.NameSegment(
+                                "dataSpecifications"));
+                        return null;
+                    }
+                    theDataSpecifications = new List<IReference>(
+                        arrayDataSpecifications.Count);
+                    int indexDataSpecifications = 0;
+                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                    {
+                        if (item == null)
+                        {
+                            error = new Reporting.Error(
+                                "Expected a non-null item, but got a null");
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                        }
+                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
+                            item ?? throw new System.InvalidOperationException(),
+                            out error);
+                        if (error != null)
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            return null;
+                        }
+                        theDataSpecifications.Add(
+                            parsedItem
+                                ?? throw new System.InvalidOperationException(
+                                    "Unexpected result null when error is null"));
+                        indexDataSpecifications++;
                     }
                 }
 
@@ -2645,57 +2645,6 @@ namespace AasCore.Aas3
                     return null;
                 }
 
-                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
-                List<IReference>? theDataSpecifications = null;
-                if (nodeDataSpecifications != null)
-                {
-                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
-                    if (arrayDataSpecifications == null)
-                    {
-                        error = new Reporting.Error(
-                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
-                            new Reporting.NameSegment(
-                                "dataSpecifications"));
-                        return null;
-                    }
-                    theDataSpecifications = new List<IReference>(
-                        arrayDataSpecifications.Count);
-                    int indexDataSpecifications = 0;
-                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
-                    {
-                        if (item == null)
-                        {
-                            error = new Reporting.Error(
-                                "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                        }
-                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
-                            item ?? throw new System.InvalidOperationException(),
-                            out error);
-                        if (error != null)
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            return null;
-                        }
-                        theDataSpecifications.Add(
-                            parsedItem
-                                ?? throw new System.InvalidOperationException(
-                                    "Unexpected result null when error is null"));
-                        indexDataSpecifications++;
-                    }
-                }
-
                 Nodes.JsonNode? nodeExtensions = obj["extensions"];
                 if (nodeExtensions == null)
                 {
@@ -2926,6 +2875,57 @@ namespace AasCore.Aas3
                             ?? throw new System.InvalidOperationException(
                                 "Unexpected result null when error is null"));
                     indexQualifiers++;
+                }
+
+                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
+                List<IReference>? theDataSpecifications = null;
+                if (nodeDataSpecifications != null)
+                {
+                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
+                    if (arrayDataSpecifications == null)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
+                        error._pathSegments.AddFirst(
+                            new Reporting.NameSegment(
+                                "dataSpecifications"));
+                        return null;
+                    }
+                    theDataSpecifications = new List<IReference>(
+                        arrayDataSpecifications.Count);
+                    int indexDataSpecifications = 0;
+                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                    {
+                        if (item == null)
+                        {
+                            error = new Reporting.Error(
+                                "Expected a non-null item, but got a null");
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                        }
+                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
+                            item ?? throw new System.InvalidOperationException(),
+                            out error);
+                        if (error != null)
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            return null;
+                        }
+                        theDataSpecifications.Add(
+                            parsedItem
+                                ?? throw new System.InvalidOperationException(
+                                    "Unexpected result null when error is null"));
+                        indexDataSpecifications++;
+                    }
                 }
 
                 Nodes.JsonNode? nodeSubmodelElementTypeValues = obj["submodelElementTypeValues"];
@@ -3089,57 +3089,6 @@ namespace AasCore.Aas3
                     return null;
                 }
 
-                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
-                List<IReference>? theDataSpecifications = null;
-                if (nodeDataSpecifications != null)
-                {
-                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
-                    if (arrayDataSpecifications == null)
-                    {
-                        error = new Reporting.Error(
-                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
-                            new Reporting.NameSegment(
-                                "dataSpecifications"));
-                        return null;
-                    }
-                    theDataSpecifications = new List<IReference>(
-                        arrayDataSpecifications.Count);
-                    int indexDataSpecifications = 0;
-                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
-                    {
-                        if (item == null)
-                        {
-                            error = new Reporting.Error(
-                                "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                        }
-                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
-                            item ?? throw new System.InvalidOperationException(),
-                            out error);
-                        if (error != null)
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            return null;
-                        }
-                        theDataSpecifications.Add(
-                            parsedItem
-                                ?? throw new System.InvalidOperationException(
-                                    "Unexpected result null when error is null"));
-                        indexDataSpecifications++;
-                    }
-                }
-
                 Nodes.JsonNode? nodeExtensions = obj["extensions"];
                 if (nodeExtensions == null)
                 {
@@ -3370,6 +3319,57 @@ namespace AasCore.Aas3
                             ?? throw new System.InvalidOperationException(
                                 "Unexpected result null when error is null"));
                     indexQualifiers++;
+                }
+
+                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
+                List<IReference>? theDataSpecifications = null;
+                if (nodeDataSpecifications != null)
+                {
+                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
+                    if (arrayDataSpecifications == null)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
+                        error._pathSegments.AddFirst(
+                            new Reporting.NameSegment(
+                                "dataSpecifications"));
+                        return null;
+                    }
+                    theDataSpecifications = new List<IReference>(
+                        arrayDataSpecifications.Count);
+                    int indexDataSpecifications = 0;
+                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                    {
+                        if (item == null)
+                        {
+                            error = new Reporting.Error(
+                                "Expected a non-null item, but got a null");
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                        }
+                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
+                            item ?? throw new System.InvalidOperationException(),
+                            out error);
+                        if (error != null)
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            return null;
+                        }
+                        theDataSpecifications.Add(
+                            parsedItem
+                                ?? throw new System.InvalidOperationException(
+                                    "Unexpected result null when error is null"));
+                        indexDataSpecifications++;
+                    }
                 }
 
                 Nodes.JsonNode? nodeValues = obj["values"];
@@ -3534,57 +3534,6 @@ namespace AasCore.Aas3
                     return null;
                 }
 
-                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
-                List<IReference>? theDataSpecifications = null;
-                if (nodeDataSpecifications != null)
-                {
-                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
-                    if (arrayDataSpecifications == null)
-                    {
-                        error = new Reporting.Error(
-                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
-                            new Reporting.NameSegment(
-                                "dataSpecifications"));
-                        return null;
-                    }
-                    theDataSpecifications = new List<IReference>(
-                        arrayDataSpecifications.Count);
-                    int indexDataSpecifications = 0;
-                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
-                    {
-                        if (item == null)
-                        {
-                            error = new Reporting.Error(
-                                "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                        }
-                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
-                            item ?? throw new System.InvalidOperationException(),
-                            out error);
-                        if (error != null)
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            return null;
-                        }
-                        theDataSpecifications.Add(
-                            parsedItem
-                                ?? throw new System.InvalidOperationException(
-                                    "Unexpected result null when error is null"));
-                        indexDataSpecifications++;
-                    }
-                }
-
                 Nodes.JsonNode? nodeExtensions = obj["extensions"];
                 if (nodeExtensions == null)
                 {
@@ -3815,6 +3764,57 @@ namespace AasCore.Aas3
                             ?? throw new System.InvalidOperationException(
                                 "Unexpected result null when error is null"));
                     indexQualifiers++;
+                }
+
+                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
+                List<IReference>? theDataSpecifications = null;
+                if (nodeDataSpecifications != null)
+                {
+                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
+                    if (arrayDataSpecifications == null)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
+                        error._pathSegments.AddFirst(
+                            new Reporting.NameSegment(
+                                "dataSpecifications"));
+                        return null;
+                    }
+                    theDataSpecifications = new List<IReference>(
+                        arrayDataSpecifications.Count);
+                    int indexDataSpecifications = 0;
+                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                    {
+                        if (item == null)
+                        {
+                            error = new Reporting.Error(
+                                "Expected a non-null item, but got a null");
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                        }
+                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
+                            item ?? throw new System.InvalidOperationException(),
+                            out error);
+                        if (error != null)
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            return null;
+                        }
+                        theDataSpecifications.Add(
+                            parsedItem
+                                ?? throw new System.InvalidOperationException(
+                                    "Unexpected result null when error is null"));
+                        indexDataSpecifications++;
+                    }
                 }
 
                 Nodes.JsonNode? nodeValueType = obj["valueType"];
@@ -3922,57 +3922,6 @@ namespace AasCore.Aas3
                     return null;
                 }
 
-                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
-                List<IReference>? theDataSpecifications = null;
-                if (nodeDataSpecifications != null)
-                {
-                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
-                    if (arrayDataSpecifications == null)
-                    {
-                        error = new Reporting.Error(
-                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
-                            new Reporting.NameSegment(
-                                "dataSpecifications"));
-                        return null;
-                    }
-                    theDataSpecifications = new List<IReference>(
-                        arrayDataSpecifications.Count);
-                    int indexDataSpecifications = 0;
-                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
-                    {
-                        if (item == null)
-                        {
-                            error = new Reporting.Error(
-                                "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                        }
-                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
-                            item ?? throw new System.InvalidOperationException(),
-                            out error);
-                        if (error != null)
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            return null;
-                        }
-                        theDataSpecifications.Add(
-                            parsedItem
-                                ?? throw new System.InvalidOperationException(
-                                    "Unexpected result null when error is null"));
-                        indexDataSpecifications++;
-                    }
-                }
-
                 Nodes.JsonNode? nodeExtensions = obj["extensions"];
                 if (nodeExtensions == null)
                 {
@@ -4203,6 +4152,57 @@ namespace AasCore.Aas3
                             ?? throw new System.InvalidOperationException(
                                 "Unexpected result null when error is null"));
                     indexQualifiers++;
+                }
+
+                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
+                List<IReference>? theDataSpecifications = null;
+                if (nodeDataSpecifications != null)
+                {
+                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
+                    if (arrayDataSpecifications == null)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
+                        error._pathSegments.AddFirst(
+                            new Reporting.NameSegment(
+                                "dataSpecifications"));
+                        return null;
+                    }
+                    theDataSpecifications = new List<IReference>(
+                        arrayDataSpecifications.Count);
+                    int indexDataSpecifications = 0;
+                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                    {
+                        if (item == null)
+                        {
+                            error = new Reporting.Error(
+                                "Expected a non-null item, but got a null");
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                        }
+                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
+                            item ?? throw new System.InvalidOperationException(),
+                            out error);
+                        if (error != null)
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            return null;
+                        }
+                        theDataSpecifications.Add(
+                            parsedItem
+                                ?? throw new System.InvalidOperationException(
+                                    "Unexpected result null when error is null"));
+                        indexDataSpecifications++;
+                    }
                 }
 
                 Nodes.JsonNode? nodeValue = obj["value"];
@@ -4284,57 +4284,6 @@ namespace AasCore.Aas3
                     return null;
                 }
 
-                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
-                List<IReference>? theDataSpecifications = null;
-                if (nodeDataSpecifications != null)
-                {
-                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
-                    if (arrayDataSpecifications == null)
-                    {
-                        error = new Reporting.Error(
-                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
-                            new Reporting.NameSegment(
-                                "dataSpecifications"));
-                        return null;
-                    }
-                    theDataSpecifications = new List<IReference>(
-                        arrayDataSpecifications.Count);
-                    int indexDataSpecifications = 0;
-                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
-                    {
-                        if (item == null)
-                        {
-                            error = new Reporting.Error(
-                                "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                        }
-                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
-                            item ?? throw new System.InvalidOperationException(),
-                            out error);
-                        if (error != null)
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            return null;
-                        }
-                        theDataSpecifications.Add(
-                            parsedItem
-                                ?? throw new System.InvalidOperationException(
-                                    "Unexpected result null when error is null"));
-                        indexDataSpecifications++;
-                    }
-                }
-
                 Nodes.JsonNode? nodeExtensions = obj["extensions"];
                 if (nodeExtensions == null)
                 {
@@ -4565,6 +4514,57 @@ namespace AasCore.Aas3
                             ?? throw new System.InvalidOperationException(
                                 "Unexpected result null when error is null"));
                     indexQualifiers++;
+                }
+
+                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
+                List<IReference>? theDataSpecifications = null;
+                if (nodeDataSpecifications != null)
+                {
+                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
+                    if (arrayDataSpecifications == null)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
+                        error._pathSegments.AddFirst(
+                            new Reporting.NameSegment(
+                                "dataSpecifications"));
+                        return null;
+                    }
+                    theDataSpecifications = new List<IReference>(
+                        arrayDataSpecifications.Count);
+                    int indexDataSpecifications = 0;
+                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                    {
+                        if (item == null)
+                        {
+                            error = new Reporting.Error(
+                                "Expected a non-null item, but got a null");
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                        }
+                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
+                            item ?? throw new System.InvalidOperationException(),
+                            out error);
+                        if (error != null)
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            return null;
+                        }
+                        theDataSpecifications.Add(
+                            parsedItem
+                                ?? throw new System.InvalidOperationException(
+                                    "Unexpected result null when error is null"));
+                        indexDataSpecifications++;
+                    }
                 }
 
                 Nodes.JsonNode? nodeValueType = obj["valueType"];
@@ -4672,57 +4672,6 @@ namespace AasCore.Aas3
                     return null;
                 }
 
-                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
-                List<IReference>? theDataSpecifications = null;
-                if (nodeDataSpecifications != null)
-                {
-                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
-                    if (arrayDataSpecifications == null)
-                    {
-                        error = new Reporting.Error(
-                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
-                            new Reporting.NameSegment(
-                                "dataSpecifications"));
-                        return null;
-                    }
-                    theDataSpecifications = new List<IReference>(
-                        arrayDataSpecifications.Count);
-                    int indexDataSpecifications = 0;
-                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
-                    {
-                        if (item == null)
-                        {
-                            error = new Reporting.Error(
-                                "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                        }
-                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
-                            item ?? throw new System.InvalidOperationException(),
-                            out error);
-                        if (error != null)
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            return null;
-                        }
-                        theDataSpecifications.Add(
-                            parsedItem
-                                ?? throw new System.InvalidOperationException(
-                                    "Unexpected result null when error is null"));
-                        indexDataSpecifications++;
-                    }
-                }
-
                 Nodes.JsonNode? nodeExtensions = obj["extensions"];
                 if (nodeExtensions == null)
                 {
@@ -4953,6 +4902,57 @@ namespace AasCore.Aas3
                             ?? throw new System.InvalidOperationException(
                                 "Unexpected result null when error is null"));
                     indexQualifiers++;
+                }
+
+                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
+                List<IReference>? theDataSpecifications = null;
+                if (nodeDataSpecifications != null)
+                {
+                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
+                    if (arrayDataSpecifications == null)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
+                        error._pathSegments.AddFirst(
+                            new Reporting.NameSegment(
+                                "dataSpecifications"));
+                        return null;
+                    }
+                    theDataSpecifications = new List<IReference>(
+                        arrayDataSpecifications.Count);
+                    int indexDataSpecifications = 0;
+                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                    {
+                        if (item == null)
+                        {
+                            error = new Reporting.Error(
+                                "Expected a non-null item, but got a null");
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                        }
+                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
+                            item ?? throw new System.InvalidOperationException(),
+                            out error);
+                        if (error != null)
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            return null;
+                        }
+                        theDataSpecifications.Add(
+                            parsedItem
+                                ?? throw new System.InvalidOperationException(
+                                    "Unexpected result null when error is null"));
+                        indexDataSpecifications++;
+                    }
                 }
 
                 Nodes.JsonNode? nodeValue = obj["value"];
@@ -5012,57 +5012,6 @@ namespace AasCore.Aas3
                     return null;
                 }
 
-                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
-                List<IReference>? theDataSpecifications = null;
-                if (nodeDataSpecifications != null)
-                {
-                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
-                    if (arrayDataSpecifications == null)
-                    {
-                        error = new Reporting.Error(
-                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
-                            new Reporting.NameSegment(
-                                "dataSpecifications"));
-                        return null;
-                    }
-                    theDataSpecifications = new List<IReference>(
-                        arrayDataSpecifications.Count);
-                    int indexDataSpecifications = 0;
-                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
-                    {
-                        if (item == null)
-                        {
-                            error = new Reporting.Error(
-                                "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                        }
-                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
-                            item ?? throw new System.InvalidOperationException(),
-                            out error);
-                        if (error != null)
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            return null;
-                        }
-                        theDataSpecifications.Add(
-                            parsedItem
-                                ?? throw new System.InvalidOperationException(
-                                    "Unexpected result null when error is null"));
-                        indexDataSpecifications++;
-                    }
-                }
-
                 Nodes.JsonNode? nodeExtensions = obj["extensions"];
                 if (nodeExtensions == null)
                 {
@@ -5293,6 +5242,57 @@ namespace AasCore.Aas3
                             ?? throw new System.InvalidOperationException(
                                 "Unexpected result null when error is null"));
                     indexQualifiers++;
+                }
+
+                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
+                List<IReference>? theDataSpecifications = null;
+                if (nodeDataSpecifications != null)
+                {
+                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
+                    if (arrayDataSpecifications == null)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
+                        error._pathSegments.AddFirst(
+                            new Reporting.NameSegment(
+                                "dataSpecifications"));
+                        return null;
+                    }
+                    theDataSpecifications = new List<IReference>(
+                        arrayDataSpecifications.Count);
+                    int indexDataSpecifications = 0;
+                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                    {
+                        if (item == null)
+                        {
+                            error = new Reporting.Error(
+                                "Expected a non-null item, but got a null");
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                        }
+                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
+                            item ?? throw new System.InvalidOperationException(),
+                            out error);
+                        if (error != null)
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            return null;
+                        }
+                        theDataSpecifications.Add(
+                            parsedItem
+                                ?? throw new System.InvalidOperationException(
+                                    "Unexpected result null when error is null"));
+                        indexDataSpecifications++;
+                    }
                 }
 
                 Nodes.JsonNode? nodeMimeType = obj["mimeType"];
@@ -5378,57 +5378,6 @@ namespace AasCore.Aas3
                     return null;
                 }
 
-                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
-                List<IReference>? theDataSpecifications = null;
-                if (nodeDataSpecifications != null)
-                {
-                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
-                    if (arrayDataSpecifications == null)
-                    {
-                        error = new Reporting.Error(
-                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
-                            new Reporting.NameSegment(
-                                "dataSpecifications"));
-                        return null;
-                    }
-                    theDataSpecifications = new List<IReference>(
-                        arrayDataSpecifications.Count);
-                    int indexDataSpecifications = 0;
-                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
-                    {
-                        if (item == null)
-                        {
-                            error = new Reporting.Error(
-                                "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                        }
-                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
-                            item ?? throw new System.InvalidOperationException(),
-                            out error);
-                        if (error != null)
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            return null;
-                        }
-                        theDataSpecifications.Add(
-                            parsedItem
-                                ?? throw new System.InvalidOperationException(
-                                    "Unexpected result null when error is null"));
-                        indexDataSpecifications++;
-                    }
-                }
-
                 Nodes.JsonNode? nodeExtensions = obj["extensions"];
                 if (nodeExtensions == null)
                 {
@@ -5659,6 +5608,57 @@ namespace AasCore.Aas3
                             ?? throw new System.InvalidOperationException(
                                 "Unexpected result null when error is null"));
                     indexQualifiers++;
+                }
+
+                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
+                List<IReference>? theDataSpecifications = null;
+                if (nodeDataSpecifications != null)
+                {
+                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
+                    if (arrayDataSpecifications == null)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
+                        error._pathSegments.AddFirst(
+                            new Reporting.NameSegment(
+                                "dataSpecifications"));
+                        return null;
+                    }
+                    theDataSpecifications = new List<IReference>(
+                        arrayDataSpecifications.Count);
+                    int indexDataSpecifications = 0;
+                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                    {
+                        if (item == null)
+                        {
+                            error = new Reporting.Error(
+                                "Expected a non-null item, but got a null");
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                        }
+                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
+                            item ?? throw new System.InvalidOperationException(),
+                            out error);
+                        if (error != null)
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            return null;
+                        }
+                        theDataSpecifications.Add(
+                            parsedItem
+                                ?? throw new System.InvalidOperationException(
+                                    "Unexpected result null when error is null"));
+                        indexDataSpecifications++;
+                    }
                 }
 
                 Nodes.JsonNode? nodeMimeType = obj["mimeType"];
@@ -5744,57 +5744,6 @@ namespace AasCore.Aas3
                     return null;
                 }
 
-                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
-                List<IReference>? theDataSpecifications = null;
-                if (nodeDataSpecifications != null)
-                {
-                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
-                    if (arrayDataSpecifications == null)
-                    {
-                        error = new Reporting.Error(
-                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
-                            new Reporting.NameSegment(
-                                "dataSpecifications"));
-                        return null;
-                    }
-                    theDataSpecifications = new List<IReference>(
-                        arrayDataSpecifications.Count);
-                    int indexDataSpecifications = 0;
-                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
-                    {
-                        if (item == null)
-                        {
-                            error = new Reporting.Error(
-                                "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                        }
-                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
-                            item ?? throw new System.InvalidOperationException(),
-                            out error);
-                        if (error != null)
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            return null;
-                        }
-                        theDataSpecifications.Add(
-                            parsedItem
-                                ?? throw new System.InvalidOperationException(
-                                    "Unexpected result null when error is null"));
-                        indexDataSpecifications++;
-                    }
-                }
-
                 Nodes.JsonNode? nodeExtensions = obj["extensions"];
                 if (nodeExtensions == null)
                 {
@@ -6025,6 +5974,57 @@ namespace AasCore.Aas3
                             ?? throw new System.InvalidOperationException(
                                 "Unexpected result null when error is null"));
                     indexQualifiers++;
+                }
+
+                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
+                List<IReference>? theDataSpecifications = null;
+                if (nodeDataSpecifications != null)
+                {
+                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
+                    if (arrayDataSpecifications == null)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
+                        error._pathSegments.AddFirst(
+                            new Reporting.NameSegment(
+                                "dataSpecifications"));
+                        return null;
+                    }
+                    theDataSpecifications = new List<IReference>(
+                        arrayDataSpecifications.Count);
+                    int indexDataSpecifications = 0;
+                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                    {
+                        if (item == null)
+                        {
+                            error = new Reporting.Error(
+                                "Expected a non-null item, but got a null");
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                        }
+                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
+                            item ?? throw new System.InvalidOperationException(),
+                            out error);
+                        if (error != null)
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            return null;
+                        }
+                        theDataSpecifications.Add(
+                            parsedItem
+                                ?? throw new System.InvalidOperationException(
+                                    "Unexpected result null when error is null"));
+                        indexDataSpecifications++;
+                    }
                 }
 
                 Nodes.JsonNode? nodeFirst = obj["first"];
@@ -6200,57 +6200,6 @@ namespace AasCore.Aas3
                     return null;
                 }
 
-                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
-                List<IReference>? theDataSpecifications = null;
-                if (nodeDataSpecifications != null)
-                {
-                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
-                    if (arrayDataSpecifications == null)
-                    {
-                        error = new Reporting.Error(
-                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
-                            new Reporting.NameSegment(
-                                "dataSpecifications"));
-                        return null;
-                    }
-                    theDataSpecifications = new List<IReference>(
-                        arrayDataSpecifications.Count);
-                    int indexDataSpecifications = 0;
-                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
-                    {
-                        if (item == null)
-                        {
-                            error = new Reporting.Error(
-                                "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                        }
-                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
-                            item ?? throw new System.InvalidOperationException(),
-                            out error);
-                        if (error != null)
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            return null;
-                        }
-                        theDataSpecifications.Add(
-                            parsedItem
-                                ?? throw new System.InvalidOperationException(
-                                    "Unexpected result null when error is null"));
-                        indexDataSpecifications++;
-                    }
-                }
-
                 Nodes.JsonNode? nodeExtensions = obj["extensions"];
                 if (nodeExtensions == null)
                 {
@@ -6481,6 +6430,57 @@ namespace AasCore.Aas3
                             ?? throw new System.InvalidOperationException(
                                 "Unexpected result null when error is null"));
                     indexQualifiers++;
+                }
+
+                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
+                List<IReference>? theDataSpecifications = null;
+                if (nodeDataSpecifications != null)
+                {
+                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
+                    if (arrayDataSpecifications == null)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
+                        error._pathSegments.AddFirst(
+                            new Reporting.NameSegment(
+                                "dataSpecifications"));
+                        return null;
+                    }
+                    theDataSpecifications = new List<IReference>(
+                        arrayDataSpecifications.Count);
+                    int indexDataSpecifications = 0;
+                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                    {
+                        if (item == null)
+                        {
+                            error = new Reporting.Error(
+                                "Expected a non-null item, but got a null");
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                        }
+                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
+                            item ?? throw new System.InvalidOperationException(),
+                            out error);
+                        if (error != null)
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            return null;
+                        }
+                        theDataSpecifications.Add(
+                            parsedItem
+                                ?? throw new System.InvalidOperationException(
+                                    "Unexpected result null when error is null"));
+                        indexDataSpecifications++;
+                    }
                 }
 
                 Nodes.JsonNode? nodeEntityType = obj["entityType"];
@@ -6700,57 +6700,6 @@ namespace AasCore.Aas3
                     return null;
                 }
 
-                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
-                List<IReference>? theDataSpecifications = null;
-                if (nodeDataSpecifications != null)
-                {
-                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
-                    if (arrayDataSpecifications == null)
-                    {
-                        error = new Reporting.Error(
-                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
-                            new Reporting.NameSegment(
-                                "dataSpecifications"));
-                        return null;
-                    }
-                    theDataSpecifications = new List<IReference>(
-                        arrayDataSpecifications.Count);
-                    int indexDataSpecifications = 0;
-                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
-                    {
-                        if (item == null)
-                        {
-                            error = new Reporting.Error(
-                                "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                        }
-                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
-                            item ?? throw new System.InvalidOperationException(),
-                            out error);
-                        if (error != null)
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            return null;
-                        }
-                        theDataSpecifications.Add(
-                            parsedItem
-                                ?? throw new System.InvalidOperationException(
-                                    "Unexpected result null when error is null"));
-                        indexDataSpecifications++;
-                    }
-                }
-
                 Nodes.JsonNode? nodeExtensions = obj["extensions"];
                 if (nodeExtensions == null)
                 {
@@ -6981,6 +6930,57 @@ namespace AasCore.Aas3
                             ?? throw new System.InvalidOperationException(
                                 "Unexpected result null when error is null"));
                     indexQualifiers++;
+                }
+
+                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
+                List<IReference>? theDataSpecifications = null;
+                if (nodeDataSpecifications != null)
+                {
+                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
+                    if (arrayDataSpecifications == null)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
+                        error._pathSegments.AddFirst(
+                            new Reporting.NameSegment(
+                                "dataSpecifications"));
+                        return null;
+                    }
+                    theDataSpecifications = new List<IReference>(
+                        arrayDataSpecifications.Count);
+                    int indexDataSpecifications = 0;
+                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                    {
+                        if (item == null)
+                        {
+                            error = new Reporting.Error(
+                                "Expected a non-null item, but got a null");
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                        }
+                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
+                            item ?? throw new System.InvalidOperationException(),
+                            out error);
+                        if (error != null)
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            return null;
+                        }
+                        theDataSpecifications.Add(
+                            parsedItem
+                                ?? throw new System.InvalidOperationException(
+                                    "Unexpected result null when error is null"));
+                        indexDataSpecifications++;
+                    }
                 }
 
                 Nodes.JsonNode? nodeObserved = obj["observed"];
@@ -7044,57 +7044,6 @@ namespace AasCore.Aas3
                     return null;
                 }
 
-                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
-                List<IReference>? theDataSpecifications = null;
-                if (nodeDataSpecifications != null)
-                {
-                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
-                    if (arrayDataSpecifications == null)
-                    {
-                        error = new Reporting.Error(
-                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
-                            new Reporting.NameSegment(
-                                "dataSpecifications"));
-                        return null;
-                    }
-                    theDataSpecifications = new List<IReference>(
-                        arrayDataSpecifications.Count);
-                    int indexDataSpecifications = 0;
-                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
-                    {
-                        if (item == null)
-                        {
-                            error = new Reporting.Error(
-                                "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                        }
-                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
-                            item ?? throw new System.InvalidOperationException(),
-                            out error);
-                        if (error != null)
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            return null;
-                        }
-                        theDataSpecifications.Add(
-                            parsedItem
-                                ?? throw new System.InvalidOperationException(
-                                    "Unexpected result null when error is null"));
-                        indexDataSpecifications++;
-                    }
-                }
-
                 Nodes.JsonNode? nodeExtensions = obj["extensions"];
                 if (nodeExtensions == null)
                 {
@@ -7325,6 +7274,57 @@ namespace AasCore.Aas3
                             ?? throw new System.InvalidOperationException(
                                 "Unexpected result null when error is null"));
                     indexQualifiers++;
+                }
+
+                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
+                List<IReference>? theDataSpecifications = null;
+                if (nodeDataSpecifications != null)
+                {
+                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
+                    if (arrayDataSpecifications == null)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
+                        error._pathSegments.AddFirst(
+                            new Reporting.NameSegment(
+                                "dataSpecifications"));
+                        return null;
+                    }
+                    theDataSpecifications = new List<IReference>(
+                        arrayDataSpecifications.Count);
+                    int indexDataSpecifications = 0;
+                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                    {
+                        if (item == null)
+                        {
+                            error = new Reporting.Error(
+                                "Expected a non-null item, but got a null");
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                        }
+                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
+                            item ?? throw new System.InvalidOperationException(),
+                            out error);
+                        if (error != null)
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            return null;
+                        }
+                        theDataSpecifications.Add(
+                            parsedItem
+                                ?? throw new System.InvalidOperationException(
+                                    "Unexpected result null when error is null"));
+                        indexDataSpecifications++;
+                    }
                 }
 
                 Nodes.JsonNode? nodeInputVariables = obj["inputVariables"];
@@ -7578,57 +7578,6 @@ namespace AasCore.Aas3
                     return null;
                 }
 
-                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
-                List<IReference>? theDataSpecifications = null;
-                if (nodeDataSpecifications != null)
-                {
-                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
-                    if (arrayDataSpecifications == null)
-                    {
-                        error = new Reporting.Error(
-                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
-                            new Reporting.NameSegment(
-                                "dataSpecifications"));
-                        return null;
-                    }
-                    theDataSpecifications = new List<IReference>(
-                        arrayDataSpecifications.Count);
-                    int indexDataSpecifications = 0;
-                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
-                    {
-                        if (item == null)
-                        {
-                            error = new Reporting.Error(
-                                "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                        }
-                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
-                            item ?? throw new System.InvalidOperationException(),
-                            out error);
-                        if (error != null)
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            return null;
-                        }
-                        theDataSpecifications.Add(
-                            parsedItem
-                                ?? throw new System.InvalidOperationException(
-                                    "Unexpected result null when error is null"));
-                        indexDataSpecifications++;
-                    }
-                }
-
                 Nodes.JsonNode? nodeExtensions = obj["extensions"];
                 if (nodeExtensions == null)
                 {
@@ -7861,41 +7810,6 @@ namespace AasCore.Aas3
                     indexQualifiers++;
                 }
 
-                return new Aas.Capability(
-                    theExtensions
-                         ?? throw new System.InvalidOperationException(
-                            "Unexpected null, had to be handled before"),
-                    theIdShort,
-                    theDisplayName,
-                    theCategory,
-                    theDescription,
-                    theKind,
-                    theSemanticId,
-                    theQualifiers
-                         ?? throw new System.InvalidOperationException(
-                            "Unexpected null, had to be handled before"),
-                    theDataSpecifications);
-            }  // internal static CapabilityFrom
-
-            /// <summary>
-            /// Deserialize an instance of ConceptDescription from <paramref name="node" />.
-            /// </summary>
-            /// <param name="node">JSON node to be parsed</param>
-            /// <param name="error">Error, if any, during the deserialization</param>
-            internal static Aas.ConceptDescription? ConceptDescriptionFrom(
-                Nodes.JsonNode node,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                Nodes.JsonObject? obj = node as Nodes.JsonObject;
-                if (obj == null)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a JsonObject, but got {node.GetType()}");
-                    return null;
-                }
-
                 Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
                 List<IReference>? theDataSpecifications = null;
                 if (nodeDataSpecifications != null)
@@ -7945,6 +7859,41 @@ namespace AasCore.Aas3
                                     "Unexpected result null when error is null"));
                         indexDataSpecifications++;
                     }
+                }
+
+                return new Aas.Capability(
+                    theExtensions
+                         ?? throw new System.InvalidOperationException(
+                            "Unexpected null, had to be handled before"),
+                    theIdShort,
+                    theDisplayName,
+                    theCategory,
+                    theDescription,
+                    theKind,
+                    theSemanticId,
+                    theQualifiers
+                         ?? throw new System.InvalidOperationException(
+                            "Unexpected null, had to be handled before"),
+                    theDataSpecifications);
+            }  // internal static CapabilityFrom
+
+            /// <summary>
+            /// Deserialize an instance of ConceptDescription from <paramref name="node" />.
+            /// </summary>
+            /// <param name="node">JSON node to be parsed</param>
+            /// <param name="error">Error, if any, during the deserialization</param>
+            internal static Aas.ConceptDescription? ConceptDescriptionFrom(
+                Nodes.JsonNode node,
+                out Reporting.Error? error)
+            {
+                error = null;
+
+                Nodes.JsonObject? obj = node as Nodes.JsonObject;
+                if (obj == null)
+                {
+                    error = new Reporting.Error(
+                        $"Expected a JsonObject, but got {node.GetType()}");
+                    return null;
                 }
 
                 Nodes.JsonNode? nodeExtensions = obj["extensions"];
@@ -8128,6 +8077,57 @@ namespace AasCore.Aas3
                     }
                 }
 
+                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
+                List<IReference>? theDataSpecifications = null;
+                if (nodeDataSpecifications != null)
+                {
+                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
+                    if (arrayDataSpecifications == null)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
+                        error._pathSegments.AddFirst(
+                            new Reporting.NameSegment(
+                                "dataSpecifications"));
+                        return null;
+                    }
+                    theDataSpecifications = new List<IReference>(
+                        arrayDataSpecifications.Count);
+                    int indexDataSpecifications = 0;
+                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                    {
+                        if (item == null)
+                        {
+                            error = new Reporting.Error(
+                                "Expected a non-null item, but got a null");
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                        }
+                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
+                            item ?? throw new System.InvalidOperationException(),
+                            out error);
+                        if (error != null)
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            return null;
+                        }
+                        theDataSpecifications.Add(
+                            parsedItem
+                                ?? throw new System.InvalidOperationException(
+                                    "Unexpected result null when error is null"));
+                        indexDataSpecifications++;
+                    }
+                }
+
                 Nodes.JsonNode? nodeIsCaseOf = obj["isCaseOf"];
                 if (nodeIsCaseOf == null)
                 {
@@ -8216,57 +8216,6 @@ namespace AasCore.Aas3
                     error = new Reporting.Error(
                         $"Expected a JsonObject, but got {node.GetType()}");
                     return null;
-                }
-
-                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
-                List<IReference>? theDataSpecifications = null;
-                if (nodeDataSpecifications != null)
-                {
-                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
-                    if (arrayDataSpecifications == null)
-                    {
-                        error = new Reporting.Error(
-                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
-                            new Reporting.NameSegment(
-                                "dataSpecifications"));
-                        return null;
-                    }
-                    theDataSpecifications = new List<IReference>(
-                        arrayDataSpecifications.Count);
-                    int indexDataSpecifications = 0;
-                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
-                    {
-                        if (item == null)
-                        {
-                            error = new Reporting.Error(
-                                "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                        }
-                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
-                            item ?? throw new System.InvalidOperationException(),
-                            out error);
-                        if (error != null)
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            return null;
-                        }
-                        theDataSpecifications.Add(
-                            parsedItem
-                                ?? throw new System.InvalidOperationException(
-                                    "Unexpected result null when error is null"));
-                        indexDataSpecifications++;
-                    }
                 }
 
                 Nodes.JsonNode? nodeExtensions = obj["extensions"];
@@ -8424,6 +8373,57 @@ namespace AasCore.Aas3
                     {
                         throw new System.InvalidOperationException(
                             "Unexpected theSemanticId null when error is also null");
+                    }
+                }
+
+                Nodes.JsonNode? nodeDataSpecifications = obj["dataSpecifications"];
+                List<IReference>? theDataSpecifications = null;
+                if (nodeDataSpecifications != null)
+                {
+                    Nodes.JsonArray? arrayDataSpecifications = nodeDataSpecifications as Nodes.JsonArray;
+                    if (arrayDataSpecifications == null)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
+                        error._pathSegments.AddFirst(
+                            new Reporting.NameSegment(
+                                "dataSpecifications"));
+                        return null;
+                    }
+                    theDataSpecifications = new List<IReference>(
+                        arrayDataSpecifications.Count);
+                    int indexDataSpecifications = 0;
+                    foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                    {
+                        if (item == null)
+                        {
+                            error = new Reporting.Error(
+                                "Expected a non-null item, but got a null");
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                        }
+                        IReference? parsedItem = DeserializeImplementation.IReferenceFrom(
+                            item ?? throw new System.InvalidOperationException(),
+                            out error);
+                        if (error != null)
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            return null;
+                        }
+                        theDataSpecifications.Add(
+                            parsedItem
+                                ?? throw new System.InvalidOperationException(
+                                    "Unexpected result null when error is null"));
+                        indexDataSpecifications++;
                     }
                 }
 
@@ -11881,18 +11881,6 @@ namespace AasCore.Aas3
             {
                 var result = new Nodes.JsonObject();
 
-                if (that.DataSpecifications != null)
-                {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (IReference item in that.DataSpecifications)
-                    {
-                        arrayDataSpecifications.Add(
-                            Transform(
-                                item));
-                    }
-                    result["dataSpecifications"] = arrayDataSpecifications;
-                }
-
                 var arrayExtensions = new Nodes.JsonArray();
                 foreach (Extension item in that.Extensions)
                 {
@@ -11933,6 +11921,18 @@ namespace AasCore.Aas3
                 {
                     result["administration"] = Transform(
                         that.Administration);
+                }
+
+                if (that.DataSpecifications != null)
+                {
+                    var arrayDataSpecifications = new Nodes.JsonArray();
+                    foreach (IReference item in that.DataSpecifications)
+                    {
+                        arrayDataSpecifications.Add(
+                            Transform(
+                                item));
+                    }
+                    result["dataSpecifications"] = arrayDataSpecifications;
                 }
 
                 if (that.DerivedFrom != null)
@@ -12016,42 +12016,6 @@ namespace AasCore.Aas3
             {
                 var result = new Nodes.JsonObject();
 
-                if (that.DataSpecifications != null)
-                {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (IReference item in that.DataSpecifications)
-                    {
-                        arrayDataSpecifications.Add(
-                            Transform(
-                                item));
-                    }
-                    result["dataSpecifications"] = arrayDataSpecifications;
-                }
-
-                if (that.Kind != null)
-                {
-                    // We need to help the static analyzer with a null coalescing.
-                    Aas.ModelingKind value = that.Kind
-                        ?? throw new System.InvalidOperationException();
-                    result["kind"] = Serialize.ModelingKindToJsonValue(
-                        value);
-                }
-
-                if (that.SemanticId != null)
-                {
-                    result["semanticId"] = Transform(
-                        that.SemanticId);
-                }
-
-                var arrayQualifiers = new Nodes.JsonArray();
-                foreach (IConstraint item in that.Qualifiers)
-                {
-                    arrayQualifiers.Add(
-                        Transform(
-                            item));
-                }
-                result["qualifiers"] = arrayQualifiers;
-
                 var arrayExtensions = new Nodes.JsonArray();
                 foreach (Extension item in that.Extensions)
                 {
@@ -12094,6 +12058,42 @@ namespace AasCore.Aas3
                         that.Administration);
                 }
 
+                if (that.Kind != null)
+                {
+                    // We need to help the static analyzer with a null coalescing.
+                    Aas.ModelingKind value = that.Kind
+                        ?? throw new System.InvalidOperationException();
+                    result["kind"] = Serialize.ModelingKindToJsonValue(
+                        value);
+                }
+
+                if (that.SemanticId != null)
+                {
+                    result["semanticId"] = Transform(
+                        that.SemanticId);
+                }
+
+                var arrayQualifiers = new Nodes.JsonArray();
+                foreach (IConstraint item in that.Qualifiers)
+                {
+                    arrayQualifiers.Add(
+                        Transform(
+                            item));
+                }
+                result["qualifiers"] = arrayQualifiers;
+
+                if (that.DataSpecifications != null)
+                {
+                    var arrayDataSpecifications = new Nodes.JsonArray();
+                    foreach (IReference item in that.DataSpecifications)
+                    {
+                        arrayDataSpecifications.Add(
+                            Transform(
+                                item));
+                    }
+                    result["dataSpecifications"] = arrayDataSpecifications;
+                }
+
                 var arraySubmodelElements = new Nodes.JsonArray();
                 foreach (ISubmodelElement item in that.SubmodelElements)
                 {
@@ -12109,18 +12109,6 @@ namespace AasCore.Aas3
             public override Nodes.JsonObject Transform(Aas.SubmodelElementList that)
             {
                 var result = new Nodes.JsonObject();
-
-                if (that.DataSpecifications != null)
-                {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (IReference item in that.DataSpecifications)
-                    {
-                        arrayDataSpecifications.Add(
-                            Transform(
-                                item));
-                    }
-                    result["dataSpecifications"] = arrayDataSpecifications;
-                }
 
                 var arrayExtensions = new Nodes.JsonArray();
                 foreach (Extension item in that.Extensions)
@@ -12178,6 +12166,18 @@ namespace AasCore.Aas3
                             item));
                 }
                 result["qualifiers"] = arrayQualifiers;
+
+                if (that.DataSpecifications != null)
+                {
+                    var arrayDataSpecifications = new Nodes.JsonArray();
+                    foreach (IReference item in that.DataSpecifications)
+                    {
+                        arrayDataSpecifications.Add(
+                            Transform(
+                                item));
+                    }
+                    result["dataSpecifications"] = arrayDataSpecifications;
+                }
 
                 result["submodelElementTypeValues"] = Serialize.SubmodelElementsToJsonValue(
                     that.SubmodelElementTypeValues);
@@ -12213,18 +12213,6 @@ namespace AasCore.Aas3
             {
                 var result = new Nodes.JsonObject();
 
-                if (that.DataSpecifications != null)
-                {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (IReference item in that.DataSpecifications)
-                    {
-                        arrayDataSpecifications.Add(
-                            Transform(
-                                item));
-                    }
-                    result["dataSpecifications"] = arrayDataSpecifications;
-                }
-
                 var arrayExtensions = new Nodes.JsonArray();
                 foreach (Extension item in that.Extensions)
                 {
@@ -12281,6 +12269,18 @@ namespace AasCore.Aas3
                             item));
                 }
                 result["qualifiers"] = arrayQualifiers;
+
+                if (that.DataSpecifications != null)
+                {
+                    var arrayDataSpecifications = new Nodes.JsonArray();
+                    foreach (IReference item in that.DataSpecifications)
+                    {
+                        arrayDataSpecifications.Add(
+                            Transform(
+                                item));
+                    }
+                    result["dataSpecifications"] = arrayDataSpecifications;
+                }
 
                 var arrayValues = new Nodes.JsonArray();
                 foreach (ISubmodelElement item in that.Values)
@@ -12298,18 +12298,6 @@ namespace AasCore.Aas3
             {
                 var result = new Nodes.JsonObject();
 
-                if (that.DataSpecifications != null)
-                {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (IReference item in that.DataSpecifications)
-                    {
-                        arrayDataSpecifications.Add(
-                            Transform(
-                                item));
-                    }
-                    result["dataSpecifications"] = arrayDataSpecifications;
-                }
-
                 var arrayExtensions = new Nodes.JsonArray();
                 foreach (Extension item in that.Extensions)
                 {
@@ -12366,6 +12354,18 @@ namespace AasCore.Aas3
                             item));
                 }
                 result["qualifiers"] = arrayQualifiers;
+
+                if (that.DataSpecifications != null)
+                {
+                    var arrayDataSpecifications = new Nodes.JsonArray();
+                    foreach (IReference item in that.DataSpecifications)
+                    {
+                        arrayDataSpecifications.Add(
+                            Transform(
+                                item));
+                    }
+                    result["dataSpecifications"] = arrayDataSpecifications;
+                }
 
                 result["valueType"] = Serialize.DataTypeDefToJsonValue(
                     that.ValueType);
@@ -12389,18 +12389,6 @@ namespace AasCore.Aas3
             {
                 var result = new Nodes.JsonObject();
 
-                if (that.DataSpecifications != null)
-                {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (IReference item in that.DataSpecifications)
-                    {
-                        arrayDataSpecifications.Add(
-                            Transform(
-                                item));
-                    }
-                    result["dataSpecifications"] = arrayDataSpecifications;
-                }
-
                 var arrayExtensions = new Nodes.JsonArray();
                 foreach (Extension item in that.Extensions)
                 {
@@ -12457,6 +12445,18 @@ namespace AasCore.Aas3
                             item));
                 }
                 result["qualifiers"] = arrayQualifiers;
+
+                if (that.DataSpecifications != null)
+                {
+                    var arrayDataSpecifications = new Nodes.JsonArray();
+                    foreach (IReference item in that.DataSpecifications)
+                    {
+                        arrayDataSpecifications.Add(
+                            Transform(
+                                item));
+                    }
+                    result["dataSpecifications"] = arrayDataSpecifications;
+                }
 
                 if (that.Value != null)
                 {
@@ -12477,18 +12477,6 @@ namespace AasCore.Aas3
             {
                 var result = new Nodes.JsonObject();
 
-                if (that.DataSpecifications != null)
-                {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (IReference item in that.DataSpecifications)
-                    {
-                        arrayDataSpecifications.Add(
-                            Transform(
-                                item));
-                    }
-                    result["dataSpecifications"] = arrayDataSpecifications;
-                }
-
                 var arrayExtensions = new Nodes.JsonArray();
                 foreach (Extension item in that.Extensions)
                 {
@@ -12545,6 +12533,18 @@ namespace AasCore.Aas3
                             item));
                 }
                 result["qualifiers"] = arrayQualifiers;
+
+                if (that.DataSpecifications != null)
+                {
+                    var arrayDataSpecifications = new Nodes.JsonArray();
+                    foreach (IReference item in that.DataSpecifications)
+                    {
+                        arrayDataSpecifications.Add(
+                            Transform(
+                                item));
+                    }
+                    result["dataSpecifications"] = arrayDataSpecifications;
+                }
 
                 result["valueType"] = Serialize.DataTypeDefToJsonValue(
                     that.ValueType);
@@ -12568,18 +12568,6 @@ namespace AasCore.Aas3
             {
                 var result = new Nodes.JsonObject();
 
-                if (that.DataSpecifications != null)
-                {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (IReference item in that.DataSpecifications)
-                    {
-                        arrayDataSpecifications.Add(
-                            Transform(
-                                item));
-                    }
-                    result["dataSpecifications"] = arrayDataSpecifications;
-                }
-
                 var arrayExtensions = new Nodes.JsonArray();
                 foreach (Extension item in that.Extensions)
                 {
@@ -12636,6 +12624,18 @@ namespace AasCore.Aas3
                             item));
                 }
                 result["qualifiers"] = arrayQualifiers;
+
+                if (that.DataSpecifications != null)
+                {
+                    var arrayDataSpecifications = new Nodes.JsonArray();
+                    foreach (IReference item in that.DataSpecifications)
+                    {
+                        arrayDataSpecifications.Add(
+                            Transform(
+                                item));
+                    }
+                    result["dataSpecifications"] = arrayDataSpecifications;
+                }
 
                 if (that.Value != null)
                 {
@@ -12650,18 +12650,6 @@ namespace AasCore.Aas3
             {
                 var result = new Nodes.JsonObject();
 
-                if (that.DataSpecifications != null)
-                {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (IReference item in that.DataSpecifications)
-                    {
-                        arrayDataSpecifications.Add(
-                            Transform(
-                                item));
-                    }
-                    result["dataSpecifications"] = arrayDataSpecifications;
-                }
-
                 var arrayExtensions = new Nodes.JsonArray();
                 foreach (Extension item in that.Extensions)
                 {
@@ -12718,6 +12706,18 @@ namespace AasCore.Aas3
                             item));
                 }
                 result["qualifiers"] = arrayQualifiers;
+
+                if (that.DataSpecifications != null)
+                {
+                    var arrayDataSpecifications = new Nodes.JsonArray();
+                    foreach (IReference item in that.DataSpecifications)
+                    {
+                        arrayDataSpecifications.Add(
+                            Transform(
+                                item));
+                    }
+                    result["dataSpecifications"] = arrayDataSpecifications;
+                }
 
                 result["mimeType"] = Nodes.JsonValue.Create(
                     that.MimeType);
@@ -12736,18 +12736,6 @@ namespace AasCore.Aas3
             {
                 var result = new Nodes.JsonObject();
 
-                if (that.DataSpecifications != null)
-                {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (IReference item in that.DataSpecifications)
-                    {
-                        arrayDataSpecifications.Add(
-                            Transform(
-                                item));
-                    }
-                    result["dataSpecifications"] = arrayDataSpecifications;
-                }
-
                 var arrayExtensions = new Nodes.JsonArray();
                 foreach (Extension item in that.Extensions)
                 {
@@ -12804,6 +12792,18 @@ namespace AasCore.Aas3
                             item));
                 }
                 result["qualifiers"] = arrayQualifiers;
+
+                if (that.DataSpecifications != null)
+                {
+                    var arrayDataSpecifications = new Nodes.JsonArray();
+                    foreach (IReference item in that.DataSpecifications)
+                    {
+                        arrayDataSpecifications.Add(
+                            Transform(
+                                item));
+                    }
+                    result["dataSpecifications"] = arrayDataSpecifications;
+                }
 
                 result["mimeType"] = Nodes.JsonValue.Create(
                     that.MimeType);
@@ -12821,18 +12821,6 @@ namespace AasCore.Aas3
             {
                 var result = new Nodes.JsonObject();
 
-                if (that.DataSpecifications != null)
-                {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (IReference item in that.DataSpecifications)
-                    {
-                        arrayDataSpecifications.Add(
-                            Transform(
-                                item));
-                    }
-                    result["dataSpecifications"] = arrayDataSpecifications;
-                }
-
                 var arrayExtensions = new Nodes.JsonArray();
                 foreach (Extension item in that.Extensions)
                 {
@@ -12889,6 +12877,18 @@ namespace AasCore.Aas3
                             item));
                 }
                 result["qualifiers"] = arrayQualifiers;
+
+                if (that.DataSpecifications != null)
+                {
+                    var arrayDataSpecifications = new Nodes.JsonArray();
+                    foreach (IReference item in that.DataSpecifications)
+                    {
+                        arrayDataSpecifications.Add(
+                            Transform(
+                                item));
+                    }
+                    result["dataSpecifications"] = arrayDataSpecifications;
+                }
 
                 result["first"] = Transform(
                     that.First);
@@ -12912,18 +12912,6 @@ namespace AasCore.Aas3
             {
                 var result = new Nodes.JsonObject();
 
-                if (that.DataSpecifications != null)
-                {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (IReference item in that.DataSpecifications)
-                    {
-                        arrayDataSpecifications.Add(
-                            Transform(
-                                item));
-                    }
-                    result["dataSpecifications"] = arrayDataSpecifications;
-                }
-
                 var arrayExtensions = new Nodes.JsonArray();
                 foreach (Extension item in that.Extensions)
                 {
@@ -12980,6 +12968,18 @@ namespace AasCore.Aas3
                             item));
                 }
                 result["qualifiers"] = arrayQualifiers;
+
+                if (that.DataSpecifications != null)
+                {
+                    var arrayDataSpecifications = new Nodes.JsonArray();
+                    foreach (IReference item in that.DataSpecifications)
+                    {
+                        arrayDataSpecifications.Add(
+                            Transform(
+                                item));
+                    }
+                    result["dataSpecifications"] = arrayDataSpecifications;
+                }
 
                 result["entityType"] = Serialize.EntityTypeToJsonValue(
                     that.EntityType);
@@ -13012,18 +13012,6 @@ namespace AasCore.Aas3
             {
                 var result = new Nodes.JsonObject();
 
-                if (that.DataSpecifications != null)
-                {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (IReference item in that.DataSpecifications)
-                    {
-                        arrayDataSpecifications.Add(
-                            Transform(
-                                item));
-                    }
-                    result["dataSpecifications"] = arrayDataSpecifications;
-                }
-
                 var arrayExtensions = new Nodes.JsonArray();
                 foreach (Extension item in that.Extensions)
                 {
@@ -13080,6 +13068,18 @@ namespace AasCore.Aas3
                             item));
                 }
                 result["qualifiers"] = arrayQualifiers;
+
+                if (that.DataSpecifications != null)
+                {
+                    var arrayDataSpecifications = new Nodes.JsonArray();
+                    foreach (IReference item in that.DataSpecifications)
+                    {
+                        arrayDataSpecifications.Add(
+                            Transform(
+                                item));
+                    }
+                    result["dataSpecifications"] = arrayDataSpecifications;
+                }
 
                 result["observed"] = Transform(
                     that.Observed);
@@ -13091,18 +13091,6 @@ namespace AasCore.Aas3
             {
                 var result = new Nodes.JsonObject();
 
-                if (that.DataSpecifications != null)
-                {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (IReference item in that.DataSpecifications)
-                    {
-                        arrayDataSpecifications.Add(
-                            Transform(
-                                item));
-                    }
-                    result["dataSpecifications"] = arrayDataSpecifications;
-                }
-
                 var arrayExtensions = new Nodes.JsonArray();
                 foreach (Extension item in that.Extensions)
                 {
@@ -13159,6 +13147,18 @@ namespace AasCore.Aas3
                             item));
                 }
                 result["qualifiers"] = arrayQualifiers;
+
+                if (that.DataSpecifications != null)
+                {
+                    var arrayDataSpecifications = new Nodes.JsonArray();
+                    foreach (IReference item in that.DataSpecifications)
+                    {
+                        arrayDataSpecifications.Add(
+                            Transform(
+                                item));
+                    }
+                    result["dataSpecifications"] = arrayDataSpecifications;
+                }
 
                 var arrayInputVariables = new Nodes.JsonArray();
                 foreach (OperationVariable item in that.InputVariables)
@@ -13204,18 +13204,6 @@ namespace AasCore.Aas3
             {
                 var result = new Nodes.JsonObject();
 
-                if (that.DataSpecifications != null)
-                {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (IReference item in that.DataSpecifications)
-                    {
-                        arrayDataSpecifications.Add(
-                            Transform(
-                                item));
-                    }
-                    result["dataSpecifications"] = arrayDataSpecifications;
-                }
-
                 var arrayExtensions = new Nodes.JsonArray();
                 foreach (Extension item in that.Extensions)
                 {
@@ -13273,13 +13261,6 @@ namespace AasCore.Aas3
                 }
                 result["qualifiers"] = arrayQualifiers;
 
-                return result;
-            }
-
-            public override Nodes.JsonObject Transform(Aas.ConceptDescription that)
-            {
-                var result = new Nodes.JsonObject();
-
                 if (that.DataSpecifications != null)
                 {
                     var arrayDataSpecifications = new Nodes.JsonArray();
@@ -13291,6 +13272,13 @@ namespace AasCore.Aas3
                     }
                     result["dataSpecifications"] = arrayDataSpecifications;
                 }
+
+                return result;
+            }
+
+            public override Nodes.JsonObject Transform(Aas.ConceptDescription that)
+            {
+                var result = new Nodes.JsonObject();
 
                 var arrayExtensions = new Nodes.JsonArray();
                 foreach (Extension item in that.Extensions)
@@ -13334,6 +13322,18 @@ namespace AasCore.Aas3
                         that.Administration);
                 }
 
+                if (that.DataSpecifications != null)
+                {
+                    var arrayDataSpecifications = new Nodes.JsonArray();
+                    foreach (IReference item in that.DataSpecifications)
+                    {
+                        arrayDataSpecifications.Add(
+                            Transform(
+                                item));
+                    }
+                    result["dataSpecifications"] = arrayDataSpecifications;
+                }
+
                 var arrayIsCaseOf = new Nodes.JsonArray();
                 foreach (IReference item in that.IsCaseOf)
                 {
@@ -13349,18 +13349,6 @@ namespace AasCore.Aas3
             public override Nodes.JsonObject Transform(Aas.View that)
             {
                 var result = new Nodes.JsonObject();
-
-                if (that.DataSpecifications != null)
-                {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (IReference item in that.DataSpecifications)
-                    {
-                        arrayDataSpecifications.Add(
-                            Transform(
-                                item));
-                    }
-                    result["dataSpecifications"] = arrayDataSpecifications;
-                }
 
                 var arrayExtensions = new Nodes.JsonArray();
                 foreach (Extension item in that.Extensions)
@@ -13399,6 +13387,18 @@ namespace AasCore.Aas3
                 {
                     result["semanticId"] = Transform(
                         that.SemanticId);
+                }
+
+                if (that.DataSpecifications != null)
+                {
+                    var arrayDataSpecifications = new Nodes.JsonArray();
+                    foreach (IReference item in that.DataSpecifications)
+                    {
+                        arrayDataSpecifications.Add(
+                            Transform(
+                                item));
+                    }
+                    result["dataSpecifications"] = arrayDataSpecifications;
                 }
 
                 var arrayContainedElements = new Nodes.JsonArray();

--- a/test_data/csharp/test_main/v3rc2/expected_output/types.cs
+++ b/test_data/csharp/test_main/v3rc2/expected_output/types.cs
@@ -744,11 +744,6 @@ namespace AasCore.Aas3
             IClass
     {
         /// <summary>
-        /// Global reference to the data specification template used by the element.
-        /// </summary>
-        public List<IReference>? DataSpecifications { get; set; }
-
-        /// <summary>
         /// An extension of the element.
         /// </summary>
         public List<Extension> Extensions { get; set; }
@@ -838,6 +833,11 @@ namespace AasCore.Aas3
         public AdministrativeInformation? Administration { get; set; }
 
         /// <summary>
+        /// Global reference to the data specification template used by the element.
+        /// </summary>
+        public List<IReference>? DataSpecifications { get; set; }
+
+        /// <summary>
         /// The reference to the AAS the AAS was derived from.
         /// </summary>
         public ModelReference? DerivedFrom { get; set; }
@@ -863,14 +863,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> DescendOnce()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -889,6 +881,14 @@ namespace AasCore.Aas3
             if (Administration != null)
             {
                 yield return Administration;
+            }
+
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+                }
             }
 
             if (DerivedFrom != null)
@@ -912,20 +912,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> Descend()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-
-                    // Recurse
-                    foreach (var anotherItem in anItem.Descend())
-                    {
-                        yield return anotherItem;
-                    }
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -967,6 +953,20 @@ namespace AasCore.Aas3
                 foreach (var anItem in Administration.Descend())
                 {
                     yield return anItem;
+                }
+            }
+
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+
+                    // Recurse
+                    foreach (var anotherItem in anItem.Descend())
+                    {
+                        yield return anotherItem;
+                    }
                 }
             }
 
@@ -1401,30 +1401,6 @@ namespace AasCore.Aas3
             IClass
     {
         /// <summary>
-        /// Global reference to the data specification template used by the element.
-        /// </summary>
-        public List<IReference>? DataSpecifications { get; set; }
-
-        /// <summary>
-        /// Kind of the element: either type or instance.
-        /// </summary>
-        /// <remarks>
-        /// Default Value = Instance
-        /// </remarks>
-        public ModelingKind? Kind { get; set; }
-
-        /// <summary>
-        /// Identifier of the semantic definition of the element. It is called semantic ID
-        /// of the element.
-        /// </summary>
-        public IReference? SemanticId { get; set; }
-
-        /// <summary>
-        /// Additional qualification of a qualifiable element.
-        /// </summary>
-        public List<IConstraint> Qualifiers { get; set; }
-
-        /// <summary>
         /// An extension of the element.
         /// </summary>
         public List<Extension> Extensions { get; set; }
@@ -1514,6 +1490,30 @@ namespace AasCore.Aas3
         public AdministrativeInformation? Administration { get; set; }
 
         /// <summary>
+        /// Kind of the element: either type or instance.
+        /// </summary>
+        /// <remarks>
+        /// Default Value = Instance
+        /// </remarks>
+        public ModelingKind? Kind { get; set; }
+
+        /// <summary>
+        /// Identifier of the semantic definition of the element. It is called semantic ID
+        /// of the element.
+        /// </summary>
+        public IReference? SemanticId { get; set; }
+
+        /// <summary>
+        /// Additional qualification of a qualifiable element.
+        /// </summary>
+        public List<IConstraint> Qualifiers { get; set; }
+
+        /// <summary>
+        /// Global reference to the data specification template used by the element.
+        /// </summary>
+        public List<IReference>? DataSpecifications { get; set; }
+
+        /// <summary>
         /// A submodel consists of zero or more submodel elements.
         /// </summary>
         public List<ISubmodelElement> SubmodelElements { get; set; }
@@ -1524,24 +1524,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> DescendOnce()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-                }
-            }
-
-            if (SemanticId != null)
-            {
-                yield return SemanticId;
-            }
-
-            foreach (var anItem in Qualifiers)
-            {
-                yield return anItem;
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -1562,6 +1544,24 @@ namespace AasCore.Aas3
                 yield return Administration;
             }
 
+            if (SemanticId != null)
+            {
+                yield return SemanticId;
+            }
+
+            foreach (var anItem in Qualifiers)
+            {
+                yield return anItem;
+            }
+
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+                }
+            }
+
             foreach (var anItem in SubmodelElements)
             {
                 yield return anItem;
@@ -1573,42 +1573,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> Descend()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-
-                    // Recurse
-                    foreach (var anotherItem in anItem.Descend())
-                    {
-                        yield return anotherItem;
-                    }
-                }
-            }
-
-            if (SemanticId != null)
-            {
-                yield return SemanticId;
-
-                // Recurse
-                foreach (var anItem in SemanticId.Descend())
-                {
-                    yield return anItem;
-                }
-            }
-
-            foreach (var anItem in Qualifiers)
-            {
-                yield return anItem;
-
-                // Recurse
-                foreach (var anotherItem in anItem.Descend())
-                {
-                    yield return anotherItem;
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -1650,6 +1614,42 @@ namespace AasCore.Aas3
                 foreach (var anItem in Administration.Descend())
                 {
                     yield return anItem;
+                }
+            }
+
+            if (SemanticId != null)
+            {
+                yield return SemanticId;
+
+                // Recurse
+                foreach (var anItem in SemanticId.Descend())
+                {
+                    yield return anItem;
+                }
+            }
+
+            foreach (var anItem in Qualifiers)
+            {
+                yield return anItem;
+
+                // Recurse
+                foreach (var anotherItem in anItem.Descend())
+                {
+                    yield return anotherItem;
+                }
+            }
+
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+
+                    // Recurse
+                    foreach (var anotherItem in anItem.Descend())
+                    {
+                        yield return anotherItem;
+                    }
                 }
             }
 
@@ -1791,11 +1791,6 @@ namespace AasCore.Aas3
             IClass
     {
         /// <summary>
-        /// Global reference to the data specification template used by the element.
-        /// </summary>
-        public List<IReference>? DataSpecifications { get; set; }
-
-        /// <summary>
         /// An extension of the element.
         /// </summary>
         public List<Extension> Extensions { get; set; }
@@ -1890,6 +1885,11 @@ namespace AasCore.Aas3
         public List<IConstraint> Qualifiers { get; set; }
 
         /// <summary>
+        /// Global reference to the data specification template used by the element.
+        /// </summary>
+        public List<IReference>? DataSpecifications { get; set; }
+
+        /// <summary>
         /// The submodel element type of the submodel elements contained in the list.
         /// </summary>
         /// <remarks>
@@ -1936,14 +1936,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> DescendOnce()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -1969,6 +1961,14 @@ namespace AasCore.Aas3
                 yield return anItem;
             }
 
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+                }
+            }
+
             foreach (var anItem in Values)
             {
                 yield return anItem;
@@ -1985,20 +1985,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> Descend()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-
-                    // Recurse
-                    foreach (var anotherItem in anItem.Descend())
-                    {
-                        yield return anotherItem;
-                    }
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -2051,6 +2037,20 @@ namespace AasCore.Aas3
                 foreach (var anotherItem in anItem.Descend())
                 {
                     yield return anotherItem;
+                }
+            }
+
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+
+                    // Recurse
+                    foreach (var anotherItem in anItem.Descend())
+                    {
+                        yield return anotherItem;
+                    }
                 }
             }
 
@@ -2164,11 +2164,6 @@ namespace AasCore.Aas3
             IClass
     {
         /// <summary>
-        /// Global reference to the data specification template used by the element.
-        /// </summary>
-        public List<IReference>? DataSpecifications { get; set; }
-
-        /// <summary>
         /// An extension of the element.
         /// </summary>
         public List<Extension> Extensions { get; set; }
@@ -2263,6 +2258,11 @@ namespace AasCore.Aas3
         public List<IConstraint> Qualifiers { get; set; }
 
         /// <summary>
+        /// Global reference to the data specification template used by the element.
+        /// </summary>
+        public List<IReference>? DataSpecifications { get; set; }
+
+        /// <summary>
         /// Submodel element contained in the struct.
         /// </summary>
         public List<ISubmodelElement> Values { get; set; }
@@ -2273,14 +2273,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> DescendOnce()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -2306,6 +2298,14 @@ namespace AasCore.Aas3
                 yield return anItem;
             }
 
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+                }
+            }
+
             foreach (var anItem in Values)
             {
                 yield return anItem;
@@ -2317,20 +2317,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> Descend()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-
-                    // Recurse
-                    foreach (var anotherItem in anItem.Descend())
-                    {
-                        yield return anotherItem;
-                    }
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -2383,6 +2369,20 @@ namespace AasCore.Aas3
                 foreach (var anotherItem in anItem.Descend())
                 {
                     yield return anotherItem;
+                }
+            }
+
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+
+                    // Recurse
+                    foreach (var anotherItem in anItem.Descend())
+                    {
+                        yield return anotherItem;
+                    }
                 }
             }
 
@@ -2510,11 +2510,6 @@ namespace AasCore.Aas3
             IClass
     {
         /// <summary>
-        /// Global reference to the data specification template used by the element.
-        /// </summary>
-        public List<IReference>? DataSpecifications { get; set; }
-
-        /// <summary>
         /// An extension of the element.
         /// </summary>
         public List<Extension> Extensions { get; set; }
@@ -2609,6 +2604,11 @@ namespace AasCore.Aas3
         public List<IConstraint> Qualifiers { get; set; }
 
         /// <summary>
+        /// Global reference to the data specification template used by the element.
+        /// </summary>
+        public List<IReference>? DataSpecifications { get; set; }
+
+        /// <summary>
         /// Data type of the value
         /// </summary>
         public DataTypeDef ValueType { get; set; }
@@ -2637,14 +2637,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> DescendOnce()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -2670,6 +2662,14 @@ namespace AasCore.Aas3
                 yield return anItem;
             }
 
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+                }
+            }
+
             if (ValueId != null)
             {
                 yield return ValueId;
@@ -2681,20 +2681,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> Descend()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-
-                    // Recurse
-                    foreach (var anotherItem in anItem.Descend())
-                    {
-                        yield return anotherItem;
-                    }
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -2747,6 +2733,20 @@ namespace AasCore.Aas3
                 foreach (var anotherItem in anItem.Descend())
                 {
                     yield return anotherItem;
+                }
+            }
+
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+
+                    // Recurse
+                    foreach (var anotherItem in anItem.Descend())
+                    {
+                        yield return anotherItem;
+                    }
                 }
             }
 
@@ -2854,11 +2854,6 @@ namespace AasCore.Aas3
             IClass
     {
         /// <summary>
-        /// Global reference to the data specification template used by the element.
-        /// </summary>
-        public List<IReference>? DataSpecifications { get; set; }
-
-        /// <summary>
         /// An extension of the element.
         /// </summary>
         public List<Extension> Extensions { get; set; }
@@ -2953,6 +2948,11 @@ namespace AasCore.Aas3
         public List<IConstraint> Qualifiers { get; set; }
 
         /// <summary>
+        /// Global reference to the data specification template used by the element.
+        /// </summary>
+        public List<IReference>? DataSpecifications { get; set; }
+
+        /// <summary>
         /// The value of the property instance.
         /// See Constraint AASd-012
         /// See Constraint AASd-065
@@ -2972,14 +2972,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> DescendOnce()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -3005,6 +2997,14 @@ namespace AasCore.Aas3
                 yield return anItem;
             }
 
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+                }
+            }
+
             if (Value != null)
             {
                 yield return Value;
@@ -3021,20 +3021,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> Descend()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-
-                    // Recurse
-                    foreach (var anotherItem in anItem.Descend())
-                    {
-                        yield return anotherItem;
-                    }
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -3087,6 +3073,20 @@ namespace AasCore.Aas3
                 foreach (var anotherItem in anItem.Descend())
                 {
                     yield return anotherItem;
+                }
+            }
+
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+
+                    // Recurse
+                    foreach (var anotherItem in anItem.Descend())
+                    {
+                        yield return anotherItem;
+                    }
                 }
             }
 
@@ -3199,11 +3199,6 @@ namespace AasCore.Aas3
             IClass
     {
         /// <summary>
-        /// Global reference to the data specification template used by the element.
-        /// </summary>
-        public List<IReference>? DataSpecifications { get; set; }
-
-        /// <summary>
         /// An extension of the element.
         /// </summary>
         public List<Extension> Extensions { get; set; }
@@ -3298,6 +3293,11 @@ namespace AasCore.Aas3
         public List<IConstraint> Qualifiers { get; set; }
 
         /// <summary>
+        /// Global reference to the data specification template used by the element.
+        /// </summary>
+        public List<IReference>? DataSpecifications { get; set; }
+
+        /// <summary>
         /// Data type of the min und max
         /// </summary>
         public DataTypeDef ValueType { get; set; }
@@ -3320,14 +3320,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> DescendOnce()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -3352,6 +3344,14 @@ namespace AasCore.Aas3
             {
                 yield return anItem;
             }
+
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+                }
+            }
         }
 
         /// <summary>
@@ -3359,20 +3359,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> Descend()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-
-                    // Recurse
-                    foreach (var anotherItem in anItem.Descend())
-                    {
-                        yield return anotherItem;
-                    }
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -3425,6 +3411,20 @@ namespace AasCore.Aas3
                 foreach (var anotherItem in anItem.Descend())
                 {
                     yield return anotherItem;
+                }
+            }
+
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+
+                    // Recurse
+                    foreach (var anotherItem in anItem.Descend())
+                    {
+                        yield return anotherItem;
+                    }
                 }
             }
         }
@@ -3517,11 +3517,6 @@ namespace AasCore.Aas3
             IClass
     {
         /// <summary>
-        /// Global reference to the data specification template used by the element.
-        /// </summary>
-        public List<IReference>? DataSpecifications { get; set; }
-
-        /// <summary>
         /// An extension of the element.
         /// </summary>
         public List<Extension> Extensions { get; set; }
@@ -3616,6 +3611,11 @@ namespace AasCore.Aas3
         public List<IConstraint> Qualifiers { get; set; }
 
         /// <summary>
+        /// Global reference to the data specification template used by the element.
+        /// </summary>
+        public List<IReference>? DataSpecifications { get; set; }
+
+        /// <summary>
         /// Reference to any other referable element of the same of any other AAS or a
         /// reference to an external object or entity.
         /// </summary>
@@ -3627,14 +3627,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> DescendOnce()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -3660,6 +3652,14 @@ namespace AasCore.Aas3
                 yield return anItem;
             }
 
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+                }
+            }
+
             if (Value != null)
             {
                 yield return Value;
@@ -3671,20 +3671,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> Descend()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-
-                    // Recurse
-                    foreach (var anotherItem in anItem.Descend())
-                    {
-                        yield return anotherItem;
-                    }
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -3737,6 +3723,20 @@ namespace AasCore.Aas3
                 foreach (var anotherItem in anItem.Descend())
                 {
                     yield return anotherItem;
+                }
+            }
+
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+
+                    // Recurse
+                    foreach (var anotherItem in anItem.Descend())
+                    {
+                        yield return anotherItem;
+                    }
                 }
             }
 
@@ -3833,11 +3833,6 @@ namespace AasCore.Aas3
             IClass
     {
         /// <summary>
-        /// Global reference to the data specification template used by the element.
-        /// </summary>
-        public List<IReference>? DataSpecifications { get; set; }
-
-        /// <summary>
         /// An extension of the element.
         /// </summary>
         public List<Extension> Extensions { get; set; }
@@ -3932,6 +3927,11 @@ namespace AasCore.Aas3
         public List<IConstraint> Qualifiers { get; set; }
 
         /// <summary>
+        /// Global reference to the data specification template used by the element.
+        /// </summary>
+        public List<IReference>? DataSpecifications { get; set; }
+
+        /// <summary>
         /// Mime type of the content of the BLOB.
         /// The mime type states which file extensions the file can have.
         /// Valid values are e.g. “application/json”, “application/xls”, ”image/jpg”
@@ -3954,14 +3954,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> DescendOnce()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -3986,6 +3978,14 @@ namespace AasCore.Aas3
             {
                 yield return anItem;
             }
+
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+                }
+            }
         }
 
         /// <summary>
@@ -3993,20 +3993,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> Descend()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-
-                    // Recurse
-                    foreach (var anotherItem in anItem.Descend())
-                    {
-                        yield return anotherItem;
-                    }
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -4059,6 +4045,20 @@ namespace AasCore.Aas3
                 foreach (var anotherItem in anItem.Descend())
                 {
                     yield return anotherItem;
+                }
+            }
+
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+
+                    // Recurse
+                    foreach (var anotherItem in anItem.Descend())
+                    {
+                        yield return anotherItem;
+                    }
                 }
             }
         }
@@ -4145,11 +4145,6 @@ namespace AasCore.Aas3
             IClass
     {
         /// <summary>
-        /// Global reference to the data specification template used by the element.
-        /// </summary>
-        public List<IReference>? DataSpecifications { get; set; }
-
-        /// <summary>
         /// An extension of the element.
         /// </summary>
         public List<Extension> Extensions { get; set; }
@@ -4244,6 +4239,11 @@ namespace AasCore.Aas3
         public List<IConstraint> Qualifiers { get; set; }
 
         /// <summary>
+        /// Global reference to the data specification template used by the element.
+        /// </summary>
+        public List<IReference>? DataSpecifications { get; set; }
+
+        /// <summary>
         /// MIME type of the content of the BLOB.
         /// The MIME type states which file extensions the file can have.
         /// </summary>
@@ -4261,14 +4261,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> DescendOnce()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -4293,6 +4285,14 @@ namespace AasCore.Aas3
             {
                 yield return anItem;
             }
+
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+                }
+            }
         }
 
         /// <summary>
@@ -4300,20 +4300,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> Descend()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-
-                    // Recurse
-                    foreach (var anotherItem in anItem.Descend())
-                    {
-                        yield return anotherItem;
-                    }
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -4366,6 +4352,20 @@ namespace AasCore.Aas3
                 foreach (var anotherItem in anItem.Descend())
                 {
                     yield return anotherItem;
+                }
+            }
+
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+
+                    // Recurse
+                    foreach (var anotherItem in anItem.Descend())
+                    {
+                        yield return anotherItem;
+                    }
                 }
             }
         }
@@ -4450,11 +4450,6 @@ namespace AasCore.Aas3
             IClass
     {
         /// <summary>
-        /// Global reference to the data specification template used by the element.
-        /// </summary>
-        public List<IReference>? DataSpecifications { get; set; }
-
-        /// <summary>
         /// An extension of the element.
         /// </summary>
         public List<Extension> Extensions { get; set; }
@@ -4549,6 +4544,11 @@ namespace AasCore.Aas3
         public List<IConstraint> Qualifiers { get; set; }
 
         /// <summary>
+        /// Global reference to the data specification template used by the element.
+        /// </summary>
+        public List<IReference>? DataSpecifications { get; set; }
+
+        /// <summary>
         /// Reference to the first element in the relationship taking the role of the subject.
         /// </summary>
         public IReference First { get; set; }
@@ -4570,14 +4570,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> DescendOnce()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -4603,6 +4595,14 @@ namespace AasCore.Aas3
                 yield return anItem;
             }
 
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+                }
+            }
+
             yield return First;
 
             yield return Second;
@@ -4618,20 +4618,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> Descend()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-
-                    // Recurse
-                    foreach (var anotherItem in anItem.Descend())
-                    {
-                        yield return anotherItem;
-                    }
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -4684,6 +4670,20 @@ namespace AasCore.Aas3
                 foreach (var anotherItem in anItem.Descend())
                 {
                     yield return anotherItem;
+                }
+            }
+
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+
+                    // Recurse
+                    foreach (var anotherItem in anItem.Descend())
+                    {
+                        yield return anotherItem;
+                    }
                 }
             }
 
@@ -4823,11 +4823,6 @@ namespace AasCore.Aas3
             IClass
     {
         /// <summary>
-        /// Global reference to the data specification template used by the element.
-        /// </summary>
-        public List<IReference>? DataSpecifications { get; set; }
-
-        /// <summary>
         /// An extension of the element.
         /// </summary>
         public List<Extension> Extensions { get; set; }
@@ -4922,6 +4917,11 @@ namespace AasCore.Aas3
         public List<IConstraint> Qualifiers { get; set; }
 
         /// <summary>
+        /// Global reference to the data specification template used by the element.
+        /// </summary>
+        public List<IReference>? DataSpecifications { get; set; }
+
+        /// <summary>
         /// Describes whether the entity is a co- managed entity or a self-managed entity.
         /// </summary>
         public EntityType EntityType { get; set; }
@@ -4957,14 +4957,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> DescendOnce()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -4990,6 +4982,14 @@ namespace AasCore.Aas3
                 yield return anItem;
             }
 
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+                }
+            }
+
             foreach (var anItem in Statements)
             {
                 yield return anItem;
@@ -5011,20 +5011,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> Descend()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-
-                    // Recurse
-                    foreach (var anotherItem in anItem.Descend())
-                    {
-                        yield return anotherItem;
-                    }
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -5077,6 +5063,20 @@ namespace AasCore.Aas3
                 foreach (var anotherItem in anItem.Descend())
                 {
                     yield return anotherItem;
+                }
+            }
+
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+
+                    // Recurse
+                    foreach (var anotherItem in anItem.Descend())
+                    {
+                        yield return anotherItem;
+                    }
                 }
             }
 
@@ -5211,11 +5211,6 @@ namespace AasCore.Aas3
             IClass
     {
         /// <summary>
-        /// Global reference to the data specification template used by the element.
-        /// </summary>
-        public List<IReference>? DataSpecifications { get; set; }
-
-        /// <summary>
         /// An extension of the element.
         /// </summary>
         public List<Extension> Extensions { get; set; }
@@ -5310,6 +5305,11 @@ namespace AasCore.Aas3
         public List<IConstraint> Qualifiers { get; set; }
 
         /// <summary>
+        /// Global reference to the data specification template used by the element.
+        /// </summary>
+        public List<IReference>? DataSpecifications { get; set; }
+
+        /// <summary>
         /// Reference to a referable, e.g. a data element or a submodel, that is being
         /// observed.
         /// </summary>
@@ -5321,14 +5321,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> DescendOnce()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -5354,6 +5346,14 @@ namespace AasCore.Aas3
                 yield return anItem;
             }
 
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+                }
+            }
+
             yield return Observed;
         }
 
@@ -5362,20 +5362,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> Descend()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-
-                    // Recurse
-                    foreach (var anotherItem in anItem.Descend())
-                    {
-                        yield return anotherItem;
-                    }
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -5428,6 +5414,20 @@ namespace AasCore.Aas3
                 foreach (var anotherItem in anItem.Descend())
                 {
                     yield return anotherItem;
+                }
+            }
+
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+
+                    // Recurse
+                    foreach (var anotherItem in anItem.Descend())
+                    {
+                        yield return anotherItem;
+                    }
                 }
             }
 
@@ -5519,11 +5519,6 @@ namespace AasCore.Aas3
             IClass
     {
         /// <summary>
-        /// Global reference to the data specification template used by the element.
-        /// </summary>
-        public List<IReference>? DataSpecifications { get; set; }
-
-        /// <summary>
         /// An extension of the element.
         /// </summary>
         public List<Extension> Extensions { get; set; }
@@ -5618,6 +5613,11 @@ namespace AasCore.Aas3
         public List<IConstraint> Qualifiers { get; set; }
 
         /// <summary>
+        /// Global reference to the data specification template used by the element.
+        /// </summary>
+        public List<IReference>? DataSpecifications { get; set; }
+
+        /// <summary>
         /// Input parameter of the operation.
         /// </summary>
         public List<OperationVariable> InputVariables { get; set; }
@@ -5638,14 +5638,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> DescendOnce()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -5671,6 +5663,14 @@ namespace AasCore.Aas3
                 yield return anItem;
             }
 
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+                }
+            }
+
             foreach (var anItem in InputVariables)
             {
                 yield return anItem;
@@ -5692,20 +5692,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> Descend()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-
-                    // Recurse
-                    foreach (var anotherItem in anItem.Descend())
-                    {
-                        yield return anotherItem;
-                    }
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -5758,6 +5744,20 @@ namespace AasCore.Aas3
                 foreach (var anotherItem in anItem.Descend())
                 {
                     yield return anotherItem;
+                }
+            }
+
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+
+                    // Recurse
+                    foreach (var anotherItem in anItem.Descend())
+                    {
+                        yield return anotherItem;
+                    }
                 }
             }
 
@@ -5963,11 +5963,6 @@ namespace AasCore.Aas3
             IClass
     {
         /// <summary>
-        /// Global reference to the data specification template used by the element.
-        /// </summary>
-        public List<IReference>? DataSpecifications { get; set; }
-
-        /// <summary>
         /// An extension of the element.
         /// </summary>
         public List<Extension> Extensions { get; set; }
@@ -6062,19 +6057,16 @@ namespace AasCore.Aas3
         public List<IConstraint> Qualifiers { get; set; }
 
         /// <summary>
+        /// Global reference to the data specification template used by the element.
+        /// </summary>
+        public List<IReference>? DataSpecifications { get; set; }
+
+        /// <summary>
         /// Iterate over all the class instances referenced from this instance
         /// without further recursion.
         /// </summary>
         public IEnumerable<IClass> DescendOnce()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -6099,6 +6091,14 @@ namespace AasCore.Aas3
             {
                 yield return anItem;
             }
+
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+                }
+            }
         }
 
         /// <summary>
@@ -6106,20 +6106,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> Descend()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-
-                    // Recurse
-                    foreach (var anotherItem in anItem.Descend())
-                    {
-                        yield return anotherItem;
-                    }
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -6172,6 +6158,20 @@ namespace AasCore.Aas3
                 foreach (var anotherItem in anItem.Descend())
                 {
                     yield return anotherItem;
+                }
+            }
+
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+
+                    // Recurse
+                    foreach (var anotherItem in anItem.Descend())
+                    {
+                        yield return anotherItem;
+                    }
                 }
             }
         }
@@ -6255,11 +6255,6 @@ namespace AasCore.Aas3
             IHasDataSpecification,
             IClass
     {
-        /// <summary>
-        /// Global reference to the data specification template used by the element.
-        /// </summary>
-        public List<IReference>? DataSpecifications { get; set; }
-
         /// <summary>
         /// An extension of the element.
         /// </summary>
@@ -6350,6 +6345,11 @@ namespace AasCore.Aas3
         public AdministrativeInformation? Administration { get; set; }
 
         /// <summary>
+        /// Global reference to the data specification template used by the element.
+        /// </summary>
+        public List<IReference>? DataSpecifications { get; set; }
+
+        /// <summary>
         /// Reference to an external definition the concept is compatible to or was derived from
         /// </summary>
         /// <remarks>
@@ -6363,14 +6363,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> DescendOnce()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -6391,6 +6383,14 @@ namespace AasCore.Aas3
                 yield return Administration;
             }
 
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+                }
+            }
+
             foreach (var anItem in IsCaseOf)
             {
                 yield return anItem;
@@ -6402,20 +6402,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> Descend()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-
-                    // Recurse
-                    foreach (var anotherItem in anItem.Descend())
-                    {
-                        yield return anotherItem;
-                    }
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -6457,6 +6443,20 @@ namespace AasCore.Aas3
                 foreach (var anItem in Administration.Descend())
                 {
                     yield return anItem;
+                }
+            }
+
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+
+                    // Recurse
+                    foreach (var anotherItem in anItem.Descend())
+                    {
+                        yield return anotherItem;
+                    }
                 }
             }
 
@@ -6553,11 +6553,6 @@ namespace AasCore.Aas3
             IClass
     {
         /// <summary>
-        /// Global reference to the data specification template used by the element.
-        /// </summary>
-        public List<IReference>? DataSpecifications { get; set; }
-
-        /// <summary>
         /// An extension of the element.
         /// </summary>
         public List<Extension> Extensions { get; set; }
@@ -6639,6 +6634,11 @@ namespace AasCore.Aas3
         public IReference? SemanticId { get; set; }
 
         /// <summary>
+        /// Global reference to the data specification template used by the element.
+        /// </summary>
+        public List<IReference>? DataSpecifications { get; set; }
+
+        /// <summary>
         /// Reference to a referable element that is contained in the view.
         /// </summary>
         public List<IReference> ContainedElements { get; set; }
@@ -6649,14 +6649,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> DescendOnce()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -6677,6 +6669,14 @@ namespace AasCore.Aas3
                 yield return SemanticId;
             }
 
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+                }
+            }
+
             foreach (var anItem in ContainedElements)
             {
                 yield return anItem;
@@ -6688,20 +6688,6 @@ namespace AasCore.Aas3
         /// </summary>
         public IEnumerable<IClass> Descend()
         {
-            if (DataSpecifications != null)
-            {
-                foreach (var anItem in DataSpecifications)
-                {
-                    yield return anItem;
-
-                    // Recurse
-                    foreach (var anotherItem in anItem.Descend())
-                    {
-                        yield return anotherItem;
-                    }
-                }
-            }
-
             foreach (var anItem in Extensions)
             {
                 yield return anItem;
@@ -6743,6 +6729,20 @@ namespace AasCore.Aas3
                 foreach (var anItem in SemanticId.Descend())
                 {
                     yield return anItem;
+                }
+            }
+
+            if (DataSpecifications != null)
+            {
+                foreach (var anItem in DataSpecifications)
+                {
+                    yield return anItem;
+
+                    // Recurse
+                    foreach (var anotherItem in anItem.Descend())
+                    {
+                        yield return anotherItem;
+                    }
                 }
             }
 

--- a/test_data/csharp/test_main/v3rc2/expected_output/verification.cs
+++ b/test_data/csharp/test_main/v3rc2/expected_output/verification.cs
@@ -548,25 +548,6 @@ namespace AasCore.Aas3
                         "    submodel => Verification.IsModelReferenceTo(submodel, KeyElements.Submodel)))");
                 }
 
-                if (that.DataSpecifications != null)
-                {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
-                    {
-                        foreach (var error in Verification.Verify(item))
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            yield return error;
-                        }
-                        indexDataSpecifications++;
-                    }
-                }
-
                 int indexExtensions = 0;
                 foreach (var item in that.Extensions)
                 {
@@ -643,6 +624,25 @@ namespace AasCore.Aas3
                             new Reporting.NameSegment(
                                 "administration"));
                         yield return error;
+                    }
+                }
+
+                if (that.DataSpecifications != null)
+                {
+                    int indexDataSpecifications = 0;
+                    foreach (var item in that.DataSpecifications)
+                    {
+                        foreach (var error in Verification.Verify(item))
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            yield return error;
+                        }
+                        indexDataSpecifications++;
                     }
                 }
 
@@ -775,66 +775,6 @@ namespace AasCore.Aas3
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.Submodel that)
             {
-                if (that.DataSpecifications != null)
-                {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
-                    {
-                        foreach (var error in Verification.Verify(item))
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            yield return error;
-                        }
-                        indexDataSpecifications++;
-                    }
-                }
-
-                if (that.Kind != null)
-                {
-                    // We need to help the static analyzer with a null coalescing.
-                    Aas.ModelingKind value = that.Kind
-                        ?? throw new System.InvalidOperationException();
-                    foreach (var error in Verification.VerifyModelingKind(value))
-                    {
-                        error._pathSegments.AddFirst(
-                            new Reporting.NameSegment(
-                                "kind"));
-                        yield return error;
-                    }
-                }
-
-                if (that.SemanticId != null)
-                {
-                    foreach (var error in Verification.Verify(that.SemanticId))
-                    {
-                        error._pathSegments.AddFirst(
-                            new Reporting.NameSegment(
-                                "semanticId"));
-                        yield return error;
-                    }
-                }
-
-                int indexQualifiers = 0;
-                foreach (var item in that.Qualifiers)
-                {
-                    foreach (var error in Verification.Verify(item))
-                    {
-                        error._pathSegments.AddFirst(
-                            new Reporting.IndexSegment(
-                                indexQualifiers));
-                        error._pathSegments.AddFirst(
-                            new Reporting.NameSegment(
-                                "qualifiers"));
-                        yield return error;
-                    }
-                    indexQualifiers++;
-                }
-
                 int indexExtensions = 0;
                 foreach (var item in that.Extensions)
                 {
@@ -914,6 +854,66 @@ namespace AasCore.Aas3
                     }
                 }
 
+                if (that.Kind != null)
+                {
+                    // We need to help the static analyzer with a null coalescing.
+                    Aas.ModelingKind value = that.Kind
+                        ?? throw new System.InvalidOperationException();
+                    foreach (var error in Verification.VerifyModelingKind(value))
+                    {
+                        error._pathSegments.AddFirst(
+                            new Reporting.NameSegment(
+                                "kind"));
+                        yield return error;
+                    }
+                }
+
+                if (that.SemanticId != null)
+                {
+                    foreach (var error in Verification.Verify(that.SemanticId))
+                    {
+                        error._pathSegments.AddFirst(
+                            new Reporting.NameSegment(
+                                "semanticId"));
+                        yield return error;
+                    }
+                }
+
+                int indexQualifiers = 0;
+                foreach (var item in that.Qualifiers)
+                {
+                    foreach (var error in Verification.Verify(item))
+                    {
+                        error._pathSegments.AddFirst(
+                            new Reporting.IndexSegment(
+                                indexQualifiers));
+                        error._pathSegments.AddFirst(
+                            new Reporting.NameSegment(
+                                "qualifiers"));
+                        yield return error;
+                    }
+                    indexQualifiers++;
+                }
+
+                if (that.DataSpecifications != null)
+                {
+                    int indexDataSpecifications = 0;
+                    foreach (var item in that.DataSpecifications)
+                    {
+                        foreach (var error in Verification.Verify(item))
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            yield return error;
+                        }
+                        indexDataSpecifications++;
+                    }
+                }
+
                 int indexSubmodelElements = 0;
                 foreach (var item in that.SubmodelElements)
                 {
@@ -934,25 +934,6 @@ namespace AasCore.Aas3
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.SubmodelElementList that)
             {
-                if (that.DataSpecifications != null)
-                {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
-                    {
-                        foreach (var error in Verification.Verify(item))
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            yield return error;
-                        }
-                        indexDataSpecifications++;
-                    }
-                }
-
                 int indexExtensions = 0;
                 foreach (var item in that.Extensions)
                 {
@@ -1052,6 +1033,25 @@ namespace AasCore.Aas3
                         yield return error;
                     }
                     indexQualifiers++;
+                }
+
+                if (that.DataSpecifications != null)
+                {
+                    int indexDataSpecifications = 0;
+                    foreach (var item in that.DataSpecifications)
+                    {
+                        foreach (var error in Verification.Verify(item))
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            yield return error;
+                        }
+                        indexDataSpecifications++;
+                    }
                 }
 
                 foreach (
@@ -1109,25 +1109,6 @@ namespace AasCore.Aas3
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.SubmodelElementStruct that)
             {
-                if (that.DataSpecifications != null)
-                {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
-                    {
-                        foreach (var error in Verification.Verify(item))
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            yield return error;
-                        }
-                        indexDataSpecifications++;
-                    }
-                }
-
                 int indexExtensions = 0;
                 foreach (var item in that.Extensions)
                 {
@@ -1227,6 +1208,25 @@ namespace AasCore.Aas3
                         yield return error;
                     }
                     indexQualifiers++;
+                }
+
+                if (that.DataSpecifications != null)
+                {
+                    int indexDataSpecifications = 0;
+                    foreach (var item in that.DataSpecifications)
+                    {
+                        foreach (var error in Verification.Verify(item))
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            yield return error;
+                        }
+                        indexDataSpecifications++;
+                    }
                 }
 
                 int indexValues = 0;
@@ -1249,25 +1249,6 @@ namespace AasCore.Aas3
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.Property that)
             {
-                if (that.DataSpecifications != null)
-                {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
-                    {
-                        foreach (var error in Verification.Verify(item))
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            yield return error;
-                        }
-                        indexDataSpecifications++;
-                    }
-                }
-
                 int indexExtensions = 0;
                 foreach (var item in that.Extensions)
                 {
@@ -1367,6 +1348,25 @@ namespace AasCore.Aas3
                         yield return error;
                     }
                     indexQualifiers++;
+                }
+
+                if (that.DataSpecifications != null)
+                {
+                    int indexDataSpecifications = 0;
+                    foreach (var item in that.DataSpecifications)
+                    {
+                        foreach (var error in Verification.Verify(item))
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            yield return error;
+                        }
+                        indexDataSpecifications++;
+                    }
                 }
 
                 foreach (var error in Verification.VerifyDataTypeDef(that.ValueType))
@@ -1403,25 +1403,6 @@ namespace AasCore.Aas3
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.MultiLanguageProperty that)
             {
-                if (that.DataSpecifications != null)
-                {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
-                    {
-                        foreach (var error in Verification.Verify(item))
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            yield return error;
-                        }
-                        indexDataSpecifications++;
-                    }
-                }
-
                 int indexExtensions = 0;
                 foreach (var item in that.Extensions)
                 {
@@ -1521,6 +1502,25 @@ namespace AasCore.Aas3
                         yield return error;
                     }
                     indexQualifiers++;
+                }
+
+                if (that.DataSpecifications != null)
+                {
+                    int indexDataSpecifications = 0;
+                    foreach (var item in that.DataSpecifications)
+                    {
+                        foreach (var error in Verification.Verify(item))
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            yield return error;
+                        }
+                        indexDataSpecifications++;
+                    }
                 }
 
                 if (that.Value != null)
@@ -1549,25 +1549,6 @@ namespace AasCore.Aas3
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.Range that)
             {
-                if (that.DataSpecifications != null)
-                {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
-                    {
-                        foreach (var error in Verification.Verify(item))
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            yield return error;
-                        }
-                        indexDataSpecifications++;
-                    }
-                }
-
                 int indexExtensions = 0;
                 foreach (var item in that.Extensions)
                 {
@@ -1667,6 +1648,25 @@ namespace AasCore.Aas3
                         yield return error;
                     }
                     indexQualifiers++;
+                }
+
+                if (that.DataSpecifications != null)
+                {
+                    int indexDataSpecifications = 0;
+                    foreach (var item in that.DataSpecifications)
+                    {
+                        foreach (var error in Verification.Verify(item))
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            yield return error;
+                        }
+                        indexDataSpecifications++;
+                    }
                 }
 
                 foreach (var error in Verification.VerifyDataTypeDef(that.ValueType))
@@ -1703,25 +1703,6 @@ namespace AasCore.Aas3
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.ReferenceElement that)
             {
-                if (that.DataSpecifications != null)
-                {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
-                    {
-                        foreach (var error in Verification.Verify(item))
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            yield return error;
-                        }
-                        indexDataSpecifications++;
-                    }
-                }
-
                 int indexExtensions = 0;
                 foreach (var item in that.Extensions)
                 {
@@ -1821,6 +1802,25 @@ namespace AasCore.Aas3
                         yield return error;
                     }
                     indexQualifiers++;
+                }
+
+                if (that.DataSpecifications != null)
+                {
+                    int indexDataSpecifications = 0;
+                    foreach (var item in that.DataSpecifications)
+                    {
+                        foreach (var error in Verification.Verify(item))
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            yield return error;
+                        }
+                        indexDataSpecifications++;
+                    }
                 }
 
                 if (that.Value != null)
@@ -1845,25 +1845,6 @@ namespace AasCore.Aas3
                         "Verification.IsMimeType(that.MimeType)");
                 }
 
-                if (that.DataSpecifications != null)
-                {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
-                    {
-                        foreach (var error in Verification.Verify(item))
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            yield return error;
-                        }
-                        indexDataSpecifications++;
-                    }
-                }
-
                 int indexExtensions = 0;
                 foreach (var item in that.Extensions)
                 {
@@ -1963,6 +1944,25 @@ namespace AasCore.Aas3
                         yield return error;
                     }
                     indexQualifiers++;
+                }
+
+                if (that.DataSpecifications != null)
+                {
+                    int indexDataSpecifications = 0;
+                    foreach (var item in that.DataSpecifications)
+                    {
+                        foreach (var error in Verification.Verify(item))
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            yield return error;
+                        }
+                        indexDataSpecifications++;
+                    }
                 }
 
                 foreach (var error in Verification.VerifyMimeTyped(that.MimeType))
@@ -1984,25 +1984,6 @@ namespace AasCore.Aas3
                         "Verification.IsMimeType(that.MimeType)");
                 }
 
-                if (that.DataSpecifications != null)
-                {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
-                    {
-                        foreach (var error in Verification.Verify(item))
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            yield return error;
-                        }
-                        indexDataSpecifications++;
-                    }
-                }
-
                 int indexExtensions = 0;
                 foreach (var item in that.Extensions)
                 {
@@ -2102,6 +2083,25 @@ namespace AasCore.Aas3
                         yield return error;
                     }
                     indexQualifiers++;
+                }
+
+                if (that.DataSpecifications != null)
+                {
+                    int indexDataSpecifications = 0;
+                    foreach (var item in that.DataSpecifications)
+                    {
+                        foreach (var error in Verification.Verify(item))
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            yield return error;
+                        }
+                        indexDataSpecifications++;
+                    }
                 }
 
                 foreach (var error in Verification.VerifyMimeTyped(that.MimeType))
@@ -2127,25 +2127,6 @@ namespace AasCore.Aas3
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.AnnotatedRelationshipElement that)
             {
-                if (that.DataSpecifications != null)
-                {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
-                    {
-                        foreach (var error in Verification.Verify(item))
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            yield return error;
-                        }
-                        indexDataSpecifications++;
-                    }
-                }
-
                 int indexExtensions = 0;
                 foreach (var item in that.Extensions)
                 {
@@ -2245,6 +2226,25 @@ namespace AasCore.Aas3
                         yield return error;
                     }
                     indexQualifiers++;
+                }
+
+                if (that.DataSpecifications != null)
+                {
+                    int indexDataSpecifications = 0;
+                    foreach (var item in that.DataSpecifications)
+                    {
+                        foreach (var error in Verification.Verify(item))
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            yield return error;
+                        }
+                        indexDataSpecifications++;
+                    }
                 }
 
                 foreach (var error in Verification.Verify(that.First))
@@ -2283,25 +2283,6 @@ namespace AasCore.Aas3
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.Entity that)
             {
-                if (that.DataSpecifications != null)
-                {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
-                    {
-                        foreach (var error in Verification.Verify(item))
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            yield return error;
-                        }
-                        indexDataSpecifications++;
-                    }
-                }
-
                 int indexExtensions = 0;
                 foreach (var item in that.Extensions)
                 {
@@ -2401,6 +2382,25 @@ namespace AasCore.Aas3
                         yield return error;
                     }
                     indexQualifiers++;
+                }
+
+                if (that.DataSpecifications != null)
+                {
+                    int indexDataSpecifications = 0;
+                    foreach (var item in that.DataSpecifications)
+                    {
+                        foreach (var error in Verification.Verify(item))
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            yield return error;
+                        }
+                        indexDataSpecifications++;
+                    }
                 }
 
                 foreach (var error in Verification.VerifyEntityType(that.EntityType))
@@ -2453,25 +2453,6 @@ namespace AasCore.Aas3
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.BasicEvent that)
             {
-                if (that.DataSpecifications != null)
-                {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
-                    {
-                        foreach (var error in Verification.Verify(item))
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            yield return error;
-                        }
-                        indexDataSpecifications++;
-                    }
-                }
-
                 int indexExtensions = 0;
                 foreach (var item in that.Extensions)
                 {
@@ -2571,6 +2552,25 @@ namespace AasCore.Aas3
                         yield return error;
                     }
                     indexQualifiers++;
+                }
+
+                if (that.DataSpecifications != null)
+                {
+                    int indexDataSpecifications = 0;
+                    foreach (var item in that.DataSpecifications)
+                    {
+                        foreach (var error in Verification.Verify(item))
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            yield return error;
+                        }
+                        indexDataSpecifications++;
+                    }
                 }
 
                 foreach (var error in Verification.Verify(that.Observed))
@@ -2585,25 +2585,6 @@ namespace AasCore.Aas3
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.Operation that)
             {
-                if (that.DataSpecifications != null)
-                {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
-                    {
-                        foreach (var error in Verification.Verify(item))
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            yield return error;
-                        }
-                        indexDataSpecifications++;
-                    }
-                }
-
                 int indexExtensions = 0;
                 foreach (var item in that.Extensions)
                 {
@@ -2703,6 +2684,25 @@ namespace AasCore.Aas3
                         yield return error;
                     }
                     indexQualifiers++;
+                }
+
+                if (that.DataSpecifications != null)
+                {
+                    int indexDataSpecifications = 0;
+                    foreach (var item in that.DataSpecifications)
+                    {
+                        foreach (var error in Verification.Verify(item))
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            yield return error;
+                        }
+                        indexDataSpecifications++;
+                    }
                 }
 
                 int indexInputVariables = 0;
@@ -2769,25 +2769,6 @@ namespace AasCore.Aas3
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.Capability that)
             {
-                if (that.DataSpecifications != null)
-                {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
-                    {
-                        foreach (var error in Verification.Verify(item))
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            yield return error;
-                        }
-                        indexDataSpecifications++;
-                    }
-                }
-
                 int indexExtensions = 0;
                 foreach (var item in that.Extensions)
                 {
@@ -2888,11 +2869,7 @@ namespace AasCore.Aas3
                     }
                     indexQualifiers++;
                 }
-            }
 
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.ConceptDescription that)
-            {
                 if (that.DataSpecifications != null)
                 {
                     int indexDataSpecifications = 0;
@@ -2911,7 +2888,11 @@ namespace AasCore.Aas3
                         indexDataSpecifications++;
                     }
                 }
+            }
 
+            public override IEnumerable<Reporting.Error> Transform(
+                Aas.ConceptDescription that)
+            {
                 int indexExtensions = 0;
                 foreach (var item in that.Extensions)
                 {
@@ -2991,6 +2972,25 @@ namespace AasCore.Aas3
                     }
                 }
 
+                if (that.DataSpecifications != null)
+                {
+                    int indexDataSpecifications = 0;
+                    foreach (var item in that.DataSpecifications)
+                    {
+                        foreach (var error in Verification.Verify(item))
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            yield return error;
+                        }
+                        indexDataSpecifications++;
+                    }
+                }
+
                 int indexIsCaseOf = 0;
                 foreach (var item in that.IsCaseOf)
                 {
@@ -3011,25 +3011,6 @@ namespace AasCore.Aas3
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.View that)
             {
-                if (that.DataSpecifications != null)
-                {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
-                    {
-                        foreach (var error in Verification.Verify(item))
-                        {
-                            error._pathSegments.AddFirst(
-                                new Reporting.IndexSegment(
-                                    indexDataSpecifications));
-                            error._pathSegments.AddFirst(
-                                new Reporting.NameSegment(
-                                    "dataSpecifications"));
-                            yield return error;
-                        }
-                        indexDataSpecifications++;
-                    }
-                }
-
                 int indexExtensions = 0;
                 foreach (var item in that.Extensions)
                 {
@@ -3098,6 +3079,25 @@ namespace AasCore.Aas3
                             new Reporting.NameSegment(
                                 "semanticId"));
                         yield return error;
+                    }
+                }
+
+                if (that.DataSpecifications != null)
+                {
+                    int indexDataSpecifications = 0;
+                    foreach (var item in that.DataSpecifications)
+                    {
+                        foreach (var error in Verification.Verify(item))
+                        {
+                            error._pathSegments.AddFirst(
+                                new Reporting.IndexSegment(
+                                    indexDataSpecifications));
+                            error._pathSegments.AddFirst(
+                                new Reporting.NameSegment(
+                                    "dataSpecifications"));
+                            yield return error;
+                        }
+                        indexDataSpecifications++;
                     }
                 }
 

--- a/test_data/intermediate/expected/class/inheritance/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/class/inheritance/expected_symbol_table.txt
@@ -235,12 +235,6 @@ SymbolTable(
           preconditions=[
             Contract(
               args=[
-                'some_property'],
-              description=None,
-              body="Comparison(\n  left=Name(\n    identifier='some_property',\n    original_node=...),\n  op='GT',\n  right=Constant(\n    value=0,\n    original_node=...),\n  original_node=...)",
-              parsed=...),
-            Contract(
-              args=[
                 'another_property'],
               description=None,
               body="Comparison(\n  left=Name(\n    identifier='another_property',\n    original_node=...),\n  op='GT',\n  right=Constant(\n    value=0,\n    original_node=...),\n  original_node=...)",
@@ -368,18 +362,6 @@ SymbolTable(
         description=None,
         contracts=Contracts(
           preconditions=[
-            Contract(
-              args=[
-                'some_property'],
-              description=None,
-              body="Comparison(\n  left=Name(\n    identifier='some_property',\n    original_node=...),\n  op='GT',\n  right=Constant(\n    value=0,\n    original_node=...),\n  original_node=...)",
-              parsed=...),
-            Contract(
-              args=[
-                'another_property'],
-              description=None,
-              body="Comparison(\n  left=Name(\n    identifier='another_property',\n    original_node=...),\n  op='GT',\n  right=Constant(\n    value=0,\n    original_node=...),\n  original_node=...)",
-              parsed=...),
             Contract(
               args=[
                 'yet_another_property'],

--- a/test_data/intermediate/expected/interface/inheritance/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/interface/inheritance/expected_symbol_table.txt
@@ -219,12 +219,6 @@ SymbolTable(
           preconditions=[
             Contract(
               args=[
-                'some_property'],
-              description=None,
-              body="Comparison(\n  left=Name(\n    identifier='some_property',\n    original_node=...),\n  op='GT',\n  right=Constant(\n    value=0,\n    original_node=...),\n  original_node=...)",
-              parsed=...),
-            Contract(
-              args=[
                 'another_property'],
               description=None,
               body="Comparison(\n  left=Name(\n    identifier='another_property',\n    original_node=...),\n  op='GT',\n  right=Constant(\n    value=0,\n    original_node=...),\n  original_node=...)",

--- a/test_data/intermediate/expected/real_meta_models/v3rc2/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/real_meta_models/v3rc2/expected_symbol_table.txt
@@ -1850,20 +1850,6 @@ SymbolTable(
       concrete_descendants=[],
       properties=[
         Property(
-          name='data_specifications',
-          type_annotation=OptionalTypeAnnotation(
-            value=ListTypeAnnotation(
-              items=OurTypeAnnotation(
-                symbol='Reference to symbol Reference',
-                parsed=...),
-              parsed=...),
-            parsed=...),
-          description=Description(
-            document=...,
-            node=...),
-          specified_for='Reference to AbstractClass Has_data_specification',
-          parsed=...),
-        Property(
           name='extensions',
           type_annotation=ListTypeAnnotation(
             items=OurTypeAnnotation(
@@ -1944,6 +1930,20 @@ SymbolTable(
             document=...,
             node=...),
           specified_for='Reference to AbstractClass Identifiable',
+          parsed=...),
+        Property(
+          name='data_specifications',
+          type_annotation=OptionalTypeAnnotation(
+            value=ListTypeAnnotation(
+              items=OurTypeAnnotation(
+                symbol='Reference to symbol Reference',
+                parsed=...),
+              parsed=...),
+            parsed=...),
+          description=Description(
+            document=...,
+            node=...),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Property(
           name='derived_from',
@@ -2456,56 +2456,6 @@ SymbolTable(
       concrete_descendants=[],
       properties=[
         Property(
-          name='data_specifications',
-          type_annotation=OptionalTypeAnnotation(
-            value=ListTypeAnnotation(
-              items=OurTypeAnnotation(
-                symbol='Reference to symbol Reference',
-                parsed=...),
-              parsed=...),
-            parsed=...),
-          description=Description(
-            document=...,
-            node=...),
-          specified_for='Reference to AbstractClass Has_data_specification',
-          parsed=...),
-        Property(
-          name='kind',
-          type_annotation=OptionalTypeAnnotation(
-            value=OurTypeAnnotation(
-              symbol='Reference to symbol Modeling_kind',
-              parsed=...),
-            parsed=...),
-          description=Description(
-            document=...,
-            node=...),
-          specified_for='Reference to AbstractClass Has_kind',
-          parsed=...),
-        Property(
-          name='semantic_ID',
-          type_annotation=OptionalTypeAnnotation(
-            value=OurTypeAnnotation(
-              symbol='Reference to symbol Reference',
-              parsed=...),
-            parsed=...),
-          description=Description(
-            document=...,
-            node=...),
-          specified_for='Reference to AbstractClass Has_semantics',
-          parsed=...),
-        Property(
-          name='qualifiers',
-          type_annotation=ListTypeAnnotation(
-            items=OurTypeAnnotation(
-              symbol='Reference to symbol Constraint',
-              parsed=...),
-            parsed=...),
-          description=Description(
-            document=...,
-            node=...),
-          specified_for='Reference to AbstractClass Qualifiable',
-          parsed=...),
-        Property(
           name='extensions',
           type_annotation=ListTypeAnnotation(
             items=OurTypeAnnotation(
@@ -2586,6 +2536,56 @@ SymbolTable(
             document=...,
             node=...),
           specified_for='Reference to AbstractClass Identifiable',
+          parsed=...),
+        Property(
+          name='kind',
+          type_annotation=OptionalTypeAnnotation(
+            value=OurTypeAnnotation(
+              symbol='Reference to symbol Modeling_kind',
+              parsed=...),
+            parsed=...),
+          description=Description(
+            document=...,
+            node=...),
+          specified_for='Reference to AbstractClass Has_kind',
+          parsed=...),
+        Property(
+          name='semantic_ID',
+          type_annotation=OptionalTypeAnnotation(
+            value=OurTypeAnnotation(
+              symbol='Reference to symbol Reference',
+              parsed=...),
+            parsed=...),
+          description=Description(
+            document=...,
+            node=...),
+          specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Property(
+          name='qualifiers',
+          type_annotation=ListTypeAnnotation(
+            items=OurTypeAnnotation(
+              symbol='Reference to symbol Constraint',
+              parsed=...),
+            parsed=...),
+          description=Description(
+            document=...,
+            node=...),
+          specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Property(
+          name='data_specifications',
+          type_annotation=OptionalTypeAnnotation(
+            value=ListTypeAnnotation(
+              items=OurTypeAnnotation(
+                symbol='Reference to symbol Reference',
+                parsed=...),
+              parsed=...),
+            parsed=...),
+          description=Description(
+            document=...,
+            node=...),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Property(
           name='submodel_elements',
@@ -2814,20 +2814,6 @@ SymbolTable(
           'Reference to ConcreteClass Submodel_element_struct'],
         properties=[
           Property(
-            name='data_specifications',
-            type_annotation=OptionalTypeAnnotation(
-              value=ListTypeAnnotation(
-                items=OurTypeAnnotation(
-                  symbol='Reference to symbol Reference',
-                  parsed=...),
-                parsed=...),
-              parsed=...),
-            description=Description(
-              document=...,
-              node=...),
-            specified_for='Reference to AbstractClass Has_data_specification',
-            parsed=...),
-          Property(
             name='extensions',
             type_annotation=ListTypeAnnotation(
               items=OurTypeAnnotation(
@@ -2922,6 +2908,20 @@ SymbolTable(
               document=...,
               node=...),
             specified_for='Reference to AbstractClass Qualifiable',
+            parsed=...),
+          Property(
+            name='data_specifications',
+            type_annotation=OptionalTypeAnnotation(
+              value=ListTypeAnnotation(
+                items=OurTypeAnnotation(
+                  symbol='Reference to symbol Reference',
+                  parsed=...),
+                parsed=...),
+              parsed=...),
+            description=Description(
+              document=...,
+              node=...),
+            specified_for='Reference to AbstractClass Has_data_specification',
             parsed=...)],
         signatures=[],
         description=Description(
@@ -2946,20 +2946,6 @@ SymbolTable(
         'Reference to ConcreteClass Submodel_element_list',
         'Reference to ConcreteClass Submodel_element_struct'],
       properties=[
-        Property(
-          name='data_specifications',
-          type_annotation=OptionalTypeAnnotation(
-            value=ListTypeAnnotation(
-              items=OurTypeAnnotation(
-                symbol='Reference to symbol Reference',
-                parsed=...),
-              parsed=...),
-            parsed=...),
-          description=Description(
-            document=...,
-            node=...),
-          specified_for='Reference to AbstractClass Has_data_specification',
-          parsed=...),
         Property(
           name='extensions',
           type_annotation=ListTypeAnnotation(
@@ -3055,6 +3041,20 @@ SymbolTable(
             document=...,
             node=...),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Property(
+          name='data_specifications',
+          type_annotation=OptionalTypeAnnotation(
+            value=ListTypeAnnotation(
+              items=OurTypeAnnotation(
+                symbol='Reference to symbol Reference',
+                parsed=...),
+              parsed=...),
+            parsed=...),
+          description=Description(
+            document=...,
+            node=...),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...)],
       methods=[],
       constructor=Constructor(
@@ -3217,20 +3217,6 @@ SymbolTable(
           'Reference to ConcreteClass Annotated_relationship_element'],
         properties=[
           Property(
-            name='data_specifications',
-            type_annotation=OptionalTypeAnnotation(
-              value=ListTypeAnnotation(
-                items=OurTypeAnnotation(
-                  symbol='Reference to symbol Reference',
-                  parsed=...),
-                parsed=...),
-              parsed=...),
-            description=Description(
-              document=...,
-              node=...),
-            specified_for='Reference to AbstractClass Has_data_specification',
-            parsed=...),
-          Property(
             name='extensions',
             type_annotation=ListTypeAnnotation(
               items=OurTypeAnnotation(
@@ -3327,6 +3313,20 @@ SymbolTable(
             specified_for='Reference to AbstractClass Qualifiable',
             parsed=...),
           Property(
+            name='data_specifications',
+            type_annotation=OptionalTypeAnnotation(
+              value=ListTypeAnnotation(
+                items=OurTypeAnnotation(
+                  symbol='Reference to symbol Reference',
+                  parsed=...),
+                parsed=...),
+              parsed=...),
+            description=Description(
+              document=...,
+              node=...),
+            specified_for='Reference to AbstractClass Has_data_specification',
+            parsed=...),
+          Property(
             name='first',
             type_annotation=OurTypeAnnotation(
               symbol='Reference to symbol Reference',
@@ -3357,20 +3357,6 @@ SymbolTable(
       concrete_descendants=[
         'Reference to ConcreteClass Annotated_relationship_element'],
       properties=[
-        Property(
-          name='data_specifications',
-          type_annotation=OptionalTypeAnnotation(
-            value=ListTypeAnnotation(
-              items=OurTypeAnnotation(
-                symbol='Reference to symbol Reference',
-                parsed=...),
-              parsed=...),
-            parsed=...),
-          description=Description(
-            document=...,
-            node=...),
-          specified_for='Reference to AbstractClass Has_data_specification',
-          parsed=...),
         Property(
           name='extensions',
           type_annotation=ListTypeAnnotation(
@@ -3466,6 +3452,20 @@ SymbolTable(
             document=...,
             node=...),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Property(
+          name='data_specifications',
+          type_annotation=OptionalTypeAnnotation(
+            value=ListTypeAnnotation(
+              items=OurTypeAnnotation(
+                symbol='Reference to symbol Reference',
+                parsed=...),
+              parsed=...),
+            parsed=...),
+          description=Description(
+            document=...,
+            node=...),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Property(
           name='first',
@@ -3661,20 +3661,6 @@ SymbolTable(
       concrete_descendants=[],
       properties=[
         Property(
-          name='data_specifications',
-          type_annotation=OptionalTypeAnnotation(
-            value=ListTypeAnnotation(
-              items=OurTypeAnnotation(
-                symbol='Reference to symbol Reference',
-                parsed=...),
-              parsed=...),
-            parsed=...),
-          description=Description(
-            document=...,
-            node=...),
-          specified_for='Reference to AbstractClass Has_data_specification',
-          parsed=...),
-        Property(
           name='extensions',
           type_annotation=ListTypeAnnotation(
             items=OurTypeAnnotation(
@@ -3769,6 +3755,20 @@ SymbolTable(
             document=...,
             node=...),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Property(
+          name='data_specifications',
+          type_annotation=OptionalTypeAnnotation(
+            value=ListTypeAnnotation(
+              items=OurTypeAnnotation(
+                symbol='Reference to symbol Reference',
+                parsed=...),
+              parsed=...),
+            parsed=...),
+          description=Description(
+            document=...,
+            node=...),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Property(
           name='submodel_element_type_values',
@@ -4020,20 +4020,6 @@ SymbolTable(
       concrete_descendants=[],
       properties=[
         Property(
-          name='data_specifications',
-          type_annotation=OptionalTypeAnnotation(
-            value=ListTypeAnnotation(
-              items=OurTypeAnnotation(
-                symbol='Reference to symbol Reference',
-                parsed=...),
-              parsed=...),
-            parsed=...),
-          description=Description(
-            document=...,
-            node=...),
-          specified_for='Reference to AbstractClass Has_data_specification',
-          parsed=...),
-        Property(
           name='extensions',
           type_annotation=ListTypeAnnotation(
             items=OurTypeAnnotation(
@@ -4128,6 +4114,20 @@ SymbolTable(
             document=...,
             node=...),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Property(
+          name='data_specifications',
+          type_annotation=OptionalTypeAnnotation(
+            value=ListTypeAnnotation(
+              items=OurTypeAnnotation(
+                symbol='Reference to symbol Reference',
+                parsed=...),
+              parsed=...),
+            parsed=...),
+          description=Description(
+            document=...,
+            node=...),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Property(
           name='values',
@@ -4322,20 +4322,6 @@ SymbolTable(
           'Reference to ConcreteClass Reference_element'],
         properties=[
           Property(
-            name='data_specifications',
-            type_annotation=OptionalTypeAnnotation(
-              value=ListTypeAnnotation(
-                items=OurTypeAnnotation(
-                  symbol='Reference to symbol Reference',
-                  parsed=...),
-                parsed=...),
-              parsed=...),
-            description=Description(
-              document=...,
-              node=...),
-            specified_for='Reference to AbstractClass Has_data_specification',
-            parsed=...),
-          Property(
             name='extensions',
             type_annotation=ListTypeAnnotation(
               items=OurTypeAnnotation(
@@ -4430,6 +4416,20 @@ SymbolTable(
               document=...,
               node=...),
             specified_for='Reference to AbstractClass Qualifiable',
+            parsed=...),
+          Property(
+            name='data_specifications',
+            type_annotation=OptionalTypeAnnotation(
+              value=ListTypeAnnotation(
+                items=OurTypeAnnotation(
+                  symbol='Reference to symbol Reference',
+                  parsed=...),
+                parsed=...),
+              parsed=...),
+            description=Description(
+              document=...,
+              node=...),
+            specified_for='Reference to AbstractClass Has_data_specification',
             parsed=...)],
         signatures=[],
         description=Description(
@@ -4447,20 +4447,6 @@ SymbolTable(
         'Reference to ConcreteClass Range',
         'Reference to ConcreteClass Reference_element'],
       properties=[
-        Property(
-          name='data_specifications',
-          type_annotation=OptionalTypeAnnotation(
-            value=ListTypeAnnotation(
-              items=OurTypeAnnotation(
-                symbol='Reference to symbol Reference',
-                parsed=...),
-              parsed=...),
-            parsed=...),
-          description=Description(
-            document=...,
-            node=...),
-          specified_for='Reference to AbstractClass Has_data_specification',
-          parsed=...),
         Property(
           name='extensions',
           type_annotation=ListTypeAnnotation(
@@ -4556,6 +4542,20 @@ SymbolTable(
             document=...,
             node=...),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Property(
+          name='data_specifications',
+          type_annotation=OptionalTypeAnnotation(
+            value=ListTypeAnnotation(
+              items=OurTypeAnnotation(
+                symbol='Reference to symbol Reference',
+                parsed=...),
+              parsed=...),
+            parsed=...),
+          description=Description(
+            document=...,
+            node=...),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...)],
       methods=[],
       constructor=Constructor(
@@ -4715,20 +4715,6 @@ SymbolTable(
       concrete_descendants=[],
       properties=[
         Property(
-          name='data_specifications',
-          type_annotation=OptionalTypeAnnotation(
-            value=ListTypeAnnotation(
-              items=OurTypeAnnotation(
-                symbol='Reference to symbol Reference',
-                parsed=...),
-              parsed=...),
-            parsed=...),
-          description=Description(
-            document=...,
-            node=...),
-          specified_for='Reference to AbstractClass Has_data_specification',
-          parsed=...),
-        Property(
           name='extensions',
           type_annotation=ListTypeAnnotation(
             items=OurTypeAnnotation(
@@ -4823,6 +4809,20 @@ SymbolTable(
             document=...,
             node=...),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Property(
+          name='data_specifications',
+          type_annotation=OptionalTypeAnnotation(
+            value=ListTypeAnnotation(
+              items=OurTypeAnnotation(
+                symbol='Reference to symbol Reference',
+                parsed=...),
+              parsed=...),
+            parsed=...),
+          description=Description(
+            document=...,
+            node=...),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Property(
           name='value_type',
@@ -5048,20 +5048,6 @@ SymbolTable(
       concrete_descendants=[],
       properties=[
         Property(
-          name='data_specifications',
-          type_annotation=OptionalTypeAnnotation(
-            value=ListTypeAnnotation(
-              items=OurTypeAnnotation(
-                symbol='Reference to symbol Reference',
-                parsed=...),
-              parsed=...),
-            parsed=...),
-          description=Description(
-            document=...,
-            node=...),
-          specified_for='Reference to AbstractClass Has_data_specification',
-          parsed=...),
-        Property(
           name='extensions',
           type_annotation=ListTypeAnnotation(
             items=OurTypeAnnotation(
@@ -5156,6 +5142,20 @@ SymbolTable(
             document=...,
             node=...),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Property(
+          name='data_specifications',
+          type_annotation=OptionalTypeAnnotation(
+            value=ListTypeAnnotation(
+              items=OurTypeAnnotation(
+                symbol='Reference to symbol Reference',
+                parsed=...),
+              parsed=...),
+            parsed=...),
+          description=Description(
+            document=...,
+            node=...),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Property(
           name='value',
@@ -5363,20 +5363,6 @@ SymbolTable(
       concrete_descendants=[],
       properties=[
         Property(
-          name='data_specifications',
-          type_annotation=OptionalTypeAnnotation(
-            value=ListTypeAnnotation(
-              items=OurTypeAnnotation(
-                symbol='Reference to symbol Reference',
-                parsed=...),
-              parsed=...),
-            parsed=...),
-          description=Description(
-            document=...,
-            node=...),
-          specified_for='Reference to AbstractClass Has_data_specification',
-          parsed=...),
-        Property(
           name='extensions',
           type_annotation=ListTypeAnnotation(
             items=OurTypeAnnotation(
@@ -5471,6 +5457,20 @@ SymbolTable(
             document=...,
             node=...),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Property(
+          name='data_specifications',
+          type_annotation=OptionalTypeAnnotation(
+            value=ListTypeAnnotation(
+              items=OurTypeAnnotation(
+                symbol='Reference to symbol Reference',
+                parsed=...),
+              parsed=...),
+            parsed=...),
+          description=Description(
+            document=...,
+            node=...),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Property(
           name='value_type',
@@ -5696,20 +5696,6 @@ SymbolTable(
       concrete_descendants=[],
       properties=[
         Property(
-          name='data_specifications',
-          type_annotation=OptionalTypeAnnotation(
-            value=ListTypeAnnotation(
-              items=OurTypeAnnotation(
-                symbol='Reference to symbol Reference',
-                parsed=...),
-              parsed=...),
-            parsed=...),
-          description=Description(
-            document=...,
-            node=...),
-          specified_for='Reference to AbstractClass Has_data_specification',
-          parsed=...),
-        Property(
           name='extensions',
           type_annotation=ListTypeAnnotation(
             items=OurTypeAnnotation(
@@ -5804,6 +5790,20 @@ SymbolTable(
             document=...,
             node=...),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Property(
+          name='data_specifications',
+          type_annotation=OptionalTypeAnnotation(
+            value=ListTypeAnnotation(
+              items=OurTypeAnnotation(
+                symbol='Reference to symbol Reference',
+                parsed=...),
+              parsed=...),
+            parsed=...),
+          description=Description(
+            document=...,
+            node=...),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Property(
           name='value',
@@ -5987,20 +5987,6 @@ SymbolTable(
       concrete_descendants=[],
       properties=[
         Property(
-          name='data_specifications',
-          type_annotation=OptionalTypeAnnotation(
-            value=ListTypeAnnotation(
-              items=OurTypeAnnotation(
-                symbol='Reference to symbol Reference',
-                parsed=...),
-              parsed=...),
-            parsed=...),
-          description=Description(
-            document=...,
-            node=...),
-          specified_for='Reference to AbstractClass Has_data_specification',
-          parsed=...),
-        Property(
           name='extensions',
           type_annotation=ListTypeAnnotation(
             items=OurTypeAnnotation(
@@ -6095,6 +6081,20 @@ SymbolTable(
             document=...,
             node=...),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Property(
+          name='data_specifications',
+          type_annotation=OptionalTypeAnnotation(
+            value=ListTypeAnnotation(
+              items=OurTypeAnnotation(
+                symbol='Reference to symbol Reference',
+                parsed=...),
+              parsed=...),
+            parsed=...),
+          description=Description(
+            document=...,
+            node=...),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Property(
           name='MIME_type',
@@ -6301,20 +6301,6 @@ SymbolTable(
       concrete_descendants=[],
       properties=[
         Property(
-          name='data_specifications',
-          type_annotation=OptionalTypeAnnotation(
-            value=ListTypeAnnotation(
-              items=OurTypeAnnotation(
-                symbol='Reference to symbol Reference',
-                parsed=...),
-              parsed=...),
-            parsed=...),
-          description=Description(
-            document=...,
-            node=...),
-          specified_for='Reference to AbstractClass Has_data_specification',
-          parsed=...),
-        Property(
           name='extensions',
           type_annotation=ListTypeAnnotation(
             items=OurTypeAnnotation(
@@ -6409,6 +6395,20 @@ SymbolTable(
             document=...,
             node=...),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Property(
+          name='data_specifications',
+          type_annotation=OptionalTypeAnnotation(
+            value=ListTypeAnnotation(
+              items=OurTypeAnnotation(
+                symbol='Reference to symbol Reference',
+                parsed=...),
+              parsed=...),
+            parsed=...),
+          description=Description(
+            document=...,
+            node=...),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Property(
           name='MIME_type',
@@ -6615,20 +6615,6 @@ SymbolTable(
       concrete_descendants=[],
       properties=[
         Property(
-          name='data_specifications',
-          type_annotation=OptionalTypeAnnotation(
-            value=ListTypeAnnotation(
-              items=OurTypeAnnotation(
-                symbol='Reference to symbol Reference',
-                parsed=...),
-              parsed=...),
-            parsed=...),
-          description=Description(
-            document=...,
-            node=...),
-          specified_for='Reference to AbstractClass Has_data_specification',
-          parsed=...),
-        Property(
           name='extensions',
           type_annotation=ListTypeAnnotation(
             items=OurTypeAnnotation(
@@ -6723,6 +6709,20 @@ SymbolTable(
             document=...,
             node=...),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Property(
+          name='data_specifications',
+          type_annotation=OptionalTypeAnnotation(
+            value=ListTypeAnnotation(
+              items=OurTypeAnnotation(
+                symbol='Reference to symbol Reference',
+                parsed=...),
+              parsed=...),
+            parsed=...),
+          description=Description(
+            document=...,
+            node=...),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Property(
           name='first',
@@ -6976,20 +6976,6 @@ SymbolTable(
       concrete_descendants=[],
       properties=[
         Property(
-          name='data_specifications',
-          type_annotation=OptionalTypeAnnotation(
-            value=ListTypeAnnotation(
-              items=OurTypeAnnotation(
-                symbol='Reference to symbol Reference',
-                parsed=...),
-              parsed=...),
-            parsed=...),
-          description=Description(
-            document=...,
-            node=...),
-          specified_for='Reference to AbstractClass Has_data_specification',
-          parsed=...),
-        Property(
           name='extensions',
           type_annotation=ListTypeAnnotation(
             items=OurTypeAnnotation(
@@ -7084,6 +7070,20 @@ SymbolTable(
             document=...,
             node=...),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Property(
+          name='data_specifications',
+          type_annotation=OptionalTypeAnnotation(
+            value=ListTypeAnnotation(
+              items=OurTypeAnnotation(
+                symbol='Reference to symbol Reference',
+                parsed=...),
+              parsed=...),
+            parsed=...),
+          description=Description(
+            document=...,
+            node=...),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Property(
           name='entity_type',
@@ -7339,20 +7339,6 @@ SymbolTable(
           'Reference to ConcreteClass Basic_Event'],
         properties=[
           Property(
-            name='data_specifications',
-            type_annotation=OptionalTypeAnnotation(
-              value=ListTypeAnnotation(
-                items=OurTypeAnnotation(
-                  symbol='Reference to symbol Reference',
-                  parsed=...),
-                parsed=...),
-              parsed=...),
-            description=Description(
-              document=...,
-              node=...),
-            specified_for='Reference to AbstractClass Has_data_specification',
-            parsed=...),
-          Property(
             name='extensions',
             type_annotation=ListTypeAnnotation(
               items=OurTypeAnnotation(
@@ -7447,6 +7433,20 @@ SymbolTable(
               document=...,
               node=...),
             specified_for='Reference to AbstractClass Qualifiable',
+            parsed=...),
+          Property(
+            name='data_specifications',
+            type_annotation=OptionalTypeAnnotation(
+              value=ListTypeAnnotation(
+                items=OurTypeAnnotation(
+                  symbol='Reference to symbol Reference',
+                  parsed=...),
+                parsed=...),
+              parsed=...),
+            description=Description(
+              document=...,
+              node=...),
+            specified_for='Reference to AbstractClass Has_data_specification',
             parsed=...)],
         signatures=[],
         description=Description(
@@ -7459,20 +7459,6 @@ SymbolTable(
       concrete_descendants=[
         'Reference to ConcreteClass Basic_Event'],
       properties=[
-        Property(
-          name='data_specifications',
-          type_annotation=OptionalTypeAnnotation(
-            value=ListTypeAnnotation(
-              items=OurTypeAnnotation(
-                symbol='Reference to symbol Reference',
-                parsed=...),
-              parsed=...),
-            parsed=...),
-          description=Description(
-            document=...,
-            node=...),
-          specified_for='Reference to AbstractClass Has_data_specification',
-          parsed=...),
         Property(
           name='extensions',
           type_annotation=ListTypeAnnotation(
@@ -7568,6 +7554,20 @@ SymbolTable(
             document=...,
             node=...),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Property(
+          name='data_specifications',
+          type_annotation=OptionalTypeAnnotation(
+            value=ListTypeAnnotation(
+              items=OurTypeAnnotation(
+                symbol='Reference to symbol Reference',
+                parsed=...),
+              parsed=...),
+            parsed=...),
+          description=Description(
+            document=...,
+            node=...),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...)],
       methods=[],
       constructor=Constructor(
@@ -7727,20 +7727,6 @@ SymbolTable(
       concrete_descendants=[],
       properties=[
         Property(
-          name='data_specifications',
-          type_annotation=OptionalTypeAnnotation(
-            value=ListTypeAnnotation(
-              items=OurTypeAnnotation(
-                symbol='Reference to symbol Reference',
-                parsed=...),
-              parsed=...),
-            parsed=...),
-          description=Description(
-            document=...,
-            node=...),
-          specified_for='Reference to AbstractClass Has_data_specification',
-          parsed=...),
-        Property(
           name='extensions',
           type_annotation=ListTypeAnnotation(
             items=OurTypeAnnotation(
@@ -7835,6 +7821,20 @@ SymbolTable(
             document=...,
             node=...),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Property(
+          name='data_specifications',
+          type_annotation=OptionalTypeAnnotation(
+            value=ListTypeAnnotation(
+              items=OurTypeAnnotation(
+                symbol='Reference to symbol Reference',
+                parsed=...),
+              parsed=...),
+            parsed=...),
+          description=Description(
+            document=...,
+            node=...),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Property(
           name='observed',
@@ -8012,20 +8012,6 @@ SymbolTable(
       concrete_descendants=[],
       properties=[
         Property(
-          name='data_specifications',
-          type_annotation=OptionalTypeAnnotation(
-            value=ListTypeAnnotation(
-              items=OurTypeAnnotation(
-                symbol='Reference to symbol Reference',
-                parsed=...),
-              parsed=...),
-            parsed=...),
-          description=Description(
-            document=...,
-            node=...),
-          specified_for='Reference to AbstractClass Has_data_specification',
-          parsed=...),
-        Property(
           name='extensions',
           type_annotation=ListTypeAnnotation(
             items=OurTypeAnnotation(
@@ -8120,6 +8106,20 @@ SymbolTable(
             document=...,
             node=...),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Property(
+          name='data_specifications',
+          type_annotation=OptionalTypeAnnotation(
+            value=ListTypeAnnotation(
+              items=OurTypeAnnotation(
+                symbol='Reference to symbol Reference',
+                parsed=...),
+              parsed=...),
+            parsed=...),
+          description=Description(
+            document=...,
+            node=...),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Property(
           name='input_variables',
@@ -8417,20 +8417,6 @@ SymbolTable(
       concrete_descendants=[],
       properties=[
         Property(
-          name='data_specifications',
-          type_annotation=OptionalTypeAnnotation(
-            value=ListTypeAnnotation(
-              items=OurTypeAnnotation(
-                symbol='Reference to symbol Reference',
-                parsed=...),
-              parsed=...),
-            parsed=...),
-          description=Description(
-            document=...,
-            node=...),
-          specified_for='Reference to AbstractClass Has_data_specification',
-          parsed=...),
-        Property(
           name='extensions',
           type_annotation=ListTypeAnnotation(
             items=OurTypeAnnotation(
@@ -8525,6 +8511,20 @@ SymbolTable(
             document=...,
             node=...),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Property(
+          name='data_specifications',
+          type_annotation=OptionalTypeAnnotation(
+            value=ListTypeAnnotation(
+              items=OurTypeAnnotation(
+                symbol='Reference to symbol Reference',
+                parsed=...),
+              parsed=...),
+            parsed=...),
+          description=Description(
+            document=...,
+            node=...),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...)],
       methods=[],
       constructor=Constructor(
@@ -8685,20 +8685,6 @@ SymbolTable(
       concrete_descendants=[],
       properties=[
         Property(
-          name='data_specifications',
-          type_annotation=OptionalTypeAnnotation(
-            value=ListTypeAnnotation(
-              items=OurTypeAnnotation(
-                symbol='Reference to symbol Reference',
-                parsed=...),
-              parsed=...),
-            parsed=...),
-          description=Description(
-            document=...,
-            node=...),
-          specified_for='Reference to AbstractClass Has_data_specification',
-          parsed=...),
-        Property(
           name='extensions',
           type_annotation=ListTypeAnnotation(
             items=OurTypeAnnotation(
@@ -8779,6 +8765,20 @@ SymbolTable(
             document=...,
             node=...),
           specified_for='Reference to AbstractClass Identifiable',
+          parsed=...),
+        Property(
+          name='data_specifications',
+          type_annotation=OptionalTypeAnnotation(
+            value=ListTypeAnnotation(
+              items=OurTypeAnnotation(
+                symbol='Reference to symbol Reference',
+                parsed=...),
+              parsed=...),
+            parsed=...),
+          description=Description(
+            document=...,
+            node=...),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Property(
           name='is_case_of',
@@ -8947,20 +8947,6 @@ SymbolTable(
       concrete_descendants=[],
       properties=[
         Property(
-          name='data_specifications',
-          type_annotation=OptionalTypeAnnotation(
-            value=ListTypeAnnotation(
-              items=OurTypeAnnotation(
-                symbol='Reference to symbol Reference',
-                parsed=...),
-              parsed=...),
-            parsed=...),
-          description=Description(
-            document=...,
-            node=...),
-          specified_for='Reference to AbstractClass Has_data_specification',
-          parsed=...),
-        Property(
           name='extensions',
           type_annotation=ListTypeAnnotation(
             items=OurTypeAnnotation(
@@ -9031,6 +9017,20 @@ SymbolTable(
             document=...,
             node=...),
           specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Property(
+          name='data_specifications',
+          type_annotation=OptionalTypeAnnotation(
+            value=ListTypeAnnotation(
+              items=OurTypeAnnotation(
+                symbol='Reference to symbol Reference',
+                parsed=...),
+              parsed=...),
+            parsed=...),
+          description=Description(
+            document=...,
+            node=...),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Property(
           name='contained_elements',


### PR DESCRIPTION
We refactor `intermediate.translate` in a major way such that the
heritage of the classes and constrained primitives is stacked only in
the second passes. The benefits are the following:

+ The code is easier to read. Instead of hacking around with the `parse`
  representation, we can use resolved references to parents.
+ We were re-parsing the properties and methods in the classes from the
  ancestors simply because we could not access them due to inappropriate
  representation. This makes the reporting of errors convoluted as we
  would have to re-report the errors on every inherited property or
  method. With this change, we parse the properties and methods only
  once and report the errors correctly.

However, this refactoring has one big drawback, which we still found
acceptable:

- The state of the symbol table is not immutable any more. We have to
  break the typing system in various places since the actual values
  during the translation are now not know ahead of time. For example,
  the serialization settings are unknown prior to executing its
  inheritance.

  Theoretically, we could introduce yet another representation to suit
  this temporal "limbo" state before the values are finalized. At this
  point in time, this would be a lot of work without any tangible
  benefits and we doubt that the readability of the code would even
  improve. In the future, if there are bugs related to the mutability of
  the symbol table in `translate` module we should definitely revisit
  this decision.