### PR TITLE
Script smoke-testing a meta-model

### DIFF
--- a/.idea/dictionaries/rist.xml
+++ b/.idea/dictionaries/rist.xml
@@ -3,6 +3,7 @@
     <words>
       <w>abcde</w>
       <w>anno</w>
+      <w>argparse</w>
       <w>atok</w>
       <w>bytearray</w>
       <w>cardinalities</w>

--- a/aas_core_codegen/main.py
+++ b/aas_core_codegen/main.py
@@ -225,7 +225,7 @@ def main(prog: str) -> int:
     # as ``--version`` so we manually hard-wire.
     if "--version" in sys.argv and "--help" not in sys.argv:
         print(aas_core_codegen.__version__)
-        return 1
+        return 0
 
     args = parser.parse_args()
 

--- a/aas_core_codegen/smoke/__init__.py
+++ b/aas_core_codegen/smoke/__init__.py
@@ -1,0 +1,1 @@
+"""Run a smoke-test as a preliminary test that a meta-model is ready for generation."""

--- a/aas_core_codegen/smoke/main.py
+++ b/aas_core_codegen/smoke/main.py
@@ -1,0 +1,118 @@
+"""Run a smoke-test as a preliminary test that a meta-model is ready for generation."""
+
+import argparse
+import pathlib
+import sys
+from typing import TextIO
+
+import aas_core_codegen
+from aas_core_codegen import parse, run, intermediate, infer_for_schema
+from aas_core_codegen.common import LinenoColumner
+import aas_core_codegen.smoke
+
+assert __doc__ == aas_core_codegen.smoke.__doc__
+
+
+def execute(model_path: pathlib.Path, stderr: TextIO) -> int:
+    """Run the smoke test."""
+    text = model_path.read_text(encoding="utf-8")
+
+    # BEFORE-RELEASE (mristin, 2021-12-13):
+    #  test all the following individual failure cases
+    atok, parse_exception = parse.source_to_atok(source=text)
+    if parse_exception:
+        if isinstance(parse_exception, SyntaxError):
+            stderr.write(
+                f"Failed to parse the meta-model {model_path}: "
+                f"invalid syntax at line {parse_exception.lineno}\n"
+            )
+        else:
+            stderr.write(
+                f"Failed to parse the meta-model {model_path}: " f"{parse_exception}\n"
+            )
+
+        return 1
+
+    import_errors = parse.check_expected_imports(atok=atok)
+    if import_errors:
+        run.write_error_report(
+            message="One or more unexpected imports in the meta-model",
+            errors=import_errors,
+            stderr=stderr,
+        )
+
+        return 1
+
+    lineno_columner = LinenoColumner(atok=atok)
+
+    parsed_symbol_table, error = parse.atok_to_symbol_table(atok=atok)
+    if error is not None:
+        run.write_error_report(
+            message=f"Failed to construct the symbol table from {model_path}",
+            errors=[lineno_columner.error_message(error)],
+            stderr=stderr,
+        )
+
+        return 1
+
+    assert parsed_symbol_table is not None
+
+    ir_symbol_table, error = intermediate.translate(
+        parsed_symbol_table=parsed_symbol_table,
+        atok=atok,
+    )
+    if error is not None:
+        run.write_error_report(
+            message=f"Failed to translate the parsed symbol table "
+            f"to intermediate symbol table "
+            f"based on {model_path}",
+            errors=[lineno_columner.error_message(error)],
+            stderr=stderr,
+        )
+
+        return 1
+
+    assert ir_symbol_table is not None
+
+    _, errors = infer_for_schema.infer_constraints_by_class(
+        symbol_table=ir_symbol_table
+    )
+    if errors is not None:
+        run.write_error_report(
+            message=f"Failed to infer the constraints by class for the schemas "
+            f"based on {model_path}",
+            errors=[lineno_columner.error_message(error) for error in errors],
+            stderr=stderr,
+        )
+
+        return 1
+
+    return 0
+
+
+def main(prog: str) -> int:
+    """Execute the main routine."""
+    # NOTE (mristin, 2022-03-28):
+    # The module ``argparse`` is not flexible enough to understand special options such
+    # as ``--version`` so we manually hard-wire.
+    if "--version" in sys.argv and "--help" not in sys.argv:
+        print(aas_core_codegen.__version__)
+        return 0
+
+    parser = argparse.ArgumentParser(prog=prog, description=__doc__)
+    parser.add_argument("--model_path", help="path to the meta-model", required=True)
+    parser.add_argument(
+        "--version", help="show the current version and exit", action="store_true"
+    )
+    args = parser.parse_args()
+
+    return execute(model_path=pathlib.Path(args.model_path), stderr=sys.stderr)
+
+
+def entry_point() -> int:
+    """Provide an entry point for a console script."""
+    return main(prog="aas-core-codegen-smoke")
+
+
+if __name__ == "__main__":
+    sys.exit(main(prog="aas-core-codegen-smoke"))

--- a/continuous_integration/check_test_meta_models_coincide.py
+++ b/continuous_integration/check_test_meta_models_coincide.py
@@ -21,6 +21,7 @@ META_MODEL_GROUPS = collections.OrderedDict(
             [
                 _REPO_DIR / "test_data/jsonschema/test_main/v3rc1/input/meta_model.py",
                 _REPO_DIR / "test_data/rdf_shacl/test_main/v3rc1/input/meta_model.py",
+                _REPO_DIR / "test_data/smoke/test_main/expected/v3rc1.py",
             ],
         ),
         (
@@ -36,6 +37,7 @@ META_MODEL_GROUPS = collections.OrderedDict(
                     _REPO_DIR / "test_data/parse/"
                     "expected/real_meta_models/v3rc2/meta_model.py"
                 ),
+                _REPO_DIR / "test_data/smoke/test_main/expected/v3rc2.py",
             ],
         ),
     ]

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,9 @@ setup(
     package_data={"aas_core_codegen": ["py.typed"]},
     data_files=[(".", ["LICENSE", "README.rst", "requirements.txt"])],
     entry_points={
-        "console_scripts": ["aas-core-codegen=aas_core_codegen.main:entry_point"]
+        "console_scripts": [
+            "aas-core-codegen=aas_core_codegen.main:entry_point",
+            "aas-core-codegen-smoke=aas_core_codegen.smoke.main:entry_point",
+        ]
     },
 )

--- a/test_data/smoke/test_main/expected/v3rc1.py
+++ b/test_data/smoke/test_main/expected/v3rc1.py
@@ -1,0 +1,3257 @@
+"""Provide the meta model for Asset Administration Shell V3 Release Candidate 1."""
+from enum import Enum
+from re import match
+from typing import List, Optional
+
+from icontract import invariant, DBC
+
+from aas_core_meta.marker import (
+    abstract,
+    serialization,
+    implementation_specific,
+    reference_in_the_book,
+    is_superset_of,
+    verification,
+)
+
+# region Book
+
+__book_url__ = (
+    "https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation"
+    "/Details_of_the_Asset_Administration_Shell_Part1_V3.pdf?__blob"
+    "=publicationFile&v=5"
+)
+__book_version__ = "V3.0RC01"
+
+
+# endregion
+
+# region Verification
+
+# noinspection SpellCheckingInspection
+@verification
+def is_IRI(text: str) -> bool:
+    """
+    Check that :paramref:`text` is a valid IRI according to RFC 3987.
+
+    :param text: Text to be checked
+    :returns: True if the :paramref:`text` conforms to the pattern
+    """
+    scheme = "[a-zA-Z][a-zA-Z0-9+\\-.]*"
+    ucschar = (
+        "[\\xa0-\\ud7ff\\uf900-\\ufdcf\\ufdf0-\\uffef\\u10000-\\u1fffd"
+        "\\u20000-\\u2fffd\\u30000-\\u3fffd\\u40000-\\u4fffd"
+        "\\u50000-\\u5fffd\\u60000-\\u6fffd\\u70000-\\u7fffd"
+        "\\u80000-\\u8fffd\\u90000-\\u9fffd\\ua0000-\\uafffd"
+        "\\ub0000-\\ubfffd\\uc0000-\\ucfffd\\ud0000-\\udfffd"
+        "\\ue1000-\\uefffd]"
+    )
+    iunreserved = f"([a-zA-Z0-9\\-._~]|{ucschar})"
+    pct_encoded = "%[0-9A-Fa-f][0-9A-Fa-f]"
+    sub_delims = "[!$&'()*+,;=]"
+    iuserinfo = f"({iunreserved}|{pct_encoded}|{sub_delims}|:)*"
+    h16 = "[0-9A-Fa-f]{1,4}"
+    dec_octet = "([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])"
+    ipv4address = f"{dec_octet}\\.{dec_octet}\\.{dec_octet}\\.{dec_octet}"
+    ls32 = f"({h16}:{h16}|{ipv4address})"
+    ipv6address = (
+        f"(({h16}:){{6}}{ls32}|::({h16}:){{5}}{ls32}|({h16})?::({h16}:){{4}}"
+        f"{ls32}|(({h16}:)?{h16})?::({h16}:){{3}}{ls32}|(({h16}:){{2}}{h16})?::"
+        f"({h16}:){{2}}{ls32}|(({h16}:){{3}}{h16})?::{h16}:{ls32}|(({h16}:){{4}}"
+        f"{h16})?::{ls32}|(({h16}:){{5}}{h16})?::{h16}|(({h16}:){{6}}{h16})?::)"
+    )
+    unreserved = "[a-zA-Z0-9\\-._~]"
+    ipvfuture = f"[vV][0-9A-Fa-f]+\\.({unreserved}|{sub_delims}|:)+"
+    ip_literal = f"\\[({ipv6address}|{ipvfuture})\\]"
+    ireg_name = f"({iunreserved}|{pct_encoded}|{sub_delims})*"
+    ihost = f"({ip_literal}|{ipv4address}|{ireg_name})"
+    port = "[0-9]*"
+    iauthority = f"({iuserinfo}@)?{ihost}(:{port})?"
+    ipchar = f"({iunreserved}|{pct_encoded}|{sub_delims}|[:@])"
+    isegment = f"({ipchar})*"
+    ipath_abempty = f"(/{isegment})*"
+    isegment_nz = f"({ipchar})+"
+    ipath_absolute = f"/({isegment_nz}(/{isegment})*)?"
+    ipath_rootless = f"{isegment_nz}(/{isegment})*"
+    ipath_empty = f"({ipchar}){{0}}"
+    ihier_part = (
+        f"(//{iauthority}{ipath_abempty}|{ipath_absolute}|"
+        f"{ipath_rootless}|{ipath_empty})"
+    )
+    iprivate = "[\\ue000-\\uf8ff\\uf0000-\\uffffd\\u100000-\\u10fffd]"
+    iquery = f"({ipchar}|{iprivate}|[/?])*"
+    ifragment = f"({ipchar}|[/?])*"
+    isegment_nz_nc = f"({iunreserved}|{pct_encoded}|{sub_delims}|@)+"
+    ipath_noscheme = f"{isegment_nz_nc}(/{isegment})*"
+    irelative_part = (
+        f"(//{iauthority}{ipath_abempty}|{ipath_absolute}|"
+        f"{ipath_noscheme}|{ipath_empty})"
+    )
+    irelative_ref = f"{irelative_part}(\\?{iquery})?(\\#{ifragment})?"
+    iri = f"{scheme}:{ihier_part}(\\?{iquery})?(\\#{ifragment})?"
+    iri_reference = f"({iri}|{irelative_ref})"
+
+    return match(f"^{iri_reference}$", text) is not None
+
+
+# noinspection SpellCheckingInspection
+@verification
+def is_IRDI(text: str) -> bool:
+    """
+    Check that :paramref:`text` is a valid IRDI.
+
+    See: https://wiki.eclass.eu/wiki/IRDI
+
+    :param text: Text to be checked
+    :returns: True if the :paramref:`text` conforms to the pattern
+    """
+    numeric = r"[0-9]"
+    safe_char = r"[A-Za-z0-9:_.]"
+
+    irdi = (
+        f"{numeric}{{4}}-{safe_char}{{1,35}}(-{safe_char}{{1,35}})?"
+        f"#{safe_char}{{2}}-{safe_char}{{6}}"
+        f"#{numeric}{{1,35}}"
+    )
+
+    return match(f"^{irdi}$", text) is not None
+
+
+# noinspection SpellCheckingInspection
+@verification
+def is_ID_short(text: str) -> bool:
+    """
+    Check that :paramref:`text` is a valid ID short according to the book.
+
+    :param text: Text to be checked
+    :returns: True if the :paramref:`text` conforms to the pattern
+    """
+    return match(r"^[a-zA-Z][a-zA-Z_0-9]*$", text) is not None
+
+
+# noinspection SpellCheckingInspection
+@verification
+def is_MIME_type(text: str) -> bool:
+    """
+    Check that :paramref:`text` conforms to the pattern of MIME type.
+
+    :param text: Text to be checked
+    :returns: True if the :paramref:`text` conforms to the pattern
+    """
+    tchar = "[!#$%&'*+\\-.^_`|~0-9a-zA-Z]"
+    token = f"({tchar})+"
+    type = f"{token}"
+    subtype = f"{token}"
+    ows = "[ \t]*"
+    obs_text = "[\\x80-\\xff]"
+    qd_text = f"([\t !#-\\[\\]-~]|{obs_text})"
+    quoted_pair = f"\\\\([\t !-~]|{obs_text})"
+    quoted_string = f'"({qd_text}|{quoted_pair})*"'
+    parameter = f"{token}=({token}|{quoted_string})"
+    media_type = f"{type}/{subtype}({ows};{ows}{parameter})*"
+
+    return match(media_type, text) is not None
+
+
+# noinspection PyUnusedLocal
+@verification
+@implementation_specific
+def value_and_data_type_match(value: str, data_type: "Data_type_def") -> bool:
+    """Check that the actual type of :paramref:`value` matches :paramref:`data_type`."""
+    raise NotImplementedError()
+
+
+# endregion
+
+# region Constrained primitive types
+
+
+@invariant(lambda self: len(self) >= 1)
+class Non_empty_string(str, DBC):
+    """Represent a string with at least one character."""
+
+    pass
+
+
+@invariant(lambda self: is_MIME_type(self))
+class MIME_typed(Non_empty_string, DBC):
+    """Represent a string that follows the pattern of a MIME type."""
+
+
+# endregion
+
+
+@abstract
+@reference_in_the_book(
+    section=(4, 7, 2, 7), fragment="4.7.2.1 Extensions (HasExtensions)"
+)
+class Has_semantics(DBC):
+    """
+    Element that can have a semantic definition.
+    """
+
+    semantic_ID: Optional["Reference"]
+    """
+    Identifier of the semantic definition of the element. It is called semantic ID
+    of the element.
+    """
+
+    def __init__(self, semantic_ID: Optional["Reference"] = None) -> None:
+        self.semantic_ID = semantic_ID
+
+
+@reference_in_the_book(section=(4, 7, 2, 1), index=2)
+class Extension(Has_semantics):
+    """
+    Single extension of an element.
+    """
+
+    name: Non_empty_string
+    """
+    Name of the extension.
+
+    :constraint AASd-077:
+        The name of an extension within HasExtensions needs to be
+        unique.
+    """
+
+    value_type: Optional["Data_type_def"]
+    """
+    Type of the value of the extension.
+
+    Default: xsd:string
+    """
+
+    value: Optional[str]
+    """
+    Value of the extension
+    """
+
+    refers_to: Optional["Reference"]
+    """
+    Reference to an element the extension refers to.
+    """
+
+    def __init__(
+        self,
+        name: Non_empty_string,
+        semantic_ID: Optional["Reference"] = None,
+        value_type: Optional["Data_type_def"] = None,
+        value: Optional[str] = None,
+        refers_to: Optional["Reference"] = None,
+    ) -> None:
+        Has_semantics.__init__(self, semantic_ID=semantic_ID)
+
+        self.name = name
+        self.value_type = value_type
+        self.value = value
+        self.refers_to = refers_to
+
+
+@abstract
+@reference_in_the_book(
+    section=(4, 7, 2, 1),
+    fragment="4.7.2.7 Semantic References Attributes (HasSemantics))",
+)
+class Has_extensions(DBC):
+    """
+    Element that can be extended by proprietary extensions.
+
+    Note: Extensions are proprietary, i.e. they do not support global interoperability.
+    """
+
+    extensions: Optional[List["Extension"]]
+    """
+    An extension of the element.
+    """
+
+    def __init__(self, extensions: Optional[List["Extension"]] = None) -> None:
+        self.extensions = extensions
+
+
+@abstract
+@invariant(lambda self: is_ID_short(self.ID_short), "Constraint AASd-002")
+@serialization(with_model_type=True)
+@reference_in_the_book(section=(4, 7, 2, 2))
+class Referable(Has_extensions):
+    """
+    An element that is referable by its :attr:`~ID_short`.
+
+    This identifier is not globally unique.
+    This identifier is unique within the name space of the element.
+    """
+
+    ID_short: Non_empty_string
+    """
+    In case of identifiable this attribute is a short name of the element.
+    In case of referable this ID is an identifying string of
+    the element within its name space.
+
+    .. note::
+
+        In case the element is a property and the property has a semantic definition
+        (:class:`.Has_semantics`) conformant to IEC61360 the idShort is typically
+        identical to the short name in English.
+    """
+
+    display_name: Optional["Lang_string_set"]
+    """
+    Display name. Can be provided in several languages.
+
+    If no display name is defined in the language requested by the application,
+    then the display name is selected in the following order if available:
+
+    * the preferred name in the requested language of the concept description defining
+      the semantics of the element
+    * If there is a default language list defined in the application,
+      then the corresponding preferred name in the language is chosen
+      according to this order.
+    * the English preferred name of the concept description defining
+      the semantics of the element
+    * the short name of the concept description-the idShort of the element
+    """
+
+    category: Optional[Non_empty_string]
+    """
+    The category is a value that gives further meta information
+    w.r.t. to the class of the element.
+    It affects the expected existence of attributes and the applicability of
+    constraints.
+
+    .. note::
+
+        The category is not identical to the semantic definition
+        (:class:`.Has_semantics`) of an element. The category
+        *e.g.* could denote that the element is a measurement value whereas the
+        semantic definition of the element would
+        denote that it is the measured temperature.
+    """
+
+    description: Optional["Lang_string_set"]
+    """
+    Description or comments on the element.
+
+    The description can be provided in several languages. If no description is defined,
+    then the definition of the concept description that defines the semantics
+    of the element is used. Additional information can be provided,
+    *e.g.*, if the element is qualified and which qualifier types can be expected
+    in which context or which additional data specification templates are provided.
+    """
+
+    def __init__(
+        self,
+        ID_short: Non_empty_string,
+        extensions: Optional[List[Extension]] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+    ) -> None:
+        Has_extensions.__init__(self, extensions=extensions)
+
+        self.ID_short = ID_short
+        self.display_name = display_name
+        self.category = category
+        self.description = description
+
+
+@abstract
+@reference_in_the_book(section=(4, 7, 2, 3))
+class Identifiable(Referable):
+    """An element that has a globally unique identifier."""
+
+    administration: Optional["Administrative_information"]
+    """
+    Administrative information of an identifiable element.
+
+    .. note::
+
+        Some of the administrative information like the version number might need to
+        be part of the identification.
+    """
+
+    identification: "Identifier"
+    """The globally unique identification of the element."""
+
+    def __init__(
+        self,
+        ID_short: Non_empty_string,
+        identification: "Identifier",
+        extensions: Optional[List[Extension]] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        administration: Optional["Administrative_information"] = None,
+    ) -> None:
+        Referable.__init__(
+            self,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            extensions=extensions,
+        )
+
+        self.identification = identification
+        self.administration = administration
+
+
+# fmt: off
+@invariant(
+    lambda self:
+    not (self.ID_type == Identifier_type.IRDI) or is_IRDI(self.ID)
+)
+@invariant(
+    lambda self:
+    not (self.ID_type == Identifier_type.IRI) or is_IRI(self.ID)
+)
+@reference_in_the_book(section=(4, 7, 2, 4), index=0)
+# fmt: on
+class Identifier(DBC):
+    """
+    Used to uniquely identify an entity by using an identifier.
+    """
+
+    ID_type: "Identifier_type"
+    """
+    Type of the  Identifier, e.g. IRI, IRDI *etc.* The supported Identifier types are
+    defined in the enumeration :class:`.Identifier_type`.
+    """
+
+    ID: Non_empty_string
+    """
+    Globally unique identifier of the element.
+
+    Its type is defined in :attr:`~ID_type`.
+    """
+
+    def __init__(
+        self,
+        ID_type: "Identifier_type",
+        ID: Non_empty_string,
+    ) -> None:
+        self.ID = ID
+        self.ID_type = ID_type
+
+
+@reference_in_the_book(section=(4, 7, 2, 4), index=1)
+class Identifier_type(Enum):
+    """Enumeration of different types of Identifiers for global identification"""
+
+    IRDI = "IRDI"
+    """
+    IRDI according to ISO29002-5 as an Identifier scheme for properties
+    and classifications.
+    """
+
+    IRI = "IRI"
+    """IRI according to Rfc 3987. Every URIis an IRI"""
+
+    Custom = "Custom"
+    """Custom identifiers like GUIDs (globally unique identifiers)"""
+
+
+@reference_in_the_book(section=(4, 7, 2, 5), index=1)
+class Modeling_kind(Enum):
+    """Enumeration for denoting whether an element is a template or an instance."""
+
+    Template = "Template"
+    """
+    Software element which specifies the common attributes shared by all instances of
+    the template.
+
+    [SOURCE: IEC TR 62390:2005-01, 3.1.25] modified
+    """
+
+    Instance = "Instance"
+    """
+    Concrete, clearly identifiable component of a certain template.
+
+    .. note::
+
+        It becomes an individual entity of a  template,  for example a
+        device model, by defining specific property values.
+
+    .. note::
+
+        In an object oriented view,  an instance denotes an object of a
+        template (class).
+
+    [SOURCE: IEC 62890:2016, 3.1.16 65/617/CDV]  modified
+    """
+
+
+@abstract
+@reference_in_the_book(
+    section=(4, 7, 2, 5),
+    index=0,
+    fragment=("4.7.2.5 Template or Instance of Model " "Element Attributes (HasKind)"),
+)
+class Has_kind(DBC):
+    """
+    An element with a kind is an element that can either represent a template or an
+    instance.
+
+    Default for an element is that it is representing an instance.
+    """
+
+    kind: Optional["Modeling_kind"]
+    """
+    Kind of the element: either type or instance.
+
+    Default Value = Instance
+    """
+
+    # TODO (all, 2021-05-28): how can ``kind`` be optional
+    #  and have a default value?
+    #  (See page 54 in the book V3RC1, kind has the cardinality ``0..1``.)
+    def __init__(self, kind: Optional["Modeling_kind"] = None) -> None:
+        self.kind = kind if kind is not None else Modeling_kind.Instance
+
+
+@abstract
+@reference_in_the_book(
+    section=(4, 7, 2, 13),
+    fragment=(
+        "4.7.2.13 Used Templates for Data Specification Attributes "
+        "(HasDataSpecification)"
+    ),
+)
+class Has_data_specification(DBC):
+    """
+    Element that can be extended by using data specification templates.
+
+    A data specification template defines a named set of additional attributes an
+    element may or shall have. The data specifications used are explicitly specified
+    with their global ID.
+    """
+
+    data_specifications: Optional[List["Reference"]]
+    """
+    Global reference to the data specification template used by the element.
+    """
+
+    # TODO (all, 2021-09-24): need to implement the constraint:
+    #  page 60 in V3RC1
+    #  :constraint AASd-050:
+    #  If the DataSpecificationContent
+    #  DataSpecificationIEC61360 is used for an element then the value of
+    #  hasDataSpecification/dataSpecification shall contain the global reference to the
+    #  IRI of the corresponding data specification template https://admin-
+    #  shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0.
+
+    def __init__(self, data_specifications: Optional[List["Reference"]] = None) -> None:
+        self.data_specifications = data_specifications
+
+
+# fmt: off
+@invariant(
+    lambda self:
+    not (self.revision is not None) or self.version is not None,
+    "Constraint AASd-005"
+)
+@reference_in_the_book(section=(4, 7, 2, 6))
+# fmt: on
+class Administrative_information(Has_data_specification):
+    """
+    Administrative meta-information for an element like version information.
+    """
+
+    version: Optional[Non_empty_string]
+    """Version of the element."""
+
+    revision: Optional[Non_empty_string]
+    """Revision of the element."""
+
+    def __init__(
+        self,
+        data_specifications: Optional[List["Reference"]] = None,
+        version: Optional[Non_empty_string] = None,
+        revision: Optional[Non_empty_string] = None,
+    ) -> None:
+        Has_data_specification.__init__(self, data_specifications=data_specifications)
+
+        self.version = version
+        self.revision = revision
+
+
+# fmt: off
+# TODO (mristin, 2021-11-17): review this constraint once the ``Constraint`` has been
+#  implemented.
+# @invariant(
+#     lambda self:
+#     are_unique(
+#         constraint.qualifier_type
+#         for constraint in self.qualifiers
+#         if isinstance(constraint, Qualifier)
+#     ),
+#     "Constraint AASd-021"
+# )
+@abstract
+@reference_in_the_book(section=(4, 7, 2, 8))
+# fmt: on
+class Qualifiable(DBC):
+    """
+    The value of a qualifiable element may be further qualified by one or more
+    qualifiers or complex formulas.
+    """
+
+    qualifiers: Optional[List["Constraint"]]
+    """Additional qualification of a qualifiable element."""
+
+    def __init__(self, qualifiers: Optional[List["Constraint"]] = None) -> None:
+        self.qualifiers = qualifiers
+
+
+@abstract
+@reference_in_the_book(section=(4, 7, 2, 9))
+@serialization(with_model_type=True)
+class Constraint(DBC):
+    """A constraint is used to further qualify or restrict an element."""
+
+
+# fmt: off
+# TODO (mristin, 2021-11-17): rewrite using XSD constraints on strings
+# @invariant(
+#     lambda self:
+#     not (self.value is not None) or is_of_type(self.value, self.value_type),
+#     "Constraint AASd-020"
+# )
+@reference_in_the_book(section=(4, 7, 2, 11))
+@serialization(with_model_type=True)
+# fmt: on
+class Qualifier(Constraint, Has_semantics):
+    """
+    A qualifier is a type-value-pair that makes additional statements w.r.t.  the value
+    of the element.
+    """
+
+    type: Non_empty_string
+    """
+    The qualifier type describes the type of the qualifier that is applied to
+    the element.
+    """
+
+    value_type: "Data_type_def"
+    """
+    Data type of the qualifier value.
+    """
+
+    value: Optional[str]
+    """
+    The qualifier value is the value of the qualifier.
+    """
+
+    value_ID: Optional["Reference"]
+    """
+    Reference to the global unique ID of a coded value.
+    """
+
+    def __init__(
+        self,
+        type: Non_empty_string,
+        value_type: "Data_type_def",
+        semantic_ID: Optional["Reference"] = None,
+        value: Optional[str] = None,
+        value_ID: Optional["Reference"] = None,
+    ) -> None:
+        Has_semantics.__init__(self, semantic_ID=semantic_ID)
+
+        self.type = type
+        self.value_type = value_type
+        self.value = value
+        self.value_ID = value_ID
+
+
+@reference_in_the_book(section=(4, 7, 2, 12))
+@serialization(with_model_type=True)
+class Formula(Constraint):
+    """
+    A formula is used to describe constraints by a logical expression.
+    """
+
+    depends_on: Optional[List["Reference"]]
+    """
+    A formula may depend on referable or even external global elements that are used in
+    the logical expression.
+
+    The value of the referenced elements needs to be accessible so that it can be
+    evaluated in the formula to true or false in the corresponding logical expression
+    it is used in.
+    """
+
+    def __init__(self, depends_on: Optional[List["Reference"]]) -> None:
+        self.depends_on = depends_on
+
+
+@reference_in_the_book(section=(4, 7, 3))
+class Asset_administration_shell(Identifiable, Has_data_specification):
+    """Structure a digital representation of an :class:`.Asset`."""
+
+    derived_from: Optional["Reference"]
+    """The reference to the AAS the AAS was derived from."""
+
+    security: Optional["Security"]
+    """Definition of the security relevant aspects of the AAS."""
+
+    asset_information: "Asset_information"
+    """Meta-information about the asset the AAS is representing."""
+
+    submodels: Optional[List["Reference"]]
+    """
+    References to submodels of the AAS.
+
+    A submodel is a description of an aspect of the asset the AAS is representing.
+    The asset of an AAS is typically described by one or more submodels. Temporarily
+    no submodel might be assigned to the AAS.
+    """
+
+    views: Optional[List["View"]]
+    """
+    Stakeholder-specific views defined for the AAS.
+
+    If needed, stakeholder specific views can be defined on the elements of the AAS.
+    """
+
+    def __init__(
+        self,
+        ID_short: Non_empty_string,
+        identification: "Identifier",
+        asset_information: "Asset_information",
+        extensions: Optional[List[Extension]] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        administration: Optional["Administrative_information"] = None,
+        data_specifications: Optional[List["Reference"]] = None,
+        derived_from: Optional["Reference"] = None,
+        security: Optional["Security"] = None,
+        submodels: Optional[List["Reference"]] = None,
+        views: Optional[List["View"]] = None,
+    ) -> None:
+        Identifiable.__init__(
+            self,
+            identification=identification,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            extensions=extensions,
+            administration=administration,
+        )
+
+        Has_data_specification.__init__(self, data_specifications=data_specifications)
+
+        self.derived_from = derived_from
+        self.asset_information = asset_information
+        self.security = security
+        self.submodels = submodels
+        self.views = views
+
+
+@reference_in_the_book(section=(4, 7, 4))
+class Asset(Identifiable, Has_data_specification):
+    """
+    An Asset describes meta data of an asset that is represented by an AAS and is
+    identical for all AAS representing this asset.
+
+    The asset has a globally unique identifier.
+    """
+
+    def __init__(
+        self,
+        ID_short: Non_empty_string,
+        identification: "Identifier",
+        extensions: Optional[List[Extension]] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        administration: Optional["Administrative_information"] = None,
+        data_specifications: Optional[List["Reference"]] = None,
+    ) -> None:
+        Identifiable.__init__(
+            self,
+            identification=identification,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            extensions=extensions,
+            administration=administration,
+        )
+
+        Has_data_specification.__init__(self, data_specifications=data_specifications)
+
+
+@reference_in_the_book(section=(4, 7, 5), index=0)
+class Asset_information(DBC):
+    """
+    Identifying meta data of the asset that is represented by an AAS.
+
+    The asset may either represent an asset type or an asset instance. The asset has
+    a globally unique identifier plus – if needed – additional domain-specific
+    (proprietary) identifiers. However, to support the corner case of very first
+    phase of lifecycle where a stabilized/constant global asset identifier does not
+    already exist, the corresponding attribute :attr:`~global_asset_ID` is optional.
+    """
+
+    asset_kind: "Asset_kind"
+    """
+    Denotes whether the Asset is of kind "Type" or "Instance".
+    """
+
+    global_asset_ID: Optional["Reference"]
+    """
+    Reference to either an Asset object or a global reference to the asset the AAS is
+    representing.
+
+    This attribute is required as soon as the AAS is exchanged via partners in the life
+    cycle of the asset. In a first phase of the life cycle the asset might not yet have
+    a global ID but already an internal identifier. The internal identifier would be
+    modelled via :attr:`~specific_asset_IDs`.
+    """
+
+    specific_asset_IDs: Optional[List["Identifier_key_value_pair"]]
+    """
+    Additional domain-specific, typically proprietary, Identifier for the asset.
+
+    For example, serial number.
+    """
+
+    bill_of_material: Optional[List["Reference"]]
+    """
+    A reference to a Submodel that defines the bill of material of the asset represented
+    by the AAS.
+
+    The submodels contain a set of entities describing the material used to compose
+    the composite I4.0 Component.
+    """
+
+    default_thumbnail: Optional["File"]
+    """
+    Thumbnail of the asset represented by the asset administration shell.
+
+    Used as default.
+    """
+
+    def __init__(
+        self,
+        asset_kind: "Asset_kind",
+        global_asset_ID: Optional["Reference"] = None,
+        specific_asset_IDs: Optional[List["Identifier_key_value_pair"]] = None,
+        bill_of_material: Optional[List["Reference"]] = None,
+        default_thumbnail: Optional["File"] = None,
+    ) -> None:
+        # TODO (Nico & Marko, 2021-09-24):
+        #  We did not know how to implement Constraint AASd-023,
+        #  see page 63 in the book V3RC1
+        self.asset_kind = asset_kind
+        self.global_asset_ID = global_asset_ID
+        self.specific_asset_IDs = specific_asset_IDs
+        self.bill_of_material = bill_of_material
+        self.default_thumbnail = default_thumbnail
+
+
+@reference_in_the_book(section=(4, 7, 5), index=1)
+class Asset_kind(Enum):
+    """
+    Enumeration for denoting whether an element is a type or an instance.
+    """
+
+    Type = "Type"
+    """
+    hardware or software element which specifies the common attributes shared by all
+    instances of the type
+
+    [SOURCE: IEC TR 62390:2005-01, 3.1.25]
+    """
+
+    Instance = "Instance"
+    """
+    concrete, clearly identifiable component of a certain type
+
+    .. note::
+
+        It becomes an individual entity of a type, for example a device, by defining
+        specific property values.
+
+    .. note::
+
+        In an object oriented view, an instance denotes an object of a class
+        (of a type).
+
+    [SOURCE: IEC 62890:2016, 3.1.16] 65/617/CDV
+    """
+
+
+@reference_in_the_book(section=(4, 7, 5), index=2)
+class Identifier_key_value_pair(Has_semantics):
+    """
+    An IdentifierKeyValuePair describes a generic identifier as key-value pair.
+    """
+
+    key: Non_empty_string
+    """Key of the identifier"""
+
+    value: "Non_empty_string"
+    """The value of the identifier with the corresponding key."""
+
+    external_subject_ID: "Reference"
+    """The (external) subject the key belongs to or has meaning to."""
+
+    def __init__(
+        self,
+        key: Non_empty_string,
+        value: Non_empty_string,
+        external_subject_ID: "Reference",
+        semantic_ID: Optional["Reference"] = None,
+    ) -> None:
+        Has_semantics.__init__(self, semantic_ID)
+        self.key = key
+        self.value = value
+        self.external_subject_ID = external_subject_ID
+
+
+@reference_in_the_book(section=(4, 7, 6))
+class Submodel(
+    Identifiable, Has_kind, Has_semantics, Qualifiable, Has_data_specification
+):
+    """
+    A submodel defines a specific aspect of the asset represented by the AAS.
+
+    A submodel is used to structure the digital representation and technical
+    functionality of an Administration Shell into distinguishable parts. Each submodel
+    refers to a well-defined domain or subject matter. Submodels can become
+    standardized and, thus, become submodels templates.
+    """
+
+    submodel_elements: Optional[List["Submodel_element"]]
+    """A submodel consists of zero or more submodel elements."""
+
+    def __init__(
+        self,
+        ID_short: Non_empty_string,
+        identification: "Identifier",
+        submodel_elements: Optional[List["Submodel_element"]],
+        extensions: Optional[List[Extension]] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        administration: Optional["Administrative_information"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Reference"] = None,
+        qualifiers: Optional[List["Constraint"]] = None,
+        data_specifications: Optional[List["Reference"]] = None,
+    ) -> None:
+        # TODO (Nico & Marko, 2021-09-24):
+        #  How should we implement Constraint AASd-062 (page 64 in V3RC1)?
+        #  Isn't this a constraint on the SubmodelElement?
+        #  A submodel does not contain any attribute called ``Property``.
+
+        Identifiable.__init__(
+            self,
+            identification=identification,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            extensions=extensions,
+            administration=administration,
+        )
+
+        Has_kind.__init__(self, kind=kind)
+
+        Has_semantics.__init__(self, semantic_ID=semantic_ID)
+
+        Qualifiable.__init__(self, qualifiers=qualifiers)
+
+        Has_data_specification.__init__(self, data_specifications=data_specifications)
+
+        self.submodel_elements = submodel_elements
+
+
+@abstract
+@reference_in_the_book(section=(4, 7, 7))
+class Submodel_element(
+    Referable, Has_kind, Has_semantics, Qualifiable, Has_data_specification
+):
+    """
+    A submodel element is an element suitable for the description and differentiation of
+    assets.
+
+    It is recommended to add a semantic ID to a submodel element.
+    """
+
+    def __init__(
+        self,
+        ID_short: Non_empty_string,
+        extensions: Optional[List[Extension]] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Reference"] = None,
+        qualifiers: Optional[List["Constraint"]] = None,
+        data_specifications: Optional[List["Reference"]] = None,
+    ) -> None:
+        Referable.__init__(
+            self,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            extensions=extensions,
+        )
+
+        Has_kind.__init__(self, kind=kind)
+
+        Has_semantics.__init__(self, semantic_ID=semantic_ID)
+
+        Qualifiable.__init__(self, qualifiers=qualifiers)
+
+        Has_data_specification.__init__(self, data_specifications=data_specifications)
+
+
+# TODO (mristin, 2021-10-27, page 77):
+#  :constraint AASd-055:
+#  If the semanticId of a RelationshipElement or an
+#  AnnotatedRelationshipElement submodel element references a  ConceptDescription then
+#  the ConceptDescription/category shall be one of following values: RELATIONSHIP.
+#
+#  🠒 We really need to think hard how we resolve the references. Should this class be
+#  implementation-specific?
+@reference_in_the_book(section=(4, 7, 8, 14))
+class Relationship_element(Submodel_element):
+    """
+    A relationship element is used to define a relationship between two referable
+    elements.
+
+    :constraint AASd-055:
+        If the semanticId of a RelationshipElement or an
+        AnnotatedRelationshipElement submodel element references a ConceptDescription
+        then the ConceptDescription/category shall be one of following values:
+        RELATIONSHIP.
+    """
+
+    first: "Reference"
+    """
+    Reference to the first element in the relationship taking the role of the subject.
+    """
+
+    second: "Reference"
+    """
+    Reference to the second element in the relationship taking the role of the object.
+    """
+
+    def __init__(
+        self,
+        ID_short: Non_empty_string,
+        first: "Reference",
+        second: "Reference",
+        extensions: Optional[List[Extension]] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Reference"] = None,
+        qualifiers: Optional[List["Constraint"]] = None,
+        data_specifications: Optional[List["Reference"]] = None,
+    ) -> None:
+        Submodel_element.__init__(
+            self,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            extensions=extensions,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+        self.first = first
+        self.second = second
+
+
+@reference_in_the_book(section=(4, 7, 8, 15))
+class Submodel_element_collection(Submodel_element):
+    """
+    A submodel element collection is a set or list of submodel elements.
+
+    :constraint AASd-059:
+        If the semanticId of a SubmodelElementCollection references a
+        ConceptDescription then the category of the ConceptDescription shall be
+        COLLECTION or ENTITY.
+
+    :constraint AASd-092:
+        If the semanticId of a SubmodelElementCollection with
+        SubmodelElementCollection/allowDuplicates == false references
+        a ConceptDescription then the ConceptDescription/category shall be ENTITY.
+
+    :constraint AASd-093:
+        If the semanticId of a SubmodelElementCollection with
+        SubmodelElementCollection/allowDuplicates == true references
+        a ConceptDescription then the ConceptDescription/category shall be COLLECTION.
+
+    Example: A set of documents is referencing a concept description of category
+    COLLECTION. A document within this collection is described as
+    a SubmodelElementCollection referencing a concept description of category ENTITY.
+
+    .. note::
+       This means that no generic semanticId can be assigned to an element within
+       a submodel element collection with allowDuplicates == false: every element within
+       the entity needs a clear and unique semantics.
+    """
+
+    value: Optional[List["Submodel_element"]]
+    """
+    Submodel element contained in the collection.
+    """
+
+    ordered: Optional[bool]
+    """
+    If ordered=false, then the elements in the collection are not ordered.
+    If ordered=true, then the elements in the collection are ordered.
+    Default = false
+
+    .. note::
+      An ordered submodel element collection is typically implemented as an indexed
+      array.
+    """
+
+    allow_duplicates: Optional[bool]
+    """
+    If allowDuplicates==true, then it is allowed that the collection contains several
+    elements with the same semantics (i.e. the same semanticId).
+
+    Default = false
+
+    :constraint AASd-026:
+        If allowDuplicates==false then it is not allowed that
+        the collection contains several elements with the same semantics (i.e. the same
+        semanticId).
+    """
+
+    def __init__(
+        self,
+        ID_short: Non_empty_string,
+        extensions: Optional[List[Extension]] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Reference"] = None,
+        qualifiers: Optional[List["Constraint"]] = None,
+        data_specifications: Optional[List["Reference"]] = None,
+        value: Optional[List["Submodel_element"]] = None,
+        ordered: Optional[bool] = None,
+        allow_duplicates: Optional[bool] = None,
+    ) -> None:
+        Submodel_element.__init__(
+            self,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            extensions=extensions,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+        self.value = value
+        self.ordered = ordered
+        self.allow_duplicates = allow_duplicates
+
+
+@abstract
+@reference_in_the_book(section=(4, 7, 8, 5))
+class Data_element(Submodel_element):
+    """
+    A data element is a submodel element that is not further composed out of
+    other submodel elements.
+
+    A data element is a submodel element that has a value. The type of value differs
+    for different subtypes of data elements.
+
+    .. note::
+
+        A controlled value is a value whose meaning is given in an external source
+        (see “ISO/TS 29002-10)
+
+    :constraint AASd-090:
+        For data elements DataElement/category shall be one of the
+        following values: CONSTANT, PARAMETER or VARIABLE.
+        Exception: File and Blob data elements.
+    """
+
+    def __init__(
+        self,
+        ID_short: Non_empty_string,
+        extensions: Optional[List[Extension]] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Reference"] = None,
+        qualifiers: Optional[List[Constraint]] = None,
+        data_specifications: Optional[List["Reference"]] = None,
+    ) -> None:
+        Submodel_element.__init__(
+            self,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            extensions=extensions,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+
+@reference_in_the_book(section=(4, 7, 8, 11))
+class Property(Data_element):
+    """
+    A property is a data element that has a single value.
+
+    :constraint AASd-007:
+        If both, the Property/value and the Property/valueId are
+        present then the value of Property/value needs to be identical to the value of
+        the referenced coded value in Property/valueId.
+
+    :constraint AASd-052a:
+        If the semanticId of a Property references a
+        ConceptDescription then the ConceptDescription/category shall be one of
+        following values: VALUE, PROPERTY.
+
+    :constraint AASd-065:
+        If the semanticId of a Property or MultiLanguageProperty
+        references a ConceptDescription with the category VALUE then the value of the
+        property is identical to DataSpecificationIEC61360/value and the valueId of the
+        property is identical to DataSpecificationIEC61360/valueId.
+
+    :constraint AASd-066:
+        If the semanticId of a Property or MultiLanguageProperty
+        references a ConceptDescription with the category PROPERTY and
+        DataSpecificationIEC61360/valueList is defined the value and valueId of the
+        property is identical to one of the value reference pair types references in the
+        value list, i.e. ValueReferencePairType/value or ValueReferencePairType/valueId,
+        resp.
+    """
+
+    value_type: "Data_type_def"
+    """
+    Data type of the value
+    """
+
+    value: Optional[str]
+    """
+    The value of the property instance.
+
+    See :constraintref:`AASd-065`
+    See :constraintref:`AASd-007`
+    """
+
+    value_ID: Optional["Reference"]
+    """
+    Reference to the global unique id of a coded value.
+
+    See :constraintref:`AASd-065`
+    See :constraintref:`AASd-007`
+    """
+
+    def __init__(
+        self,
+        ID_short: Non_empty_string,
+        value_type: "Data_type_def",
+        extensions: Optional[List[Extension]] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Reference"] = None,
+        qualifiers: Optional[List[Constraint]] = None,
+        data_specifications: Optional[List["Reference"]] = None,
+        value: Optional[str] = None,
+        value_ID: Optional["Reference"] = None,
+    ) -> None:
+        Data_element.__init__(
+            self,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            extensions=extensions,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+        self.value_type = value_type
+        self.value = value
+        self.value_ID = value_ID
+
+
+@reference_in_the_book(section=(4, 7, 8, 9))
+class Multi_language_property(Data_element):
+    """
+    A property is a data element that has a multi-language value.
+
+    See :constraintref:`AASd-065`
+
+    :constraint AASd-052b:
+        If the semanticId of a MultiLanguageProperty references
+        a ConceptDescription then the ConceptDescription/category shall be one of
+        following values: PROPERTY.
+
+    :constraint AASd-012:
+        If both, the MultiLanguageProperty/value and the
+        MultiLanguageProperty/valueId are present then for each string in a specific
+        language the meaning must be the same as specified in
+        MultiLanguageProperty/valueId.
+
+    :constraint AASd-067:
+        If the semanticId of a MultiLanguageProperty references a
+        ConceptDescription then DataSpecificationIEC61360/dataType shall be
+        STRING_TRANSLATABLE.
+    """
+
+    value: Optional["Lang_string_set"]
+    """
+    The value of the property instance.
+    See :constraintref:`AASd-012`
+    See :constraintref:`AASd-065`
+    """
+
+    value_ID: Optional["Reference"]
+    """
+    Reference to the global unique id of a coded value.
+    See :constraintref:`AASd-012`
+    See :constraintref:`AASd-065`
+    """
+
+    def __init__(
+        self,
+        ID_short: Non_empty_string,
+        extensions: Optional[List[Extension]] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Reference"] = None,
+        qualifiers: Optional[List[Constraint]] = None,
+        data_specifications: Optional[List["Reference"]] = None,
+        value: Optional["Lang_string_set"] = None,
+        value_ID: Optional["Reference"] = None,
+    ) -> None:
+        Data_element.__init__(
+            self,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            extensions=extensions,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+        self.value = value
+        self.value_ID = value_ID
+
+
+@reference_in_the_book(section=(4, 7, 8, 12))
+class Range(Data_element):
+    """
+    A range data element is a data element that defines a range with min and max.
+
+    :constraint AASd-053:
+        If the semanticId of a Range submodel element references a
+        ConceptDescription then the ConceptDescription/category shall be one of following
+        values: PROPERTY.
+
+    :constraint AASd-068:
+        If the semanticId of a Range submodel element references a
+        ConceptDescription then DataSpecificationIEC61360/dataType shall be a numerical
+        one, i.e. REAL_* or RATIONAL_*.
+
+    :constraint AASd-069:
+        If the semanticId of a Range references a ConceptDescription
+        then DataSpecificationIEC61360/levelType shall be identical to the set
+        {Min, Max}.
+    """
+
+    value_type: "Data_type_def"
+    """
+    Data type of the min und max
+    """
+
+    min: Optional[str]
+    """
+    The minimum value of the range.
+    If the min value is missing, then the value is assumed to be negative infinite.
+    """
+
+    max: Optional[str]
+    """
+    The maximum value of the range.
+    If the max value is missing,  then the value is assumed to be positive infinite.
+    """
+
+    def __init__(
+        self,
+        ID_short: Non_empty_string,
+        value_type: "Data_type_def",
+        extensions: Optional[List[Extension]] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Reference"] = None,
+        qualifiers: Optional[List[Constraint]] = None,
+        data_specifications: Optional[List["Reference"]] = None,
+        min: Optional[str] = None,
+        max: Optional[str] = None,
+    ) -> None:
+        Data_element.__init__(
+            self,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            extensions=extensions,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+        self.value_type = value_type
+        self.min = min
+        self.max = max
+
+
+@reference_in_the_book(section=(4, 7, 8, 13))
+class Reference_element(Data_element):
+    """
+    A reference element is a data element that defines a logical reference to another
+    element within the same or another AAS or a reference to an external object or
+    entity.
+    """
+
+    value: Optional["Reference"]
+    """
+    Reference to any other referable element of the same of any other AAS or a
+    reference to an external object or entity.
+
+    :constraint AASd-054:
+        If the semanticId of a ReferenceElement submodel element
+        references a ConceptDescription then the ConceptDescription/category shall be
+        one of following values: REFERENCE.
+    """
+
+    def __init__(
+        self,
+        ID_short: Non_empty_string,
+        extensions: Optional[List[Extension]] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Reference"] = None,
+        qualifiers: Optional[List[Constraint]] = None,
+        data_specifications: Optional[List["Reference"]] = None,
+        value: Optional["Reference"] = None,
+    ) -> None:
+        Data_element.__init__(
+            self,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            extensions=extensions,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+        self.value = value
+
+
+@reference_in_the_book(section=(4, 7, 8, 4))
+class Blob(Data_element):
+    """
+    A BLOB is a data element that represents a file that is contained with its source
+    code in the value attribute.
+    """
+
+    MIME_type: MIME_typed
+    """
+    MIME type of the content of the BLOB.
+
+    The MIME type states which file extensions the file can have.
+    Valid values are e.g. “application/json”, “application/xls”, ”image/jpg”
+    The allowed values are defined as in RFC2046.
+    """
+
+    value: Optional[bytearray]
+    """
+    The value of the BLOB instance of a blob data element.
+
+    .. note::
+      In contrast to the file property the file content is stored directly as value
+      in the Blob data element.
+
+    :constraint AASd-057:
+        The semanticId of a File or Blob submodel element shall only
+        reference a ConceptDescription with the category DOCUMENT.
+    """
+
+    def __init__(
+        self,
+        ID_short: Non_empty_string,
+        MIME_type: MIME_typed,
+        extensions: Optional[List[Extension]] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Reference"] = None,
+        qualifiers: Optional[List[Constraint]] = None,
+        data_specifications: Optional[List["Reference"]] = None,
+        value: Optional[bytearray] = None,
+    ) -> None:
+        Data_element.__init__(
+            self,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            extensions=extensions,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+        self.MIME_type = MIME_type
+        self.value = value
+
+
+@reference_in_the_book(section=(4, 7, 8, 8))
+class File(Data_element):
+    """
+    A File is a data element that represents an address to a file.
+    The value is an URI that can represent an absolute or relative path.
+
+    See :constraintref:`AASd-057`
+    """
+
+    MIME_type: MIME_typed
+    """
+    MIME  type of the content of the BLOB.
+
+    The  MIME  type states which file extensions the file can have.
+    """
+
+    value: Optional[str]
+    """
+    Path and name of the referenced file (with file extension).
+    The path can be absolute or relative.
+    """
+
+    def __init__(
+        self,
+        ID_short: Non_empty_string,
+        MIME_type: MIME_typed,
+        extensions: Optional[List[Extension]] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Reference"] = None,
+        qualifiers: Optional[List[Constraint]] = None,
+        data_specifications: Optional[List["Reference"]] = None,
+        value: Optional[str] = None,
+    ) -> None:
+        Data_element.__init__(
+            self,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            extensions=extensions,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+        self.MIME_type = MIME_type
+        self.value = value
+
+
+@reference_in_the_book(section=(4, 7, 8, 1))
+class Annotated_relationship_element(Relationship_element):
+    """
+    An annotated relationship element is a relationship element that can be annotated
+    with additional data elements.
+    """
+
+    annotations: Optional[List["Reference"]]
+    """
+    A reference to a data element that represents an annotation that holds for
+    the relationship between the two elements.
+    """
+
+    def __init__(
+        self,
+        ID_short: Non_empty_string,
+        first: "Reference",
+        second: "Reference",
+        extensions: Optional[List[Extension]] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Reference"] = None,
+        qualifiers: Optional[List["Constraint"]] = None,
+        data_specifications: Optional[List["Reference"]] = None,
+        annotations: Optional[List["Reference"]] = None,
+    ) -> None:
+        Relationship_element.__init__(
+            self,
+            first=first,
+            second=second,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            extensions=extensions,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+        self.annotations = annotations
+
+
+# TODO (mristin, 2021-10-27):
+#  Most of the classes inheriting from Data_element need to specify the invariant:
+#  "Constraint AASd-090"
+#  For data elements DataElement/category shall be one of the
+#  following values: CONSTANT, PARAMETER or VARIABLE. Exception: File and Blob
+#  data elements.
+
+# TODO (mristin, 2021-10-29): We can not implement this constraint, correct?
+#  🠒 Double-check with Nico!
+#  :constraint AASd-061:
+#  If the semanticId of a Event submodel element references
+#  a ConceptDescription then the category of the ConceptDescription shall be one of
+#  the following: EVENT.
+
+
+@reference_in_the_book(section=(4, 7, 8, 6), index=1)
+class Entity_type(Enum):
+    """
+    Enumeration for denoting whether an entity is a self-managed entity or a co-managed
+    entity.
+    """
+
+    Co_managed_entity = "CoManagedEntity"
+    """
+    For co-managed entities there is no separate AAS. Co-managed entities need to be
+    part of a self-managed entity.
+    """
+
+    Self_managed_entity = "SelfManagedEntity"
+    """
+    Self-Managed Entities have their own AAS but can be part of the bill of material of
+    a composite self-managed entity. The asset of an I4.0 Component is a self-managed
+    entity per definition."
+    """
+
+
+@reference_in_the_book(section=(4, 7, 8, 6))
+class Entity(Submodel_element):
+    """
+    An entity is a submodel element that is used to model entities.
+
+    :constraint AASd-056:
+        If the semanticId of a Entity submodel element
+        references a ConceptDescription then the ConceptDescription/category shall
+        be one of following values: ENTITY. The ConceptDescription describes
+        the elements assigned to the entity via Entity/statement.
+    """
+
+    entity_type: "Entity_type"
+    """
+    Describes whether the entity is a co- managed entity or a self-managed entity.
+    """
+
+    statements: Optional[List["Submodel_element"]]
+    """
+    Describes statements applicable to the entity by a set of submodel elements,
+    typically with a qualified value.
+    """
+
+    global_asset_ID: Optional["Reference"]
+    """
+    Reference to the asset the entity is representing.
+
+    :constraint AASd-014:
+        Either the attribute globalAssetId or specificAssetId of an
+        Entity must be set if Entity/entityType is set to “SelfManagedEntity”. They are
+        not existing otherwise.
+    """
+
+    specific_asset_ID: Optional["Identifier_key_value_pair"]
+    """
+    Reference to an identifier key value pair representing a specific identifier
+    of the asset represented by the asset administration shell.
+    See :constraintref:`AASd-014`
+    """
+
+    def __init__(
+        self,
+        ID_short: Non_empty_string,
+        entity_type: "Entity_type",
+        extensions: Optional[List[Extension]] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Reference"] = None,
+        qualifiers: Optional[List["Constraint"]] = None,
+        data_specifications: Optional[List["Reference"]] = None,
+        statements: Optional[List["Submodel_element"]] = None,
+        global_asset_ID: Optional["Reference"] = None,
+        specific_asset_ID: Optional["Identifier_key_value_pair"] = None,
+    ) -> None:
+        Submodel_element.__init__(
+            self,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            extensions=extensions,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+        self.statements = statements
+        self.entity_type = entity_type
+        self.global_asset_ID = global_asset_ID
+        self.specific_asset_ID = specific_asset_ID
+
+
+@abstract
+@reference_in_the_book(section=(4, 7, 8, 7))
+class Event(Submodel_element):
+    """
+    An event.
+    """
+
+    def __init__(
+        self,
+        ID_short: Non_empty_string,
+        extensions: Optional[List["Extension"]] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        kind: Optional[Modeling_kind] = None,
+        semantic_ID: Optional["Reference"] = None,
+        qualifiers: Optional[List[Constraint]] = None,
+        data_specifications: Optional[List["Reference"]] = None,
+    ) -> None:
+        Submodel_element.__init__(
+            self,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            extensions=extensions,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+
+@reference_in_the_book(section=(4, 7, 8, 2))
+class Basic_Event(Event):
+    """
+    A basic event.
+    """
+
+    observed: "Reference"
+    """
+    Reference to a referable, e.g. a data element or a submodel, that is being
+    observed.
+    """
+
+    def __init__(
+        self,
+        ID_short: Non_empty_string,
+        observed: "Reference",
+        extensions: Optional[List["Extension"]] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        kind: Optional[Modeling_kind] = None,
+        semantic_ID: Optional["Reference"] = None,
+        qualifiers: Optional[List[Constraint]] = None,
+        data_specifications: Optional[List["Reference"]] = None,
+    ) -> None:
+        Event.__init__(
+            self,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            extensions=extensions,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+        self.observed = observed
+
+
+@reference_in_the_book(section=(4, 7, 8, 10))
+class Operation(Submodel_element):
+    """
+    An operation is a submodel element with input and output variables.
+
+    :constraint AASd-060:
+        If the semanticId of a Operation submodel element
+        references a ConceptDescription then the category of the ConceptDescription
+        shall be one of the following values: FUNCTION.
+    """
+
+    input_variables: Optional[List["Operation_variable"]]
+    """
+    Input parameter of the operation.
+    """
+
+    output_variables: Optional[List["Operation_variable"]]
+    """
+    Output parameter of the operation.
+    """
+
+    inoutput_variables: Optional[List["Operation_variable"]]
+    """
+    Parameter that is input and output of the operation.
+    """
+
+    def __init__(
+        self,
+        ID_short: Non_empty_string,
+        extensions: Optional[List["Extension"]] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Reference"] = None,
+        qualifiers: Optional[List["Constraint"]] = None,
+        data_specifications: Optional[List["Reference"]] = None,
+        input_variables: Optional[List["Operation_variable"]] = None,
+        output_variables: Optional[List["Operation_variable"]] = None,
+        inoutput_variables: Optional[List["Operation_variable"]] = None,
+    ) -> None:
+        Submodel_element.__init__(
+            self,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            extensions=extensions,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+        self.input_variables = input_variables
+        self.output_variables = output_variables
+        self.inoutput_variables = inoutput_variables
+
+
+@reference_in_the_book(section=(4, 7, 8, 10), index=1)
+class Operation_variable:
+    """
+    An operation variable is a submodel element that is used as input or output variable
+    of an operation.
+    """
+
+    value: "Submodel_element"
+    """
+    Describes the needed argument for an operation via a submodel element of
+    kind=Template.
+    Constraint AASd-008: The submodel element value of an operation variable shall be
+    of kind=Template.
+    """
+
+    def __init__(self, value: "Submodel_element") -> None:
+        self.value = value
+
+
+@reference_in_the_book(section=(4, 7, 8, 3))
+class Capability(Submodel_element):
+    """
+    A capability is the implementation-independent description of the potential of an
+    asset to achieve a certain effect in the physical or virtual world.
+    """
+
+    def __init__(
+        self,
+        ID_short: Non_empty_string,
+        extensions: Optional[List["Extension"]] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Reference"] = None,
+        qualifiers: Optional[List["Constraint"]] = None,
+        data_specifications: Optional[List["Reference"]] = None,
+    ) -> None:
+        Submodel_element.__init__(
+            self,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            extensions=extensions,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+
+@reference_in_the_book(section=(4, 7, 9))
+class Concept_description(Identifiable, Has_data_specification):
+    """
+    The semantics of a property or other elements that may have a semantic description
+    is defined by a concept description. The description of the concept should follow a
+    standardized schema (realized as data specification template).
+
+    :constraint AASd-051:
+        A ConceptDescription shall have one of the following
+        categories:
+        VALUE, PROPERTY, REFERENCE, DOCUMENT, CAPABILITY, RELATIONSHIP, COLLECTION,
+        FUNCTION, EVENT, ENTITY, APPLICATION_CLASS, QUALIFIER, VIEW. Default: PROPERTY.
+    """
+
+    is_case_of: Optional[List["Reference"]]
+    """
+    Reference to an external definition the concept is compatible to or was derived
+    from.
+
+    .. note::
+       Compare to is-case-of relationship in ISO 13584-32 & IEC EN 61360"
+    """
+
+    def __init__(
+        self,
+        ID_short: Non_empty_string,
+        identification: "Identifier",
+        extensions: Optional[List[Extension]] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        administration: Optional["Administrative_information"] = None,
+        data_specifications: Optional[List["Reference"]] = None,
+        is_case_of: Optional[List["Reference"]] = None,
+    ) -> None:
+        Identifiable.__init__(
+            self,
+            identification=identification,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            extensions=extensions,
+            administration=administration,
+        )
+
+        Has_data_specification.__init__(self, data_specifications=data_specifications)
+
+        self.is_case_of = is_case_of
+
+
+@reference_in_the_book(section=(4, 7, 10))
+class View(Referable, Has_semantics, Has_data_specification):
+    """
+    A view is a collection of referable elements w.r.t. to a specific viewpoint of one
+    or more stakeholders.
+
+    .. note::
+       Views are a projection of submodel elements for a given perspective.
+       They are not equivalent to submodels.
+
+    :constraint AASd-064:
+        If the semanticId of a View references a ConceptDescription
+        then the category of the ConceptDescription shall be VIEW.
+    """
+
+    contained_elements: Optional[List["Reference"]]
+    """
+    Reference to a referable element that is contained in the view.
+    """
+
+    def __init__(
+        self,
+        ID_short: Non_empty_string,
+        extensions: Optional[List["Extension"]] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        semantic_ID: Optional["Reference"] = None,
+        data_specifications: Optional[List["Reference"]] = None,
+        contained_elements: Optional[List["Reference"]] = None,
+    ) -> None:
+        Referable.__init__(
+            self,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            extensions=extensions,
+        )
+
+        Has_semantics.__init__(self, semantic_ID)
+
+        Has_data_specification.__init__(
+            self,
+            data_specifications=data_specifications,
+        )
+
+        self.contained_elements = contained_elements
+
+
+@invariant(lambda self: len(self.keys) >= 1)
+@reference_in_the_book(
+    section=(4, 7, 11),
+    fragment="4.7.11 Referencing in Asset Administration Shells",
+)
+class Reference(DBC):
+    """
+    Reference to either a model element of the same or another AAs or to an external
+    entity.
+
+    A reference is an ordered list of keys, each key referencing an element. The
+    complete list of keys may for example be concatenated to a path that then gives
+    unique access to an element or entity.
+    """
+
+    keys: List["Key"]
+    """Unique references in their name space."""
+
+    def __init__(self, keys: List["Key"]) -> None:
+        self.keys = keys
+
+
+# fmt: off
+@invariant(
+    lambda self:
+    not (self.ID_type == Key_type.IRI) or is_IRI(self.value)
+)
+@invariant(
+    lambda self:
+    not (self.ID_type == Key_type.IRDI) or is_IRDI(self.value)
+)
+@invariant(
+    lambda self:
+    not (self.type == Key_elements.Global_reference)
+    or (self.ID_type != Key_type.ID_short and self.ID_type != Key_type.Fragment_ID),
+    "Constraint AASd-080"
+)
+@invariant(
+    lambda self:
+    not (self.type == Key_elements.Asset_administration_shell)
+    or (self.ID_type != Key_type.ID_short and self.ID_type != Key_type.Fragment_ID),
+    "Constraint AASd-081"
+)
+@reference_in_the_book(
+    section=(4, 7, 11), index=1,
+    fragment="4.7.11 Referencing in Asset Administration Shells")
+# fmt: on
+class Key(DBC):
+    """A key is a reference to an element by its id."""
+
+    type: "Key_elements"
+    """
+    Denote which kind of entity is referenced.
+
+    In case type = :attr:`~Key_elements.Global_reference` then the key represents
+    a global unique id.
+
+    In case type = :attr:`~Key_type.Fragment_ID` the key represents a bookmark or
+    a similar local identifier within its parent element as specified by the key that
+    precedes this key.
+
+    In all other cases the key references a model element of the same or of another AAS.
+    The name of the model element is explicitly listed.
+    """
+
+    value: Non_empty_string
+    """The key value, for example an IRDI if the :attr:`~ID_type` is IRDI."""
+
+    ID_type: "Key_type"
+    """
+    Type of the key value.
+
+    :constraint AASd-080:
+        In case Key/type == GlobalReference idType shall not be any
+        LocalKeyType (IdShort, FragmentId).
+
+    :constraint AASd-081:
+        In case Key/type==AssetAdministrationShell Key/idType shall
+        not be any LocalKeyType (IdShort, FragmentId).
+    """
+
+    def __init__(
+        self, type: "Key_elements", value: Non_empty_string, ID_type: "Key_type"
+    ) -> None:
+        self.type = type
+        self.value = value
+        self.ID_type = ID_type
+
+
+@reference_in_the_book(
+    section=(4, 7, 11),
+    index=4,
+    fragment="4.7.11 Referencing in Asset Administration Shells",
+)
+class Identifiable_elements(Enum):
+    """Enumeration of all identifiable elements within an asset administration shell."""
+
+    Asset = "Asset"
+    Asset_administration_shell = "AssetAdministrationShell"
+    Concept_description = "ConceptDescription"
+    Submodel = "Submodel"
+
+
+@reference_in_the_book(
+    section=(4, 7, 11),
+    index=3,
+    fragment="4.7.11 Referencing in Asset Administration Shells",
+)
+@is_superset_of(enums=[Identifiable_elements])
+class Referable_elements(Enum):
+    """Enumeration of all referable elements within an asset administration shell"""
+
+    Access_permission_rule = "AccessPermissionRule"
+    Annotated_relationship_element = "AnnotatedRelationshipElement"
+    Asset = "Asset"
+    Asset_administration_shell = "AssetAdministrationShell"
+    Basic_event = "BasicEvent"
+    Blob = "Blob"
+    Capability = "Capability"
+    Concept_description = "ConceptDescription"
+    Concept_dictionary = "ConceptDictionary"
+    Data_element = "DataElement"
+    """
+    Data element.
+
+    .. note::
+
+        Data Element is abstract, *i.e.* if a key uses :attr:`~Data_element`
+        the reference may be a Property, a File *etc.*
+    """
+
+    Entity = "Entity"
+    Event = "Event"
+    """
+    Event.
+
+    .. note::
+
+        Event is abstract.
+    """
+
+    File = "File"
+    Multi_language_property = "MultiLanguageProperty"
+    Operation = "Operation"
+    Property = "Property"
+    Range = "Range"
+    Reference_element = "ReferenceElement"
+    Relationship_element = "RelationshipElement"
+    Submodel = "Submodel"
+    Submodel_element = "SubmodelElement"
+    """
+    Submodel Element
+
+    .. note::
+
+        Submodel Element is abstract, *i.e.* if a key uses :attr:`~Submodel_element`
+        the reference may be a Property, a :class:`.Submodel_element_collection`,
+        an Operation *etc.*
+    """
+
+    Submodel_element_collection = "SubmodelElementCollection"
+    View = "View"
+
+
+@reference_in_the_book(
+    section=(4, 7, 11),
+    index=2,
+    fragment="4.7.11 Referencing in Asset Administration Shells",
+)
+@is_superset_of(enums=[Referable_elements])
+class Key_elements(Enum):
+    """Enumeration of different key value types within a key."""
+
+    Global_reference = "GlobalReference"
+    """reference to an element not belonging to an asset administration shell"""
+
+    Fragment_reference = "FragmentReference"
+    """
+    unique reference to an element within a file.
+
+    The file itself is assumed to be part of an asset administration shell.
+    """
+
+    Access_permission_rule = "AccessPermissionRule"
+    Annotated_relationship_element = "AnnotatedRelationshipElement"
+    Asset = "Asset"
+    Asset_administration_shell = "AssetAdministrationShell"
+    Basic_event = "BasicEvent"
+    Blob = "Blob"
+    Capability = "Capability"
+    Concept_description = "ConceptDescription"
+    Concept_dictionary = "ConceptDictionary"
+    Data_element = "DataElement"
+    """
+    Data element.
+
+    .. note::
+
+        Data Element is abstract, *i.e.* if a key uses :attr:`~Data_element`
+        the reference may be a Property, a File *etc.*
+    """
+
+    Entity = "Entity"
+    Event = "Event"
+    """
+    Event.
+
+    .. note::
+
+        Event is abstract.
+    """
+
+    File = "File"
+    Multi_language_property = "MultiLanguageProperty"
+    """Property with a value that can be provided in multiple languages"""
+
+    Operation = "Operation"
+    Property = "Property"
+    Range = "Range"
+    """Range with min and max"""
+
+    Reference_element = "ReferenceElement"
+    Relationship_element = "RelationshipElement"
+    Submodel = "Submodel"
+    Submodel_element = "SubmodelElement"
+    """
+    Submodel Element
+
+    .. note::
+
+        Submodel Element is abstract, *i.e.* if a key uses :attr:`~Submodel_element`
+        the reference may be a Property, a :class:`.Submodel_element_collection`,
+        an Operation *etc.*
+    """
+
+    Submodel_element_collection = "SubmodelElementCollection"
+    View = "View"
+
+
+@reference_in_the_book(
+    section=(4, 7, 11),
+    index=6,
+    fragment="4.7.11 Referencing in Asset Administration Shells",
+)
+class Local_key_type(Enum):
+    """Enumeration of different key value types within a key."""
+
+    ID_short = "IdShort"
+    """idShort of a referable element"""
+
+    Fragment_ID = "FragmentId"
+    """Identifier of a fragment within a file"""
+
+
+@reference_in_the_book(
+    section=(4, 7, 11),
+    index=5,
+    fragment="4.7.11 Referencing in Asset Administration Shells",
+)
+@is_superset_of(enums=[Local_key_type, Identifier_type])
+class Key_type(Enum):
+    """Enumeration of different key value types within a key."""
+
+    ID_short = "IdShort"
+    """idShort of a referable element"""
+
+    Fragment_ID = "FragmentId"
+    """Identifier of a fragment within a file"""
+
+    IRDI = "IRDI"
+    """
+    IRDI according to ISO29002-5 as an Identifier scheme for properties and
+    classifications.
+    """
+
+    IRI = "IRI"
+    """IRI according to Rfc 3987. Every URI is an IRI."""
+
+    Custom = "Custom"
+    """Custom identifiers like GUIDs (globally unique identifiers)"""
+
+
+@reference_in_the_book(section=(4, 7, 13, 2), fragment="4.7.13.2 Data Types")
+class Data_type_def(Enum):
+    Any_URI = "anyUri"
+    Base64_binary = "base64Binary"
+    Boolean = "boolean"
+    Date = "date"
+    Datetime = "dateTime"
+    Datetime_stamp = "dateTimeStamp"
+    Decimal = "decimal"
+    Integer = "integer"
+    Long = "long"
+    Int = "int"
+    Short = "short"
+    Byte = "byte"
+    Non_negative_integer = "nonNegativeInteger"
+    Positive_integer = "positiveInteger"
+    Unsigned_long = "unsignedLong"
+    Unsigned_int = "unsignedInt"
+    Unsigned_short = "unsignedShort"
+    Unsigned_byte = "unsignedByte"
+    Non_positive_integer = "nonPositiveInteger"
+    Negative_integer = "negativeInteger"
+    Double = "double"
+    Duration = "duration"
+    Day_time_duration = "dayTimeDuration"
+    Year_month_duration = "yearMonthDuration"
+    Float = "float"
+    G_day = "gDay"
+    G_month = "gMonth"
+    G_month_day = "gMonthDay"
+    G_year = "gYear"
+    G_year_month = "gYearMonth"
+    Hex_binary = "hexBinary"
+    Notation = "NOTATION"
+    Q_name = "QName"
+    String = "string"
+    Normalized_string = "normalizedString"
+    Token = "token"
+    Language = "language"
+    Name = "Name"
+    N_C_name = "NCName"
+    Entity = "ENTITY"
+    ID = "ID"
+    IDREF = "IDREF"
+    N_M_token = "NMTOKEN"
+    Time = "time"
+
+
+@implementation_specific
+@reference_in_the_book(section=(4, 7, 13, 2), index=2, fragment="4.7.13.2 Data Types")
+class Lang_string_set(DBC):
+    """
+    A set of strings, each annotated by the language of the string.
+
+    The meaning of the string in each language shall be the same.
+    """
+
+
+@abstract
+@reference_in_the_book(
+    section=(4, 8, 1),
+    fragment="4.8.1 Concept of Data Specification Templates",
+)
+class Data_specification_content(DBC):
+    # No table for class in the book
+    # to be implemented
+    pass
+
+
+@reference_in_the_book(
+    section=(4, 8, 2),
+    index=3,
+    fragment=("4.8.2 Predefined Templates for Property and Value Descriptions"),
+)
+class Data_type_IEC_61360(Enum):
+    Date = "DATE"
+    String = "STRING"
+    String_translatable = "STRING_TRANSLATABLE"
+    Integer_Measure = "INTEGER_MEASURE"
+    Integer_count = "INTEGER_COUNT"
+    Integer_currency = "INTEGER_CURRENCY"
+    Real_measure = "REAL_MEASURE"
+    Real_count = "REAL_COUNT"
+    Real_currency = "REAL_CURRENCY"
+    Boolean = "BOOLEAN"
+    URL = "URL"
+    Rational = "RATIONAL"
+    Rational_measure = "RATIONAL_MEASURE"
+    Time = "TIME"
+    Timestamp = "TIMESTAMP"
+
+
+@reference_in_the_book(
+    section=(4, 8, 2),
+    index=4,
+    fragment=("4.8.2 Predefined Templates for Property and Value Descriptions"),
+)
+class Level_type(Enum):
+    Min = "Min"
+    Max = "Max"
+    Nom = "Nom"
+    Typ = "Typ"
+
+
+@reference_in_the_book(
+    section=(4, 8, 2),
+    index=2,
+    fragment=("4.8.2 Predefined Templates for Property and Value Descriptions"),
+)
+class Value_reference_pair(DBC):
+    """
+    A value reference pair within a value list. Each value has a global unique id
+    defining its semantic.
+    """
+
+    value: str
+    """
+    The value of the referenced concept definition of the value in valueId.
+    """
+
+    value_ID: "Reference"
+    """
+    Global unique id of the value.
+    """
+
+    def __init__(self, value: str, value_ID: "Reference") -> None:
+        self.value = value
+        self.value_ID = value_ID
+
+
+@invariant(lambda self: len(self.value_reference_pair_types) >= 1)
+@reference_in_the_book(
+    section=(4, 8, 2),
+    index=1,
+    fragment=("4.8.2 Predefined Templates for Property and Value Descriptions"),
+)
+class Value_list(DBC):
+    """
+    A set of value reference pairs.
+    """
+
+    value_reference_pair_types: List["Value_reference_pair"]
+    """
+    A pair of a value together with its global unique id.
+    """
+
+    def __init__(
+        self, value_reference_pair_types: List["Value_reference_pair"]
+    ) -> None:
+        self.value_reference_pair_types = value_reference_pair_types
+
+
+@reference_in_the_book(
+    section=(4, 8, 2),
+    fragment=("4.8.2 Predefined Templates for Property and Value Descriptions"),
+)
+class Data_specification_IEC_61360(Data_specification_content):
+    """
+    Content of data specification template for concept descriptions conformant to
+    IEC 61360.
+    Although the IEC61360 attributes listed in this template are defined for properties
+    and values and value lists only it is also possible to use the template for other
+    definition This is shown in the tables Table 7, Table 8, Table 9 and Table 10.
+
+    :constraint AASd-075:
+        For all ConceptDescriptions using data specification template
+        IEC61360
+        (http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0)
+        values for the attributes not being marked as mandatory or optional in tables
+        Table 7, Table 8, Table 9 and Table 10.depending on its category are ignored and
+        handled as undefined.
+    """
+
+    preferred_name: "Lang_string_set"
+    """
+    Preferred name
+
+    :constraint AASd-076:
+        For all ConceptDescriptions using data specification template
+        IEC61360
+        (http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0)
+        at least a preferred name in English shall be defined.
+    """
+
+    short_name: Optional["Lang_string_set"]
+    """
+    Short name
+    """
+
+    unit: Optional[Non_empty_string]
+    """
+    Unit
+    """
+
+    unit_ID: Optional["Reference"]
+    """
+    Unique unit id
+    """
+
+    source_of_definition: Optional[Non_empty_string]
+    """
+    Source of definition
+    """
+
+    symbol: Optional[Non_empty_string]
+    """
+    Symbol
+    """
+
+    data_type: Optional["Data_type_IEC_61360"]
+    """
+    Data Type
+
+    :constraint AASd-070:
+        For a ConceptDescription with category PROPERTY or VALUE using
+        data specification template IEC61360
+        (http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0) -
+        DataSpecificationIEC61360/dataType is mandatory and shall be defined.
+
+    :constraint AASd-071:
+        For a ConceptDescription with category REFERENCE using data
+        specification template IEC61360
+        (http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0) -
+        DataSpecificationIEC61360/dataType is STRING by default.
+
+    :constraint AASd-072:
+        For a ConceptDescription with category DOCUMENT using data
+        specification template IEC61360
+        (http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0) -
+        DataSpecificationIEC61360/dataType shall be one of the following values:
+        STRING or URL.
+
+    :constraint AASd-073:
+        For a ConceptDescription with category QUALIFIER using data
+        specification template IEC61360
+        (http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0) -
+        DataSpecificationIEC61360/dataType is mandatory and shall be defined.
+    """
+
+    definition: Optional["Lang_string_set"]
+    """
+    Definition in different languages
+
+    :constraint AASd-074:
+        For all ConceptDescriptions except for ConceptDescriptions of
+        category VALUE using data specification template IEC61360
+        (http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0) -
+        DataSpecificationIEC61360/definition is mandatory and shall be defined at least
+        in English.
+    """
+
+    value_format: Optional[Non_empty_string]
+    """
+    Value Format
+    """
+
+    value_list: Optional["Value_list"]
+    """
+    List of allowed values
+    """
+
+    value: Optional[str]
+    """
+    Value
+    """
+
+    value_ID: Optional["Reference"]
+    """
+    Unique value id
+    """
+
+    level_type: Optional["Level_type"]
+    """
+    Set of levels.
+    """
+
+    def __init__(
+        self,
+        preferred_name: "Lang_string_set",
+        short_name: Optional["Lang_string_set"] = None,
+        unit: Optional[Non_empty_string] = None,
+        unit_ID: Optional["Reference"] = None,
+        source_of_definition: Optional[Non_empty_string] = None,
+        symbol: Optional[Non_empty_string] = None,
+        data_type: Optional["Data_type_IEC_61360"] = None,
+        definition: Optional["Lang_string_set"] = None,
+        value_format: Optional[Non_empty_string] = None,
+        value_list: Optional["Value_list"] = None,
+        value: Optional[str] = None,
+        value_ID: Optional["Reference"] = None,
+        level_type: Optional["Level_type"] = None,
+    ) -> None:
+        self.preferred_name = preferred_name
+        self.short_name = short_name
+        self.unit = unit
+        self.unit_ID = unit_ID
+        self.source_of_definition = source_of_definition
+        self.symbol = symbol
+        self.data_type = data_type
+        self.definition = definition
+        self.value_format = value_format
+        self.value_list = value_list
+        self.value = value
+        self.value_ID = value_ID
+        self.level_type = level_type
+
+
+@reference_in_the_book(
+    section=(4, 8, 3),
+    fragment="4.8.3 Predefined Templates for Unit Concept Descriptions",
+)
+class Data_specification_physical_unit(Data_specification_content):
+    # TODO (sadu, 2021-11-17): No table for class in the book
+
+    unit_name: Non_empty_string
+    """
+    TODO
+    """
+
+    unit_symbol: Non_empty_string
+    """
+    TODO
+    """
+
+    definition: "Lang_string_set"
+    """
+    TODO
+    """
+
+    SI_notation: Optional[Non_empty_string]
+    """
+    TODO
+    """
+
+    SI_name: Optional[Non_empty_string]
+    """
+    TODO
+    """
+
+    DIN_notation: Optional[Non_empty_string]
+    """
+    TODO
+    """
+
+    ECE_name: Optional[Non_empty_string]
+    """
+    TODO
+    """
+
+    ECE_code: Optional[Non_empty_string]
+    """
+    TODO
+    """
+
+    NIST_name: Optional[Non_empty_string]
+    """
+    TODO
+    """
+
+    source_of_definition: Optional[Non_empty_string]
+    """
+    TODO
+    """
+
+    conversion_factor: Optional[Non_empty_string]
+    """
+    TODO
+    """
+
+    registration_authority_ID: Optional[Non_empty_string]
+    """
+    TODO
+    """
+
+    supplier: Optional[Non_empty_string]
+    """
+    TODO
+    """
+
+    def __init__(
+        self,
+        unit_name: Non_empty_string,
+        unit_symbol: Non_empty_string,
+        definition: "Lang_string_set",
+        SI_notation: Optional[Non_empty_string] = None,
+        SI_name: Optional[Non_empty_string] = None,
+        DIN_notation: Optional[Non_empty_string] = None,
+        ECE_name: Optional[Non_empty_string] = None,
+        ECE_code: Optional[Non_empty_string] = None,
+        NIST_name: Optional[Non_empty_string] = None,
+        source_of_definition: Optional[Non_empty_string] = None,
+        conversion_factor: Optional[Non_empty_string] = None,
+        registration_authority_ID: Optional[Non_empty_string] = None,
+        supplier: Optional[Non_empty_string] = None,
+    ) -> None:
+        self.unit_name = unit_name
+        self.unit_symbol = unit_symbol
+        self.definition = definition
+        self.SI_notation = SI_notation
+        self.SI_name = SI_name
+        self.DIN_notation = DIN_notation
+        self.ECE_name = ECE_name
+        self.ECE_code = ECE_code
+        self.NIST_name = NIST_name
+        self.source_of_definition = source_of_definition
+        self.conversion_factor = conversion_factor
+        self.registration_authority_ID = registration_authority_ID
+        self.supplier = supplier
+
+
+# TODO (Nico & Marko, 2021-09-24):
+#  We need to list in a comment all the constraints which were not implemented.
+
+# TODO (mristin, 2021-10-27): re-order the entities so that they follow the structure
+#  in the book as much as possible, but be careful about the inheritance
+
+# TODO (mristin, 2021-10-27): write a code generator that outputs the JSON schema and
+#  then compare it against the
+#  https://github.com/admin-shell-io/aas-specs/blob/master/schemas/json/aas.json
+
+
+@abstract
+@serialization(with_model_type=True)
+@reference_in_the_book(section=(5, 3, 3))
+class Certificate(DBC):
+    """
+    Certificate
+    """
+
+    policy_administration_point: "Policy_administration_point"
+    """
+    The access control administration policy point of the AAS.
+    """
+
+    def __init__(
+        self, policy_administration_point: "Policy_administration_point"
+    ) -> None:
+        self.policy_administration_point = policy_administration_point
+
+
+@reference_in_the_book(section=(5, 3, 3), index=1)
+class Blob_certificate(Certificate):
+    """
+    Certificate provided as BLOB
+    """
+
+    blob_certificate: "Blob"
+    """
+    Certificate as BLOB.
+    """
+
+    last_certificate: bool
+    """
+    Denotes whether this certificate is the certificated that fast added last.
+    """
+
+    contained_extensions: Optional[List["Reference"]]
+    """
+    Extensions contained in the certificate.
+    """
+
+    def __init__(
+        self,
+        policy_administration_point: "Policy_administration_point",
+        blob_certificate: "Blob",
+        last_certificate: bool,
+        contained_extensions: Optional[List["Reference"]] = None,
+    ) -> None:
+        Certificate.__init__(
+            self, policy_administration_point=policy_administration_point
+        )
+
+        self.blob_certificate = blob_certificate
+        self.last_certificate = last_certificate
+        self.contained_extensions = contained_extensions
+
+
+@reference_in_the_book(section=(5, 3, 5), index=3)
+@invariant(lambda self: len(self.object_attributes) >= 1)
+class Object_attributes(DBC):
+    """
+    A set of data elements that describe object attributes. These attributes need to
+    refer to a data element within an existing submodel.
+    """
+
+    object_attributes: List[Reference]
+    """
+    Reference to a data element that further classifies an object.
+    """
+
+    def __init__(self, object_attributes: List[Reference]) -> None:
+        self.object_attributes = object_attributes
+
+
+@reference_in_the_book(section=(5, 3, 5), index=4)
+class Permission(DBC):
+    """
+    Description of a single permission.
+    """
+
+    permission: Reference
+    """
+    Reference to a property that defines the semantics of the permission.
+
+    Constraint AASs-010: The property referenced in Permission/permission shall have
+    the category “CONSTANT”.
+    Constraint AASs-011: The property referenced in Permission/permission shall be
+    part of the submodel that is referenced within the “selectablePermissions” attribute
+    of “AccessControl”."
+    """
+
+    kind_of_permission: "Permission_kind"
+    """
+    Description of the kind of permission. Possible kind of permission also include the
+    denial of the permission.
+
+    Values:
+    * Allow
+    * Deny
+    * NotApplicable
+    * Undefined"
+    """
+
+    def __init__(
+        self, permission: Reference, kind_of_permission: "Permission_kind"
+    ) -> None:
+        self.permission = permission
+        self.kind_of_permission = kind_of_permission
+
+
+@reference_in_the_book(section=(5, 3, 5), index=5)
+@invariant(lambda self: len(self.subject_attributes) >= 1)
+class Subject_attributes:
+    """
+    A set of data elements that further classifies a specific subject.
+    """
+
+    subject_attributes: List["Reference"]
+    """
+    A data element that further classifies a specific subject.
+
+    :constraint AASs-015:
+        The data element SubjectAttributes/subjectAttribute shall be
+        part of the submodel that is referenced within the “selectableSubjectAttributes”
+        attribute of “AccessControl”."
+    """
+
+    def __init__(self, subject_attributes: List["Reference"]) -> None:
+        self.subject_attributes = subject_attributes
+
+
+@reference_in_the_book(section=(5, 3, 5), index=2)
+class Permissions_per_object(DBC):
+    """
+    Table that defines access permissions for a specified object. The object is any
+    referable element in the AAS. Additionally, object attributes can be defined that
+    further specify the kind of object the permissions apply to.
+    """
+
+    object: Reference
+    """
+    Element to which permission shall be assigned.
+    """
+
+    target_object_attributes: Optional["Object_attributes"]
+    """
+    Target object attributes that need to be fulfilled so that the access permissions
+    apply to the accessing subject.
+    """
+
+    permissions: Optional[List["Permission"]]
+    """
+    Permissions assigned to the object.
+    The permissions hold for all subjects as specified in the access permission rule."
+    """
+
+    def __init__(
+        self,
+        object: Reference,
+        target_object_attributes: Optional["Object_attributes"] = None,
+        permissions: Optional[List["Permission"]] = None,
+    ) -> None:
+        self.object = object
+        self.target_object_attributes = target_object_attributes
+        self.permissions = permissions
+
+
+@reference_in_the_book(section=(5, 3, 5), index=1)
+class Access_permission_rule(Referable, Qualifiable):
+    """
+    Table that defines access permissions per authenticated subject for a set of objects
+    (referable elements).
+    """
+
+    target_subject_attributes: "Subject_attributes"
+    """
+    Target subject attributes that need to be fulfilled by accessing subject to get the
+    permissions defined by this rule.
+    """
+
+    permissions_per_object: Optional[List["Permissions_per_object"]]
+    """
+    Set of object-permission pairs that define the permissions per object within
+    the access permission rule.
+    """
+
+    def __init__(
+        self,
+        ID_short: Non_empty_string,
+        target_subject_attributes: "Subject_attributes",
+        extensions: Optional[List["Extension"]] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        qualifiers: Optional[List["Constraint"]] = None,
+        permissions_per_object: Optional[List["Permissions_per_object"]] = None,
+    ) -> None:
+        Referable.__init__(
+            self,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            extensions=extensions,
+        )
+
+        Qualifiable.__init__(self, qualifiers=qualifiers)
+
+        self.target_subject_attributes = target_subject_attributes
+        self.permissions_per_object = permissions_per_object
+
+
+@reference_in_the_book(section=(5, 3, 5))
+class Access_control(DBC):
+    """
+    Access Control defines the local access control policy administration point.
+    Access Control has the major task to define the access permission rules.
+    """
+
+    access_permission_rules: Optional[List["Access_permission_rule"]]
+    """
+    Access permission rules of the AAS describing the rights assigned to (already
+    authenticated) subjects to access elements of the AAS.
+    """
+
+    selectable_subject_attributes: Optional[Reference]
+    """
+    Reference to a submodel defining the authenticated subjects that are configured for
+    the AAS. They are selectable by the access permission rules to assign permissions
+    to the subjects.
+
+    Default: reference to the submodel referenced via defaultSubjectAttributes.
+    """
+
+    default_subject_attributes: Reference
+    """
+    Reference to a submodel defining the default subjects’ attributes for the AAS that
+    can be used to describe access permission rules.
+
+    The submodel is of kind=Template.
+    """
+
+    selectable_permissions: Optional[Reference]
+    """
+    Reference to a submodel defining which permissions can be assigned to the subjects.
+
+    Default: reference to the submodel referenced via defaultPermissions
+    """
+
+    default_permissions: Reference
+    """
+    Reference to a submodel defining the default permissions for the AAS.
+    """
+
+    selectable_environment_attributes: Optional[Reference]
+    """
+    Reference to a submodel defining which environment attributes can be accessed
+    *via* the permission rules defined for the AAS, i.e. attributes that are
+    not describing the asset itself.
+
+    Default: reference to the submodel referenced via defaultEnvironmentAttributes
+    """
+
+    default_environment_attributes: Optional[Reference]
+    """
+    Reference to a submodel defining default environment attributes, *i.e.* attributes
+    that are not describing the asset itself.
+
+    The submodel is of kind=Template.
+
+    At the same type the values of these environment attributes need to be accessible
+    when evaluating the access permission rules. This is realized as a policy
+    information point.
+    """
+
+    def __init__(
+        self,
+        default_subject_attributes: Reference,
+        default_permissions: Reference,
+        access_permission_rules: Optional[List["Access_permission_rule"]] = None,
+        selectable_subject_attributes: Optional[Reference] = None,
+        selectable_permissions: Optional[Reference] = None,
+        selectable_environment_attributes: Optional[Reference] = None,
+        default_environment_attributes: Optional[Reference] = None,
+    ) -> None:
+        self.default_subject_attributes = default_subject_attributes
+        self.selectable_permissions = selectable_permissions
+        self.default_permissions = default_permissions
+        self.access_permission_rules = access_permission_rules
+        self.selectable_subject_attributes = selectable_subject_attributes
+        self.selectable_environment_attributes = selectable_environment_attributes
+        self.default_environment_attributes = default_environment_attributes
+
+
+@reference_in_the_book(section=(5, 3, 4), index=1)
+class Policy_administration_point(DBC):
+    """
+    Definition of a security policy administration point (PAP).
+    """
+
+    external_access_control: bool
+    """
+    If :attr:`~external_access_control` True then an Endpoint to an external access
+    control defining a policy administration point to be used by the AAS needs
+    to be configured.
+    """
+
+    local_access_control: Optional["Access_control"]
+    """
+    The policy administration point of access control as realized by the AAS itself.
+
+    Constraint AASs-009: Either there is an external policy administration point
+    endpoint defined (PolicyAdministrationPoint/externalPolicyDecisionPoints=true) or
+    the AAS has its own access control.
+    """
+
+    def __init__(
+        self,
+        external_access_control: bool,
+        local_access_control: Optional["Access_control"] = None,
+    ) -> None:
+        self.external_access_control = external_access_control
+        self.local_access_control = local_access_control
+
+
+@reference_in_the_book(section=(5, 3, 4), index=2)
+class Policy_information_points(DBC):
+    """
+    Defines the security policy information points (PIP).
+    Serves as the retrieval source of attributes, or the data required for policy
+    evaluation to provide the information needed by the policy decision point to make
+    the decisions.
+    """
+
+    external_information_points: bool
+    """
+    If externalInformationPoints True then at least one Endpoint to external available
+    information needs to be configured for the AAS.
+    """
+
+    internal_information_points: Optional[List[Reference]]
+    """
+    Reference to a  Submodel defining information used by security access permission
+    rules.
+    """
+
+    def __init__(
+        self,
+        external_information_points: bool,
+        internal_information_points: Optional[List[Reference]] = None,
+    ) -> None:
+        self.external_information_points = external_information_points
+        self.internal_information_points = internal_information_points
+
+
+@reference_in_the_book(section=(5, 3, 4), index=3)
+class Policy_enforcement_points(DBC):
+    """
+    Defines the security policy enforcement points (PEP).
+    """
+
+    external_policy_enforcement_point: bool
+    """
+    If externalPolicyEnforcementPoint True then an Endpoint to external available
+    enforcement point taking needs to be configured for the AAS.
+    """
+
+    def __init__(self, external_policy_enforcement_point: bool) -> None:
+        self.external_policy_enforcement_point = external_policy_enforcement_point
+
+
+@reference_in_the_book(section=(5, 3, 4), index=4)
+class Policy_decision_point(DBC):
+    """
+    Defines the security policy decision points (PDP).
+    """
+
+    external_policy_decision_points: bool
+    """
+    If externalPolicyDecisionPoints True then Endpoints to external available decision
+    points taking into consideration for access control for the AAS need to be
+    configured.
+    """
+
+    def __init__(self, external_policy_decision_points: bool) -> None:
+        self.external_policy_decision_points = external_policy_decision_points
+
+
+@reference_in_the_book(section=(5, 3, 4))
+class Access_control_policy_points(DBC):
+    """
+    Container for access control policy points.
+    """
+
+    policy_administration_point: "Policy_administration_point"
+    """
+    The access control administration policy point of the AAS.
+    """
+
+    policy_decision_point: "Policy_decision_point"
+    """
+    The access control policy decision point of the AAS.
+    """
+
+    policy_enforcement_points: "Policy_enforcement_points"
+    """
+    The access control policy enforcement point of the AAS.
+    """
+
+    policy_information_points: Optional["Policy_information_points"]
+    """
+    The access control policy information points of the AAS.
+    """
+
+    def __init__(
+        self,
+        policy_administration_point: "Policy_administration_point",
+        policy_decision_point: "Policy_decision_point",
+        policy_enforcement_points: "Policy_enforcement_points",
+        policy_information_points: Optional["Policy_information_points"] = None,
+    ) -> None:
+        self.policy_administration_point = policy_administration_point
+        self.policy_decision_point = policy_decision_point
+        self.policy_enforcement_points = policy_enforcement_points
+        self.policy_information_points = policy_information_points
+
+
+@reference_in_the_book(section=(5, 3, 2))
+class Security(DBC):
+    """
+    Container for security relevant information of the AAS.
+    """
+
+    access_control_policy_points: "Access_control_policy_points"
+    """
+    Access control policy points of the AAS.
+    """
+
+    certificates: Optional[List["Certificate"]]
+    """
+    Authenticating Certificates of the AAS and its submodels etc.
+    """
+
+    required_certificate_extensions: Optional[List["Reference"]]
+    """
+    Certificate extensions as required by the AAS
+    """
+
+    def __init__(
+        self,
+        access_control_policy_points: "Access_control_policy_points",
+        certificates: Optional[List["Certificate"]] = None,
+        required_certificate_extensions: Optional[List["Reference"]] = None,
+    ) -> None:
+        self.access_control_policy_points = access_control_policy_points
+        self.certificates = certificates
+        self.required_certificate_extensions = required_certificate_extensions
+
+
+@reference_in_the_book(section=(5, 3, 5), index=6)
+class Permission_kind(Enum):
+    """
+    Enumeration of the kind of permissions that is given to the assignment of
+    a permission to a subject.
+    """
+
+    Allow = "Allow"
+    """
+    Allow the permission given to the subject.
+    """
+
+    Deny = "Deny"
+    """
+    Explicitly deny the permission given to the subject.
+    """
+
+    Not_applicable = "NotApplicable"
+    """
+    The permission is not applicable to the subject.
+    """
+
+    Undefined = "Undefined"
+    """
+    It is undefined whether the permission is allowed, not applicable or denied to
+    the subject.
+    """
+
+
+# TODO: make this environment implementation-specific in the final implementation.
+#  + Sketch what methods it should implement.
+#  + Sketch what invariants it should implement.
+class Asset_administration_shell_environment:
+    """Model the environment as the entry point for referencing and serialization."""
+
+    asset_administration_shells: Optional[List[Asset_administration_shell]]
+
+    assets: Optional[List[Asset]]
+
+    submodels: Optional[List[Submodel]]
+
+    concept_descriptions: Optional[List[Concept_description]]
+
+    def __init__(
+        self,
+        asset_administration_shells: Optional[List[Asset_administration_shell]] = None,
+        assets: Optional[List[Asset]] = None,
+        submodels: Optional[List[Submodel]] = None,
+        concept_descriptions: Optional[List[Concept_description]] = None,
+    ) -> None:
+        self.asset_administration_shells = asset_administration_shells
+        self.assets = assets
+        self.submodels = submodels
+        self.concept_descriptions = concept_descriptions

--- a/test_data/smoke/test_main/expected/v3rc2.py
+++ b/test_data/smoke/test_main/expected/v3rc2.py
@@ -1,0 +1,3318 @@
+"""Provide the meta model for Asset Administration Shell V3.0 Release Candidate 2."""
+from enum import Enum
+from re import match
+from typing import List, Optional
+
+from icontract import invariant, DBC
+
+from aas_core_meta.marker import (
+    abstract,
+    serialization,
+    implementation_specific,
+    reference_in_the_book,
+    is_superset_of,
+    verification,
+)
+
+# TODO (sadu, 2021-11-17): book URL should be updated when published
+__book_url__ = "TBA"
+__book_version__ = "V3.0RC02"
+
+
+# region Verification
+
+# noinspection SpellCheckingInspection
+@verification
+def is_MIME_type(text: str) -> bool:
+    """
+    Check that :paramref:`text` conforms to the pattern of MIME type.
+
+    :param text: Text to be checked
+    :returns: True if the :paramref:`text` conforms to the pattern
+    """
+    tchar = "[!#$%&'*+\\-.^_`|~0-9a-zA-Z]"
+    token = f"({tchar})+"
+    type = f"{token}"
+    subtype = f"{token}"
+    ows = "[ \t]*"
+    obs_text = "[\\x80-\\xff]"
+    qd_text = f"([\t !#-\\[\\]-~]|{obs_text})"
+    quoted_pair = f"\\\\([\t !-~]|{obs_text})"
+    quoted_string = f'"({qd_text}|{quoted_pair})*"'
+    parameter = f"{token}=({token}|{quoted_string})"
+    media_type = f"{type}/{subtype}({ows};{ows}{parameter})*"
+
+    return match(media_type, text) is not None
+
+
+@verification
+@implementation_specific
+def is_model_reference_to(
+    reference: "Model_reference", expected_type: "Key_elements"
+) -> bool:
+    """Check that the target of the model reference matches the expected ``target``."""
+    # This implementation is only for reference. It needs to be adapted for each
+    # implementation separately.
+    return len(reference.keys) == 0 or reference.keys[-1].type == expected_type
+
+
+# endregion
+
+# region Constrained primitive types
+
+
+class Resource(DBC):
+    """
+    Resource represents an address to a file (a locator). The value is an URI that
+    can represent an absolute or relative path
+    """
+
+    path: "Asset_kind"
+    """
+    Path and name of the resource (with file extension).
+    The path can be absolute or relative.
+
+    """
+    content_type: Optional["Content_type"]
+    """
+    Content type of the content of the file.
+    The content type states which file extensions the file can have.
+
+    """
+
+    def __init__(
+        self,
+        path: "Asset_kind",
+        content_type: Optional["Content_type"] = None,
+    ) -> None:
+        self.path = path
+        self.content_type = content_type
+
+
+class Date_time(str, DBC):
+    pass
+
+
+class Date_time_stamp(str, DBC):
+    pass
+
+
+@invariant(lambda self: len(self) >= 1)
+class Non_empty_string(str, DBC):
+    """Represent a string with at least one character."""
+
+    pass
+
+
+@reference_in_the_book(section=(5, 7, 11, 2))
+class Blob_type(bytearray, DBC):
+    """
+    Group of bytes to represent file content (binaries and non-binaries)
+
+    """
+
+    pass
+
+
+@reference_in_the_book(section=(5, 7, 12, 3), index=4)
+class Data_type_def_RDF(Enum):
+    """
+    Enumeration listing all RDF types
+    """
+
+    Lang_string = "rdf:langString"
+    """
+    String with a language tag
+
+    .. note::
+
+        RDF requires IETF BCP 47  language tags, i.e. simple two-letter language tags
+        for Locales like “de” conformant to ISO 639-1 are allowed as well as language
+        tags plus extension like “de-DE” for country code, dialect etc. like in “en-US”
+        or “en-GB” for English (United Kingdom) and English (United States).
+        IETF language tags are referencing ISO 639, ISO 3166 and ISO 15924.
+
+    """
+
+
+@reference_in_the_book(section=(7, 7, 11, 3), index=1)
+class Decimal_build_in_types(Enum):
+    Integer = "xs:integer"
+    Long = "xs:long"
+    Int = "xs:int"
+    Short = "xs:short"
+    Byte = "xs:byte"
+    Non_negative_integer = "xs:NonNegativeInteger"
+    Positive_integer = "xs:positiveInteger"
+    Unsigned_long = "xs:unsignedLong"
+    Unsigned_int = "xs:unsignedInt"
+    Unsigned_short = "xs:unsignedShort"
+    Unsigned_byte = "xs:unsignedByte"
+    Non_positive_integer = "xs:nonPositiveInteger"
+    Negative_integer = "xs:negativeInteger"
+
+
+@reference_in_the_book(section=(5, 7, 11, 3), index=2)
+class Duration_build_in_types(Enum):
+    Day_time_duration = "xs:dayTimeDuration"
+    Year_month_duration = "xs:yearMonthDuration"
+
+
+@reference_in_the_book(section=(5, 7, 11, 3), index=3)
+class Primitive_types(Enum):
+    Any_URI = "xs:anyURI"
+    Base_64_binary = "xs:base64Binary"
+    Boolean = "xs:boolean"
+    Date = "xs:date"
+    Date_time = "xs:dateTime"
+    Date_time_stamp = "xs:dateTimeStamp"
+    Decimal = "xs:decimal"
+    Double = "xs:double"
+    Duration = "xs:duration"
+    Float = "xs:float"
+    G_day = "xs:gDay"
+    G_month = "xs:gMonth"
+    G_month_day = "xs:gMonthDay"
+    G_year = "xs:gYear"
+    G_year_month = "xs:gYearMonth"
+    Hex_binary = "xs:hexBinary"
+    String = "xs:string"
+    Time = "xs:time"
+
+
+@reference_in_the_book(section=(5, 7, 11, 3))
+@is_superset_of(
+    enums=[
+        Decimal_build_in_types,
+        Duration_build_in_types,
+        Primitive_types,
+    ]
+)
+class Data_type_def_XSD(Enum):
+    """
+    Enumeration listing all xsd anySimpleTypes
+    """
+
+    Any_URI = "xs:anyURI"
+    Base_64_binary = "xs:base64Binary"
+    Boolean = "xs:boolean"
+    Date = "xs:date"
+    Date_time = "xs:dateTime"
+    Date_time_stamp = "xs:dateTimeStamp"
+    Decimal = "xs:decimal"
+    Double = "xs:double"
+    Duration = "xs:duration"
+    Float = "xs:float"
+    G_day = "xs:gDay"
+    G_month = "xs:gMonth"
+    G_month_day = "xs:gMonthDay"
+    G_year = "xs:gYear"
+    G_year_month = "xs:gYearMonth"
+    Hex_binary = "xs:hexBinary"
+    String = "xs:string"
+    Time = "xs:time"
+    Day_time_duration = "xs:dayTimeDuration"
+    Year_month_duration = "xs:yearMonthDuration"
+    Integer = "xs:integer"
+    Long = "xs:long"
+    Int = "xs:int"
+    Short = "xs:short"
+    Byte = "xs:byte"
+    Non_negative_integer = "xs:NonNegativeInteger"
+    Positive_integer = "xs:positiveInteger"
+    Unsigned_long = "xs:unsignedLong"
+    Unsigned_int = "xs:unsignedInt"
+    Unsigned_short = "xs:unsignedShort"
+    Unsigned_byte = "xs:unsignedByte"
+    Non_positive_integer = "xs:nonPositiveInteger"
+    Negative_integer = "xs:negativeInteger"
+
+
+@is_superset_of(enums=[Data_type_def_XSD, Data_type_def_RDF])
+class Data_type_def(Enum):
+    """
+    string with values of enumerations DataTypeDefXsd, Data_type_def_Rdf
+    """
+
+    Any_URI = "xs:anyURI"
+    Base_64_binary = "xs:base64Binary"
+    Boolean = "xs:boolean"
+    Date = "xs:date"
+    Date_time = "xs:dateTime"
+    Date_time_stamp = "xs:dateTimeStamp"
+    Decimal = "xs:decimal"
+    Double = "xs:double"
+    Duration = "xs:duration"
+    Float = "xs:float"
+    G_day = "xs:gDay"
+    G_month = "xs:gMonth"
+    G_month_day = "xs:gMonthDay"
+    G_year = "xs:gYear"
+    G_year_month = "xs:gYearMonth"
+    Hex_binary = "xs:hexBinary"
+    String = "xs:string"
+    Time = "xs:time"
+    Day_time_duration = "xs:dayTimeDuration"
+    Year_month_duration = "xs:yearMonthDuration"
+    Integer = "xs:integer"
+    Long = "xs:long"
+    Int = "xs:int"
+    Short = "xs:short"
+    Byte = "xs:byte"
+    Non_negative_integer = "xs:NonNegativeInteger"
+    Positive_integer = "xs:positiveInteger"
+    Unsigned_long = "xs:unsignedLong"
+    Unsigned_int = "xs:unsignedInt"
+    Unsigned_short = "xs:unsignedShort"
+    Unsigned_byte = "xs:unsignedByte"
+    Non_positive_integer = "xs:nonPositiveInteger"
+    Negative_integer = "xs:negativeInteger"
+    Lang_string = "rdf:langString"
+
+
+class Identifier(Non_empty_string, DBC):
+    """
+    string
+    """
+
+    pass
+
+
+class Lang_string_set(Non_empty_string, DBC):
+    """
+    Array of elements of type langString
+
+    .. note::
+        langString is a RDF data type.
+
+    A langString is a string value tagged with a language code.
+    It depends on the serialization rules for a technology how
+    this is realized.
+    """
+
+    pass
+
+
+@invariant(lambda self: is_MIME_type(self))
+class Content_type(Non_empty_string, DBC):
+    """
+    string
+
+    .. note::
+        Any content type as in RFC2046.
+
+    A media type (also MIME type and content type) […] is a two-part
+    identifier for file formats and format contents transmitted on
+    the Internet. The Internet Assigned Numbers Authority (IANA) is
+    the official authority for the standardization and publication of
+    these classifications. Media types were originally defined in
+    Request for Comments 2045 in November 1996 as a part of MIME
+    (Multipurpose Internet Mail Extensions) specification, for denoting
+    type of email message content and attachments.
+    """
+
+    pass
+
+
+class Path_type(Non_empty_string, DBC):
+    """
+    string
+
+    .. note::
+
+        Any string conformant to RFC8089 , the “file” URI scheme (for
+        relative and absolute file paths)
+    """
+
+    pass
+
+
+class Qualifier_type(Non_empty_string, DBC):
+    """
+    string
+    """
+
+    pass
+
+
+@is_superset_of(enums=[Data_type_def_XSD])
+class Value_data_type(Enum):
+    """
+    any xsd atomic type as specified via DataTypeDefXsd
+    """
+
+    Any_URI = "xs:anyURI"
+    Base_64_binary = "xs:base64Binary"
+    Boolean = "xs:boolean"
+    Date = "xs:date"
+    Date_time = "xs:dateTime"
+    Date_time_stamp = "xs:dateTimeStamp"
+    Decimal = "xs:decimal"
+    Double = "xs:double"
+    Duration = "xs:duration"
+    Float = "xs:float"
+    G_day = "xs:gDay"
+    G_month = "xs:gMonth"
+    G_month_day = "xs:gMonthDay"
+    G_year = "xs:gYear"
+    G_year_month = "xs:gYearMonth"
+    Hex_binary = "xs:hexBinary"
+    String = "xs:string"
+    Time = "xs:time"
+    Day_time_duration = "xs:dayTimeDuration"
+    Year_month_duration = "xs:yearMonthDuration"
+    Integer = "xs:integer"
+    Long = "xs:long"
+    Int = "xs:int"
+    Short = "xs:short"
+    Byte = "xs:byte"
+    Non_negative_integer = "xs:NonNegativeInteger"
+    Positive_integer = "xs:positiveInteger"
+    Unsigned_long = "xs:unsignedLong"
+    Unsigned_int = "xs:unsignedInt"
+    Unsigned_short = "xs:unsignedShort"
+    Unsigned_byte = "xs:unsignedByte"
+    Non_positive_integer = "xs:nonPositiveInteger"
+    Negative_integer = "xs:negativeInteger"
+
+
+@invariant(lambda self: is_MIME_type(self))
+class MIME_typed(Non_empty_string, DBC):
+    """Represent a string that follows the pattern of a MIME type."""
+
+
+# endregion
+
+
+@abstract
+@reference_in_the_book(section=(5, 7, 10, 4))
+@serialization(with_model_type=True)
+class Reference(DBC):
+    """
+    Reference to either a model element of the same or another AAs or to an external
+    entity.
+    """
+
+
+@abstract
+@reference_in_the_book(section=(5, 7, 2, 1))
+class Has_extensions(DBC):
+    """
+    Element that can be extended by proprietary extensions.
+
+    Note: Extensions are proprietary, i.e. they do not support global interoperability.
+    """
+
+    extensions: List["Extension"]
+    """
+    An extension of the element.
+    """
+
+    def __init__(self, extensions: Optional[List["Extension"]] = None) -> None:
+        self.extensions = extensions if extensions is not None else []
+
+
+@abstract
+@reference_in_the_book(section=(5, 7, 2, 2))
+@serialization(with_model_type=True)
+class Referable(Has_extensions):
+    """
+    An element that is referable by its :attr:`~ID_short`.
+
+    This identifier is not globally unique.
+    This identifier is unique within the name space of the element.
+    """
+
+    ID_short: Optional[Non_empty_string]
+    """
+    In case of identifiables this attribute is a short name of the element.
+    In case of referable this ID is an identifying string of
+    the element within its name space.
+
+    .. note::
+
+        In case the element is a property and the property has a semantic definition
+        (:class:`.Has_semantics`) conformant to IEC61360 the idShort is typically
+        identical to the short name in English.
+
+    :constraint AASd-027:
+        idShort of Referables shall have a maximum length of 128
+        characters.
+    """
+
+    display_name: Optional["Lang_string_set"]
+    """
+    Display name. Can be provided in several languages.
+
+    If no display name is defined in the language requested by the application,
+    then the display name is selected in the following order if available:
+
+    * the preferred name in the requested language of the concept description defining
+      the semantics of the element
+    * If there is a default language list defined in the application,
+      then the corresponding preferred name in the language is chosen
+      according to this order.
+    * the English preferred name of the concept description defining
+      the semantics of the element
+    * the short name of the concept description
+    * the idShort of the element
+    """
+
+    category: Optional[Non_empty_string]
+    """
+    The category is a value that gives further meta information
+    w.r.t. to the class of the element.
+    It affects the expected existence of attributes and the applicability of
+    constraints.
+
+    .. note::
+
+        The category is not identical to the semantic definition
+        (:class:`.Has_semantics`) of an element. The category
+        *e.g.* could denote that the element is a measurement value whereas the
+        semantic definition of the element would
+        denote that it is the measured temperature.
+    """
+
+    description: Optional["Lang_string_set"]
+    """
+    Description or comments on the element.
+
+    The description can be provided in several languages.
+
+    If no description is defined, then the definition of the concept
+    description that defines the semantics of the element is used.
+
+    Additional information can be provided, *e.g.*, if the element is
+    qualified and which qualifier types can be expected in which
+    context or which additional data specification templates are
+    provided.
+    """
+
+    checksum: Optional["Non_empty_string"]
+    """
+    Checksum to be used to determine if an Referable (including its
+    aggregated hild elements) has changed.
+
+    The checksum is calculated by the user's tool environment.
+    The checksum has no semantic meaning for an asset administration
+    shell model and there is no requirement for asset administration
+    shell tools to manage the checksum
+
+    """
+
+    def __init__(
+        self,
+        extensions: Optional[List["Extension"]] = None,
+        ID_short: Optional[Non_empty_string] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        checksum: Optional["Non_empty_string"] = None,
+    ) -> None:
+        Has_extensions.__init__(self, extensions=extensions)
+
+        self.ID_short = ID_short
+        self.display_name = display_name
+        self.category = category
+        self.description = description
+        self.checksum = checksum
+
+
+@abstract
+@reference_in_the_book(section=(5, 7, 2, 4))
+class Has_kind(DBC):
+    """
+    An element with a kind is an element that can either represent a template or an
+    instance.
+
+    Default for an element is that it is representing an instance.
+    """
+
+    kind: Optional["Modeling_kind"]
+    """
+    Kind of the element: either type or instance.
+
+    Default Value = Instance
+    """
+
+    # TODO (all, 2021-05-28): how can ``kind`` be optional
+    #  and have a default value?
+    #  (See page 52 in the book V3.0RC02, kind has the cardinality ``0..1``.)
+    def __init__(self, kind: Optional["Modeling_kind"] = None) -> None:
+        self.kind = kind if kind is not None else Modeling_kind.Instance
+
+
+@abstract
+@reference_in_the_book(section=(5, 7, 2, 6))
+class Has_semantics(DBC):
+    """
+    Element that can have a semantic definition.
+    """
+
+    semantic_ID: Optional["Global_reference"]
+    """
+    Identifier of the semantic definition of the element. It is called semantic ID
+    of the element.
+    """
+
+    def __init__(self, semantic_ID: Optional["Global_reference"] = None) -> None:
+        self.semantic_ID = semantic_ID
+
+
+@abstract
+@reference_in_the_book(section=(5, 7, 2, 7))
+@serialization(with_model_type=True)
+# fmt: on
+class Qualifiable(DBC):
+    """
+    The value of a qualifiable element may be further qualified by one or more
+    qualifiers or complex formulas.
+    """
+
+    qualifiers: List["Qualifier"]
+    """
+    Additional qualification of a qualifiable element.
+
+    :constraint AASd-021:
+        Every qualifiable can only have one qualifier with the same Qualifier/type.
+    """
+
+    def __init__(self, qualifiers: Optional[List["Qualifier"]] = None) -> None:
+        self.qualifiers = qualifiers if qualifiers is not None else []
+
+
+@abstract
+@reference_in_the_book(section=(5, 7, 2, 9))
+class Has_data_specification(DBC):
+    """
+    Element that can be extended by using data specification templates.
+
+    A data specification template defines a named set of additional attributes an
+    element may or shall have. The data specifications used are explicitly specified
+    with their global ID.
+    """
+
+    data_specifications: Optional[List["Global_reference"]]
+    """
+    Global reference to the data specification template used by the element.
+    """
+
+    def __init__(
+        self, data_specifications: Optional[List["Global_reference"]] = None
+    ) -> None:
+        self.data_specifications = (
+            data_specifications if data_specifications is not None else []
+        )
+
+
+@abstract
+@reference_in_the_book(section=(5, 7, 6))
+class Submodel_element(
+    Referable, Has_kind, Has_semantics, Qualifiable, Has_data_specification
+):
+    """
+    A submodel element is an element suitable for the description and differentiation of
+    assets.
+
+    It is recommended to add a semantic ID to a submodel element.
+    """
+
+    def __init__(
+        self,
+        extensions: Optional[List["Extension"]] = None,
+        ID_short: Optional[Non_empty_string] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        checksum: Optional["Non_empty_string"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Global_reference"] = None,
+        qualifiers: Optional[List["Qualifier"]] = None,
+        data_specifications: Optional[List["Global_reference"]] = None,
+    ) -> None:
+        Referable.__init__(
+            self,
+            extensions=extensions,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            checksum=checksum,
+        )
+
+        Has_kind.__init__(self, kind=kind)
+
+        Has_semantics.__init__(self, semantic_ID=semantic_ID)
+
+        Qualifiable.__init__(self, qualifiers=qualifiers)
+
+        Has_data_specification.__init__(self, data_specifications=data_specifications)
+
+
+# fmt: off
+# TODO (mristin, 2021-11-17): rewrite using XSD constraints on strings
+# @invariant(
+#     lambda self:
+#     not (self.value is not None) or is_of_type(self.value, self.value_type),
+#     "Constraint AASd-020"
+# )
+@reference_in_the_book(section=(5, 7, 2, 8))
+@serialization(with_model_type=True)
+# fmt: on
+class Qualifier(Has_semantics):
+    """
+    A qualifier is a type-value-pair that makes additional statements w.r.t.  the value
+    of the element.
+
+    :constraint AASd-006:
+        If both, the value and the valueId of a Qualifier are present then the value
+        needs to be identical to the value of the referenced coded value in
+        Qualifier/valueId.
+
+    :constraint AASd-020:
+        The value of Qualifier/value shall be consistent to the data type as defined in
+        Qualifier/valueType
+    """
+
+    type: "Qualifier_type"
+    """
+    The qualifier type describes the type of the qualifier that is applied to
+    the element.
+    """
+
+    value_type: "Data_type_def_XSD"
+    """
+    Data type of the qualifier value.
+    """
+
+    value: Optional["Value_data_type"]
+    """
+    The qualifier value is the value of the qualifier.
+    """
+
+    value_ID: Optional["Global_reference"]
+    """
+    Reference to the global unique ID of a coded value.
+    """
+
+    def __init__(
+        self,
+        type: "Qualifier_type",
+        value_type: "Data_type_def_XSD",
+        semantic_ID: Optional["Global_reference"] = None,
+        value: Optional["Value_data_type"] = None,
+        value_ID: Optional["Global_reference"] = None,
+    ) -> None:
+        Has_semantics.__init__(self, semantic_ID=semantic_ID)
+
+        self.type = type
+        self.value_type = value_type
+        self.value = value
+        self.value_ID = value_ID
+
+
+@abstract
+@reference_in_the_book(section=(5, 7, 7, 5))
+class Data_element(Submodel_element):
+    """
+    A data element is a submodel element that is not further composed out of
+    other submodel elements.
+
+    A data element is a submodel element that has a value. The type of value differs
+    for different subtypes of data elements.
+
+    A controlled value is a value whose meaning is given in an external source
+    (see “ISO/TS 29002-10:2009(E)”).
+
+    :constraint AASd-090:
+        For data elements DataElement/category shall be one of the following values:
+        CONSTANT, PARAMETER or VARIABLE.
+    """
+
+    def __init__(
+        self,
+        extensions: Optional[List["Extension"]] = None,
+        ID_short: Optional[Non_empty_string] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        checksum: Optional["Non_empty_string"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Global_reference"] = None,
+        qualifiers: Optional[List[Qualifier]] = None,
+        data_specifications: Optional[List["Global_reference"]] = None,
+    ) -> None:
+        Submodel_element.__init__(
+            self,
+            extensions=extensions,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            checksum=checksum,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+
+@reference_in_the_book(section=(5, 7, 7, 15))
+class Reference_element(Data_element):
+    """
+    A reference element is a data element that defines a logical reference to another
+    element within the same or another AAS or a reference to an external object or
+    entity.
+
+    """
+
+    value: Optional["Reference"]
+    """
+    Global reference to an external object or entity or a logical reference to
+    another element within the same or another AAS (i.e. a model reference to
+    a Referable).
+    """
+
+    def __init__(
+        self,
+        extensions: Optional[List["Extension"]] = None,
+        ID_short: Optional[Non_empty_string] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        checksum: Optional["Non_empty_string"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Global_reference"] = None,
+        qualifiers: Optional[List[Qualifier]] = None,
+        data_specifications: Optional[List["Global_reference"]] = None,
+        value: Optional["Reference"] = None,
+    ) -> None:
+        Data_element.__init__(
+            self,
+            extensions=extensions,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            checksum=checksum,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+        self.value = value
+
+
+# TODO (mristin, 2022-03-26):
+#  Uncomment once the discussion regarding the covariant return types has been resolved.
+# @reference_in_the_book(section=(5, 7, 7, 9))
+# class Global_reference_element(Reference_element):
+#     """
+#     A global reference element is a data element that references an external object or entity.
+#     """
+#
+#     value: Optional["Global_reference"]
+#     """
+#     Global reference to an external object or entity.
+#     """
+#
+#     def __init__(
+#         self,
+#         ID_short: Non_empty_string,
+#         extensions: Optional[List["Extension"]] = None,
+#         display_name: Optional["Lang_string_set"] = None,
+#         category: Optional[Non_empty_string] = None,
+#         description: Optional["Lang_string_set"] = None,
+#         kind: Optional["Modeling_kind"] = None,
+#         semantic_ID: Optional["Global_reference"] = None,
+#         qualifiers: Optional[List[Qualifier]] = None,
+#         data_specifications: Optional[List["Global_reference"]] = None,
+#         value: Optional["Global_reference"] = None,
+#     ) -> None:
+#         Reference_element.__init__(
+#             self,
+#             extensions=extensions,
+#             ID_short=ID_short,
+#             display_name=display_name,
+#             category=category,
+#             description=description,
+#             kind=kind,
+#             semantic_ID=semantic_ID,
+#             qualifiers=qualifiers,
+#             data_specifications=data_specifications,
+#         )
+#         self.value = value
+#
+#
+# @reference_in_the_book(section=(5, 7, 7, 10))
+# class Model_reference_element(Reference_element):
+#     """
+#     A model reference element is a data element that defines
+#     a logical reference to another element within the same or another AAS
+#     """
+#
+#     value: Optional["Model_reference"]
+#     """
+#     A logical reference to another element within the same or another AAS
+#     """
+#
+#     def __init__(
+#         self,
+#         ID_short: Non_empty_string,
+#         extensions: Optional[List["Extension"]] = None,
+#         display_name: Optional["Lang_string_set"] = None,
+#         category: Optional[Non_empty_string] = None,
+#         description: Optional["Lang_string_set"] = None,
+#         kind: Optional["Modeling_kind"] = None,
+#         semantic_ID: Optional["Global_reference"] = None,
+#         qualifiers: Optional[List[Qualifier]] = None,
+#         data_specifications: Optional[List["Global_reference"]] = None,
+#         value: Optional["Model_reference"] = None,
+#     ) -> None:
+#         Reference_element.__init__(
+#             self,
+#             extensions=extensions,
+#             ID_short=ID_short,
+#             display_name=display_name,
+#             category=category,
+#             description=description,
+#             kind=kind,
+#             semantic_ID=semantic_ID,
+#             qualifiers=qualifiers,
+#             data_specifications=data_specifications,
+#         )
+#         self.value = value
+
+
+@reference_in_the_book(section=(5, 7, 10, 2))
+@serialization(with_model_type=True)
+class Global_reference(Reference):
+    """
+    Reference to an external entity.
+    """
+
+    value: "Identifier"
+    """
+    Unique identifier
+
+    The identifier can be a concatenation of different identifiers, for example
+    representing an IRDI path etc.
+    """
+
+    def __init__(self, value: "Identifier") -> None:
+        self.value = value
+
+
+@invariant(lambda self: len(self.keys) >= 1)
+@reference_in_the_book(section=(5, 7, 10, 3))
+@serialization(with_model_type=True)
+class Model_reference(Reference):
+    """
+    Reference to a model element of the same or another AAS.
+    A model reference is an ordered list of keys, each key referencing an element.
+    The complete list of keys may for example be concatenated to a path that then gives
+    unique access to an element.
+    """
+
+    keys: List["Key"]
+    """
+    Unique references in their name space.
+    """
+
+    referred_semantic_ID: Optional["Global_reference"]
+    """
+    SemanticId of the referenced model element.
+    """
+
+    def __init__(
+        self,
+        keys: List["Key"],
+        referred_semantic_ID: Optional["Global_reference"] = None,
+    ) -> None:
+        self.keys = keys
+        self.referred_semantic_ID = referred_semantic_ID
+
+
+@reference_in_the_book(section=(5, 7, 10, 3), index=1)
+class Key(DBC):
+    """A key is a reference to an element by its ID."""
+
+    type: "Key_elements"
+    # TODO (g1zzm0, 2021-12-13):
+    #  We had to introduce ``Key_elements.Global_reference`` as it was missing in
+    #  the meta-model, but was referenced here in the book.
+    #  Analogously for ``Key_elements.Fragment_reference``. It was written here as
+    #  ``Fragment_ID``. This description needs to be revised either here or in the book.
+    """
+    Denote which kind of entity is referenced.
+
+    In case type = :attr:`~Key_elements.Global_reference` then the key represents
+    a global unique id.
+
+    In case type = :attr:`~Key_elements.Fragment_reference` the key represents
+    a bookmark or a similar local identifier within its parent element as specified by
+    the key that precedes this key.
+
+    In all other cases the key references a model element of the same or of another AAS.
+    The name of the model element is explicitly listed.
+    """
+
+    value: Non_empty_string
+
+    # TODO (g1zzm0, 2021-12-13):
+    #  The docstring references a non-existing attribute ``ID_type`` which has been
+    #  removed in this version, but existed in V3RC01. The description needs to be
+    #  revised in the book.
+    # """The key value, for example an IRDI if the :attr:`~ID_type` is IRDI."""
+
+    def __init__(self, type: "Key_elements", value: Non_empty_string) -> None:
+        self.type = type
+        self.value = value
+
+
+@reference_in_the_book(section=(5, 7, 2, 1), index=1)
+class Extension(Has_semantics):
+    """
+    Single extension of an element.
+    """
+
+    name: Non_empty_string
+    """
+    Name of the extension.
+
+    :constraint AASd-077:
+        The name of an extension within HasExtensions needs to be unique.
+    """
+
+    value_type: Optional["Data_type_def_XSD"]
+    """
+    Type of the value of the extension.
+
+    Default: xsd:string
+    """
+
+    value: Optional["Value_data_type"]
+    """
+    Value of the extension
+    """
+
+    refers_to: Optional["Model_reference"]
+    """
+    Reference to an element the extension refers to.
+    """
+
+    def __init__(
+        self,
+        name: Non_empty_string,
+        semantic_ID: Optional["Global_reference"] = None,
+        value_type: Optional["Data_type_def_XSD"] = None,
+        value: Optional["Value_data_type"] = None,
+        # ToDo: Make refs_to -> ModelReference<Referable>
+        refers_to: Optional["Model_reference"] = None,
+    ) -> None:
+        Has_semantics.__init__(self, semantic_ID=semantic_ID)
+
+        self.name = name
+        self.value_type = value_type
+        self.value = value
+        self.refers_to = refers_to
+
+
+@abstract
+@reference_in_the_book(section=(5, 7, 2, 3))
+class Identifiable(Referable):
+    """An element that has a globally unique identifier."""
+
+    ID: "Identifier"
+    """The globally unique identification of the element."""
+
+    administration: Optional["Administrative_information"]
+    """
+    Administrative information of an identifiable element.
+
+    .. note::
+
+        Some of the administrative information like the version number might need to
+        be part of the identification.
+    """
+
+    def __init__(
+        self,
+        ID: "Identifier",
+        extensions: Optional[List["Extension"]] = None,
+        ID_short: Optional[Non_empty_string] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        checksum: Optional["Non_empty_string"] = None,
+        administration: Optional["Administrative_information"] = None,
+    ) -> None:
+        Referable.__init__(
+            self,
+            extensions=extensions,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            checksum=checksum,
+        )
+
+        self.ID = ID
+        self.administration = administration
+
+
+@reference_in_the_book(section=(5, 7, 2, 4), index=1)
+class Modeling_kind(Enum):
+    """Enumeration for denoting whether an element is a template or an instance."""
+
+    Template = "TEMPLATE"
+    """
+    Software element which specifies the common attributes shared by all instances of
+    the template.
+
+    [SOURCE: IEC TR 62390:2005-01, 3.1.25] modified
+    """
+
+    Instance = "INSTANCE"
+    """
+    Concrete, clearly identifiable component of a certain template.
+
+    .. note::
+
+        It becomes an individual entity of a  template,  for example a
+        device model, by defining specific property values.
+
+    .. note::
+
+        In an object oriented view,  an instance denotes an object of a
+        template (class).
+
+    [SOURCE: IEC 62890:2016, 3.1.16 65/617/CDV]  modified
+    """
+
+
+# fmt: off
+@invariant(
+    lambda self:
+    not (self.revision is not None) or self.version is not None,
+    "Constraint AASd-005"
+)
+@reference_in_the_book(section=(5, 7, 2, 5))
+# fmt: on
+class Administrative_information(Has_data_specification):
+    """
+    Administrative meta-information for an element like version
+    information.
+
+    :constraint AASd-005:
+        If AdministrativeInformation/version is not specified than also
+        AdministrativeInformation/revision shall be unspecified. This means, a revision
+        requires a version. If there is no version there is no revision neither.
+        Revision is optional.
+    """
+
+    version: Optional[Non_empty_string]
+    """Version of the element."""
+
+    revision: Optional[Non_empty_string]
+    """Revision of the element."""
+
+    def __init__(
+        self,
+        data_specifications: Optional[List["Global_reference"]] = None,
+        version: Optional[Non_empty_string] = None,
+        revision: Optional[Non_empty_string] = None,
+    ) -> None:
+        Has_data_specification.__init__(self, data_specifications=data_specifications)
+
+        self.version = version
+        self.revision = revision
+
+
+@reference_in_the_book(section=(5, 7, 3))
+@serialization(with_model_type=True)
+class Asset_administration_shell(Identifiable, Has_data_specification):
+    """An asset administration shell."""
+
+    asset_information: "Asset_information"
+    """Meta-information about the asset the AAS is representing."""
+
+    # todo: Nico Model_reference --> ModelReference<Submodel>
+    submodels: List["Model_reference"]
+    """
+    References to submodels of the AAS.
+
+    A submodel is a description of an aspect of the asset the AAS is representing.
+    The asset of an AAS is typically described by one or more submodels.
+    Temporarily no submodel might be assigned to the AAS.
+    """
+
+    # todo: Nico Model_reference --> ModelReference<AssetAdministrationShell>
+    derived_from: Optional["Model_reference"]
+    """The reference to the AAS the AAS was derived from."""
+
+    def __init__(
+        self,
+        ID: Identifier,
+        asset_information: "Asset_information",
+        extensions: Optional[List["Extension"]] = None,
+        ID_short: Optional[Non_empty_string] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        checksum: Optional["Non_empty_string"] = None,
+        administration: Optional["Administrative_information"] = None,
+        data_specifications: Optional[List["Global_reference"]] = None,
+        submodels: Optional[List["Model_reference"]] = None,
+        derived_from: Optional["Model_reference"] = None,
+    ) -> None:
+        Identifiable.__init__(
+            self,
+            ID=ID,
+            extensions=extensions,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            checksum=checksum,
+            administration=administration,
+        )
+
+        Has_data_specification.__init__(self, data_specifications=data_specifications)
+
+        self.derived_from = derived_from
+        self.asset_information = asset_information
+        self.submodels = submodels if submodels is not None else []
+
+
+@reference_in_the_book(section=(5, 7, 4))
+class Asset_information(DBC):
+    """
+    In AssetInformation identifying meta data of the asset that is represented by an AAS
+    is defined.
+
+    The asset may either represent an asset type or an asset instance.
+    The asset has a globally unique identifier plus – if needed – additional domain
+    specific (proprietary) identifiers. However, to support the corner case of very
+    first phase of lifecycle where a stabilised/constant global asset identifier does
+    not already exist, the corresponding attribute “globalAssetId” is optional.
+
+    """
+
+    asset_kind: "Asset_kind"
+    """
+    Denotes whether the Asset is of kind "Type" or "Instance".
+    """
+
+    global_asset_ID: Optional["Global_reference"]
+    """
+    Reference to either an Asset object or a global reference to the asset the AAS is
+    representing.
+
+    This attribute is required as soon as the AAS is exchanged via partners in the life
+    cycle of the asset. In a first phase of the life cycle the asset might not yet have
+    a global ID but already an internal identifier. The internal identifier would be
+    modelled via :attr:`~specific_asset_ID`.
+    """
+
+    specific_asset_ID: Optional["Identifier_key_value_pair"]
+    """
+    Additional domain-specific, typically proprietary, Identifier for the asset.
+
+    For example, serial number.
+    """
+
+    default_thumbnail: Optional["Resource"]
+    """
+    Thumbnail of the asset represented by the asset administration shell.
+
+    Used as default.
+    """
+
+    def __init__(
+        self,
+        asset_kind: "Asset_kind",
+        global_asset_ID: Optional["Global_reference"] = None,
+        specific_asset_ID: Optional["Identifier_key_value_pair"] = None,
+        default_thumbnail: Optional["Resource"] = None,
+    ) -> None:
+        self.asset_kind = asset_kind
+        self.global_asset_ID = global_asset_ID
+        self.specific_asset_ID = specific_asset_ID
+        self.default_thumbnail = default_thumbnail
+
+
+@reference_in_the_book(section=(5, 7, 4), index=2)
+class Asset_kind(Enum):
+    """
+    Enumeration for denoting whether an element is a type or an instance.
+    """
+
+    Type = "Type"
+    """
+    hardware or software element which specifies the common attributes shared by all
+    instances of the type
+
+    [SOURCE: IEC TR 62390:2005-01, 3.1.25]
+    """
+
+    Instance = "Instance"
+    """
+    concrete, clearly identifiable component of a certain type
+
+    .. note::
+
+        It becomes an individual entity of a type, for example a device, by defining
+        specific property values.
+
+    .. note::
+
+        In an object oriented view, an instance denotes an object of a class
+        (of a type).
+
+    [SOURCE: IEC 62890:2016, 3.1.16] 65/617/CDV
+    """
+
+
+@reference_in_the_book(section=(5, 7, 4), index=3)
+class Identifier_key_value_pair(Has_semantics):
+    """
+    An IdentifierKeyValuePair describes a generic identifier as key-value pair.
+    """
+
+    key: Non_empty_string
+    """Key of the identifier"""
+
+    value: Non_empty_string
+    """The value of the identifier with the corresponding key."""
+
+    external_subject_ID: Optional["Global_reference"]
+    """The (external) subject the key belongs to or has meaning to."""
+
+    def __init__(
+        self,
+        key: Non_empty_string,
+        value: Non_empty_string,
+        semantic_ID: Optional["Global_reference"] = None,
+        external_subject_ID: Optional["Global_reference"] = None,
+    ) -> None:
+        Has_semantics.__init__(self, semantic_ID)
+        self.key = key
+        self.value = value
+        self.external_subject_ID = external_subject_ID
+
+
+@reference_in_the_book(section=(5, 7, 5))
+class Submodel(
+    Identifiable, Has_kind, Has_semantics, Qualifiable, Has_data_specification
+):
+    """
+    A submodel defines a specific aspect of the asset represented by the AAS.
+
+    A submodel is used to structure the digital representation and technical
+    functionality of an Administration Shell into distinguishable parts. Each submodel
+    refers to a well-defined domain or subject matter. Submodels can become
+    standardized and, thus, become submodels templates.
+    """
+
+    submodel_elements: List["Submodel_element"]
+    """A submodel consists of zero or more submodel elements."""
+
+    def __init__(
+        self,
+        ID: Identifier,
+        extensions: Optional[List["Extension"]] = None,
+        ID_short: Optional[Non_empty_string] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        checksum: Optional["Non_empty_string"] = None,
+        administration: Optional["Administrative_information"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Global_reference"] = None,
+        qualifiers: Optional[List["Qualifier"]] = None,
+        data_specifications: Optional[List["Global_reference"]] = None,
+        submodel_elements: Optional[List["Submodel_element"]] = None,
+    ) -> None:
+        Identifiable.__init__(
+            self,
+            ID=ID,
+            extensions=extensions,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            checksum=checksum,
+            administration=administration,
+        )
+
+        Has_kind.__init__(self, kind=kind)
+
+        Has_semantics.__init__(self, semantic_ID=semantic_ID)
+
+        Qualifiable.__init__(self, qualifiers=qualifiers)
+
+        Has_data_specification.__init__(self, data_specifications=data_specifications)
+
+        self.submodel_elements = (
+            submodel_elements if submodel_elements is not None else []
+        )
+
+
+# TODO (mristin, 2021-10-27, page 77):
+#  :constraint AASd-055: If the semanticId of a RelationshipElement or an
+#  AnnotatedRelationshipElement submodel element references a  ConceptDescription then
+#  the ConceptDescription/category shall be one of following values: RELATIONSHIP.
+#
+#  🠒 We really need to think hard how we resolve the references. Should this class be
+#  implementation-specific?
+@reference_in_the_book(section=(5, 7, 7, 16))
+@abstract
+class Relationship_element(Submodel_element):
+    """
+    A relationship element is used to define a relationship between two elements
+    being either referable (model reference) or external (global reference).
+
+    """
+
+    first: "Reference"
+    """
+    Reference to the first element in the relationship taking the role of the subject.
+    """
+
+    second: "Reference"
+    """
+    Reference to the second element in the relationship taking the role of the object.
+    """
+
+    def __init__(
+        self,
+        first: "Reference",
+        second: "Reference",
+        extensions: Optional[List["Extension"]] = None,
+        ID_short: Optional[Non_empty_string] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        checksum: Optional["Non_empty_string"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Global_reference"] = None,
+        qualifiers: Optional[List["Qualifier"]] = None,
+        data_specifications: Optional[List["Global_reference"]] = None,
+    ) -> None:
+        Submodel_element.__init__(
+            self,
+            extensions=extensions,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            checksum=checksum,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+        self.first = first
+        self.second = second
+
+
+@reference_in_the_book(section=(5, 7, 7, 17))
+class Submodel_element_list(Submodel_element):
+    """
+    A submodel element list is an ordered collection of submodel elements.
+
+    :constraint AASd-107:
+        If a first level child element in a SubmodelElementList has a semanticId it
+        shall be identical to SubmodelElementList/semanticIdListElement.
+
+    :constraint AASd-114:
+        If two first level child elements in a SubmodelElementList have a semanticId
+        then they shall be identical.
+
+    :constraint AASd-115:
+        If a first level child element in a SubmodelElementList does not specify
+        a semanticId then the value is assumed to be identical to
+        SubmodelElementList/semanticIdListElement.
+
+    :constraint AASd-108:
+        All first level child elements in a SubmodelElementList shall have the same
+        submodel element type as specified in SubmodelElementList/typeValueListElement.
+
+    :constraint AASd-109:
+        If SubmodelElementList/typeValueListElement equal to Property or Range
+        SubmodelElementList/valueTypeListElement shall be set and all first level
+        child elements in the SubmodelElementList shall have the the value type as
+        specified in SubmodelElementList/valueTypeListElement.
+    """
+
+    type_value_list_element: "Submodel_element_elements"
+    """
+    The submodel element type of the submodel elements contained in the list.
+    """
+
+    order_relevant: Optional["bool"]
+    """
+    Defines whether order in list is relevant. If orderRelevant = False then the list
+    is representing a set or a bag.
+    Default: True
+    """
+
+    values: Optional[List["Submodel_element"]]
+    """
+    Submodel element contained in the list.
+    The list is ordered.
+
+    """
+    semantic_id_list_element: Optional["Global_reference"]
+    """
+    The submodel element type of the submodel elements contained in the list.
+    """
+
+    value_type_list_element: Optional["Data_type_def_XSD"]
+    """
+    The value type of the submodel element contained in the list.
+    """
+
+    def __init__(
+        self,
+        type_value_list_element: "Submodel_element_elements",
+        extensions: Optional[List["Extension"]] = None,
+        ID_short: Optional[Non_empty_string] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        checksum: Optional["Non_empty_string"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Global_reference"] = None,
+        qualifiers: Optional[List["Qualifier"]] = None,
+        data_specifications: Optional[List["Global_reference"]] = None,
+        order_relevant: Optional["bool"] = None,
+        values: Optional[List["Submodel_element"]] = None,
+        semantic_id_list_element: Optional["Global_reference"] = None,
+        value_type_list_element: Optional["Data_type_def_XSD"] = None,
+    ) -> None:
+        Submodel_element.__init__(
+            self,
+            extensions=extensions,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            checksum=checksum,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+        self.type_value_list_element = type_value_list_element
+        self.order_relevant = order_relevant
+        self.values = values if values is not None else []
+        self.semantic_id_list_element = semantic_id_list_element
+        self.value_type_list_element = value_type_list_element
+
+
+@reference_in_the_book(section=(5, 7, 7, 18))
+class Submodel_element_struct(Submodel_element):
+    """
+    A submodel element struct is is a logical encapsulation of multiple values. It has
+    a number of of submodel elements.
+    """
+
+    values: Optional[List["Submodel_element"]]
+    """
+    Submodel element contained in the struct.
+    """
+
+    def __init__(
+        self,
+        extensions: Optional[List["Extension"]] = None,
+        ID_short: Optional[Non_empty_string] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        checksum: Optional["Non_empty_string"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Global_reference"] = None,
+        qualifiers: Optional[List["Qualifier"]] = None,
+        data_specifications: Optional[List["Global_reference"]] = None,
+        values: Optional[List["Submodel_element"]] = None,
+    ) -> None:
+        Submodel_element.__init__(
+            self,
+            extensions=extensions,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            checksum=checksum,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+        self.values = values if values is not None else []
+
+
+@reference_in_the_book(section=(5, 7, 7, 13))
+class Property(Data_element):
+    """
+    A property is a data element that has a single value.
+
+    :constraint AASd-007:
+        If both, the Property/value and the Property/valueId are present then the value
+        of Property/value needs to be identical to the value of the referenced coded
+        value in Property/valueId.
+    """
+
+    value_type: "Data_type_def_XSD"
+    """
+    Data type of the value
+    """
+
+    value: Optional["Value_data_type"]
+    """
+    The value of the property instance.
+    """
+
+    value_ID: Optional["Global_reference"]
+    """
+    Reference to the global unique ID of a coded value.
+    """
+
+    def __init__(
+        self,
+        value_type: "Data_type_def_XSD",
+        extensions: Optional[List["Extension"]] = None,
+        ID_short: Optional[Non_empty_string] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        checksum: Optional["Non_empty_string"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Global_reference"] = None,
+        qualifiers: Optional[List[Qualifier]] = None,
+        data_specifications: Optional[List["Global_reference"]] = None,
+        value: Optional["Value_data_type"] = None,
+        value_ID: Optional["Global_reference"] = None,
+    ) -> None:
+        Data_element.__init__(
+            self,
+            extensions=extensions,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            checksum=checksum,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+        self.value_type = value_type
+        self.value = value
+        self.value_ID = value_ID
+
+
+@reference_in_the_book(section=(5, 7, 7, 11))
+class Multi_language_property(Data_element):
+    """
+    A property is a data element that has a multi-language value.
+
+    :constraint AASd-012:
+        If both, the MultiLanguageProperty/value and the MultiLanguageProperty/valueId
+        are present then for each string in a specific language the meaning must be
+        the same as specified in MultiLanguageProperty/valueId.
+    """
+
+    value: Optional["Lang_string_set"]
+    """
+    The value of the property instance.
+    """
+
+    value_ID: Optional["Global_reference"]
+    """
+    Reference to the global unique ID of a coded value.
+    """
+
+    def __init__(
+        self,
+        extensions: Optional[List["Extension"]] = None,
+        ID_short: Optional[Non_empty_string] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        checksum: Optional["Non_empty_string"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Global_reference"] = None,
+        qualifiers: Optional[List[Qualifier]] = None,
+        data_specifications: Optional[List["Global_reference"]] = None,
+        value: Optional["Lang_string_set"] = None,
+        value_ID: Optional["Global_reference"] = None,
+    ) -> None:
+        Data_element.__init__(
+            self,
+            extensions=extensions,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            checksum=checksum,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+        self.value = value
+        self.value_ID = value_ID
+
+
+@reference_in_the_book(section=(5, 7, 7, 14))
+class Range(Data_element):
+    """
+    A range data element is a data element that defines a range with min and max.
+
+    """
+
+    value_type: "Data_type_def_XSD"
+    """
+    Data type of the min und max
+    """
+
+    min: Optional["Value_data_type"]
+    """
+    The minimum value of the range.
+    If the min value is missing, then the value is assumed to be negative infinite.
+    """
+
+    max: Optional["Value_data_type"]
+    """
+    The maximum value of the range.
+    If the max value is missing,  then the value is assumed to be positive infinite.
+    """
+
+    def __init__(
+        self,
+        value_type: "Data_type_def_XSD",
+        extensions: Optional[List["Extension"]] = None,
+        ID_short: Optional[Non_empty_string] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        checksum: Optional["Non_empty_string"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Global_reference"] = None,
+        qualifiers: Optional[List[Qualifier]] = None,
+        data_specifications: Optional[List["Global_reference"]] = None,
+        min: Optional["Value_data_type"] = None,
+        max: Optional["Value_data_type"] = None,
+    ) -> None:
+        Data_element.__init__(
+            self,
+            extensions=extensions,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            checksum=checksum,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+        self.value_type = value_type
+        self.min = min
+        self.max = max
+
+
+@reference_in_the_book(section=(5, 7, 7, 4))
+@invariant(lambda self: is_MIME_type(self.MIME_type))
+class Blob(Data_element):
+    """
+    A BLOB is a data element that represents a file that is contained with its source
+    code in the value attribute.
+    """
+
+    MIME_type: MIME_typed
+    """
+    Mime type of the content of the BLOB.
+    The mime type states which file extensions the file can have.
+    Valid values are e.g. “application/json”, “application/xls”, ”image/jpg”
+    The allowed values are defined as in RFC2046.
+    """
+
+    value: Optional["Blob_type"]
+    """
+    The value of the BLOB instance of a blob data element.
+
+    .. note::
+
+        In contrast to the file property the file content is stored directly as value
+        in the Blob data element.
+    """
+
+    def __init__(
+        self,
+        MIME_type: MIME_typed,
+        extensions: Optional[List["Extension"]] = None,
+        ID_short: Optional[Non_empty_string] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        checksum: Optional["Non_empty_string"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Global_reference"] = None,
+        qualifiers: Optional[List[Qualifier]] = None,
+        data_specifications: Optional[List["Global_reference"]] = None,
+        value: Optional["Blob_type"] = None,
+    ) -> None:
+        Data_element.__init__(
+            self,
+            extensions=extensions,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            checksum=checksum,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+        self.MIME_type = MIME_type
+        self.value = value
+
+
+@reference_in_the_book(section=(5, 7, 7, 8))
+@invariant(lambda self: is_MIME_type(self.content_type))
+class File(Data_element):
+    """
+    A File is a data element that represents an address to a file.
+
+    The value is an URI that can represent an absolute or relative path.
+    """
+
+    content_type: "Content_type"
+    """
+    Content type of the content of the file.
+
+    The content type states which file extensions the file can have.
+    """
+
+    value: Optional["Path_type"]
+    """
+    Path and name of the referenced file (with file extension).
+    The path can be absolute or relative.
+    """
+
+    def __init__(
+        self,
+        content_type: "Content_type",
+        extensions: Optional[List["Extension"]] = None,
+        ID_short: Optional[Non_empty_string] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        checksum: Optional["Non_empty_string"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Global_reference"] = None,
+        qualifiers: Optional[List[Qualifier]] = None,
+        data_specifications: Optional[List["Global_reference"]] = None,
+        value: Optional["Path_type"] = None,
+    ) -> None:
+        Data_element.__init__(
+            self,
+            extensions=extensions,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            checksum=checksum,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+        self.content_type = content_type
+        self.value = value
+
+
+@reference_in_the_book(section=(5, 7, 7, 1))
+class Annotated_relationship_element(Relationship_element):
+    """
+    An annotated relationship element is a relationship element that can be annotated
+    with additional data elements.
+    """
+
+    annotation: List[Data_element]
+    """
+    A data element that represents an annotation that holds for the relationship
+    between the two elements
+    """
+
+    def __init__(
+        self,
+        first: "Reference",
+        second: "Reference",
+        extensions: Optional[List["Extension"]] = None,
+        ID_short: Optional[Non_empty_string] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        checksum: Optional["Non_empty_string"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Global_reference"] = None,
+        qualifiers: Optional[List[Qualifier]] = None,
+        data_specifications: Optional[List["Global_reference"]] = None,
+        annotation: Optional[List[Data_element]] = None,
+    ) -> None:
+        Relationship_element.__init__(
+            self,
+            first=first,
+            second=second,
+            extensions=extensions,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            checksum=checksum,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+        self.annotation = annotation if annotation is not None else []
+
+
+@reference_in_the_book(section=(5, 7, 7, 2), index=1)
+class Direction(Enum):
+    """
+    Direction
+    """
+
+    input = "INPUT"
+    """
+    Input direction.
+    """
+
+    output = "OUTPUT"
+    """
+    Output direction
+    """
+
+
+@reference_in_the_book(section=(5, 7, 7, 2), index=2)
+class State_of_event(Enum):
+    """
+    State of an event
+    """
+
+    on = "ON"
+    """
+    Event is on
+    """
+
+    off = "OFF"
+    """
+    Event is off.
+    """
+
+
+@abstract
+@reference_in_the_book(section=(5, 7, 7, 7))
+class Event_element(Submodel_element):
+    """
+    An event element.
+    """
+
+    def __init__(
+        self,
+        extensions: Optional[List["Extension"]] = None,
+        ID_short: Optional[Non_empty_string] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        checksum: Optional["Non_empty_string"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Global_reference"] = None,
+        qualifiers: Optional[List[Qualifier]] = None,
+        data_specifications: Optional[List["Global_reference"]] = None,
+    ) -> None:
+        Submodel_element.__init__(
+            self,
+            extensions=extensions,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            checksum=checksum,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+
+@reference_in_the_book(section=(5, 7, 7, 2))
+class Basic_event_element(Event_element):
+    """
+    A basic event element.
+    """
+
+    observed: "Model_reference"
+    """
+    Reference to the Referable, which defines the scope of the event. Can be AAS, Submodel
+    or SubmodelElement. Reference to a referable, e.g. a data element or a submodel, that
+    is being observed.
+    """
+
+    direction: "Direction"
+    """
+    Direction of event.
+    Can be { Input, Output }.
+    """
+
+    state: "State_of_event"
+    """
+    State of event.
+    Can be { On, Off }.
+    """
+
+    message_topic: Optional["Non_empty_string"]
+    """
+    Information for the outer message infrastructure for scheduling the event to the
+    respective communication channel.
+    """
+
+    message_broker: Optional["Model_reference"]
+    """
+    Information, which outer message infrastructure shall handle messages for
+    the EventElement. Refers to a Submodel, SubmodelElementList, SubmodelElementStruct or
+    Entity, which contains DataElements describing the proprietary specification for
+    the message broker.
+
+    .. note::
+        for different message infrastructure, e.g. OPC UA or MQTT or AMQP, these
+        proprietary specification could be standardized by having respective Submodels.
+    """
+
+    last_update: Optional["Date_time"]
+    """
+    Timestamp in UTC, when the last event was received (input direction) or sent
+    (output direction).
+    """
+
+    min_interval: Optional["Date_time"]
+    """
+    For input direction, reports on the maximum frequency, the software entity behind
+    the respective Referable can handle input events. For output events, specifies
+    the maximum frequency of outputting this event to an outer infrastructure.
+    Might be not specified, that is, there is no minimum interval.
+    """
+
+    max_interval: Optional["Date_time"]
+    """
+    For input direction: not applicable.
+    For output direction: maximum interval in time, the respective Referable shall send
+    an update of the status of the event, even if no other trigger condition for
+    the event was not met. Might be not specified, that is, there is no maximum interval.
+    """
+
+    def __init__(
+        self,
+        observed: "Model_reference",
+        direction: "Direction",
+        state: "State_of_event",
+        extensions: Optional[List["Extension"]] = None,
+        ID_short: Optional[Non_empty_string] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        checksum: Optional["Non_empty_string"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Global_reference"] = None,
+        qualifiers: Optional[List[Qualifier]] = None,
+        data_specifications: Optional[List["Global_reference"]] = None,
+        message_topic: Optional["Non_empty_string"] = None,
+        message_broker: Optional["Model_reference"] = None,
+        last_update: Optional["Date_time"] = None,
+        min_interval: Optional["Date_time"] = None,
+        max_interval: Optional["Date_time"] = None,
+    ) -> None:
+        Event_element.__init__(
+            self,
+            extensions=extensions,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            checksum=checksum,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+        self.observed = observed
+        self.direction = direction
+        self.state = state
+        self.message_topic = message_topic
+        self.message_broker = message_broker
+        self.last_update = last_update
+        self.min_interval = min_interval
+        self.max_interval = max_interval
+
+
+@reference_in_the_book(section=(5, 7, 7, 2), index=3)
+class Event_payload(DBC):
+    """
+    Defines the necessary information of an event instance sent out or received.
+
+    .. note::
+        the payload is not part of the information model as exchanged via
+        the AASX package format but used in re-active Asset Administration Shells.
+    """
+
+    source: "Model_reference"
+    """
+    Reference to the source event element, including identification of AAS, Submodel,
+    SubmodelElements.
+    """
+
+    source_semantic_id: Optional["Global_reference"]
+    """
+    semanticId of the source event element, if available
+    """
+
+    observable_reference: "Model_reference"
+    """
+    Reference to the referable, which defines the scope of the event.
+    Can be AAS, Submodel or SubmodelElement.
+    """
+
+    observable_semantic_id: Optional["Global_reference"]
+    """
+    semanticId of the referable which defines the scope of the event, if available.
+    """
+
+    topic: Optional["Non_empty_string"]
+    """
+    Information for the outer message infrastructure for scheduling the event to
+    the respective communication channel.
+    """
+
+    subject_id: Optional["Global_reference"]
+    """
+    Subject, who/which initiated the creation.
+    """
+
+    time_stamp: "Date_time_stamp"
+    """
+    Timestamp in UTC, when this event was triggered.
+    """
+
+    payload: Optional["Non_empty_string"]
+    """
+    Event specific payload.
+    """
+
+    def __init__(
+        self,
+        source: "Model_reference",
+        observable_reference: "Model_reference",
+        time_stamp: "Date_time_stamp",
+        source_semantic_id: Optional["Global_reference"] = None,
+        observable_semantic_id: Optional["Global_reference"] = None,
+        topic: Optional["Non_empty_string"] = None,
+        subject_id: Optional["Global_reference"] = None,
+        payload: Optional["Non_empty_string"] = None,
+    ) -> None:
+
+        self.source = source
+        self.observable_reference = observable_reference
+        self.time_stamp = time_stamp
+        self.source_semantic_id = source_semantic_id
+        self.observable_semantic_id = observable_semantic_id
+        self.topic = topic
+        self.subject_id = subject_id
+        self.payload = payload
+
+
+@reference_in_the_book(section=(5, 7, 7, 6), index=1)
+class Entity_type(Enum):
+    """
+    Enumeration for denoting whether an entity is a self-managed entity or a co-managed
+    entity.
+    """
+
+    Co_managed_entity = "COMANAGEDENTITY"
+    """
+    For co-managed entities there is no separate AAS. Co-managed entities need to be
+    part of a self-managed entity.
+    """
+
+    Self_managed_entity = "SELFMANAGEDENTITY"
+    """
+    Self-Managed Entities have their own AAS but can be part of the bill of material of
+    a composite self-managed entity. The asset of an I4.0 Component is a self-managed
+    entity per definition."
+    """
+
+
+@reference_in_the_book(section=(5, 7, 7, 6))
+class Entity(Submodel_element):
+    """
+    An entity is a submodel element that is used to model entities.
+
+    :constraint AASd-014:
+        Either the attribute globalAssetId or specificAssetId of an Entity must be set
+        if Entity/entityType is set to “SelfManagedEntity”. They are not existing
+        otherwise.
+    """
+
+    entity_type: "Entity_type"
+    """
+    Describes whether the entity is a co- managed entity or a self-managed entity.
+    """
+
+    statements: Optional[List["Submodel_element"]]
+    """
+    Describes statements applicable to the entity by a set of submodel elements,
+    typically with a qualified value.
+    """
+
+    global_asset_ID: Optional["Reference"]
+    """
+    Reference to the asset the entity is representing.
+    """
+
+    specific_asset_ID: Optional["Identifier_key_value_pair"]
+    """
+    Reference to an identifier key value pair representing a specific identifier
+    of the asset represented by the asset administration shell.
+    """
+
+    def __init__(
+        self,
+        entity_type: "Entity_type",
+        extensions: Optional[List["Extension"]] = None,
+        ID_short: Optional[Non_empty_string] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        checksum: Optional["Non_empty_string"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Global_reference"] = None,
+        qualifiers: Optional[List["Qualifier"]] = None,
+        data_specifications: Optional[List["Global_reference"]] = None,
+        statements: Optional[List["Submodel_element"]] = None,
+        global_asset_ID: Optional["Reference"] = None,
+        specific_asset_ID: Optional["Identifier_key_value_pair"] = None,
+    ) -> None:
+        Submodel_element.__init__(
+            self,
+            extensions=extensions,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            checksum=checksum,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+        self.statements = statements if statements is not None else []
+        self.entity_type = entity_type
+        self.global_asset_ID = global_asset_ID
+        self.specific_asset_ID = specific_asset_ID
+
+
+@abstract
+@reference_in_the_book(section=(6, 7, 7, 7))
+class Event(Submodel_element):
+    """
+    An event.
+
+    :constraint AASd-061:
+        If the semanticId of a Event submodel element references a ConceptDescription
+        then the category of the ConceptDescription shall be one of the following:
+        EVENT.
+    """
+
+    def __init__(
+        self,
+        extensions: Optional[List["Extension"]] = None,
+        ID_short: Optional[Non_empty_string] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        checksum: Optional["Non_empty_string"] = None,
+        kind: Optional[Modeling_kind] = None,
+        semantic_ID: Optional["Global_reference"] = None,
+        qualifiers: Optional[List[Qualifier]] = None,
+        data_specifications: Optional[List["Global_reference"]] = None,
+    ) -> None:
+        Submodel_element.__init__(
+            self,
+            extensions=extensions,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            checksum=checksum,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+
+@reference_in_the_book(section=(6, 7, 7, 2))
+class Basic_Event(Event):
+    """
+    A basic event.
+    """
+
+    observed: "Reference"
+    """
+    Reference to a referable, e.g. a data element or a submodel, that is being
+    observed.
+    """
+
+    def __init__(
+        self,
+        observed: "Reference",
+        extensions: Optional[List["Extension"]] = None,
+        ID_short: Optional[Non_empty_string] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        checksum: Optional["Non_empty_string"] = None,
+        kind: Optional[Modeling_kind] = None,
+        semantic_ID: Optional["Global_reference"] = None,
+        qualifiers: Optional[List[Qualifier]] = None,
+        data_specifications: Optional[List["Global_reference"]] = None,
+    ) -> None:
+        Event.__init__(
+            self,
+            extensions=extensions,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            checksum=checksum,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+        self.observed = observed
+
+
+@reference_in_the_book(section=(5, 7, 7, 12))
+class Operation(Submodel_element):
+    """
+    An operation is a submodel element with input and output variables.
+    """
+
+    input_variables: Optional[List["Operation_variable"]]
+    """
+    Input parameter of the operation.
+    """
+
+    output_variables: Optional[List["Operation_variable"]]
+    """
+    Output parameter of the operation.
+    """
+
+    inoutput_variables: Optional[List["Operation_variable"]]
+    """
+    Parameter that is input and output of the operation.
+    """
+
+    def __init__(
+        self,
+        extensions: Optional[List["Extension"]] = None,
+        ID_short: Optional[Non_empty_string] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        checksum: Optional["Non_empty_string"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Global_reference"] = None,
+        qualifiers: Optional[List["Qualifier"]] = None,
+        data_specifications: Optional[List[Global_reference]] = None,
+        input_variables: Optional[List["Operation_variable"]] = None,
+        output_variables: Optional[List["Operation_variable"]] = None,
+        inoutput_variables: Optional[List["Operation_variable"]] = None,
+    ) -> None:
+        Submodel_element.__init__(
+            self,
+            extensions=extensions,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            checksum=checksum,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+        self.input_variables = input_variables if input_variables is not None else []
+        self.output_variables = output_variables if output_variables is not None else []
+        self.inoutput_variables = (
+            inoutput_variables if inoutput_variables is not None else []
+        )
+
+
+@reference_in_the_book(section=(5, 7, 7, 13), index=1)
+class Operation_variable(DBC):
+    """
+    An operation variable is a submodel element that is used as input or output variable
+    of an operation.
+
+    .. note::
+        Note: OperationVariable is introduced as separate class to enable future extensions,
+        e.g. for adding a default value, cardinality (option/mandatory).
+    """
+
+    value: "Submodel_element"
+    """
+    Describes the needed argument for an operation via a submodel element
+    """
+
+    def __init__(self, value: "Submodel_element") -> None:
+        self.value = value
+
+
+@reference_in_the_book(section=(5, 7, 7, 4))
+class Capability(Submodel_element):
+    """
+    A capability is the implementation-independent description of the potential of an
+    asset to achieve a certain effect in the physical or virtual world.
+
+    .. note::
+        The semanticId of a capability is typically an ontology. Thus, reasoning on
+        capabilities is enabled.
+    """
+
+    def __init__(
+        self,
+        extensions: Optional[List["Extension"]] = None,
+        ID_short: Optional[Non_empty_string] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        checksum: Optional["Non_empty_string"] = None,
+        kind: Optional["Modeling_kind"] = None,
+        semantic_ID: Optional["Global_reference"] = None,
+        qualifiers: Optional[List["Qualifier"]] = None,
+        data_specifications: Optional[List[Global_reference]] = None,
+    ) -> None:
+        Submodel_element.__init__(
+            self,
+            extensions=extensions,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            checksum=checksum,
+            kind=kind,
+            semantic_ID=semantic_ID,
+            qualifiers=qualifiers,
+            data_specifications=data_specifications,
+        )
+
+
+@reference_in_the_book(section=(5, 7, 8))
+@serialization(with_model_type=True)
+class Concept_description(Identifiable, Has_data_specification):
+    """
+    The semantics of a property or other elements that may have a semantic description
+    is defined by a concept description. The description of the concept should follow a
+    standardized schema (realized as data specification template).
+
+    :constraint AASd-051:
+        A ConceptDescription shall have one of the following categories
+        VALUE, PROPERTY, REFERENCE, DOCUMENT, CAPABILITY, RELATIONSHIP, COLLECTION,
+        FUNCTION, EVENT, ENTITY, APPLICATION_CLASS, QUALIFIER, VIEW.
+
+        Default: PROPERTY.
+    """
+
+    is_case_of: Optional[List["Global_reference"]]
+    """
+    Reference to an external definition the concept is compatible to or was derived from
+
+    .. note::
+       Compare to is-case-of relationship in ISO 13584-32 & IEC EN 61360"
+    """
+
+    def __init__(
+        self,
+        ID: Identifier,
+        extensions: Optional[List["Extension"]] = None,
+        ID_short: Optional[Non_empty_string] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        checksum: Optional["Non_empty_string"] = None,
+        administration: Optional["Administrative_information"] = None,
+        data_specifications: Optional[List[Global_reference]] = None,
+        is_case_of: Optional[List["Global_reference"]] = None,
+    ) -> None:
+        Identifiable.__init__(
+            self,
+            ID=ID,
+            extensions=extensions,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            checksum=checksum,
+            administration=administration,
+        )
+
+        Has_data_specification.__init__(self, data_specifications=data_specifications)
+
+        self.is_case_of = is_case_of if is_case_of is not None else []
+
+
+@reference_in_the_book(section=(5, 7, 9))
+@serialization(with_model_type=True)
+class View(Referable, Has_semantics, Has_data_specification):
+    """
+    A view is a collection of referable elements w.r.t. to a specific viewpoint of one
+    or more stakeholders.
+
+    .. note::
+
+       Views are a projection of submodel elements for a given perspective.
+       They are not equivalent to submodels.
+
+    :constraint AASd-064:
+        If the semanticId of a View references a ConceptDescription
+        then the category of the ConceptDescription shall be VIEW.
+    """
+
+    contained_elements: List["Reference"]
+    """
+    Reference to a referable element that is contained in the view.
+    """
+
+    def __init__(
+        self,
+        extensions: Optional[List["Extension"]] = None,
+        ID_short: Optional[Non_empty_string] = None,
+        display_name: Optional["Lang_string_set"] = None,
+        category: Optional[Non_empty_string] = None,
+        description: Optional["Lang_string_set"] = None,
+        checksum: Optional["Non_empty_string"] = None,
+        semantic_ID: Optional["Global_reference"] = None,
+        data_specifications: Optional[List["Global_reference"]] = None,
+        contained_elements: Optional[List["Reference"]] = None,
+    ) -> None:
+        Referable.__init__(
+            self,
+            extensions=extensions,
+            ID_short=ID_short,
+            display_name=display_name,
+            category=category,
+            description=description,
+            checksum=checksum,
+        )
+
+        Has_semantics.__init__(self, semantic_ID)
+
+        Has_data_specification.__init__(self, data_specifications=data_specifications)
+
+        self.contained_elements = (
+            contained_elements if contained_elements is not None else []
+        )
+
+
+@reference_in_the_book(section=(5, 7, 10, 3), index=5)
+class Identifiable_elements(Enum):
+    """
+    Enumeration of all identifiable elements within an asset administration shell.
+    """
+
+    Asset_administration_shell = "AssetAdministrationShell"
+    Concept_description = "ConceptDescription"
+    Submodel = "Submodel"
+
+
+@reference_in_the_book(section=(5, 7, 10, 3), index=4)
+class Submodel_element_elements(Enum):
+    """
+    Enumeration of all referable elements within an asset administration shell.
+    """
+
+    Annotated_relationship_element = "AnnotatedRelationshipElement"
+    Basic_event_element = "BasicEventElement"
+    Blob = "Blob"
+    Capability = "Capability"
+    Data_element = "DataElement"
+    """
+    Data Element.
+
+    .. note::
+        Data Element is abstract, *i.e.* if a key uses “DataElement” the reference may
+        be a Property, a File etc.
+    """
+    Entity = "Entity"
+    Event_element = "EventElement"
+    """
+    Event element
+
+    .. note::
+
+        Event is abstract
+    """
+    File = "File"
+
+    Multi_language_property = "MultiLanguageProperty"
+    """
+    Property with a value that can be provided in multiple languages
+    """
+    Operation = "Operation"
+    Property = "Property"
+    Range = "Range"
+    """
+    Range with min and max
+    """
+    Reference_element = "ReferenceElement"
+    """
+    Reference
+    """
+    Relationship_element = "RelationshipElement"
+    """
+    Relationship
+    """
+
+    Submodel_element = "SubmodelElement"
+    """
+    Submodel Element
+
+    .. note::
+
+        Submodel Element is abstract, i.e. if a key uses “SubmodelElement”
+        the reference may be a Property, a SubmodelElementList,
+        an Operation etc.
+    """
+    Submodel_element_list = "SubmodelElementList"
+    """
+    List of Submodel Elements
+    """
+    Submodel_element_struct = "SubmodelElementStruct"
+    """
+    Struct of Submodel Elements
+    """
+
+
+@reference_in_the_book(section=(5, 7, 10, 3), index=3)
+@is_superset_of(enums=[Submodel_element_elements, Identifiable_elements])
+class Referable_elements(Enum):
+    """
+    Enumeration of all referable elements within an asset administration shell
+    """
+
+    Annotated_relationship_element = "AnnotatedRelationshipElement"
+    Asset_administration_shell = "AssetAdministrationShell"
+    Basic_event_element = "BasicEventElement"
+    Blob = "Blob"
+    Capability = "Capability"
+    Concept_description = "ConceptDescription"
+    Data_element = "DataElement"
+    """
+    Data element.
+
+    .. note::
+
+        Data Element is abstract, *i.e.* if a key uses :attr:`~Data_element`
+        the reference may be a Property, a File *etc.*
+    """
+
+    Entity = "Entity"
+    Event_element = "EventElement"
+    """
+    Event.
+
+    .. note::
+
+        Event Element is abstract.
+    """
+
+    File = "File"
+
+    Multi_language_property = "MultiLanguageProperty"
+    """
+    Property with a value that can be provided in multiple languages
+    """
+    Operation = "Operation"
+    Property = "Property"
+    Range = "Range"
+    """
+    Range with min and max
+    """
+    Reference_element = "ReferenceElement"
+    """
+    Reference
+    """
+    Relationship_element = "RelationshipElement"
+    """
+    Relationship
+    """
+    Submodel = "Submodel"
+    Submodel_element = "SubmodelElement"
+    """
+    Submodel Element
+
+    .. note::
+
+        Submodel Element is abstract, *i.e.* if a key uses :attr:`~Submodel_element`
+        the reference may be a Property, a SubmodelElementCollection,
+        an Operation *etc.*
+    """
+
+    Submodel_element_list = "SubmodelElementList"
+    """
+    List of Submodel Elements
+    """
+    Submodel_element_struct = "SubmodelElementStruct"
+    """
+    Struct of Submodel Elements
+    """
+
+
+@reference_in_the_book(section=(5, 7, 10, 3), index=2)
+@is_superset_of(enums=[Referable_elements])
+class Key_elements(Enum):
+    """Enumeration of different key value types within a key."""
+
+    Fragment_reference = "FragmentReference"
+    """
+    Bookmark or a similar local identifier of a subordinate part of
+    a primary resource
+    """
+
+    Global_reference = "GlobalReference"
+
+    Annotated_relationship_element = "AnnotatedRelationshipElement"
+    Asset_administration_shell = "AssetAdministrationShell"
+    Basic_event_element = "BasicEventElement"
+    Blob = "Blob"
+    Capability = "Capability"
+    Concept_description = "ConceptDescription"
+    Data_element = "DataElement"
+    """
+    Data element.
+
+    .. note::
+
+        Data Element is abstract, *i.e.* if a key uses :attr:`~Data_element`
+        the reference may be a Property, a File *etc.*
+    """
+
+    Entity = "Entity"
+    Event_element = "EventElement"
+    """
+    Event.
+
+    .. note::
+
+        Event element is abstract.
+    """
+
+    File = "File"
+
+    Multi_language_property = "MultiLanguageProperty"
+    """Property with a value that can be provided in multiple languages"""
+
+    Operation = "Operation"
+    Property = "Property"
+    Range = "Range"
+    """Range with min and max"""
+
+    Reference_element = "ReferenceElement"
+    """
+    Reference
+    """
+    Relationship_element = "RelationshipElement"
+    """
+    Relationship
+    """
+    Submodel = "Submodel"
+    Submodel_element = "SubmodelElement"
+    """
+    Submodel Element
+
+    .. note::
+
+        Submodel Element is abstract, *i.e.* if a key uses :attr:`~Submodel_element`
+        the reference may be a Property, a SubmodelElementCollection`,
+        an Operation *etc.*
+    """
+
+    Submodel_element_list = "SubmodelElementList"
+    """
+    List of Submodel Elements
+    """
+    Submodel_element_struct = "SubmodelElementStruct"
+    """
+    Struct of Submodel Elements
+    """
+
+
+@abstract
+@serialization(with_model_type=True)
+@reference_in_the_book(section=(6, 1))
+class Data_specification_content(DBC):
+    """
+    Missing summary.
+
+    .. note::
+        The Data Specification Templates do not belong to the meta-model of the Asset
+        Administration Shell. In serializations that choose specific templates
+        the corresponding data specification content may be directly incorporated.
+    """
+
+    # TODO (sadu 2021-11-17)
+    # No table for class in the book
+    # to be implemented
+    pass
+
+
+@reference_in_the_book(section=(6, 8, 2, 3), index=2)
+class Data_type_IEC61360(Enum):
+    Date = "DATE"
+    """
+    values containing a calendar date, conformant to ISO 8601:2004 Format yyyy-mm-dd
+    Example from IEC 61360-1:2017: "1999-05-31" is the [DATE] representation of:
+    31 May 1999.
+    """
+    String = "STRING"
+    """
+    values consisting of sequence of characters but cannot be translated into other
+    languages
+    """
+    String_translatable = "STRING_TRANSLATABLE"
+    """
+    values containing string but shall be represented as different string in different
+    languages
+    """
+    Integer_Measure = "INTEGER_MEASURE"
+    """
+    values containing values that are measure of type INTEGER. In addition such a value
+    comes with a physical unit.
+    """
+    Integer_count = "INTEGER_COUNT"
+    """
+    values containing values of type INTEGER but are no currencies or measures
+    """
+    Integer_currency = "INTEGER_CURRENCY"
+    """
+    values containing values of type INTEGER that are currencies
+    """
+    Real_measure = "REAL_MEASURE"
+    """
+    values containing values that are measures of type REAL. In addition such a value
+    comes with a physical unit.
+    """
+    Real_count = "REAL_COUNT"
+    """
+    values containing numbers that can be written as a terminating or non-terminating
+    decimal; a rational or irrational number but are no currencies or measures
+    """
+    Real_currency = "REAL_CURRENCY"
+    """
+    values containing values of type REAL that are currencies
+    """
+    Boolean = "BOOLEAN"
+    """
+    values representing truth of logic or Boolean algebra (TRUE, FALSE)
+    """
+    IRI = "IRI"
+    """
+    values containing values of type STRING conformant to Rfc 3987
+
+    .. note::
+        In IEC61360-1 (2017) only URI is supported. An Iri type allows in particular to
+        express a URL or an URI
+    """
+    IRDI = "IRDI"
+    """
+    values conforming to ISO/IEC 11179 series global identifier sequences IRDI can be
+    used instead of the more specific data types ICID or ISO29002_IRDI. ICID values are
+    value conformant to an IRDI, where the delimiter between RAI and ID is “#” while the
+    delimiter between DI and VI is confined to “##” ISO29002_IRDI values are values
+    containing a global identifier that identifies an administrated item in a registry.
+    The structure of this identifier complies with identifier syntax defined in ISO/TS
+    29002-5. The identifier shall fulfill the requirements specified in ISO/TS 29002-5
+    for an "international registration data identifier" (IRDI).
+    """
+    Rational = "RATIONAL"
+    """
+    values containing values of type rational
+    """
+    Rational_measure = "RATIONAL_MEASURE"
+    """
+    values containing values of type rational.
+    In addition such a value comes with a physical unit.
+    """
+    Time = "TIME"
+    """
+    values containing a time, conformant to ISO 8601:2004 but restricted to
+    what is allowed in the corresponding type in xml.
+    Format hh:mm (ECLASS) Example from IEC 61360-1:2017: "13:20:00-05:00" is the [TIME]
+    representation of: 1.20 p.m. for Eastern Standard Time,
+    which is 5 hours behind Coordinated Universal Time (UTC).
+    """
+    Timestamp = "TIMESTAMP"
+    """
+    values containing a time, conformant to ISO 8601:2004 but restricted to
+    what is allowed in the corresponding type in xml. Format yyyy-mm-dd hh:mm (ECLASS)
+    """
+    File = "FILE"
+    """
+    values containing an address to a file. The values are of type URI and can represent
+    an absolute or relative path. IEC61360 does not support the file type.
+    """
+    HTML = "HTML"
+    """
+    Values containing string with any sequence of characters, using the syntax of HTML5
+    (see W3C Recommendation 28:2014)
+    """
+    Blob = "BLOB"
+    """
+    values containing the content of a file. Values may be binaries.
+    HTML conformant to HTML5 is a special blob. In IEC61360 binary is for a sequence of
+    bits, each bit being represented by “0” and “1” only. A binary is a blob but a blob
+    may also contain other source code.
+    """
+
+
+@reference_in_the_book(section=(6, 8, 2, 3), index=5)
+class Level_type(Enum):
+    Min = "Min"
+    Max = "Max"
+    Nom = "Nom"
+    Type = "Type"
+
+
+@reference_in_the_book(section=(6, 8, 2, 3), index=4)
+class Value_reference_pair(DBC):
+    """
+    A value reference pair within a value list. Each value has a global unique id
+    defining its semantic.
+    """
+
+    value: Non_empty_string
+    """
+    The value of the referenced concept definition of the value in valueId.
+    """
+
+    value_ID: "Reference"
+    """
+    Global unique id of the value.
+
+    :constraint AASd-078:
+        If the valueId of a ValueReferencePair references a
+        ConceptDescription then the ConceptDescription/category shall be one of
+        following values: VALUE.
+    """
+
+    def __init__(self, value: Non_empty_string, value_ID: "Reference") -> None:
+        self.value = value
+        self.value_ID = value_ID
+
+
+@reference_in_the_book(section=(6, 8, 2, 3), index=3)
+class Value_list(DBC):
+    """
+    A set of value reference pairs.
+    """
+
+    value_reference_pairs: List["Value_reference_pair"]
+    """
+    A pair of a value together with its global unique id.
+    """
+
+    def __init__(
+        self, value_reference_pairs: Optional[List["Value_reference_pair"]] = None
+    ) -> None:
+        self.value_reference_pairs = (
+            value_reference_pairs if value_reference_pairs is not None else []
+        )
+
+
+@reference_in_the_book(section=(6, 8, 2, 3))
+class Data_specification_IEC61360(Data_specification_content):
+    """
+    Content of data specification template for concept descriptions conformant to
+    IEC 61360.
+    """
+
+    preferred_name: Optional["Lang_string_set"]
+    """
+    Preferred name
+
+    :constraint AASd-076:
+        For all ConceptDescriptions using data specification template
+        IEC61360
+        (http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0)
+        at least a preferred name in English shall be defined.
+    """
+
+    short_name: Optional["Lang_string_set"]
+    """
+    Short name
+    """
+
+    unit: Optional[Non_empty_string]
+    """
+    Unit
+    """
+
+    unit_ID: Optional["Reference"]
+    """
+    Unique unit id
+    """
+
+    source_of_definition: Optional[Non_empty_string]
+    """
+    Source of definition
+    """
+
+    symbol: Optional[Non_empty_string]
+    """
+    Symbol
+    """
+
+    data_type: Optional["Data_type_IEC61360"]
+    """
+    Data Type
+
+    :constraint AASd-070:
+        For a ConceptDescription with category PROPERTY or VALUE using
+        data specification template IEC61360
+        (http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0) -
+        DataSpecificationIEC61360/dataType is mandatory and shall be defined.
+
+    :constraint AASd-071:
+        For a ConceptDescription with category REFERENCE using data
+        specification template IEC61360
+        (http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0) -
+        DataSpecificationIEC61360/dataType is STRING by default.
+
+    :constraint AASd-072:
+        For a ConceptDescription with category DOCUMENT using data
+        specification template IEC61360
+        (http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0) -
+        DataSpecificationIEC61360/dataType shall be one of the following values: STRING or
+        URL.
+
+    :constraint AASd-073:
+        For a ConceptDescription with category QUALIFIER using data
+        specification template IEC61360
+        (http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0) -
+        DataSpecificationIEC61360/dataType is mandatory and shall be defined.
+
+    :constraint AASd-103:
+        If DataSpecificationIEC61360/-dataType one of: INTEGER_MEASURE,
+        REAL_MEASURE, RATIONAL_MEASURE, INTEGER_CURRENCY, REAL_CURRENCY, then
+        DataSpecificationIEC61360/unit or DataSpecificationIEC61360/unitId shall be
+        defined.
+    """
+
+    definition: Optional["Lang_string_set"]
+    """
+    Definition in different languages
+
+    :constraint AASd-074:
+        For all ConceptDescriptions except for ConceptDescriptions of
+        category VALUE using data specification template IEC61360
+        (http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/2/0) -
+        DataSpecificationIEC61360/definition is mandatory and shall be defined at least
+        in English.
+    """
+
+    value_format: Optional[Non_empty_string]
+    """
+    Value Format
+    """
+
+    value_list: Optional["Value_list"]
+    """
+    List of allowed values
+
+    See :constraintref:`AASd-102`
+    """
+
+    value: Optional[Non_empty_string]
+    """
+    Value
+
+    :constraint AASd-101:
+        If DataSpecificationIEC61360/category equal to VALUE then
+        DataSpecificationIEC61360/value shall be set.
+
+    :constraint AASd-102:
+        If DataSpecificationIEC61360/value or
+        DataSpecificationIEC61360/valueId is not empty then
+        DataSpecificationIEC61360/valueList shall be empty and vice versa.
+    """
+
+    value_ID: Optional["Reference"]
+    """
+    Unique value id
+
+    See :constraintref:`AASd-102`
+    """
+
+    level_type: Optional["Level_type"]
+    """
+    Set of levels.
+    """
+
+    def __init__(
+        self,
+        preferred_name: Optional["Lang_string_set"] = None,
+        short_name: Optional["Lang_string_set"] = None,
+        unit: Optional[Non_empty_string] = None,
+        unit_ID: Optional["Reference"] = None,
+        source_of_definition: Optional[Non_empty_string] = None,
+        symbol: Optional[Non_empty_string] = None,
+        data_type: Optional["Data_type_IEC61360"] = None,
+        definition: Optional["Lang_string_set"] = None,
+        value_format: Optional[Non_empty_string] = None,
+        value_list: Optional["Value_list"] = None,
+        value: Optional[Non_empty_string] = None,
+        value_ID: Optional["Reference"] = None,
+        level_type: Optional["Level_type"] = None,
+    ) -> None:
+        self.preferred_name = preferred_name
+        self.short_name = short_name
+        self.unit = unit
+        self.unit_ID = unit_ID
+        self.source_of_definition = source_of_definition
+        self.symbol = symbol
+        self.data_type = data_type
+        self.definition = definition
+        self.value_format = value_format
+        self.value_list = value_list
+        self.value = value
+        self.value_ID = value_ID
+        self.level_type = level_type
+
+
+@reference_in_the_book(section=(6, 8, 3, 2))
+class Data_specification_physical_unit(Data_specification_content):
+    """TODO"""
+
+    # TODO (sadu 2021-11-17)
+    # No table for class in the book
+
+    unit_name: Optional[Non_empty_string]
+    """
+    Unit Name
+    """
+
+    unit_symbol: Optional[Non_empty_string]
+    """
+    Unit Symbol
+    """
+
+    definition: Optional["Lang_string_set"]
+    """
+    Definition
+    """
+
+    SI_notation: Optional[Non_empty_string]
+    """
+    SI Notation
+    """
+
+    DIN_notation: Optional[Non_empty_string]
+    """
+    DIN Notation
+    """
+
+    ECE_name: Optional[Non_empty_string]
+    """
+    ECE Name
+    """
+
+    ECE_code: Optional[Non_empty_string]
+    """
+    ECE Code
+    """
+
+    NIST_name: Optional[Non_empty_string]
+    """
+    NIST Name
+    """
+
+    source_of_definition: Optional[Non_empty_string]
+    """
+    Source Of Definition
+    """
+
+    conversion_factor: Optional[Non_empty_string]
+    """
+    Conversion Factor
+    """
+
+    registration_authority_ID: Optional[Non_empty_string]
+    """
+    Registration Authority ID
+    """
+
+    supplier: Optional[Non_empty_string]
+    """
+    Supplier
+    """
+
+    def __init__(
+        self,
+        unit_name: Optional[Non_empty_string] = None,
+        unit_symbol: Optional[Non_empty_string] = None,
+        definition: Optional["Lang_string_set"] = None,
+        SI_notation: Optional[Non_empty_string] = None,
+        DIN_notation: Optional[Non_empty_string] = None,
+        ECE_name: Optional[Non_empty_string] = None,
+        ECE_code: Optional[Non_empty_string] = None,
+        NIST_name: Optional[Non_empty_string] = None,
+        source_of_definition: Optional[Non_empty_string] = None,
+        conversion_factor: Optional[Non_empty_string] = None,
+        registration_authority_ID: Optional[Non_empty_string] = None,
+        supplier: Optional[Non_empty_string] = None,
+    ) -> None:
+        self.unit_name = unit_name
+        self.unit_symbol = unit_symbol
+        self.definition = definition
+        self.SI_notation = SI_notation
+        self.DIN_notation = DIN_notation
+        self.ECE_name = ECE_name
+        self.ECE_code = ECE_code
+        self.NIST_name = NIST_name
+        self.source_of_definition = source_of_definition
+        self.conversion_factor = conversion_factor
+        self.registration_authority_ID = registration_authority_ID
+        self.supplier = supplier
+
+
+# TODO (Nico & Marko, 2021-09-24):
+#  We need to list in a comment all the constraints which were not implemented.
+
+# TODO (mristin, 2021-10-27): re-order the entities so that they follow the structure
+#  in the book as much as possible, but be careful about the inheritance
+
+
+@reference_in_the_book(section=(5, 7, 9))
+class Environment:
+    """
+    Container for the sets of different identifiables.
+
+    .. note::
+        w.r.t. file exchange: There is exactly one environment independent on how many
+        files the contained elements are splitted. If the file is splitted then there
+        shall be no element with the same identifier in two different files.
+    """
+
+    asset_administration_shells: Optional[List[Asset_administration_shell]]
+    """
+    Asset administration shell
+    """
+
+    submodels: Optional[List[Submodel]]
+    """
+    Submodel
+    """
+
+    concept_descriptions: Optional[List[Concept_description]]
+    """
+    Concept description
+    """
+
+    def __init__(
+        self,
+        asset_administration_shells: Optional[List[Asset_administration_shell]] = None,
+        submodels: Optional[List[Submodel]] = None,
+        concept_descriptions: Optional[List[Concept_description]] = None,
+    ) -> None:
+        self.asset_administration_shells = asset_administration_shells
+        self.submodels = submodels
+        self.concept_descriptions = concept_descriptions
+
+
+@reference_in_the_book(section=(6, 1))
+class Data_specification(DBC):
+    """
+    A template consists of the DataSpecificationContent containing the additional attributes
+    to be added to the element instance that references the data specification template and
+    meta information about the template itself.
+
+    .. note::
+        The Data Specification Templates do not belong to the metamodel of the asset
+        administration shell. In serializations that choose specific templates
+        the corresponding data specification content may be directly incorporated.
+    """
+
+    ID: "Identifier"
+    """The globally unique identification of the element."""
+
+    administration: Optional["Administrative_information"]
+    """
+    Administrative information of an identifiable element.
+
+    .. note::
+
+        Some of the administrative information like the version number might need to
+        be part of the identification.
+    """
+
+    description: Optional["Lang_string_set"]
+    """
+    Description or comments on the element.
+
+    The description can be provided in several languages.
+
+    If no description is defined, then the definition of the concept
+    description that defines the semantics of the element is used.
+
+    Additional information can be provided, *e.g.*, if the element is
+    qualified and which qualifier types can be expected in which
+    context or which additional data specification templates are
+    provided.
+    """
+
+    data_specification_content: Optional["Data_specification_content"]
+
+    def __init__(
+        self,
+        ID: "Identifier",
+        administration: Optional["Administrative_information"] = None,
+        description: Optional["Lang_string_set"] = None,
+        data_specification_content: Optional["Data_specification_content"] = None,
+    ) -> None:
+        self.ID = ID
+        self.administration = administration
+        self.description = description
+        self.data_specification_content = data_specification_content

--- a/test_data/smoke/test_main/unexpected/infer_for_schema_error/expected_stderr.txt
+++ b/test_data/smoke/test_main/unexpected/infer_for_schema_error/expected_stderr.txt
@@ -1,0 +1,2 @@
+Failed to infer the constraints by class for the schemas based on <meta_model.py>:
+* At line 2 and column 2: The property some_prop has conflicting invariants on the length: The exact length, 11, contradicts another exactly expected length 10.

--- a/test_data/smoke/test_main/unexpected/infer_for_schema_error/meta_model.py
+++ b/test_data/smoke/test_main/unexpected/infer_for_schema_error/meta_model.py
@@ -1,0 +1,12 @@
+# The invariants are contradicting.
+@invariant(lambda self: len(self.some_prop) == 10)
+@invariant(lambda self: len(self.some_prop) == 11)
+class Something:
+    some_prop: str
+
+    def __init__(self, some_prop: str) -> None:
+        self.some_prop = some_prop
+
+
+__book_version__ = "dummy"
+__book_url__ = "dummy"

--- a/test_data/smoke/test_main/unexpected/intermediate_error/expected_stderr.txt
+++ b/test_data/smoke/test_main/unexpected/intermediate_error/expected_stderr.txt
@@ -1,0 +1,4 @@
+Failed to translate the parsed symbol table to intermediate symbol table based on <meta_model.py>:
+* At line 1 and column 1: Failed to translate the parsed symbol table to an intermediate symbol table
+    At line 2 and column 2: The class 'Something' has one or more concrete descendants ('Concrete'), but its serialization setting ``with_model_type`` has not been set. We need to discriminate on model type at the de-serialization.
+    At line 6 and column 2: The class 'Concrete' needs to have serialization setting ``with_model_type`` set since it is among the concrete descendant classes of the class 'Something'. We need to discriminate on model type at the de-serialization

--- a/test_data/smoke/test_main/unexpected/intermediate_error/meta_model.py
+++ b/test_data/smoke/test_main/unexpected/intermediate_error/meta_model.py
@@ -1,0 +1,18 @@
+# ``with_model_type`` is missing in the serialization.
+class Something:
+    pass
+
+
+class Concrete(Something):
+    pass
+
+
+class Bundle:
+    something: Something
+
+    def __init__(self, something: Something) -> None:
+        self.something = something
+
+
+__book_version__ = "dummy"
+__book_url__ = "dummy"

--- a/test_data/smoke/test_main/unexpected/parse_error/expected_stderr.txt
+++ b/test_data/smoke/test_main/unexpected/parse_error/expected_stderr.txt
@@ -1,0 +1,4 @@
+Failed to construct the symbol table from <meta_model.py>:
+* Failed to parse the meta-model
+    The book URL (given as assignment to ``__book_url__``) is missing
+    The book version (given as assignment to ``__book_version__``) is missing

--- a/test_data/smoke/test_main/unexpected/parse_error/meta_model.py
+++ b/test_data/smoke/test_main/unexpected/parse_error/meta_model.py
@@ -1,0 +1,5 @@
+class Something:
+    pass
+
+
+# No book version will cause an error.

--- a/tests/smoke/test_main.py
+++ b/tests/smoke/test_main.py
@@ -1,0 +1,81 @@
+import io
+import os
+import pathlib
+import unittest
+
+from aas_core_codegen.smoke import main as smoke_main
+
+
+class Test_against_recorded(unittest.TestCase):
+    RERECORD = os.environ.get("AAS_CORE_CODEGEN_RERECORD", "").lower() in (
+        "1",
+        "true",
+        "on",
+    )
+    RERECORD = True  # TODO (mristin, 2022-03-28): debug
+
+    # TODO (mristin, 2022-03-28): add meta-models in precommit script
+
+    def test_cases(self) -> None:
+        repo_dir = pathlib.Path(os.path.realpath(__file__)).parent.parent.parent
+
+        parent_case_dir = repo_dir / "test_data" / "smoke" / "test_main"
+        assert parent_case_dir.exists() and parent_case_dir.is_dir(), parent_case_dir
+
+        expected_dir = parent_case_dir / "expected"
+
+        for model_pth in sorted(expected_dir.glob("**/*.py")):
+            assert model_pth.is_file(), f"{model_pth=}"
+
+            stderr = io.StringIO()
+            return_code = smoke_main.execute(model_path=model_pth, stderr=stderr)
+            if return_code != 0:
+                parts = [
+                    f"Unexpected non-zero return code from the smoke script "
+                    f"on {model_pth}: {return_code}"
+                ]
+                if stderr.getvalue():
+                    parts.append(f"The captured STDERR was:\n{stderr.getvalue()}")
+
+                raise AssertionError("\n\n".join(parts))
+
+        unexpected_dir = parent_case_dir / "unexpected"
+
+        for model_pth in sorted(unexpected_dir.glob("**/*.py")):
+            stderr = io.StringIO()
+
+            return_code = smoke_main.execute(model_path=model_pth, stderr=stderr)
+
+            if return_code == 0:
+                parts = [
+                    f"Unexpected zero return code from the smoke script "
+                    f"on {model_pth}: {return_code}"
+                ]
+                if stderr.getvalue():
+                    parts.append(f"The captured STDERR was:\n{stderr.getvalue()}")
+
+                raise AssertionError("\n\n".join(parts))
+
+            if stderr.getvalue() == "":
+                raise AssertionError(
+                    f"Unexpected no STDERR from the smoke script on {model_pth}"
+                )
+
+            stderr_pth = model_pth.parent / "expected_stderr.txt"
+
+            normalized_stderr = stderr.getvalue().replace(
+                str(model_pth), f"<{model_pth.name}>"
+            )
+
+            if Test_against_recorded.RERECORD:
+                stderr_pth.write_text(normalized_stderr, encoding="utf-8")
+            else:
+                self.assertEqual(
+                    normalized_stderr,
+                    stderr_pth.read_text(encoding="utf-8"),
+                    stderr_pth,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
We write a script to run the common pre-generation steps (parsing,
translation, infer constraints for schema). This allows us to run
smoke-tests on mea-models *before* generating the code.

This is particularly useful for continuous integration in, say,
aas-core-meta repository.