### PR TITLE
Exclude `ast` class names from errors

### DIFF
--- a/aas_core_codegen/parse/_translate.py
+++ b/aas_core_codegen/parse/_translate.py
@@ -1704,14 +1704,15 @@ def _enum_to_symbol(
             cursor += 1
 
         else:
+
             return (
                 None,
                 Error(
                     node.body[cursor],
                     f"Expected either a docstring at the beginning or an assignment "
                     f"in an enumeration, "
-                    f"but got the body element {type(node.body[cursor])} "
-                    f"at index {cursor} of the class definition {node.name!r}: "
+                    f"but got an unexpected body element at index {cursor} "
+                    f"of the class definition {node.name!r}: "
                     f"{atok.get_text(node.body[cursor])}",
                 ),
             )

--- a/test_data/parse/unexpected/enum/non_assignment/expected_error.txt
+++ b/test_data/parse/unexpected/enum/non_assignment/expected_error.txt
@@ -1,1 +1,1 @@
-Expected either a docstring at the beginning or an assignment in an enumeration, but got the body element <class '_ast.Expr'> at index 1 of the class definition 'Some_enum': some_func()
+Expected either a docstring at the beginning or an assignment in an enumeration, but got an unexpected body element at index 1 of the class definition 'Some_enum': some_func()


### PR DESCRIPTION
We have to exclude the type of the problematic `ast` nodes from the
errors since they differ between Python versions. This makes:

1) testing a bit harder (as we'd have to have different test data
   *per Python version*), and
2) reporting errors would be confusing if the user and the developer
   have different Python versions.