### PR TITLE
Remove a TODO from `tests.smoke`

### DIFF
--- a/tests/smoke/test_main.py
+++ b/tests/smoke/test_main.py
@@ -12,9 +12,6 @@ class Test_against_recorded(unittest.TestCase):
         "true",
         "on",
     )
-    RERECORD = True  # TODO (mristin, 2022-03-28): debug
-
-    # TODO (mristin, 2022-03-28): add meta-models in precommit script
 
     def test_cases(self) -> None:
         repo_dir = pathlib.Path(os.path.realpath(__file__)).parent.parent.parent


### PR DESCRIPTION
We mistakenly merged a TODO in the module `tests.smoke` since it lacked
the `__init__.py` marker in the directory and was thus omitted by
pylint.