### PR TITLE
Produce better errors on unexpected enum elements

### DIFF
--- a/aas_core_codegen/parse/_translate.py
+++ b/aas_core_codegen/parse/_translate.py
@@ -1708,9 +1708,11 @@ def _enum_to_symbol(
                 None,
                 Error(
                     node.body[cursor],
-                    f"Expected either a docstring or an assignment "
+                    f"Expected either a docstring at the beginning or an assignment "
                     f"in an enumeration, "
-                    f"but got: {atok.get_text(node.body[cursor])}",
+                    f"but got the body element {type(node.body[cursor])} "
+                    f"at index {cursor} of the class definition {node.name!r}: "
+                    f"{atok.get_text(node.body[cursor])}",
                 ),
             )
 

--- a/test_data/parse/unexpected/enum/non_assignment/expected_error.txt
+++ b/test_data/parse/unexpected/enum/non_assignment/expected_error.txt
@@ -1,1 +1,1 @@
-Expected either a docstring or an assignment in an enumeration, but got: some_func()
+Expected either a docstring at the beginning or an assignment in an enumeration, but got the body element <class '_ast.Expr'> at index 1 of the class definition 'Some_enum': some_func()


### PR DESCRIPTION
When we parse an enumeration and there were errors, they were not
conclusive enough. We try to improve them with necessary details in this
patch.