### PR TITLE
Check the order of properties and constructor args

### DIFF
--- a/test_data/csharp/test_main/v3rc2/expected_output/jsonization.cs
+++ b/test_data/csharp/test_main/v3rc2/expected_output/jsonization.cs
@@ -1055,9 +1055,9 @@ namespace AasCore.Aas3
                 }
 
                 return new Aas.AdministrativeInformation(
+                    theDataSpecifications,
                     theVersion,
-                    theRevision,
-                    theDataSpecifications);
+                    theRevision);
             }  // internal static AdministrativeInformationFrom
 
             /// <summary>
@@ -1349,9 +1349,9 @@ namespace AasCore.Aas3
                     theValueType
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"),
+                    theSemanticId,
                     theValue,
-                    theValueId,
-                    theSemanticId);
+                    theValueId);
             }  // internal static QualifierFrom
 
             /// <summary>
@@ -1781,10 +1781,10 @@ namespace AasCore.Aas3
                     theAssetInformation
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"),
-                    theIdShort,
                     theExtensions
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"),
+                    theIdShort,
                     theDisplayName,
                     theCategory,
                     theDescription,
@@ -2052,8 +2052,8 @@ namespace AasCore.Aas3
                     theValue
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"),
-                    theExternalSubjectId,
-                    theSemanticId);
+                    theSemanticId,
+                    theExternalSubjectId);
             }  // internal static IdentifierKeyValuePairFrom
 
             /// <summary>
@@ -2459,13 +2459,10 @@ namespace AasCore.Aas3
                     theId
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"),
-                    theIdShort,
-                    theSubmodelElements
-                         ?? throw new System.InvalidOperationException(
-                            "Unexpected null, had to be handled before"),
                     theExtensions
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"),
+                    theIdShort,
                     theDisplayName,
                     theCategory,
                     theDescription,
@@ -2475,7 +2472,10 @@ namespace AasCore.Aas3
                     theQualifiers
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"),
-                    theDataSpecifications);
+                    theDataSpecifications,
+                    theSubmodelElements
+                         ?? throw new System.InvalidOperationException(
+                            "Unexpected null, had to be handled before"));
             }  // internal static SubmodelFrom
 
             /// <summary>
@@ -3886,10 +3886,10 @@ namespace AasCore.Aas3
                     theValueType
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"),
-                    theIdShort,
                     theExtensions
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"),
+                    theIdShort,
                     theDisplayName,
                     theCategory,
                     theDescription,
@@ -4248,10 +4248,10 @@ namespace AasCore.Aas3
                 }
 
                 return new Aas.MultiLanguageProperty(
-                    theIdShort,
                     theExtensions
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"),
+                    theIdShort,
                     theDisplayName,
                     theCategory,
                     theDescription,
@@ -4636,10 +4636,10 @@ namespace AasCore.Aas3
                     theValueType
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"),
-                    theIdShort,
                     theExtensions
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"),
+                    theIdShort,
                     theDisplayName,
                     theCategory,
                     theDescription,
@@ -4977,10 +4977,10 @@ namespace AasCore.Aas3
                 }
 
                 return new Aas.ReferenceElement(
-                    theIdShort,
                     theExtensions
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"),
+                    theIdShort,
                     theDisplayName,
                     theCategory,
                     theDescription,
@@ -5343,10 +5343,10 @@ namespace AasCore.Aas3
                     theMimeType
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"),
-                    theIdShort,
                     theExtensions
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"),
+                    theIdShort,
                     theDisplayName,
                     theCategory,
                     theDescription,
@@ -5709,10 +5709,10 @@ namespace AasCore.Aas3
                     theMimeType
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"),
-                    theIdShort,
                     theExtensions
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"),
+                    theIdShort,
                     theDisplayName,
                     theCategory,
                     theDescription,
@@ -7010,10 +7010,10 @@ namespace AasCore.Aas3
                     theObserved
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"),
-                    theIdShort,
                     theExtensions
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"),
+                    theIdShort,
                     theDisplayName,
                     theCategory,
                     theDescription,
@@ -8185,18 +8185,18 @@ namespace AasCore.Aas3
                     theId
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"),
-                    theIdShort,
                     theExtensions
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"),
+                    theIdShort,
                     theDisplayName,
                     theCategory,
                     theDescription,
                     theAdministration,
+                    theDataSpecifications,
                     theIsCaseOf
                          ?? throw new System.InvalidOperationException(
-                            "Unexpected null, had to be handled before"),
-                    theDataSpecifications);
+                            "Unexpected null, had to be handled before"));
             }  // internal static ConceptDescriptionFrom
 
             /// <summary>

--- a/test_data/csharp/test_main/v3rc2/expected_output/types.cs
+++ b/test_data/csharp/test_main/v3rc2/expected_output/types.cs
@@ -500,9 +500,9 @@ namespace AasCore.Aas3
         }
 
         public AdministrativeInformation(
+            List<IReference>? dataSpecifications = null,
             string? version = null,
-            string? revision = null,
-            List<IReference>? dataSpecifications = null)
+            string? revision = null)
         {
             DataSpecifications = dataSpecifications;
             Version = version;
@@ -651,9 +651,9 @@ namespace AasCore.Aas3
         public Qualifier(
             string type,
             DataTypeDef valueType,
+            IReference? semanticId = null,
             string? value = null,
-            IReference? valueId = null,
-            IReference? semanticId = null)
+            IReference? valueId = null)
         {
             SemanticId = semanticId;
             Type = type;
@@ -1085,8 +1085,8 @@ namespace AasCore.Aas3
         public AssetAdministrationShell(
             string id,
             AssetInformation assetInformation,
-            string? idShort = null,
             List<Extension>? extensions = null,
+            string? idShort = null,
             LangStringSet? displayName = null,
             string? category = null,
             LangStringSet? description = null,
@@ -1422,8 +1422,8 @@ namespace AasCore.Aas3
         public IdentifierKeyValuePair(
             string key,
             string value,
-            IReference? externalSubjectId = null,
-            IReference? semanticId = null)
+            IReference? semanticId = null,
+            IReference? externalSubjectId = null)
         {
             SemanticId = semanticId;
             Key = key;
@@ -1770,9 +1770,8 @@ namespace AasCore.Aas3
 
         public Submodel(
             string id,
-            string? idShort = null,
-            List<ISubmodelElement>? submodelElements = null,
             List<Extension>? extensions = null,
+            string? idShort = null,
             LangStringSet? displayName = null,
             string? category = null,
             LangStringSet? description = null,
@@ -1780,7 +1779,8 @@ namespace AasCore.Aas3
             ModelingKind? kind = null,
             IReference? semanticId = null,
             List<IConstraint>? qualifiers = null,
-            List<IReference>? dataSpecifications = null)
+            List<IReference>? dataSpecifications = null,
+            List<ISubmodelElement>? submodelElements = null)
         {
             Extensions = (extensions != null)
                 ? extensions
@@ -2983,8 +2983,8 @@ namespace AasCore.Aas3
 
         public Property(
             DataTypeDef valueType,
-            string? idShort = null,
             List<Extension>? extensions = null,
+            string? idShort = null,
             LangStringSet? displayName = null,
             string? category = null,
             LangStringSet? description = null,
@@ -3364,8 +3364,8 @@ namespace AasCore.Aas3
         }
 
         public MultiLanguageProperty(
-            string? idShort = null,
             List<Extension>? extensions = null,
+            string? idShort = null,
             LangStringSet? displayName = null,
             string? category = null,
             LangStringSet? description = null,
@@ -3711,8 +3711,8 @@ namespace AasCore.Aas3
 
         public Range(
             DataTypeDef valueType,
-            string? idShort = null,
             List<Extension>? extensions = null,
+            string? idShort = null,
             LangStringSet? displayName = null,
             string? category = null,
             LangStringSet? description = null,
@@ -4059,8 +4059,8 @@ namespace AasCore.Aas3
         }
 
         public ReferenceElement(
-            string? idShort = null,
             List<Extension>? extensions = null,
+            string? idShort = null,
             LangStringSet? displayName = null,
             string? category = null,
             LangStringSet? description = null,
@@ -4397,8 +4397,8 @@ namespace AasCore.Aas3
 
         public Blob(
             string mimeType,
-            string? idShort = null,
             List<Extension>? extensions = null,
+            string? idShort = null,
             LangStringSet? displayName = null,
             string? category = null,
             LangStringSet? description = null,
@@ -4729,8 +4729,8 @@ namespace AasCore.Aas3
 
         public File(
             string mimeType,
-            string? idShort = null,
             List<Extension>? extensions = null,
+            string? idShort = null,
             LangStringSet? displayName = null,
             string? category = null,
             LangStringSet? description = null,
@@ -5868,8 +5868,8 @@ namespace AasCore.Aas3
 
         public BasicEvent(
             IReference observed,
-            string? idShort = null,
             List<Extension>? extensions = null,
+            string? idShort = null,
             LangStringSet? displayName = null,
             string? category = null,
             LangStringSet? description = null,
@@ -6970,14 +6970,14 @@ namespace AasCore.Aas3
 
         public ConceptDescription(
             string id,
-            string? idShort = null,
             List<Extension>? extensions = null,
+            string? idShort = null,
             LangStringSet? displayName = null,
             string? category = null,
             LangStringSet? description = null,
             AdministrativeInformation? administration = null,
-            List<IReference>? isCaseOf = null,
-            List<IReference>? dataSpecifications = null)
+            List<IReference>? dataSpecifications = null,
+            List<IReference>? isCaseOf = null)
         {
             Extensions = (extensions != null)
                 ? extensions

--- a/test_data/csharp/test_main/v3rc2/input/meta_model.py
+++ b/test_data/csharp/test_main/v3rc2/input/meta_model.py
@@ -409,9 +409,9 @@ class Administrative_information(Has_data_specification):
 
     def __init__(
             self,
+            data_specifications: Optional[List["Reference"]] = None,
             version: Optional[Non_empty_string] = None,
             revision: Optional[Non_empty_string] = None,
-            data_specifications: Optional[List["Reference"]] = None,
     ) -> None:
         Has_data_specification.__init__(self, data_specifications=data_specifications)
 
@@ -496,9 +496,9 @@ class Qualifier(Constraint, Has_semantics):
             self,
             type: Non_empty_string,
             value_type: "Data_type_def",
+            semantic_ID: Optional["Reference"] = None,
             value: Optional[Non_empty_string] = None,
             value_ID: Optional["Reference"] = None,
-            semantic_ID: Optional["Reference"] = None,
     ) -> None:
         Has_semantics.__init__(self, semantic_ID=semantic_ID)
 
@@ -578,8 +578,8 @@ class Asset_administration_shell(Identifiable, Has_data_specification):
             self,
             ID: Non_empty_string,
             asset_information: "Asset_information",
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -719,10 +719,11 @@ class Identifier_key_value_pair(Has_semantics):
             self,
             key: Non_empty_string,
             value: Non_empty_string,
-            external_subject_ID: Optional["Reference"] = None,
             semantic_ID: Optional["Reference"] = None,
+            external_subject_ID: Optional["Reference"] = None,
     ) -> None:
         Has_semantics.__init__(self, semantic_ID)
+
         self.key = key
         self.value = value
         self.external_subject_ID = external_subject_ID
@@ -747,9 +748,8 @@ class Submodel(
     def __init__(
             self,
             ID: Non_empty_string,
-            ID_short: Optional[Non_empty_string] = None,
-            submodel_elements: Optional[List["Submodel_element"]] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -758,6 +758,7 @@ class Submodel(
             semantic_ID: Optional["Reference"] = None,
             qualifiers: Optional[List["Constraint"]] = None,
             data_specifications: Optional[List["Reference"]] = None,
+            submodel_elements: Optional[List["Submodel_element"]] = None,
     ) -> None:
         # TODO (Nico & Marko, 2021-09-24):
         #  How should we implement Constraint AASd-062 (page 64 in V3RC1)?
@@ -1123,8 +1124,8 @@ class Property(Data_element):
     def __init__(
             self,
             value_type: "Data_type_def",
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -1195,8 +1196,8 @@ class Multi_language_property(Data_element):
 
     def __init__(
             self,
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -1265,8 +1266,8 @@ class Range(Data_element):
     def __init__(
             self,
             value_type: "Data_type_def",
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -1321,8 +1322,8 @@ class Reference_element(Data_element):
 
     def __init__(
             self,
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -1385,8 +1386,8 @@ class Blob(Data_element):
     def __init__(
             self,
             MIME_type: MIME_typed,
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -1443,8 +1444,8 @@ class File(Data_element):
     def __init__(
             self,
             MIME_type: MIME_typed,
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -1684,8 +1685,8 @@ class Basic_Event(Event):
     def __init__(
             self,
             observed: "Reference",
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -1853,14 +1854,14 @@ class Concept_description(Identifiable, Has_data_specification):
     def __init__(
             self,
             ID: Non_empty_string,
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
             administration: Optional["Administrative_information"] = None,
-            is_case_of: Optional[List["Reference"]] = None,
             data_specifications: Optional[List["Reference"]] = None,
+            is_case_of: Optional[List["Reference"]] = None,
     ) -> None:
         Identifiable.__init__(
             self,

--- a/test_data/intermediate/expected/real_meta_models/v3rc2/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/real_meta_models/v3rc2/expected_symbol_table.txt
@@ -1582,6 +1582,19 @@ SymbolTable(
         name='__init__',
         arguments=[
           Argument(
+            name='data_specifications',
+            type_annotation=OptionalTypeAnnotation(
+              value=ListTypeAnnotation(
+                items=OurTypeAnnotation(
+                  symbol='Reference to symbol Reference',
+                  parsed=...),
+                parsed=...),
+              parsed=...),
+            default=DefaultConstant(
+              value=None,
+              parsed=...),
+            parsed=...),
+          Argument(
             name='version',
             type_annotation=OptionalTypeAnnotation(
               value=OurTypeAnnotation(
@@ -1597,19 +1610,6 @@ SymbolTable(
             type_annotation=OptionalTypeAnnotation(
               value=OurTypeAnnotation(
                 symbol='Reference to symbol Non_empty_string',
-                parsed=...),
-              parsed=...),
-            default=DefaultConstant(
-              value=None,
-              parsed=...),
-            parsed=...),
-          Argument(
-            name='data_specifications',
-            type_annotation=OptionalTypeAnnotation(
-              value=ListTypeAnnotation(
-                items=OurTypeAnnotation(
-                  symbol='Reference to symbol Reference',
-                  parsed=...),
                 parsed=...),
               parsed=...),
             default=DefaultConstant(
@@ -1941,6 +1941,17 @@ SymbolTable(
             default=None,
             parsed=...),
           Argument(
+            name='semantic_ID',
+            type_annotation=OptionalTypeAnnotation(
+              value=OurTypeAnnotation(
+                symbol='Reference to symbol Reference',
+                parsed=...),
+              parsed=...),
+            default=DefaultConstant(
+              value=None,
+              parsed=...),
+            parsed=...),
+          Argument(
             name='value',
             type_annotation=OptionalTypeAnnotation(
               value=OurTypeAnnotation(
@@ -1953,17 +1964,6 @@ SymbolTable(
             parsed=...),
           Argument(
             name='value_ID',
-            type_annotation=OptionalTypeAnnotation(
-              value=OurTypeAnnotation(
-                symbol='Reference to symbol Reference',
-                parsed=...),
-              parsed=...),
-            default=DefaultConstant(
-              value=None,
-              parsed=...),
-            parsed=...),
-          Argument(
-            name='semantic_ID',
             type_annotation=OptionalTypeAnnotation(
               value=OurTypeAnnotation(
                 symbol='Reference to symbol Reference',
@@ -2289,10 +2289,12 @@ SymbolTable(
             default=None,
             parsed=...),
           Argument(
-            name='ID_short',
+            name='extensions',
             type_annotation=OptionalTypeAnnotation(
-              value=OurTypeAnnotation(
-                symbol='Reference to symbol Non_empty_string',
+              value=ListTypeAnnotation(
+                items=OurTypeAnnotation(
+                  symbol='Reference to symbol Extension',
+                  parsed=...),
                 parsed=...),
               parsed=...),
             default=DefaultConstant(
@@ -2300,12 +2302,10 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='extensions',
+            name='ID_short',
             type_annotation=OptionalTypeAnnotation(
-              value=ListTypeAnnotation(
-                items=OurTypeAnnotation(
-                  symbol='Reference to symbol Extension',
-                  parsed=...),
+              value=OurTypeAnnotation(
+                symbol='Reference to symbol Non_empty_string',
                 parsed=...),
               parsed=...),
             default=DefaultConstant(
@@ -2712,7 +2712,7 @@ SymbolTable(
             default=None,
             parsed=...),
           Argument(
-            name='external_subject_ID',
+            name='semantic_ID',
             type_annotation=OptionalTypeAnnotation(
               value=OurTypeAnnotation(
                 symbol='Reference to symbol Reference',
@@ -2723,7 +2723,7 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='semantic_ID',
+            name='external_subject_ID',
             type_annotation=OptionalTypeAnnotation(
               value=OurTypeAnnotation(
                 symbol='Reference to symbol Reference',
@@ -2983,36 +2983,23 @@ SymbolTable(
             default=None,
             parsed=...),
           Argument(
-            name='ID_short',
-            type_annotation=OptionalTypeAnnotation(
-              value=OurTypeAnnotation(
-                symbol='Reference to symbol Non_empty_string',
-                parsed=...),
-              parsed=...),
-            default=DefaultConstant(
-              value=None,
-              parsed=...),
-            parsed=...),
-          Argument(
-            name='submodel_elements',
-            type_annotation=OptionalTypeAnnotation(
-              value=ListTypeAnnotation(
-                items=OurTypeAnnotation(
-                  symbol='Reference to symbol Submodel_element',
-                  parsed=...),
-                parsed=...),
-              parsed=...),
-            default=DefaultConstant(
-              value=None,
-              parsed=...),
-            parsed=...),
-          Argument(
             name='extensions',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
                   symbol='Reference to symbol Extension',
                   parsed=...),
+                parsed=...),
+              parsed=...),
+            default=DefaultConstant(
+              value=None,
+              parsed=...),
+            parsed=...),
+          Argument(
+            name='ID_short',
+            type_annotation=OptionalTypeAnnotation(
+              value=OurTypeAnnotation(
+                symbol='Reference to symbol Non_empty_string',
                 parsed=...),
               parsed=...),
             default=DefaultConstant(
@@ -3104,6 +3091,19 @@ SymbolTable(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
                   symbol='Reference to symbol Reference',
+                  parsed=...),
+                parsed=...),
+              parsed=...),
+            default=DefaultConstant(
+              value=None,
+              parsed=...),
+            parsed=...),
+          Argument(
+            name='submodel_elements',
+            type_annotation=OptionalTypeAnnotation(
+              value=ListTypeAnnotation(
+                items=OurTypeAnnotation(
+                  symbol='Reference to symbol Submodel_element',
                   parsed=...),
                 parsed=...),
               parsed=...),
@@ -5675,10 +5675,12 @@ SymbolTable(
             default=None,
             parsed=...),
           Argument(
-            name='ID_short',
+            name='extensions',
             type_annotation=OptionalTypeAnnotation(
-              value=OurTypeAnnotation(
-                symbol='Reference to symbol Non_empty_string',
+              value=ListTypeAnnotation(
+                items=OurTypeAnnotation(
+                  symbol='Reference to symbol Extension',
+                  parsed=...),
                 parsed=...),
               parsed=...),
             default=DefaultConstant(
@@ -5686,12 +5688,10 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='extensions',
+            name='ID_short',
             type_annotation=OptionalTypeAnnotation(
-              value=ListTypeAnnotation(
-                items=OurTypeAnnotation(
-                  symbol='Reference to symbol Extension',
-                  parsed=...),
+              value=OurTypeAnnotation(
+                symbol='Reference to symbol Non_empty_string',
                 parsed=...),
               parsed=...),
             default=DefaultConstant(
@@ -6048,10 +6048,12 @@ SymbolTable(
         name='__init__',
         arguments=[
           Argument(
-            name='ID_short',
+            name='extensions',
             type_annotation=OptionalTypeAnnotation(
-              value=OurTypeAnnotation(
-                symbol='Reference to symbol Non_empty_string',
+              value=ListTypeAnnotation(
+                items=OurTypeAnnotation(
+                  symbol='Reference to symbol Extension',
+                  parsed=...),
                 parsed=...),
               parsed=...),
             default=DefaultConstant(
@@ -6059,12 +6061,10 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='extensions',
+            name='ID_short',
             type_annotation=OptionalTypeAnnotation(
-              value=ListTypeAnnotation(
-                items=OurTypeAnnotation(
-                  symbol='Reference to symbol Extension',
-                  parsed=...),
+              value=OurTypeAnnotation(
+                symbol='Reference to symbol Non_empty_string',
                 parsed=...),
               parsed=...),
             default=DefaultConstant(
@@ -6438,10 +6438,12 @@ SymbolTable(
             default=None,
             parsed=...),
           Argument(
-            name='ID_short',
+            name='extensions',
             type_annotation=OptionalTypeAnnotation(
-              value=OurTypeAnnotation(
-                symbol='Reference to symbol Non_empty_string',
+              value=ListTypeAnnotation(
+                items=OurTypeAnnotation(
+                  symbol='Reference to symbol Extension',
+                  parsed=...),
                 parsed=...),
               parsed=...),
             default=DefaultConstant(
@@ -6449,12 +6451,10 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='extensions',
+            name='ID_short',
             type_annotation=OptionalTypeAnnotation(
-              value=ListTypeAnnotation(
-                items=OurTypeAnnotation(
-                  symbol='Reference to symbol Extension',
-                  parsed=...),
+              value=OurTypeAnnotation(
+                symbol='Reference to symbol Non_empty_string',
                 parsed=...),
               parsed=...),
             default=DefaultConstant(
@@ -6794,10 +6794,12 @@ SymbolTable(
         name='__init__',
         arguments=[
           Argument(
-            name='ID_short',
+            name='extensions',
             type_annotation=OptionalTypeAnnotation(
-              value=OurTypeAnnotation(
-                symbol='Reference to symbol Non_empty_string',
+              value=ListTypeAnnotation(
+                items=OurTypeAnnotation(
+                  symbol='Reference to symbol Extension',
+                  parsed=...),
                 parsed=...),
               parsed=...),
             default=DefaultConstant(
@@ -6805,12 +6807,10 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='extensions',
+            name='ID_short',
             type_annotation=OptionalTypeAnnotation(
-              value=ListTypeAnnotation(
-                items=OurTypeAnnotation(
-                  symbol='Reference to symbol Extension',
-                  parsed=...),
+              value=OurTypeAnnotation(
+                symbol='Reference to symbol Non_empty_string',
                 parsed=...),
               parsed=...),
             default=DefaultConstant(
@@ -7154,10 +7154,12 @@ SymbolTable(
             default=None,
             parsed=...),
           Argument(
-            name='ID_short',
+            name='extensions',
             type_annotation=OptionalTypeAnnotation(
-              value=OurTypeAnnotation(
-                symbol='Reference to symbol Non_empty_string',
+              value=ListTypeAnnotation(
+                items=OurTypeAnnotation(
+                  symbol='Reference to symbol Extension',
+                  parsed=...),
                 parsed=...),
               parsed=...),
             default=DefaultConstant(
@@ -7165,12 +7167,10 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='extensions',
+            name='ID_short',
             type_annotation=OptionalTypeAnnotation(
-              value=ListTypeAnnotation(
-                items=OurTypeAnnotation(
-                  symbol='Reference to symbol Extension',
-                  parsed=...),
+              value=OurTypeAnnotation(
+                symbol='Reference to symbol Non_empty_string',
                 parsed=...),
               parsed=...),
             default=DefaultConstant(
@@ -7519,10 +7519,12 @@ SymbolTable(
             default=None,
             parsed=...),
           Argument(
-            name='ID_short',
+            name='extensions',
             type_annotation=OptionalTypeAnnotation(
-              value=OurTypeAnnotation(
-                symbol='Reference to symbol Non_empty_string',
+              value=ListTypeAnnotation(
+                items=OurTypeAnnotation(
+                  symbol='Reference to symbol Extension',
+                  parsed=...),
                 parsed=...),
               parsed=...),
             default=DefaultConstant(
@@ -7530,12 +7532,10 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='extensions',
+            name='ID_short',
             type_annotation=OptionalTypeAnnotation(
-              value=ListTypeAnnotation(
-                items=OurTypeAnnotation(
-                  symbol='Reference to symbol Extension',
-                  parsed=...),
+              value=OurTypeAnnotation(
+                symbol='Reference to symbol Non_empty_string',
                 parsed=...),
               parsed=...),
             default=DefaultConstant(
@@ -9176,10 +9176,12 @@ SymbolTable(
             default=None,
             parsed=...),
           Argument(
-            name='ID_short',
+            name='extensions',
             type_annotation=OptionalTypeAnnotation(
-              value=OurTypeAnnotation(
-                symbol='Reference to symbol Non_empty_string',
+              value=ListTypeAnnotation(
+                items=OurTypeAnnotation(
+                  symbol='Reference to symbol Extension',
+                  parsed=...),
                 parsed=...),
               parsed=...),
             default=DefaultConstant(
@@ -9187,12 +9189,10 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='extensions',
+            name='ID_short',
             type_annotation=OptionalTypeAnnotation(
-              value=ListTypeAnnotation(
-                items=OurTypeAnnotation(
-                  symbol='Reference to symbol Extension',
-                  parsed=...),
+              value=OurTypeAnnotation(
+                symbol='Reference to symbol Non_empty_string',
                 parsed=...),
               parsed=...),
             default=DefaultConstant(
@@ -10263,10 +10263,12 @@ SymbolTable(
             default=None,
             parsed=...),
           Argument(
-            name='ID_short',
+            name='extensions',
             type_annotation=OptionalTypeAnnotation(
-              value=OurTypeAnnotation(
-                symbol='Reference to symbol Non_empty_string',
+              value=ListTypeAnnotation(
+                items=OurTypeAnnotation(
+                  symbol='Reference to symbol Extension',
+                  parsed=...),
                 parsed=...),
               parsed=...),
             default=DefaultConstant(
@@ -10274,12 +10276,10 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='extensions',
+            name='ID_short',
             type_annotation=OptionalTypeAnnotation(
-              value=ListTypeAnnotation(
-                items=OurTypeAnnotation(
-                  symbol='Reference to symbol Extension',
-                  parsed=...),
+              value=OurTypeAnnotation(
+                symbol='Reference to symbol Non_empty_string',
                 parsed=...),
               parsed=...),
             default=DefaultConstant(
@@ -10331,7 +10331,7 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='is_case_of',
+            name='data_specifications',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
@@ -10344,7 +10344,7 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='data_specifications',
+            name='is_case_of',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(

--- a/test_data/intermediate/expected/real_meta_models/v3rc2/meta_model.py
+++ b/test_data/intermediate/expected/real_meta_models/v3rc2/meta_model.py
@@ -409,9 +409,9 @@ class Administrative_information(Has_data_specification):
 
     def __init__(
             self,
+            data_specifications: Optional[List["Reference"]] = None,
             version: Optional[Non_empty_string] = None,
             revision: Optional[Non_empty_string] = None,
-            data_specifications: Optional[List["Reference"]] = None,
     ) -> None:
         Has_data_specification.__init__(self, data_specifications=data_specifications)
 
@@ -496,9 +496,9 @@ class Qualifier(Constraint, Has_semantics):
             self,
             type: Non_empty_string,
             value_type: "Data_type_def",
+            semantic_ID: Optional["Reference"] = None,
             value: Optional[Non_empty_string] = None,
             value_ID: Optional["Reference"] = None,
-            semantic_ID: Optional["Reference"] = None,
     ) -> None:
         Has_semantics.__init__(self, semantic_ID=semantic_ID)
 
@@ -578,8 +578,8 @@ class Asset_administration_shell(Identifiable, Has_data_specification):
             self,
             ID: Non_empty_string,
             asset_information: "Asset_information",
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -719,10 +719,11 @@ class Identifier_key_value_pair(Has_semantics):
             self,
             key: Non_empty_string,
             value: Non_empty_string,
-            external_subject_ID: Optional["Reference"] = None,
             semantic_ID: Optional["Reference"] = None,
+            external_subject_ID: Optional["Reference"] = None,
     ) -> None:
         Has_semantics.__init__(self, semantic_ID)
+
         self.key = key
         self.value = value
         self.external_subject_ID = external_subject_ID
@@ -747,9 +748,8 @@ class Submodel(
     def __init__(
             self,
             ID: Non_empty_string,
-            ID_short: Optional[Non_empty_string] = None,
-            submodel_elements: Optional[List["Submodel_element"]] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -758,6 +758,7 @@ class Submodel(
             semantic_ID: Optional["Reference"] = None,
             qualifiers: Optional[List["Constraint"]] = None,
             data_specifications: Optional[List["Reference"]] = None,
+            submodel_elements: Optional[List["Submodel_element"]] = None,
     ) -> None:
         # TODO (Nico & Marko, 2021-09-24):
         #  How should we implement Constraint AASd-062 (page 64 in V3RC1)?
@@ -1123,8 +1124,8 @@ class Property(Data_element):
     def __init__(
             self,
             value_type: "Data_type_def",
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -1195,8 +1196,8 @@ class Multi_language_property(Data_element):
 
     def __init__(
             self,
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -1265,8 +1266,8 @@ class Range(Data_element):
     def __init__(
             self,
             value_type: "Data_type_def",
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -1321,8 +1322,8 @@ class Reference_element(Data_element):
 
     def __init__(
             self,
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -1385,8 +1386,8 @@ class Blob(Data_element):
     def __init__(
             self,
             MIME_type: MIME_typed,
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -1443,8 +1444,8 @@ class File(Data_element):
     def __init__(
             self,
             MIME_type: MIME_typed,
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -1684,8 +1685,8 @@ class Basic_Event(Event):
     def __init__(
             self,
             observed: "Reference",
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -1853,14 +1854,14 @@ class Concept_description(Identifiable, Has_data_specification):
     def __init__(
             self,
             ID: Non_empty_string,
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
             administration: Optional["Administrative_information"] = None,
-            is_case_of: Optional[List["Reference"]] = None,
             data_specifications: Optional[List["Reference"]] = None,
+            is_case_of: Optional[List["Reference"]] = None,
     ) -> None:
         Identifiable.__init__(
             self,

--- a/test_data/intermediate/unexpected/properties_and_constructor_arguments_do_not_match/after_inheritance/expected_error.txt
+++ b/test_data/intermediate/unexpected/properties_and_constructor_arguments_do_not_match/after_inheritance/expected_error.txt
@@ -1,0 +1,1 @@
+The order of constructor arguments and properties for the class 'Something' is not maintained where they match by name. The partial order of constructor arguments should be: ['property_a', 'property_b', 'property_e', 'property_f', 'property_c', 'property_d', 'property_g', 'property_h']

--- a/test_data/intermediate/unexpected/properties_and_constructor_arguments_do_not_match/after_inheritance/meta_model.py
+++ b/test_data/intermediate/unexpected/properties_and_constructor_arguments_do_not_match/after_inheritance/meta_model.py
@@ -1,0 +1,58 @@
+class SomethingAbstract:
+    property_a: str
+    property_b: str
+
+    property_c: Optional[str]
+    property_d: Optional[str]
+
+    def __init__(
+            self,
+            property_a: str,
+            property_b: str,
+            property_c: Optional[str] = None,
+            property_d: Optional[str] = None
+    ) -> None:
+        self.property_a = property_a
+        self.property_b = property_b
+        self.property_c = property_c
+        self.property_d = property_d
+
+
+class Something(SomethingAbstract):
+    property_e: str
+    property_f: str
+
+    property_g: Optional[str]
+    property_h: Optional[str]
+
+    # NOTE (mristin, 2022-03-25):
+    # The order of the inherited and defined properties do not match the order of
+    # the constructor arguments.
+
+    def __init__(
+            self,
+            property_e: str,
+            property_f: str,
+            property_a: str,
+            property_b: str,
+            property_g: Optional[str] = None,
+            property_h: Optional[str] = None,
+            property_c: Optional[str] = None,
+            property_d: Optional[str] = None
+    ) -> None:
+        SomethingAbstract.__init__(
+            self,
+            property_a=property_a,
+            property_b=property_b,
+            property_c=property_c,
+            property_d=property_d
+        )
+
+        self.property_e = property_e
+        self.property_f = property_f
+        self.property_g = property_g
+        self.property_h = property_h
+
+
+__book_url__ = "dummy"
+__book_version__ = "dummy"

--- a/test_data/intermediate/unexpected/properties_and_constructor_arguments_do_not_match/within_class/expected_error.txt
+++ b/test_data/intermediate/unexpected/properties_and_constructor_arguments_do_not_match/within_class/expected_error.txt
@@ -1,0 +1,1 @@
+The order of constructor arguments and properties for the class 'Something' is not maintained where they match by name. The partial order of constructor arguments should be: ['property_a', 'property_b', 'property_c', 'property_d']

--- a/test_data/intermediate/unexpected/properties_and_constructor_arguments_do_not_match/within_class/meta_model.py
+++ b/test_data/intermediate/unexpected/properties_and_constructor_arguments_do_not_match/within_class/meta_model.py
@@ -1,0 +1,22 @@
+class Something:
+    property_a: str
+    property_b: str
+
+    property_c: Optional[str]
+    property_d: Optional[str]
+
+    def __init__(
+            self,
+            property_b: str,
+            property_a: str,
+            property_d: Optional[str] = None,
+            property_c: Optional[str] = None,
+    ) -> None:
+        self.property_a = property_a
+        self.property_b = property_b
+        self.property_c = property_c
+        self.property_d = property_d
+
+
+__book_url__ = "dummy"
+__book_version__ = "dummy"

--- a/test_data/jsonschema/test_main/v3rc1/input/meta_model.py
+++ b/test_data/jsonschema/test_main/v3rc1/input/meta_model.py
@@ -341,10 +341,10 @@ class Referable(Has_extensions):
     def __init__(
         self,
         ID_short: Non_empty_string,
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
     ) -> None:
         Has_extensions.__init__(self, extensions=extensions)
 
@@ -374,12 +374,12 @@ class Identifiable(Referable):
 
     def __init__(
         self,
-        identification: "Identifier",
         ID_short: Non_empty_string,
+        identification: "Identifier",
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         administration: Optional["Administrative_information"] = None,
     ) -> None:
         Referable.__init__(
@@ -426,8 +426,8 @@ class Identifier(DBC):
 
     def __init__(
         self,
-        ID: Non_empty_string,
         ID_type: "Identifier_type",
+        ID: Non_empty_string,
     ) -> None:
         self.ID = ID
         self.ID_type = ID_type
@@ -564,9 +564,9 @@ class Administrative_information(Has_data_specification):
 
     def __init__(
         self,
+        data_specifications: Optional[List["Reference"]] = None,
         version: Optional[Non_empty_string] = None,
         revision: Optional[Non_empty_string] = None,
-        data_specifications: Optional[List["Reference"]] = None,
     ) -> None:
         Has_data_specification.__init__(self, data_specifications=data_specifications)
 
@@ -650,9 +650,9 @@ class Qualifier(Constraint, Has_semantics):
         self,
         type: Non_empty_string,
         value_type: "Data_type_def",
+        semantic_ID: Optional["Reference"] = None,
         value: Optional[str] = None,
         value_ID: Optional["Reference"] = None,
-        semantic_ID: Optional["Reference"] = None,
     ) -> None:
         Has_semantics.__init__(self, semantic_ID=semantic_ID)
 
@@ -714,13 +714,13 @@ class Asset_administration_shell(Identifiable, Has_data_specification):
 
     def __init__(
         self,
-        identification: "Identifier",
         ID_short: Non_empty_string,
+        identification: "Identifier",
         asset_information: "Asset_information",
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         administration: Optional["Administrative_information"] = None,
         data_specifications: Optional[List["Reference"]] = None,
         derived_from: Optional["Reference"] = None,
@@ -759,12 +759,12 @@ class Asset(Identifiable, Has_data_specification):
 
     def __init__(
         self,
-        identification: "Identifier",
         ID_short: Non_empty_string,
+        identification: "Identifier",
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         administration: Optional["Administrative_information"] = None,
         data_specifications: Optional[List["Reference"]] = None,
     ) -> None:
@@ -929,13 +929,13 @@ class Submodel(
 
     def __init__(
         self,
-        identification: "Identifier",
         ID_short: Non_empty_string,
+        identification: "Identifier",
         submodel_elements: Optional[List["Submodel_element"]],
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         administration: Optional["Administrative_information"] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
@@ -984,10 +984,10 @@ class Submodel_element(
     def __init__(
         self,
         ID_short: Non_empty_string,
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List["Constraint"]] = None,
@@ -1047,10 +1047,10 @@ class Relationship_element(Submodel_element):
         ID_short: Non_empty_string,
         first: "Reference",
         second: "Reference",
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List["Constraint"]] = None,
@@ -1135,10 +1135,10 @@ class Submodel_element_collection(Submodel_element):
     def __init__(
         self,
         ID_short: Non_empty_string,
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List["Constraint"]] = None,
@@ -1189,10 +1189,10 @@ class Data_element(Submodel_element):
     def __init__(
         self,
         ID_short: Non_empty_string,
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List[Constraint]] = None,
@@ -1267,10 +1267,10 @@ class Property(Data_element):
         self,
         ID_short: Non_empty_string,
         value_type: "Data_type_def",
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List[Constraint]] = None,
@@ -1337,10 +1337,10 @@ class Multi_language_property(Data_element):
     def __init__(
         self,
         ID_short: Non_empty_string,
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List[Constraint]] = None,
@@ -1407,10 +1407,10 @@ class Range(Data_element):
         self,
         ID_short: Non_empty_string,
         value_type: "Data_type_def",
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List[Constraint]] = None,
@@ -1458,10 +1458,10 @@ class Reference_element(Data_element):
     def __init__(
         self,
         ID_short: Non_empty_string,
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List[Constraint]] = None,
@@ -1517,10 +1517,10 @@ class Blob(Data_element):
         self,
         ID_short: Non_empty_string,
         MIME_type: MIME_typed,
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List[Constraint]] = None,
@@ -1570,10 +1570,10 @@ class File(Data_element):
         self,
         ID_short: Non_empty_string,
         MIME_type: MIME_typed,
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List[Constraint]] = None,
@@ -1615,10 +1615,10 @@ class Annotated_relationship_element(Relationship_element):
         ID_short: Non_empty_string,
         first: "Reference",
         second: "Reference",
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List["Constraint"]] = None,
@@ -1723,10 +1723,10 @@ class Entity(Submodel_element):
         self,
         ID_short: Non_empty_string,
         entity_type: "Entity_type",
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List["Constraint"]] = None,
@@ -1764,10 +1764,10 @@ class Event(Submodel_element):
     def __init__(
         self,
         ID_short: Non_empty_string,
+        extensions: Optional[List["Extension"]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List["Extension"]] = None,
         kind: Optional[Modeling_kind] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List[Constraint]] = None,
@@ -1801,12 +1801,12 @@ class Basic_Event(Event):
 
     def __init__(
         self,
-        observed: "Reference",
         ID_short: Non_empty_string,
+        observed: "Reference",
+        extensions: Optional[List["Extension"]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List["Extension"]] = None,
         kind: Optional[Modeling_kind] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List[Constraint]] = None,
@@ -1857,10 +1857,10 @@ class Operation(Submodel_element):
     def __init__(
         self,
         ID_short: Non_empty_string,
+        extensions: Optional[List["Extension"]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List["Extension"]] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List["Constraint"]] = None,
@@ -1916,10 +1916,10 @@ class Capability(Submodel_element):
     def __init__(
         self,
         ID_short: Non_empty_string,
+        extensions: Optional[List["Extension"]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List["Extension"]] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List["Constraint"]] = None,
@@ -1964,15 +1964,15 @@ class Concept_description(Identifiable, Has_data_specification):
 
     def __init__(
         self,
-        identification: "Identifier",
         ID_short: Non_empty_string,
+        identification: "Identifier",
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         administration: Optional["Administrative_information"] = None,
-        is_case_of: Optional[List["Reference"]] = None,
         data_specifications: Optional[List["Reference"]] = None,
+        is_case_of: Optional[List["Reference"]] = None,
     ) -> None:
         Identifiable.__init__(
             self,
@@ -2013,10 +2013,10 @@ class View(Referable, Has_semantics, Has_data_specification):
     def __init__(
         self,
         ID_short: Non_empty_string,
+        extensions: Optional[List["Extension"]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List["Extension"]] = None,
         semantic_ID: Optional["Reference"] = None,
         data_specifications: Optional[List["Reference"]] = None,
         contained_elements: Optional[List["Reference"]] = None,
@@ -2932,10 +2932,10 @@ class Access_permission_rule(Referable, Qualifiable):
         self,
         ID_short: Non_empty_string,
         target_subject_attributes: "Subject_attributes",
+        extensions: Optional[List["Extension"]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List["Extension"]] = None,
         qualifiers: Optional[List["Constraint"]] = None,
         permissions_per_object: Optional[List["Permissions_per_object"]] = None,
     ) -> None:
@@ -3021,9 +3021,9 @@ class Access_control(DBC):
         self,
         default_subject_attributes: Reference,
         default_permissions: Reference,
-        selectable_permissions: Optional[Reference] = None,
         access_permission_rules: Optional[List["Access_permission_rule"]] = None,
         selectable_subject_attributes: Optional[Reference] = None,
+        selectable_permissions: Optional[Reference] = None,
         selectable_environment_attributes: Optional[Reference] = None,
         default_environment_attributes: Optional[Reference] = None,
     ) -> None:

--- a/test_data/jsonschema/test_main/v3rc2/input/meta_model.py
+++ b/test_data/jsonschema/test_main/v3rc2/input/meta_model.py
@@ -409,9 +409,9 @@ class Administrative_information(Has_data_specification):
 
     def __init__(
             self,
+            data_specifications: Optional[List["Reference"]] = None,
             version: Optional[Non_empty_string] = None,
             revision: Optional[Non_empty_string] = None,
-            data_specifications: Optional[List["Reference"]] = None,
     ) -> None:
         Has_data_specification.__init__(self, data_specifications=data_specifications)
 
@@ -496,9 +496,9 @@ class Qualifier(Constraint, Has_semantics):
             self,
             type: Non_empty_string,
             value_type: "Data_type_def",
+            semantic_ID: Optional["Reference"] = None,
             value: Optional[Non_empty_string] = None,
             value_ID: Optional["Reference"] = None,
-            semantic_ID: Optional["Reference"] = None,
     ) -> None:
         Has_semantics.__init__(self, semantic_ID=semantic_ID)
 
@@ -578,8 +578,8 @@ class Asset_administration_shell(Identifiable, Has_data_specification):
             self,
             ID: Non_empty_string,
             asset_information: "Asset_information",
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -719,10 +719,11 @@ class Identifier_key_value_pair(Has_semantics):
             self,
             key: Non_empty_string,
             value: Non_empty_string,
-            external_subject_ID: Optional["Reference"] = None,
             semantic_ID: Optional["Reference"] = None,
+            external_subject_ID: Optional["Reference"] = None,
     ) -> None:
         Has_semantics.__init__(self, semantic_ID)
+
         self.key = key
         self.value = value
         self.external_subject_ID = external_subject_ID
@@ -747,9 +748,8 @@ class Submodel(
     def __init__(
             self,
             ID: Non_empty_string,
-            ID_short: Optional[Non_empty_string] = None,
-            submodel_elements: Optional[List["Submodel_element"]] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -758,6 +758,7 @@ class Submodel(
             semantic_ID: Optional["Reference"] = None,
             qualifiers: Optional[List["Constraint"]] = None,
             data_specifications: Optional[List["Reference"]] = None,
+            submodel_elements: Optional[List["Submodel_element"]] = None,
     ) -> None:
         # TODO (Nico & Marko, 2021-09-24):
         #  How should we implement Constraint AASd-062 (page 64 in V3RC1)?
@@ -1123,8 +1124,8 @@ class Property(Data_element):
     def __init__(
             self,
             value_type: "Data_type_def",
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -1195,8 +1196,8 @@ class Multi_language_property(Data_element):
 
     def __init__(
             self,
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -1265,8 +1266,8 @@ class Range(Data_element):
     def __init__(
             self,
             value_type: "Data_type_def",
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -1321,8 +1322,8 @@ class Reference_element(Data_element):
 
     def __init__(
             self,
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -1385,8 +1386,8 @@ class Blob(Data_element):
     def __init__(
             self,
             MIME_type: MIME_typed,
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -1443,8 +1444,8 @@ class File(Data_element):
     def __init__(
             self,
             MIME_type: MIME_typed,
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -1684,8 +1685,8 @@ class Basic_Event(Event):
     def __init__(
             self,
             observed: "Reference",
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -1853,14 +1854,14 @@ class Concept_description(Identifiable, Has_data_specification):
     def __init__(
             self,
             ID: Non_empty_string,
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
             administration: Optional["Administrative_information"] = None,
-            is_case_of: Optional[List["Reference"]] = None,
             data_specifications: Optional[List["Reference"]] = None,
+            is_case_of: Optional[List["Reference"]] = None,
     ) -> None:
         Identifiable.__init__(
             self,

--- a/test_data/parse/expected/real_meta_models/v3rc2/expected_symbol_table.txt
+++ b/test_data/parse/expected/real_meta_models/v3rc2/expected_symbol_table.txt
@@ -834,6 +834,22 @@ UnverifiedSymbolTable(
               default=None,
               node=...),
             Argument(
+              name='data_specifications',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  SubscriptedTypeAnnotation(
+                    identifier='List',
+                    subscripts=[
+                      AtomicTypeAnnotation(
+                        identifier='Reference',
+                        node=...)],
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
               name='version',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
@@ -852,22 +868,6 @@ UnverifiedSymbolTable(
                 subscripts=[
                   AtomicTypeAnnotation(
                     identifier='Non_empty_string',
-                    node=...)],
-                node=...),
-              default=Default(
-                node=...),
-              node=...),
-            Argument(
-              name='data_specifications',
-              type_annotation=SubscriptedTypeAnnotation(
-                identifier='Optional',
-                subscripts=[
-                  SubscriptedTypeAnnotation(
-                    identifier='List',
-                    subscripts=[
-                      AtomicTypeAnnotation(
-                        identifier='Reference',
-                        node=...)],
                     node=...)],
                 node=...),
               default=Default(
@@ -1071,6 +1071,18 @@ UnverifiedSymbolTable(
               default=None,
               node=...),
             Argument(
+              name='semantic_ID',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Reference',
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
               name='value',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
@@ -1084,18 +1096,6 @@ UnverifiedSymbolTable(
               node=...),
             Argument(
               name='value_ID',
-              type_annotation=SubscriptedTypeAnnotation(
-                identifier='Optional',
-                subscripts=[
-                  AtomicTypeAnnotation(
-                    identifier='Reference',
-                    node=...)],
-                node=...),
-              default=Default(
-                node=...),
-              node=...),
-            Argument(
-              name='semantic_ID',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
                 subscripts=[
@@ -1277,18 +1277,6 @@ UnverifiedSymbolTable(
               default=None,
               node=...),
             Argument(
-              name='ID_short',
-              type_annotation=SubscriptedTypeAnnotation(
-                identifier='Optional',
-                subscripts=[
-                  AtomicTypeAnnotation(
-                    identifier='Non_empty_string',
-                    node=...)],
-                node=...),
-              default=Default(
-                node=...),
-              node=...),
-            Argument(
               name='extensions',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
@@ -1299,6 +1287,18 @@ UnverifiedSymbolTable(
                       AtomicTypeAnnotation(
                         identifier='Extension',
                         node=...)],
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='ID_short',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Non_empty_string',
                     node=...)],
                 node=...),
               default=Default(
@@ -1651,7 +1651,7 @@ UnverifiedSymbolTable(
               default=None,
               node=...),
             Argument(
-              name='external_subject_ID',
+              name='semantic_ID',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
                 subscripts=[
@@ -1663,7 +1663,7 @@ UnverifiedSymbolTable(
                 node=...),
               node=...),
             Argument(
-              name='semantic_ID',
+              name='external_subject_ID',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
                 subscripts=[
@@ -1739,34 +1739,6 @@ UnverifiedSymbolTable(
               default=None,
               node=...),
             Argument(
-              name='ID_short',
-              type_annotation=SubscriptedTypeAnnotation(
-                identifier='Optional',
-                subscripts=[
-                  AtomicTypeAnnotation(
-                    identifier='Non_empty_string',
-                    node=...)],
-                node=...),
-              default=Default(
-                node=...),
-              node=...),
-            Argument(
-              name='submodel_elements',
-              type_annotation=SubscriptedTypeAnnotation(
-                identifier='Optional',
-                subscripts=[
-                  SubscriptedTypeAnnotation(
-                    identifier='List',
-                    subscripts=[
-                      AtomicTypeAnnotation(
-                        identifier='Submodel_element',
-                        node=...)],
-                    node=...)],
-                node=...),
-              default=Default(
-                node=...),
-              node=...),
-            Argument(
               name='extensions',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
@@ -1777,6 +1749,18 @@ UnverifiedSymbolTable(
                       AtomicTypeAnnotation(
                         identifier='Extension',
                         node=...)],
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='ID_short',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Non_empty_string',
                     node=...)],
                 node=...),
               default=Default(
@@ -1880,6 +1864,22 @@ UnverifiedSymbolTable(
                     subscripts=[
                       AtomicTypeAnnotation(
                         identifier='Reference',
+                        node=...)],
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='submodel_elements',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  SubscriptedTypeAnnotation(
+                    identifier='List',
+                    subscripts=[
+                      AtomicTypeAnnotation(
+                        identifier='Submodel_element',
                         node=...)],
                     node=...)],
                 node=...),
@@ -2933,18 +2933,6 @@ UnverifiedSymbolTable(
               default=None,
               node=...),
             Argument(
-              name='ID_short',
-              type_annotation=SubscriptedTypeAnnotation(
-                identifier='Optional',
-                subscripts=[
-                  AtomicTypeAnnotation(
-                    identifier='Non_empty_string',
-                    node=...)],
-                node=...),
-              default=Default(
-                node=...),
-              node=...),
-            Argument(
               name='extensions',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
@@ -2955,6 +2943,18 @@ UnverifiedSymbolTable(
                       AtomicTypeAnnotation(
                         identifier='Extension',
                         node=...)],
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='ID_short',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Non_empty_string',
                     node=...)],
                 node=...),
               default=Default(
@@ -3144,18 +3144,6 @@ UnverifiedSymbolTable(
               default=None,
               node=...),
             Argument(
-              name='ID_short',
-              type_annotation=SubscriptedTypeAnnotation(
-                identifier='Optional',
-                subscripts=[
-                  AtomicTypeAnnotation(
-                    identifier='Non_empty_string',
-                    node=...)],
-                node=...),
-              default=Default(
-                node=...),
-              node=...),
-            Argument(
               name='extensions',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
@@ -3166,6 +3154,18 @@ UnverifiedSymbolTable(
                       AtomicTypeAnnotation(
                         identifier='Extension',
                         node=...)],
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='ID_short',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Non_empty_string',
                     node=...)],
                 node=...),
               default=Default(
@@ -3371,18 +3371,6 @@ UnverifiedSymbolTable(
               default=None,
               node=...),
             Argument(
-              name='ID_short',
-              type_annotation=SubscriptedTypeAnnotation(
-                identifier='Optional',
-                subscripts=[
-                  AtomicTypeAnnotation(
-                    identifier='Non_empty_string',
-                    node=...)],
-                node=...),
-              default=Default(
-                node=...),
-              node=...),
-            Argument(
               name='extensions',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
@@ -3393,6 +3381,18 @@ UnverifiedSymbolTable(
                       AtomicTypeAnnotation(
                         identifier='Extension',
                         node=...)],
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='ID_short',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Non_empty_string',
                     node=...)],
                 node=...),
               default=Default(
@@ -3569,18 +3569,6 @@ UnverifiedSymbolTable(
               default=None,
               node=...),
             Argument(
-              name='ID_short',
-              type_annotation=SubscriptedTypeAnnotation(
-                identifier='Optional',
-                subscripts=[
-                  AtomicTypeAnnotation(
-                    identifier='Non_empty_string',
-                    node=...)],
-                node=...),
-              default=Default(
-                node=...),
-              node=...),
-            Argument(
               name='extensions',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
@@ -3591,6 +3579,18 @@ UnverifiedSymbolTable(
                       AtomicTypeAnnotation(
                         identifier='Extension',
                         node=...)],
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='ID_short',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Non_empty_string',
                     node=...)],
                 node=...),
               default=Default(
@@ -3771,18 +3771,6 @@ UnverifiedSymbolTable(
               default=None,
               node=...),
             Argument(
-              name='ID_short',
-              type_annotation=SubscriptedTypeAnnotation(
-                identifier='Optional',
-                subscripts=[
-                  AtomicTypeAnnotation(
-                    identifier='Non_empty_string',
-                    node=...)],
-                node=...),
-              default=Default(
-                node=...),
-              node=...),
-            Argument(
               name='extensions',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
@@ -3793,6 +3781,18 @@ UnverifiedSymbolTable(
                       AtomicTypeAnnotation(
                         identifier='Extension',
                         node=...)],
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='ID_short',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Non_empty_string',
                     node=...)],
                 node=...),
               default=Default(
@@ -3977,18 +3977,6 @@ UnverifiedSymbolTable(
               default=None,
               node=...),
             Argument(
-              name='ID_short',
-              type_annotation=SubscriptedTypeAnnotation(
-                identifier='Optional',
-                subscripts=[
-                  AtomicTypeAnnotation(
-                    identifier='Non_empty_string',
-                    node=...)],
-                node=...),
-              default=Default(
-                node=...),
-              node=...),
-            Argument(
               name='extensions',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
@@ -3999,6 +3987,18 @@ UnverifiedSymbolTable(
                       AtomicTypeAnnotation(
                         identifier='Extension',
                         node=...)],
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='ID_short',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Non_empty_string',
                     node=...)],
                 node=...),
               default=Default(
@@ -4822,18 +4822,6 @@ UnverifiedSymbolTable(
               default=None,
               node=...),
             Argument(
-              name='ID_short',
-              type_annotation=SubscriptedTypeAnnotation(
-                identifier='Optional',
-                subscripts=[
-                  AtomicTypeAnnotation(
-                    identifier='Non_empty_string',
-                    node=...)],
-                node=...),
-              default=Default(
-                node=...),
-              node=...),
-            Argument(
               name='extensions',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
@@ -4844,6 +4832,18 @@ UnverifiedSymbolTable(
                       AtomicTypeAnnotation(
                         identifier='Extension',
                         node=...)],
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='ID_short',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Non_empty_string',
                     node=...)],
                 node=...),
               default=Default(
@@ -5469,18 +5469,6 @@ UnverifiedSymbolTable(
               default=None,
               node=...),
             Argument(
-              name='ID_short',
-              type_annotation=SubscriptedTypeAnnotation(
-                identifier='Optional',
-                subscripts=[
-                  AtomicTypeAnnotation(
-                    identifier='Non_empty_string',
-                    node=...)],
-                node=...),
-              default=Default(
-                node=...),
-              node=...),
-            Argument(
               name='extensions',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
@@ -5491,6 +5479,18 @@ UnverifiedSymbolTable(
                       AtomicTypeAnnotation(
                         identifier='Extension',
                         node=...)],
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='ID_short',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Non_empty_string',
                     node=...)],
                 node=...),
               default=Default(
@@ -5545,7 +5545,7 @@ UnverifiedSymbolTable(
                 node=...),
               node=...),
             Argument(
-              name='is_case_of',
+              name='data_specifications',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
                 subscripts=[
@@ -5561,7 +5561,7 @@ UnverifiedSymbolTable(
                 node=...),
               node=...),
             Argument(
-              name='data_specifications',
+              name='is_case_of',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
                 subscripts=[

--- a/test_data/parse/expected/real_meta_models/v3rc2/meta_model.py
+++ b/test_data/parse/expected/real_meta_models/v3rc2/meta_model.py
@@ -409,9 +409,9 @@ class Administrative_information(Has_data_specification):
 
     def __init__(
             self,
+            data_specifications: Optional[List["Reference"]] = None,
             version: Optional[Non_empty_string] = None,
             revision: Optional[Non_empty_string] = None,
-            data_specifications: Optional[List["Reference"]] = None,
     ) -> None:
         Has_data_specification.__init__(self, data_specifications=data_specifications)
 
@@ -496,9 +496,9 @@ class Qualifier(Constraint, Has_semantics):
             self,
             type: Non_empty_string,
             value_type: "Data_type_def",
+            semantic_ID: Optional["Reference"] = None,
             value: Optional[Non_empty_string] = None,
             value_ID: Optional["Reference"] = None,
-            semantic_ID: Optional["Reference"] = None,
     ) -> None:
         Has_semantics.__init__(self, semantic_ID=semantic_ID)
 
@@ -578,8 +578,8 @@ class Asset_administration_shell(Identifiable, Has_data_specification):
             self,
             ID: Non_empty_string,
             asset_information: "Asset_information",
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -719,10 +719,11 @@ class Identifier_key_value_pair(Has_semantics):
             self,
             key: Non_empty_string,
             value: Non_empty_string,
-            external_subject_ID: Optional["Reference"] = None,
             semantic_ID: Optional["Reference"] = None,
+            external_subject_ID: Optional["Reference"] = None,
     ) -> None:
         Has_semantics.__init__(self, semantic_ID)
+
         self.key = key
         self.value = value
         self.external_subject_ID = external_subject_ID
@@ -747,9 +748,8 @@ class Submodel(
     def __init__(
             self,
             ID: Non_empty_string,
-            ID_short: Optional[Non_empty_string] = None,
-            submodel_elements: Optional[List["Submodel_element"]] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -758,6 +758,7 @@ class Submodel(
             semantic_ID: Optional["Reference"] = None,
             qualifiers: Optional[List["Constraint"]] = None,
             data_specifications: Optional[List["Reference"]] = None,
+            submodel_elements: Optional[List["Submodel_element"]] = None,
     ) -> None:
         # TODO (Nico & Marko, 2021-09-24):
         #  How should we implement Constraint AASd-062 (page 64 in V3RC1)?
@@ -1123,8 +1124,8 @@ class Property(Data_element):
     def __init__(
             self,
             value_type: "Data_type_def",
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -1195,8 +1196,8 @@ class Multi_language_property(Data_element):
 
     def __init__(
             self,
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -1265,8 +1266,8 @@ class Range(Data_element):
     def __init__(
             self,
             value_type: "Data_type_def",
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -1321,8 +1322,8 @@ class Reference_element(Data_element):
 
     def __init__(
             self,
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -1385,8 +1386,8 @@ class Blob(Data_element):
     def __init__(
             self,
             MIME_type: MIME_typed,
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -1443,8 +1444,8 @@ class File(Data_element):
     def __init__(
             self,
             MIME_type: MIME_typed,
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -1684,8 +1685,8 @@ class Basic_Event(Event):
     def __init__(
             self,
             observed: "Reference",
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
@@ -1853,14 +1854,14 @@ class Concept_description(Identifiable, Has_data_specification):
     def __init__(
             self,
             ID: Non_empty_string,
-            ID_short: Optional[Non_empty_string] = None,
             extensions: Optional[List["Extension"]] = None,
+            ID_short: Optional[Non_empty_string] = None,
             display_name: Optional["Lang_string_set"] = None,
             category: Optional[Non_empty_string] = None,
             description: Optional["Lang_string_set"] = None,
             administration: Optional["Administrative_information"] = None,
-            is_case_of: Optional[List["Reference"]] = None,
             data_specifications: Optional[List["Reference"]] = None,
+            is_case_of: Optional[List["Reference"]] = None,
     ) -> None:
         Identifiable.__init__(
             self,

--- a/test_data/rdf_shacl/test_main/v3rc1/input/meta_model.py
+++ b/test_data/rdf_shacl/test_main/v3rc1/input/meta_model.py
@@ -341,10 +341,10 @@ class Referable(Has_extensions):
     def __init__(
         self,
         ID_short: Non_empty_string,
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
     ) -> None:
         Has_extensions.__init__(self, extensions=extensions)
 
@@ -374,12 +374,12 @@ class Identifiable(Referable):
 
     def __init__(
         self,
-        identification: "Identifier",
         ID_short: Non_empty_string,
+        identification: "Identifier",
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         administration: Optional["Administrative_information"] = None,
     ) -> None:
         Referable.__init__(
@@ -426,8 +426,8 @@ class Identifier(DBC):
 
     def __init__(
         self,
-        ID: Non_empty_string,
         ID_type: "Identifier_type",
+        ID: Non_empty_string,
     ) -> None:
         self.ID = ID
         self.ID_type = ID_type
@@ -564,9 +564,9 @@ class Administrative_information(Has_data_specification):
 
     def __init__(
         self,
+        data_specifications: Optional[List["Reference"]] = None,
         version: Optional[Non_empty_string] = None,
         revision: Optional[Non_empty_string] = None,
-        data_specifications: Optional[List["Reference"]] = None,
     ) -> None:
         Has_data_specification.__init__(self, data_specifications=data_specifications)
 
@@ -650,9 +650,9 @@ class Qualifier(Constraint, Has_semantics):
         self,
         type: Non_empty_string,
         value_type: "Data_type_def",
+        semantic_ID: Optional["Reference"] = None,
         value: Optional[str] = None,
         value_ID: Optional["Reference"] = None,
-        semantic_ID: Optional["Reference"] = None,
     ) -> None:
         Has_semantics.__init__(self, semantic_ID=semantic_ID)
 
@@ -714,13 +714,13 @@ class Asset_administration_shell(Identifiable, Has_data_specification):
 
     def __init__(
         self,
-        identification: "Identifier",
         ID_short: Non_empty_string,
+        identification: "Identifier",
         asset_information: "Asset_information",
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         administration: Optional["Administrative_information"] = None,
         data_specifications: Optional[List["Reference"]] = None,
         derived_from: Optional["Reference"] = None,
@@ -759,12 +759,12 @@ class Asset(Identifiable, Has_data_specification):
 
     def __init__(
         self,
-        identification: "Identifier",
         ID_short: Non_empty_string,
+        identification: "Identifier",
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         administration: Optional["Administrative_information"] = None,
         data_specifications: Optional[List["Reference"]] = None,
     ) -> None:
@@ -929,13 +929,13 @@ class Submodel(
 
     def __init__(
         self,
-        identification: "Identifier",
         ID_short: Non_empty_string,
+        identification: "Identifier",
         submodel_elements: Optional[List["Submodel_element"]],
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         administration: Optional["Administrative_information"] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
@@ -984,10 +984,10 @@ class Submodel_element(
     def __init__(
         self,
         ID_short: Non_empty_string,
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List["Constraint"]] = None,
@@ -1047,10 +1047,10 @@ class Relationship_element(Submodel_element):
         ID_short: Non_empty_string,
         first: "Reference",
         second: "Reference",
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List["Constraint"]] = None,
@@ -1135,10 +1135,10 @@ class Submodel_element_collection(Submodel_element):
     def __init__(
         self,
         ID_short: Non_empty_string,
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List["Constraint"]] = None,
@@ -1189,10 +1189,10 @@ class Data_element(Submodel_element):
     def __init__(
         self,
         ID_short: Non_empty_string,
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List[Constraint]] = None,
@@ -1267,10 +1267,10 @@ class Property(Data_element):
         self,
         ID_short: Non_empty_string,
         value_type: "Data_type_def",
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List[Constraint]] = None,
@@ -1337,10 +1337,10 @@ class Multi_language_property(Data_element):
     def __init__(
         self,
         ID_short: Non_empty_string,
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List[Constraint]] = None,
@@ -1407,10 +1407,10 @@ class Range(Data_element):
         self,
         ID_short: Non_empty_string,
         value_type: "Data_type_def",
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List[Constraint]] = None,
@@ -1458,10 +1458,10 @@ class Reference_element(Data_element):
     def __init__(
         self,
         ID_short: Non_empty_string,
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List[Constraint]] = None,
@@ -1517,10 +1517,10 @@ class Blob(Data_element):
         self,
         ID_short: Non_empty_string,
         MIME_type: MIME_typed,
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List[Constraint]] = None,
@@ -1570,10 +1570,10 @@ class File(Data_element):
         self,
         ID_short: Non_empty_string,
         MIME_type: MIME_typed,
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List[Constraint]] = None,
@@ -1615,10 +1615,10 @@ class Annotated_relationship_element(Relationship_element):
         ID_short: Non_empty_string,
         first: "Reference",
         second: "Reference",
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List["Constraint"]] = None,
@@ -1723,10 +1723,10 @@ class Entity(Submodel_element):
         self,
         ID_short: Non_empty_string,
         entity_type: "Entity_type",
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List["Constraint"]] = None,
@@ -1764,10 +1764,10 @@ class Event(Submodel_element):
     def __init__(
         self,
         ID_short: Non_empty_string,
+        extensions: Optional[List["Extension"]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List["Extension"]] = None,
         kind: Optional[Modeling_kind] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List[Constraint]] = None,
@@ -1801,12 +1801,12 @@ class Basic_Event(Event):
 
     def __init__(
         self,
-        observed: "Reference",
         ID_short: Non_empty_string,
+        observed: "Reference",
+        extensions: Optional[List["Extension"]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List["Extension"]] = None,
         kind: Optional[Modeling_kind] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List[Constraint]] = None,
@@ -1857,10 +1857,10 @@ class Operation(Submodel_element):
     def __init__(
         self,
         ID_short: Non_empty_string,
+        extensions: Optional[List["Extension"]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List["Extension"]] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List["Constraint"]] = None,
@@ -1916,10 +1916,10 @@ class Capability(Submodel_element):
     def __init__(
         self,
         ID_short: Non_empty_string,
+        extensions: Optional[List["Extension"]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List["Extension"]] = None,
         kind: Optional["Modeling_kind"] = None,
         semantic_ID: Optional["Reference"] = None,
         qualifiers: Optional[List["Constraint"]] = None,
@@ -1964,15 +1964,15 @@ class Concept_description(Identifiable, Has_data_specification):
 
     def __init__(
         self,
-        identification: "Identifier",
         ID_short: Non_empty_string,
+        identification: "Identifier",
+        extensions: Optional[List[Extension]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List[Extension]] = None,
         administration: Optional["Administrative_information"] = None,
-        is_case_of: Optional[List["Reference"]] = None,
         data_specifications: Optional[List["Reference"]] = None,
+        is_case_of: Optional[List["Reference"]] = None,
     ) -> None:
         Identifiable.__init__(
             self,
@@ -2013,10 +2013,10 @@ class View(Referable, Has_semantics, Has_data_specification):
     def __init__(
         self,
         ID_short: Non_empty_string,
+        extensions: Optional[List["Extension"]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List["Extension"]] = None,
         semantic_ID: Optional["Reference"] = None,
         data_specifications: Optional[List["Reference"]] = None,
         contained_elements: Optional[List["Reference"]] = None,
@@ -2932,10 +2932,10 @@ class Access_permission_rule(Referable, Qualifiable):
         self,
         ID_short: Non_empty_string,
         target_subject_attributes: "Subject_attributes",
+        extensions: Optional[List["Extension"]] = None,
         display_name: Optional["Lang_string_set"] = None,
         category: Optional[Non_empty_string] = None,
         description: Optional["Lang_string_set"] = None,
-        extensions: Optional[List["Extension"]] = None,
         qualifiers: Optional[List["Constraint"]] = None,
         permissions_per_object: Optional[List["Permissions_per_object"]] = None,
     ) -> None:
@@ -3021,9 +3021,9 @@ class Access_control(DBC):
         self,
         default_subject_attributes: Reference,
         default_permissions: Reference,
-        selectable_permissions: Optional[Reference] = None,
         access_permission_rules: Optional[List["Access_permission_rule"]] = None,
         selectable_subject_attributes: Optional[Reference] = None,
+        selectable_permissions: Optional[Reference] = None,
         selectable_environment_attributes: Optional[Reference] = None,
         default_environment_attributes: Optional[Reference] = None,
     ) -> None:


### PR DESCRIPTION
We verify that the order of the properties and the order of the
constructor arguments is consistent. We match them simply by names and
do not analyze the code any further.

We hope that this makes the meta-model more consistent and thus easier
to read.