### PR TITLE
Fix swallowed errors in `infer_for_schema`

### DIFF
--- a/aas_core_codegen/infer_for_schema/_inline.py
+++ b/aas_core_codegen/infer_for_schema/_inline.py
@@ -359,12 +359,12 @@ def infer_constraints_by_class(
 
         # endregion
 
-        if len(errors) > 0:
-            return None, errors
-
         result[symbol] = ConstraintsByProperty(
             len_constraints_by_property=len_constraints_by_property,
             patterns_by_property=patterns_by_property,
         )
+
+    if len(errors) > 0:
+        return None, errors
 
     return result, None

--- a/aas_core_codegen/infer_for_schema/_len.py
+++ b/aas_core_codegen/infer_for_schema/_len.py
@@ -285,7 +285,6 @@ def _match_len_constraint_on_property(
 ) -> Optional[_LenConstraintOnProperty]:
     """Match a len constraint on a property such as ``len(self.something) < 42``."""
     len_constraint_on_member_or_name = _match_len_constraint_on_member_or_name(node)
-
     if len_constraint_on_member_or_name:
         prop_name = infer_for_schema_common.match_property(
             len_constraint_on_member_or_name.member_or_name
@@ -489,7 +488,7 @@ LENGTHABLE_PRIMITIVES = frozenset(
 # fmt: on
 def infer_len_constraint_of_self(
     constrained_primitive: intermediate.ConstrainedPrimitive,
-) -> Tuple[Optional[LenConstraint], Optional[List[Error]],]:
+) -> Tuple[Optional[LenConstraint], Optional[List[Error]]]:
     """
     Infer the constraint on ``len(self)``.
 


### PR DESCRIPTION
We had an indentation error in a loop so the reporting of errors was
always skipped in `infer_for_schema` for length constraints.

This patch fixes the issue.