### PR TITLE
Upgrade black to 22.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     # fmt: off
     extras_require={
         "dev": [
-            "black==22.1.0",
+            "black==22.3.0",
             "mypy==0.930",
             "pylint==2.12.2",
             "pydocstyle>=2.1.1,<3",


### PR DESCRIPTION
We had problems on the remote CI server complaining about the `click`
library. We simply upgrade black to the latest version and hope that
this upgrade fixes the issue.