### PR TITLE
Remark why pre-conditions are not conjunctions

### DIFF
--- a/aas_core_codegen/intermediate/_translate.py
+++ b/aas_core_codegen/intermediate/_translate.py
@@ -2747,14 +2747,14 @@ def _second_pass_to_stack_constructors_in_place(
             # internal clients in the submodules.
 
             # noinspection PyFinal
-            symbol.constructor.contracts.snapshots = list(
+            symbol.constructor.contracts.snapshots = list(  # type: ignore
                 itertools.chain(
                     inherited_snapshots, symbol.constructor.contracts.snapshots
                 )
             )
 
             # noinspection PyFinal
-            symbol.constructor.contracts.postconditions = list(
+            symbol.constructor.contracts.postconditions = list(  # type: ignore
                 itertools.chain(
                     inherited_postconditions,
                     symbol.constructor.contracts.postconditions,

--- a/aas_core_codegen/intermediate/_types.py
+++ b/aas_core_codegen/intermediate/_types.py
@@ -624,6 +624,28 @@ class Snapshot:
 class Contracts:
     """Represent the set of contracts for a method or a function."""
 
+    # NOTE (mristin, 2022-04-7):
+    # Common programming languages which work with contracts usually implement
+    # pre-conditions in a disjunctive normal form, *i.e.* as a disjunction of
+    # conjunctions, where at least one conjunction needs to hold. The individual
+    # conjunctions correspond to the levels of the inheritance hierarchy.
+    #
+    # However, we have not touched methods at the moment nor their proper inheritance.
+    # Therefore we leave the pre-conditions in the intermediate representation as they
+    # would appear in the code, without inheritance and hence without disjunctions.
+    # In the future, once we want to tackle the methods as a feature, we need to change
+    # the way how we model and resolve the pre-conditions through
+    # the inheritance hierarchy.
+
+    #: Pre-conditions that need to hold *before* the call
+    preconditions: Final[Sequence[Contract]]
+
+    #: Snapshots which are captured *before* the call
+    snapshots: Final[Sequence[Snapshot]]
+
+    #: Post-conditions that need to hold *after* the call
+    postconditions: Final[Sequence[Contract]]
+
     def __init__(
         self,
         preconditions: Sequence[Contract],


### PR DESCRIPTION
We add a note in the types of the intermediate representation why the
pre-conditions of a method are not modeled in the disjunctive normal
form which is common for programming languages supporting contracts.

Namely, we do not handle overriding of the methods at the moment, so we
leave this change in the intermediate representation for the future. The
note was however necessary to avoid confusion.