### PR TITLE
Undo escaping of `\x??` in XSD

### DIFF
--- a/test_data/xsd/test_main/v3rc2/expected_output/schema.xml
+++ b/test_data/xsd/test_main/v3rc2/expected_output/schema.xml
@@ -11,7 +11,7 @@
       <xs:element name="contentType" minOccurs="0">
         <xs:simpleType>
           <xs:restriction base="xs:string">
-            <xs:pattern value="([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+/([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+([ 	]*;[ 	]*([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+=(([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+|&quot;(([	 !#-\[\]-~]|[\x80-\xff])|\\([	 !-~]|[\x80-\xff]))*&quot;))*"/>
+            <xs:pattern value="([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+/([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+([ 	]*;[ 	]*([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+=(([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+|&quot;(([	 !#-\[\]-~]|[-ÿ])|\\([	 !-~]|[-ÿ]))*&quot;))*"/>
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
@@ -786,7 +786,7 @@
       <xs:element name="mimeType">
         <xs:simpleType>
           <xs:restriction base="xs:string">
-            <xs:pattern value="([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+/([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+([ 	]*;[ 	]*([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+=(([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+|&quot;(([	 !#-\[\]-~]|[\x80-\xff])|\\([	 !-~]|[\x80-\xff]))*&quot;))*"/>
+            <xs:pattern value="([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+/([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+([ 	]*;[ 	]*([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+=(([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+|&quot;(([	 !#-\[\]-~]|[-ÿ])|\\([	 !-~]|[-ÿ]))*&quot;))*"/>
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
@@ -809,7 +809,7 @@
       <xs:element name="contentType">
         <xs:simpleType>
           <xs:restriction base="xs:string">
-            <xs:pattern value="([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+/([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+([ 	]*;[ 	]*([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+=(([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+|&quot;(([	 !#-\[\]-~]|[\x80-\xff])|\\([	 !-~]|[\x80-\xff]))*&quot;))*"/>
+            <xs:pattern value="([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+/([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+([ 	]*;[ 	]*([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+=(([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+|&quot;(([	 !#-\[\]-~]|[-ÿ])|\\([	 !-~]|[-ÿ]))*&quot;))*"/>
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>

--- a/tests/xsd/test_main.py
+++ b/tests/xsd/test_main.py
@@ -8,6 +8,60 @@ import tempfile
 import unittest
 
 import aas_core_codegen.main
+from aas_core_codegen.xsd import main as xsd_main
+
+
+class Test_undo_escaping_x(unittest.TestCase):
+    def test_empty(self) -> None:
+        self.assertEqual("", xsd_main._undo_escaping_backslash_x_in_pattern(""))
+
+    def test_no_escaped(self) -> None:
+        self.assertEqual(
+            "test me", xsd_main._undo_escaping_backslash_x_in_pattern("test me")
+        )
+
+    def test_only_escaped(self) -> None:
+        self.assertEqual(
+            "\xff", xsd_main._undo_escaping_backslash_x_in_pattern("\\xff")
+        )
+
+    def test_prefix(self) -> None:
+        self.assertEqual(
+            "A\xff", xsd_main._undo_escaping_backslash_x_in_pattern("A\\xff")
+        )
+
+    def test_suffix(self) -> None:
+        self.assertEqual(
+            "\xffB", xsd_main._undo_escaping_backslash_x_in_pattern("\\xffB")
+        )
+
+    def test_prefix_suffix(self) -> None:
+        self.assertEqual(
+            "A\xffB", xsd_main._undo_escaping_backslash_x_in_pattern("A\\xffB")
+        )
+
+    def test_multiple(self) -> None:
+        self.assertEqual(
+            "A\xf1B\xf2C",
+            xsd_main._undo_escaping_backslash_x_in_pattern("A\\xf1B\\xf2C"),
+        )
+
+    def test_complex(self) -> None:
+        pattern = (
+            "([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+/([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+([ \t]*;"
+            "[ \t]*([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+=(([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+|"
+            '"(([\t !#-\\[\\]-~]|[\\x80-\\xff])|\\\\([\t !-~]|[\\x80-\\xff]))*"))*'
+        )
+
+        expected = (
+            "([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+/([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+([ \t]*;"
+            "[ \t]*([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+=(([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+|"
+            '"(([\t !#-\\[\\]-~]|[\x80-\xff])|\\\\([\t !-~]|[\x80-\xff]))*"))*'
+        )
+
+        self.assertEqual(
+            expected, xsd_main._undo_escaping_backslash_x_in_pattern(pattern)
+        )
 
 
 class Test_against_recorded(unittest.TestCase):


### PR DESCRIPTION
Many schema validators do not handle special escape characters `\x??` in
`xs:pattern` correctly, we have to undo the escaping in the patterns
and put them in `xs:pattern` in their original unicode characters.