### PR TITLE
Include constraints in description iterations

### DIFF
--- a/aas_core_codegen/csharp/description.py
+++ b/aas_core_codegen/csharp/description.py
@@ -18,6 +18,7 @@ from aas_core_codegen.csharp.common import INDENT as I
 from aas_core_codegen.intermediate import (
     doc as intermediate_doc,
     rendering as intermediate_rendering,
+    _translate as intermediate_translate,
 )
 
 
@@ -62,6 +63,15 @@ class _ElementRenderer(intermediate_rendering.DocutilsElementTransformer[str]):
                 assert_never(element.symbol)
 
         else:
+            # NOTE (mristin, 2022-03-30):
+            # This is a very special case where we had problems with an interface.
+            # We leave this check here, just in case the bug resurfaces.
+            if isinstance(element.symbol, intermediate_translate._PlaceholderSymbol):
+                return None, [
+                    f"Unexpected placeholder for the symbol: {element.symbol}; "
+                    f"this is a bug"
+                ]
+
             assert_never(element.symbol)
 
         assert name is not None
@@ -104,6 +114,18 @@ class _ElementRenderer(intermediate_rendering.DocutilsElementTransformer[str]):
 
             cref = f"{symbol_name}.{literal_name}"
         else:
+            # NOTE (mristin, 2022-03-30):
+            # This is a very special case where we had problems with an interface.
+            # We leave this check here, just in case the bug resurfaces.
+            if isinstance(
+                element.reference, intermediate_translate._PlaceholderAttributeReference
+            ):
+                return None, [
+                    f"Unexpected placeholder "
+                    f"for the attribute reference: {element.reference}; "
+                    f"this is a bug"
+                ]
+
             assert_never(element.reference)
 
         assert cref is not None

--- a/aas_core_codegen/intermediate/_translate.py
+++ b/aas_core_codegen/intermediate/_translate.py
@@ -143,6 +143,9 @@ class _PlaceholderAttributeReference:
         """Initialize with the given values."""
         self.path = path
 
+    def __repr__(self) -> str:
+        return f"{_PlaceholderAttributeReference.__name__}(path={self.path!r})"
+
 
 # noinspection PyUnusedLocal
 def _attribute_reference_role(  # type: ignore
@@ -726,6 +729,9 @@ class _PlaceholderSymbol:
     def __init__(self, name: str) -> None:
         """Initialize with the given values."""
         self.name = name
+
+    def __repr__(self) -> str:
+        return f"{_PlaceholderSymbol.__name__}(name={self.name!r})"
 
 
 def _propagate_parsed_reference_in_the_book(
@@ -1807,6 +1813,10 @@ def _find_all_in_property_description(
 
     for remark in property_description.remarks:
         for element in remark.findall(element_type):
+            yield element, property_description
+
+    for body in property_description.constraints_by_identifier.values():
+        for element in body.findall(element_type):
             yield element, property_description
 
 


### PR DESCRIPTION
We mistakenly omitted property constraints when we iterated over the
description elements. This resulted in unresolved attribute references.