### PR TITLE
Add pylint disables in `tests.smoke`

### DIFF
--- a/tests/smoke/test_main.py
+++ b/tests/smoke/test_main.py
@@ -1,3 +1,7 @@
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-class-docstring
+# pylint: disable=missing-function-docstring
+
 import io
 import os
 import pathlib


### PR DESCRIPTION
For some reason, pylint forgot to warn us about the missing disables in
the `tests.smoke` and we hastly merged in the changes.