### PR TITLE
Wrap the invariant descriptions in C#

### DIFF
--- a/aas_core_codegen/csharp/common.py
+++ b/aas_core_codegen/csharp/common.py
@@ -12,7 +12,7 @@ from aas_core_codegen.csharp import naming as csharp_naming
 
 @ensure(lambda result: result.startswith('"'))
 @ensure(lambda result: result.endswith('"'))
-def string_literal(text: str) -> str:
+def string_literal(text: str) -> Stripped:
     """Generate a C# string literal from the ``text``."""
     escaped = []  # type: List[str]
 
@@ -38,7 +38,7 @@ def string_literal(text: str) -> str:
         else:
             escaped.append(character)
 
-    return '"{}"'.format("".join(escaped))
+    return Stripped('"{}"'.format("".join(escaped)))
 
 
 def needs_escaping(text: str) -> bool:

--- a/aas_core_codegen/csharp/verification/_generate.py
+++ b/aas_core_codegen/csharp/verification/_generate.py
@@ -945,6 +945,88 @@ assert all(
 )
 
 
+@ensure(lambda text, result: text == "".join(result))
+def _wrap_invariant_description(text: str) -> List[str]:
+    """
+    Wrap the invariant description as ``text`` into multiple tokens.
+
+    The tokens are split based on the whitespace. We make sure the articles are not
+    left hanging between the lines. A line should observe a pre-defined line limit,
+    if possible.
+
+    No new lines are added — the description should be given to the user in the original
+    formatting. We merely split it in string literals for better code readability.
+    """
+    parts = text.split(" ")
+    if len(parts) == 1:
+        return [text]
+
+    # NOTE (mristin, 2022-04-8):
+    # We do not want to cut out "the", "a" and "an" on separate lines, so we split
+    # the text once more in tokens where the articles are kept in the same token as
+    # the word.
+    tokens = []  # type: List[str]
+
+    article = None  # type: Optional[str]
+    for part in parts:
+        if article is None:
+            if part in ("a", "an", "the"):
+                article = part
+                continue
+            else:
+                tokens.append(part)
+        else:
+            if part in ("a", "an", "the"):
+                # Append the previously observed ``article``;
+                # the ``part`` becomes a new article.
+                tokens.append(article)
+                article = part
+                continue
+
+            tokens.append(f"{article} {part}")
+            article = None
+
+    if article is not None:
+        tokens.append(article)
+
+    # NOTE (mristin, 2022-04-8):
+    # We add space to the tokens so that it is easier to re-flow them.
+    tokens = [
+        f"{token} " if i < len(tokens) - 1 else token for i, token in enumerate(tokens)
+    ]
+    assert "".join(tokens) == text
+
+    # NOTE (mristin, 2022-04-8):
+    # The line width of 60 characters is an arbitrary, but plausible limit. Please
+    # consider that the text will be indented, so you have to add some slack.
+    line_width = 60
+
+    segments = []  # type: List[str]
+
+    accumulation_len = 0
+    accumulation = []  # type: List[str]
+
+    for token in tokens:
+        if len(token) > line_width:
+            segments.append("".join(accumulation))
+            segments.append(token)
+            accumulation_len = 0
+            accumulation = []
+
+        elif accumulation_len + len(token) > line_width:
+            segments.append("".join(accumulation))
+            accumulation_len = len(token)
+            accumulation = [token]
+        else:
+            accumulation_len += len(token)
+            accumulation.append(token)
+
+    if accumulation_len > 0:
+        segments.append("".join(accumulation))
+
+    return segments
+
+
 @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
 def _transpile_invariant(
     invariant: intermediate.Invariant,
@@ -1013,18 +1095,32 @@ def _transpile_invariant(
         )
     )
 
-    lines = []  # type: List[str]
+    message_literals = []  # type: List[Stripped]
     if invariant.description is not None:
-        lines = invariant.description.splitlines()
+        # NOTE (mristin, 2022-04-8):
+        # We need to wrap the description in multiple literals as a single long
+        # string literal is often too much for the readability.
+        invariant_description_lines = _wrap_invariant_description(invariant.description)
+        for i, line in enumerate(invariant_description_lines):
+            if i < len(invariant_description_lines) - 1:
+                message_literals.append(csharp_common.string_literal(line))
+            else:
+                message_literals.append(csharp_common.string_literal(f"{line}\n"))
 
-    lines = lines + expr.splitlines()
-
-    for i, line in enumerate(lines):
-        if i < len(lines) - 1:
-            line_literal = csharp_common.string_literal(line + "\n")
-            writer.write(f"{II}{line_literal} +\n")
+    expr_lines = expr.splitlines()
+    for i, line in enumerate(expr_lines):
+        if i < len(expr_lines) - 1:
+            literal = csharp_common.string_literal(line + "\n")
         else:
-            writer.write(f"{II}{csharp_common.string_literal(line)});")
+            literal = csharp_common.string_literal(line)
+
+        message_literals.append(literal)
+
+    for i, literal in enumerate(message_literals):
+        if i < len(message_literals) - 1:
+            writer.write(f"{II}{literal} +\n")
+        else:
+            writer.write(f"{II}{literal});")
 
     writer.write("\n}")
 

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/verification.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/verification.cs
@@ -1580,7 +1580,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-020: The value shall be consistent to the data type as defined in value_type.\n" +
+                        "Constraint AASd-020: The value shall be consistent to " +
+                        "the data type as defined in value_type.\n" +
                         "!(that.Value != null)\n" +
                         "|| Verification.ValueConsistentWithXsdType(that.Value, that.ValueType)");
                 }
@@ -1644,7 +1645,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.\n" +
+                        "Constraint AASd-077: The name of an extension within " +
+                        "Has_extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
                 }
@@ -1655,7 +1657,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-027: ID-short shall have a maximum length of 128 characters.\n" +
+                        "Constraint AASd-027: ID-short shall have a maximum length " +
+                        "of 128 characters.\n" +
                         "!(that.IdShort != null)\n" +
                         "|| (that.IdShort.Length <= 128)");
                 }
@@ -1666,7 +1669,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.\n" +
+                        "Constraint AASd-021: Every qualifiable can only have one " +
+                        "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
                 }
@@ -1678,7 +1682,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-090: For data elements category shall be one of the following values: CONSTANT, PARAMETER or VARIABLE\n" +
+                        "Constraint AASd-090: For data elements category shall be " +
+                        "one of the following values: CONSTANT, PARAMETER or VARIABLE\n" +
                         "that.Category == \"CONSTANT\"\n" +
                         "|| that.Category == \"PARAMETER\"\n" +
                         "|| that.Category == \"VARIABLE\"");
@@ -1971,7 +1976,10 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-005: If version is not specified than also revision shall be unspecified. This means, a revision requires a version. If there is no version there is no revision neither. Revision is optional.\n" +
+                        "Constraint AASd-005: If version is not specified than also " +
+                        "revision shall be unspecified. This means, a revision " +
+                        "requires a version. If there is no version there is no " +
+                        "revision neither. Revision is optional.\n" +
                         "!(that.Revision != null)\n" +
                         "|| (that.Version != null)");
                 }
@@ -2027,7 +2035,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.\n" +
+                        "Constraint AASd-077: The name of an extension within " +
+                        "Has_extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
                 }
@@ -2038,7 +2047,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-027: ID-short shall have a maximum length of 128 characters.\n" +
+                        "Constraint AASd-027: ID-short shall have a maximum length " +
+                        "of 128 characters.\n" +
                         "!(that.IdShort != null)\n" +
                         "|| (that.IdShort.Length <= 128)");
                 }
@@ -2320,7 +2330,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.\n" +
+                        "Constraint AASd-077: The name of an extension within " +
+                        "Has_extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
                 }
@@ -2331,7 +2342,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-027: ID-short shall have a maximum length of 128 characters.\n" +
+                        "Constraint AASd-027: ID-short shall have a maximum length " +
+                        "of 128 characters.\n" +
                         "!(that.IdShort != null)\n" +
                         "|| (that.IdShort.Length <= 128)");
                 }
@@ -2342,7 +2354,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.\n" +
+                        "Constraint AASd-021: Every qualifiable can only have one " +
+                        "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
                 }
@@ -2559,7 +2572,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.\n" +
+                        "Constraint AASd-077: The name of an extension within " +
+                        "Has_extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
                 }
@@ -2570,7 +2584,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-027: ID-short shall have a maximum length of 128 characters.\n" +
+                        "Constraint AASd-027: ID-short shall have a maximum length " +
+                        "of 128 characters.\n" +
                         "!(that.IdShort != null)\n" +
                         "|| (that.IdShort.Length <= 128)");
                 }
@@ -2581,7 +2596,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.\n" +
+                        "Constraint AASd-021: Every qualifiable can only have one " +
+                        "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
                 }
@@ -2599,7 +2615,9 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-107: If a first level child element has a semantic ID it shall be identical to semantic ID list element.\n" +
+                        "Constraint AASd-107: If a first level child element has " +
+                        "a semantic ID it shall be identical to semantic ID list " +
+                        "element.\n" +
                         "!(\n" +
                         "    (that.Value != null)\n" +
                         "    && (that.SemanticIdListElement != null)\n" +
@@ -2617,7 +2635,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-114: If two first level child elements have a semantic ID then they shall be identical.\n" +
+                        "Constraint AASd-114: If two first level child elements have " +
+                        "a semantic ID then they shall be identical.\n" +
                         "!(that.Value != null)\n" +
                         "|| Verification.SubmodelElementsHaveIdenticalSemanticIds(that.Value)");
                 }
@@ -2631,7 +2650,9 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-108: All first level child elements shall have the same submodel element type as specified in type value list element.\n" +
+                        "Constraint AASd-108: All first level child elements shall " +
+                        "have the same submodel element type as specified in type " +
+                        "value list element.\n" +
                         "!(that.Value != null)\n" +
                         "|| (\n" +
                         "    that.Value.All(\n" +
@@ -2654,7 +2675,10 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-109: If type value list element is equal to Property or Range value type list element shall be set and all first level child elements shall have the value type as specified in value type list element.\n" +
+                        "Constraint AASd-109: If type value list element is equal to " +
+                        "Property or Range value type list element shall be set and " +
+                        "all first level child elements shall have the value type as " +
+                        "specified in value type list element.\n" +
                         "!(\n" +
                         "    (that.Value != null)\n" +
                         "    && (\n" +
@@ -2896,7 +2920,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.\n" +
+                        "Constraint AASd-077: The name of an extension within " +
+                        "Has_extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
                 }
@@ -2907,7 +2932,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-027: ID-short shall have a maximum length of 128 characters.\n" +
+                        "Constraint AASd-027: ID-short shall have a maximum length " +
+                        "of 128 characters.\n" +
                         "!(that.IdShort != null)\n" +
                         "|| (that.IdShort.Length <= 128)");
                 }
@@ -2918,7 +2944,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.\n" +
+                        "Constraint AASd-021: Every qualifiable can only have one " +
+                        "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
                 }
@@ -3116,7 +3143,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.\n" +
+                        "Constraint AASd-077: The name of an extension within " +
+                        "Has_extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
                 }
@@ -3127,7 +3155,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-027: ID-short shall have a maximum length of 128 characters.\n" +
+                        "Constraint AASd-027: ID-short shall have a maximum length " +
+                        "of 128 characters.\n" +
                         "!(that.IdShort != null)\n" +
                         "|| (that.IdShort.Length <= 128)");
                 }
@@ -3138,7 +3167,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.\n" +
+                        "Constraint AASd-021: Every qualifiable can only have one " +
+                        "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
                 }
@@ -3150,7 +3180,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-090: For data elements category shall be one of the following values: CONSTANT, PARAMETER or VARIABLE\n" +
+                        "Constraint AASd-090: For data elements category shall be " +
+                        "one of the following values: CONSTANT, PARAMETER or VARIABLE\n" +
                         "that.Category == \"CONSTANT\"\n" +
                         "|| that.Category == \"PARAMETER\"\n" +
                         "|| that.Category == \"VARIABLE\"");
@@ -3343,7 +3374,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.\n" +
+                        "Constraint AASd-077: The name of an extension within " +
+                        "Has_extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
                 }
@@ -3354,7 +3386,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-027: ID-short shall have a maximum length of 128 characters.\n" +
+                        "Constraint AASd-027: ID-short shall have a maximum length " +
+                        "of 128 characters.\n" +
                         "!(that.IdShort != null)\n" +
                         "|| (that.IdShort.Length <= 128)");
                 }
@@ -3365,7 +3398,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.\n" +
+                        "Constraint AASd-021: Every qualifiable can only have one " +
+                        "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
                 }
@@ -3377,7 +3411,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-090: For data elements category shall be one of the following values: CONSTANT, PARAMETER or VARIABLE\n" +
+                        "Constraint AASd-090: For data elements category shall be " +
+                        "one of the following values: CONSTANT, PARAMETER or VARIABLE\n" +
                         "that.Category == \"CONSTANT\"\n" +
                         "|| that.Category == \"PARAMETER\"\n" +
                         "|| that.Category == \"VARIABLE\"");
@@ -3552,7 +3587,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.\n" +
+                        "Constraint AASd-077: The name of an extension within " +
+                        "Has_extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
                 }
@@ -3563,7 +3599,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-027: ID-short shall have a maximum length of 128 characters.\n" +
+                        "Constraint AASd-027: ID-short shall have a maximum length " +
+                        "of 128 characters.\n" +
                         "!(that.IdShort != null)\n" +
                         "|| (that.IdShort.Length <= 128)");
                 }
@@ -3574,7 +3611,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.\n" +
+                        "Constraint AASd-021: Every qualifiable can only have one " +
+                        "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
                 }
@@ -3586,7 +3624,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-090: For data elements category shall be one of the following values: CONSTANT, PARAMETER or VARIABLE\n" +
+                        "Constraint AASd-090: For data elements category shall be " +
+                        "one of the following values: CONSTANT, PARAMETER or VARIABLE\n" +
                         "that.Category == \"CONSTANT\"\n" +
                         "|| that.Category == \"PARAMETER\"\n" +
                         "|| that.Category == \"VARIABLE\"");
@@ -3789,7 +3828,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.\n" +
+                        "Constraint AASd-077: The name of an extension within " +
+                        "Has_extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
                 }
@@ -3800,7 +3840,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-027: ID-short shall have a maximum length of 128 characters.\n" +
+                        "Constraint AASd-027: ID-short shall have a maximum length " +
+                        "of 128 characters.\n" +
                         "!(that.IdShort != null)\n" +
                         "|| (that.IdShort.Length <= 128)");
                 }
@@ -3811,7 +3852,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.\n" +
+                        "Constraint AASd-021: Every qualifiable can only have one " +
+                        "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
                 }
@@ -3823,7 +3865,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-090: For data elements category shall be one of the following values: CONSTANT, PARAMETER or VARIABLE\n" +
+                        "Constraint AASd-090: For data elements category shall be " +
+                        "one of the following values: CONSTANT, PARAMETER or VARIABLE\n" +
                         "that.Category == \"CONSTANT\"\n" +
                         "|| that.Category == \"PARAMETER\"\n" +
                         "|| that.Category == \"VARIABLE\"");
@@ -3995,7 +4038,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.\n" +
+                        "Constraint AASd-077: The name of an extension within " +
+                        "Has_extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
                 }
@@ -4006,7 +4050,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-027: ID-short shall have a maximum length of 128 characters.\n" +
+                        "Constraint AASd-027: ID-short shall have a maximum length " +
+                        "of 128 characters.\n" +
                         "!(that.IdShort != null)\n" +
                         "|| (that.IdShort.Length <= 128)");
                 }
@@ -4017,7 +4062,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.\n" +
+                        "Constraint AASd-021: Every qualifiable can only have one " +
+                        "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
                 }
@@ -4029,7 +4075,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-090: For data elements category shall be one of the following values: CONSTANT, PARAMETER or VARIABLE\n" +
+                        "Constraint AASd-090: For data elements category shall be " +
+                        "one of the following values: CONSTANT, PARAMETER or VARIABLE\n" +
                         "that.Category == \"CONSTANT\"\n" +
                         "|| that.Category == \"PARAMETER\"\n" +
                         "|| that.Category == \"VARIABLE\"");
@@ -4201,7 +4248,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.\n" +
+                        "Constraint AASd-077: The name of an extension within " +
+                        "Has_extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
                 }
@@ -4212,7 +4260,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-027: ID-short shall have a maximum length of 128 characters.\n" +
+                        "Constraint AASd-027: ID-short shall have a maximum length " +
+                        "of 128 characters.\n" +
                         "!(that.IdShort != null)\n" +
                         "|| (that.IdShort.Length <= 128)");
                 }
@@ -4223,7 +4272,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.\n" +
+                        "Constraint AASd-021: Every qualifiable can only have one " +
+                        "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
                 }
@@ -4410,7 +4460,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.\n" +
+                        "Constraint AASd-077: The name of an extension within " +
+                        "Has_extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
                 }
@@ -4421,7 +4472,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-027: ID-short shall have a maximum length of 128 characters.\n" +
+                        "Constraint AASd-027: ID-short shall have a maximum length " +
+                        "of 128 characters.\n" +
                         "!(that.IdShort != null)\n" +
                         "|| (that.IdShort.Length <= 128)");
                 }
@@ -4432,7 +4484,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.\n" +
+                        "Constraint AASd-021: Every qualifiable can only have one " +
+                        "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
                 }
@@ -4746,7 +4799,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.\n" +
+                        "Constraint AASd-077: The name of an extension within " +
+                        "Has_extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
                 }
@@ -4757,7 +4811,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-027: ID-short shall have a maximum length of 128 characters.\n" +
+                        "Constraint AASd-027: ID-short shall have a maximum length " +
+                        "of 128 characters.\n" +
                         "!(that.IdShort != null)\n" +
                         "|| (that.IdShort.Length <= 128)");
                 }
@@ -4768,7 +4823,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.\n" +
+                        "Constraint AASd-021: Every qualifiable can only have one " +
+                        "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
                 }
@@ -4794,7 +4850,9 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-014: Either the attribute global asset ID or specific asset ID must be set if entity type is set to 'SelfManagedEntity'. They are not existing otherwise.\n" +
+                        "Constraint AASd-014: Either the attribute global asset ID " +
+                        "or specific asset ID must be set if entity type is set to " +
+                        "'SelfManagedEntity'. They are not existing otherwise.\n" +
                         "(\n" +
                         "    that.EntityType == EntityType.SelfManagedEntity\n" +
                         "    && (\n" +
@@ -5010,7 +5068,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.\n" +
+                        "Constraint AASd-077: The name of an extension within " +
+                        "Has_extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
                 }
@@ -5021,7 +5080,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-027: ID-short shall have a maximum length of 128 characters.\n" +
+                        "Constraint AASd-027: ID-short shall have a maximum length " +
+                        "of 128 characters.\n" +
                         "!(that.IdShort != null)\n" +
                         "|| (that.IdShort.Length <= 128)");
                 }
@@ -5032,7 +5092,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.\n" +
+                        "Constraint AASd-021: Every qualifiable can only have one " +
+                        "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
                 }
@@ -5192,7 +5253,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.\n" +
+                        "Constraint AASd-077: The name of an extension within " +
+                        "Has_extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
                 }
@@ -5203,7 +5265,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-027: ID-short shall have a maximum length of 128 characters.\n" +
+                        "Constraint AASd-027: ID-short shall have a maximum length " +
+                        "of 128 characters.\n" +
                         "!(that.IdShort != null)\n" +
                         "|| (that.IdShort.Length <= 128)");
                 }
@@ -5214,7 +5277,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.\n" +
+                        "Constraint AASd-021: Every qualifiable can only have one " +
+                        "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
                 }
@@ -5435,7 +5499,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.\n" +
+                        "Constraint AASd-077: The name of an extension within " +
+                        "Has_extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
                 }
@@ -5446,7 +5511,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-027: ID-short shall have a maximum length of 128 characters.\n" +
+                        "Constraint AASd-027: ID-short shall have a maximum length " +
+                        "of 128 characters.\n" +
                         "!(that.IdShort != null)\n" +
                         "|| (that.IdShort.Length <= 128)");
                 }
@@ -5457,7 +5523,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.\n" +
+                        "Constraint AASd-021: Every qualifiable can only have one " +
+                        "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
                 }
@@ -5609,7 +5676,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.\n" +
+                        "Constraint AASd-077: The name of an extension within " +
+                        "Has_extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
                 }
@@ -5620,7 +5688,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-027: ID-short shall have a maximum length of 128 characters.\n" +
+                        "Constraint AASd-027: ID-short shall have a maximum length " +
+                        "of 128 characters.\n" +
                         "!(that.IdShort != null)\n" +
                         "|| (that.IdShort.Length <= 128)");
                 }
@@ -5631,7 +5700,11 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-051: A concept description shall have one of the following categories: 'VALUE', 'PROPERTY', 'REFERENCE', 'DOCUMENT', 'CAPABILITY',; 'RELATIONSHIP', 'COLLECTION', 'FUNCTION', 'EVENT', 'ENTITY', 'APPLICATION_CLASS', 'QUALIFIER', 'VIEW'.\n" +
+                        "Constraint AASd-051: A concept description shall have one " +
+                        "of the following categories: 'VALUE', 'PROPERTY', " +
+                        "'REFERENCE', 'DOCUMENT', 'CAPABILITY',; 'RELATIONSHIP', " +
+                        "'COLLECTION', 'FUNCTION', 'EVENT', 'ENTITY', " +
+                        "'APPLICATION_CLASS', 'QUALIFIER', 'VIEW'.\n" +
                         "!(that.Category != null)\n" +
                         "|| Verification.ConceptDescriptionCategoryIsValid(that.Category)");
                 }
@@ -5777,7 +5850,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.\n" +
+                        "Constraint AASd-077: The name of an extension within " +
+                        "Has_extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
                 }
@@ -5788,7 +5862,8 @@ namespace AasCore.Aas3
                 {
                     yield return new Reporting.Error(
                         "Invariant violated:\n" +
-                        "Constraint AASd-027: ID-short shall have a maximum length of 128 characters.\n" +
+                        "Constraint AASd-027: ID-short shall have a maximum length " +
+                        "of 128 characters.\n" +
                         "!(that.IdShort != null)\n" +
                         "|| (that.IdShort.Length <= 128)");
                 }

--- a/tests/csharp/test_verification.py
+++ b/tests/csharp/test_verification.py
@@ -1,0 +1,95 @@
+# pylint: disable=missing-docstring
+import unittest
+
+from aas_core_codegen.csharp import verification as csharp_verification
+
+
+class Test_wrap_invariant_description(unittest.TestCase):
+    def test_empty(self) -> None:
+        got = csharp_verification._generate._wrap_invariant_description(text="")
+
+        self.assertListEqual([""], got)
+
+    def test_short_word(self) -> None:
+        got = csharp_verification._generate._wrap_invariant_description(
+            text="something short"
+        )
+
+        self.assertListEqual(["something short"], got)
+
+    # noinspection SpellCheckingInspection
+    def test_normal_text(self) -> None:
+        text = (
+            "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, "
+            "sed diam nonumy eirmod tempor invidunt ut labore et dolore magna "
+            "aliquyam erat, sed diam voluptua. At vero eos et accusam et "
+            "justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea "
+            "takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit "
+            "amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt "
+            "ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos "
+            "et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, "
+            "no sea takimata sanctus est Lorem ipsum dolor sit amet."
+        )
+
+        expected = [
+            "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, ",
+            "sed diam nonumy eirmod tempor invidunt ut labore et dolore ",
+            "magna aliquyam erat, sed diam voluptua. At vero eos et ",
+            "accusam et justo duo dolores et ea rebum. Stet clita kasd ",
+            "gubergren, no sea takimata sanctus est Lorem ipsum dolor ",
+            "sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing ",
+            "elitr, sed diam nonumy eirmod tempor invidunt ut labore et ",
+            "dolore magna aliquyam erat, sed diam voluptua. At vero eos ",
+            "et accusam et justo duo dolores et ea rebum. Stet clita ",
+            "kasd gubergren, no sea takimata sanctus est Lorem ipsum ",
+            "dolor sit amet.",
+        ]
+
+        got = csharp_verification._generate._wrap_invariant_description(text=text)
+        self.assertListEqual(expected, got)
+
+    def test_very_long_word(self) -> None:
+        word = "1234567890" * 90
+
+        text = f"prefix {word} suffix"
+
+        expected = ["prefix ", f"{word} ", "suffix"]
+
+        got = csharp_verification._generate._wrap_invariant_description(text=text)
+        self.assertListEqual(expected, got)
+
+    def test_article_kept_on_the_same_line(self) -> None:
+        somethings = " ".join(["a something"] * 10)
+
+        text = f"prefix {somethings} suffix"
+
+        expected = [
+            "prefix a something a something a something a something ",
+            "a something a something a something a something a something ",
+            "a something suffix",
+        ]
+
+        got = csharp_verification._generate._wrap_invariant_description(text=text)
+        self.assertListEqual(expected, got)
+
+    def test_only_articles(self) -> None:
+        text = " ".join(["a an the"] * 60)
+        expected = [
+            "a an the a an the a an the a an the a an the a an the a an ",
+            "the a an the a an the a an the a an the a an the a an the a ",
+            "an the a an the a an the a an the a an the a an the a an ",
+            "the a an the a an the a an the a an the a an the a an the a ",
+            "an the a an the a an the a an the a an the a an the a an ",
+            "the a an the a an the a an the a an the a an the a an the a ",
+            "an the a an the a an the a an the a an the a an the a an ",
+            "the a an the a an the a an the a an the a an the a an the a ",
+            "an the a an the a an the a an the a an the a an the a an ",
+            "the a an the",
+        ]
+
+        got = csharp_verification._generate._wrap_invariant_description(text=text)
+        self.assertListEqual(expected, got)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
We need to re-flow the invariant descriptions in the generated C# code
to a pre-defined line width. Otherwise, the code is barely readable in
cases where invariant descriptions are long.