### PR TITLE
Fix formatting of multi-line invariants in C#

### DIFF
--- a/aas_core_codegen/csharp/verification/_generate.py
+++ b/aas_core_codegen/csharp/verification/_generate.py
@@ -870,13 +870,14 @@ class _InvariantTranspiler(
         ):
             iteration = Stripped(f"({iteration})")
 
+        # NOTE (mristin, 2022-04-7):
+        # We can not use ``textwrap.dedent`` here since ``condition`` contains multiple
+        # lines.
         return (
             Stripped(
-                textwrap.dedent(
-                    f"""\
-                {iteration}.All(
-                {I}{variable} => {condition})"""
-                )
+                f"""\
+{iteration}.All(
+{I}{variable} => {condition})"""
             ),
             None,
         )


### PR DESCRIPTION
We mistakenly used ``textwrap.dedent`` which fails when one of the
string interpolations consists of multiple lines.

With this patch, we fix the issue by avoiding ``textwrap.dedent`` and
using a vanilla string literal.