### PR TITLE
Script syncing of the test meta-models

### DIFF
--- a/continuous_integration/check_test_meta_models_coincide.py
+++ b/continuous_integration/check_test_meta_models_coincide.py
@@ -1,0 +1,70 @@
+"""
+Check that the test meta-models coincide.
+
+The meta-models are grouped by the version. All the meta-models within a group must
+coincide.
+"""
+
+import argparse
+import collections
+import difflib
+import os
+import pathlib
+import sys
+
+_REPO_DIR = pathlib.Path(os.path.realpath(__file__)).parent.parent
+
+META_MODEL_GROUPS = collections.OrderedDict(
+    [
+        (
+            "V3RC01",
+            [
+                _REPO_DIR / "test_data/jsonschema/test_main/v3rc1/input/meta_model.py",
+                _REPO_DIR / "test_data/rdf_shacl/test_main/v3rc1/input/meta_model.py",
+            ],
+        ),
+        (
+            "V3RC02",
+            [
+                _REPO_DIR / "test_data/csharp/test_main/v3rc2/input/meta_model.py",
+                (
+                    _REPO_DIR / "test_data/intermediate/"
+                    "expected/real_meta_models/v3rc2/meta_model.py"
+                ),
+                _REPO_DIR / "test_data/jsonschema/test_main/v3rc2/input/meta_model.py",
+                (
+                    _REPO_DIR / "test_data/parse/"
+                    "expected/real_meta_models/v3rc2/meta_model.py"
+                ),
+            ],
+        ),
+    ]
+)
+
+
+def main() -> int:
+    """Execute the main routine."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    _ = parser.parse_args()
+
+    for version, group in META_MODEL_GROUPS.items():
+        assert len(group) >= 1, f"At least one path expected in the group {version!r}."
+
+        expected = group[0].read_text(encoding="utf-8").splitlines()
+        for pth in group[1:]:
+            got = pth.read_text(encoding="utf-8").splitlines()
+            if expected != got:
+                print(f"The files {group[0]} and {pth} do not match:", file=sys.stderr)
+                diff = difflib.context_diff(
+                    expected, got, fromfile=str(group[0]), tofile=str(pth)
+                )
+
+                for line in diff:
+                    print(line, file=sys.stderr)
+                return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dev_scripts/sync_meta_model.py
+++ b/dev_scripts/sync_meta_model.py
@@ -1,0 +1,96 @@
+"""
+Copy one meta-model over different locations in the ``test_data`` to sync them.
+
+This is practical if you are developing and polishing a meta-model at the same time
+and would like to finally propagate the changes once done.
+
+The meta-models are grouped by version. You pick a "golden" meta-model from a group and
+the remaining models in the group are synced. Meta-models from the other groups are left
+unchanged.
+"""
+
+import argparse
+import os
+import pathlib
+import shlex
+import shutil
+import sys
+
+import continuous_integration.check_test_meta_models_coincide
+
+
+def main() -> int:
+    """Execute the main routine."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--model_path",
+        help="path to the golden meta-model which should be synced",
+        required=True,
+    )
+    args = parser.parse_args()
+
+    model_pth = pathlib.Path(os.path.realpath(args.model_path))
+
+    choices = [
+        pth
+        for group in (
+            continuous_integration.check_test_meta_models_coincide.META_MODEL_GROUPS.values()
+        )
+        for pth in group
+    ]
+
+    if model_pth not in choices:
+        cwd = pathlib.Path(os.getcwd())
+        choices_joined = "\n".join(
+            str(pth.relative_to(cwd)) if cwd in pth.parents else str(pth)
+            for pth in choices
+        )
+
+        print(
+            f"The --model_path {shlex.quote(str(model_pth))} is not specified in "
+            f"any of the groups. The specified model paths are:\n{choices_joined}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not model_pth.exists():
+        print(f"The model path does not exist: {model_pth}", file=sys.stderr)
+        return 1
+
+    if not model_pth.is_file():
+        print(f"The model path does not point to a file: {model_pth}", file=sys.stderr)
+        return 1
+
+    found = False
+    for (
+        group
+    ) in (
+        continuous_integration.check_test_meta_models_coincide.META_MODEL_GROUPS.values()
+    ):
+        if model_pth in group:
+            found = True
+
+            for pth in group:
+                if pth == model_pth:
+                    continue
+                else:
+                    # noinspection PyBroadException
+                    try:
+                        shutil.copy(src=str(model_pth), dst=str(pth))
+                    except Exception as exception:
+                        print(
+                            f"Failed to copy the golden model {model_pth} "
+                            f"to {pth}: {exception}",
+                            file=sys.stderr,
+                        )
+                        return 1
+    assert found, (
+        "We should have found the model in the groups; "
+        "otherwise our choices in the specification of the argparse are not correct."
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
We group the test meta-models by version and enforce that they coincide
within the same group. However, we often develop the code and *change*
a meta-model at the same time. Once we are done with the development, we
had to tediously sync the meta-models within the group by hand.

In this change, we write a script to automate this syncing in order to
speed the development process.