### PR TITLE
Fix XSD to use correct environment type

### DIFF
--- a/test_data/xsd/test_main/v3rc2/expected_output/schema.xml
+++ b/test_data/xsd/test_main/v3rc2/expected_output/schema.xml
@@ -2,7 +2,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.admin-shell.io/aas/3/0" elementFormDefault="qualified" targetNamespace="http://www.admin-shell.io/aas/3/0">
   
     
-  <xs:element name="assetAdministrationShellEnvironment" type="assetAdministrationShellEnvironment_t"/>
+  <xs:element name="environment" type="environment_t"/>
   
 
   <xs:group name="resource">

--- a/test_data/xsd/test_main/v3rc2/input/snippets/root_element.xml
+++ b/test_data/xsd/test_main/v3rc2/input/snippets/root_element.xml
@@ -4,5 +4,5 @@
         elementFormDefault="qualified"
         targetNamespace="http://www.admin-shell.io/aas/3/0"
 >
-    <xs:element name="assetAdministrationShellEnvironment" type="assetAdministrationShellEnvironment_t" />
+    <xs:element name="environment" type="environment_t" />
 </xs:schema>


### PR DESCRIPTION
We fix the snippet in the test data to use the appropriate type for the
environment (`environment_t`). Previously, we mistakenly took the type
from V3RC01, `assetAdministrationShellEnvironment_t`.