### PR TITLE
Represent string constants as literals in C#

### DIFF
--- a/aas_core_codegen/csharp/verification/_generate.py
+++ b/aas_core_codegen/csharp/verification/_generate.py
@@ -631,7 +631,7 @@ class _InvariantTranspiler(
         elif isinstance(node.value, (int, float)):
             return Stripped(str(node.value)), None
         elif isinstance(node.value, str):
-            return Stripped(repr(node.value)), None
+            return Stripped(csharp_common.string_literal(node.value)), None
         else:
             assert_never(node.value)
 


### PR DESCRIPTION
We mistakenly used ``repr`` to represent string literals in invariants.
With this patch, we correctly render the constant as a proper C# string
literal.