### PR TITLE
Fix `NOTE` comments

### DIFF
--- a/aas_core_codegen/csharp/verification/_generate.py
+++ b/aas_core_codegen/csharp/verification/_generate.py
@@ -441,7 +441,7 @@ class _InvariantTranspiler(
         if isinstance(node.antecedent, no_parentheses_types_in_this_context):
             not_antecedent = f"!{antecedent}"
         else:
-            # NOTE (mristin, 2022-04-7):
+            # NOTE (mristin, 2022-04-07):
             # This is a very rudimentary heuristic for breaking the lines, and can be
             # greatly improved by rendering into C# code. However, at this point, we
             # lack time for more sophisticated reformatting approaches.
@@ -454,7 +454,7 @@ class _InvariantTranspiler(
                 not_antecedent = f"!({antecedent})"
 
         if not isinstance(node.consequent, no_parentheses_types_in_this_context):
-            # NOTE (mristin, 2022-04-7):
+            # NOTE (mristin, 2022-04-07):
             # This is a very rudimentary heuristic for breaking the lines, and can be
             # greatly improved by rendering into C# code. However, at this point, we
             # lack time for more sophisticated reformatting approaches.
@@ -763,7 +763,7 @@ class _InvariantTranspiler(
             )
 
             if not isinstance(value_node, no_parentheses_types_in_this_context):
-                # NOTE (mristin, 2022-04-7):
+                # NOTE (mristin, 2022-04-07):
                 # This is a very rudimentary heuristic for breaking the lines, and can
                 # be greatly improved by rendering into C# code. However, at this point,
                 # we lack time for more sophisticated reformatting approaches.
@@ -816,7 +816,7 @@ class _InvariantTranspiler(
             )
 
             if not isinstance(value_node, no_parentheses_types_in_this_context):
-                # NOTE (mristin, 2022-04-7):
+                # NOTE (mristin, 2022-04-07):
                 # This is a very rudimentary heuristic for breaking the lines, and can
                 # be greatly improved by rendering into C# code. However, at this point,
                 # we lack time for more sophisticated reformatting approaches.
@@ -926,7 +926,7 @@ class _InvariantTranspiler(
         ):
             iteration = Stripped(f"({iteration})")
 
-        # NOTE (mristin, 2022-04-7):
+        # NOTE (mristin, 2022-04-07):
         # We can not use ``textwrap.dedent`` here since ``condition`` contains multiple
         # lines.
         return (
@@ -961,7 +961,7 @@ def _wrap_invariant_description(text: str) -> List[str]:
     if len(parts) == 1:
         return [text]
 
-    # NOTE (mristin, 2022-04-8):
+    # NOTE (mristin, 2022-04-08):
     # We do not want to cut out "the", "a" and "an" on separate lines, so we split
     # the text once more in tokens where the articles are kept in the same token as
     # the word.
@@ -989,14 +989,14 @@ def _wrap_invariant_description(text: str) -> List[str]:
     if article is not None:
         tokens.append(article)
 
-    # NOTE (mristin, 2022-04-8):
+    # NOTE (mristin, 2022-04-08):
     # We add space to the tokens so that it is easier to re-flow them.
     tokens = [
         f"{token} " if i < len(tokens) - 1 else token for i, token in enumerate(tokens)
     ]
     assert "".join(tokens) == text
 
-    # NOTE (mristin, 2022-04-8):
+    # NOTE (mristin, 2022-04-08):
     # The line width of 60 characters is an arbitrary, but plausible limit. Please
     # consider that the text will be indented, so you have to add some slack.
     line_width = 60
@@ -1097,7 +1097,7 @@ def _transpile_invariant(
 
     message_literals = []  # type: List[Stripped]
     if invariant.description is not None:
-        # NOTE (mristin, 2022-04-8):
+        # NOTE (mristin, 2022-04-08):
         # We need to wrap the description in multiple literals as a single long
         # string literal is often too much for the readability.
         invariant_description_lines = _wrap_invariant_description(invariant.description)

--- a/aas_core_codegen/infer_for_schema/_inline.py
+++ b/aas_core_codegen/infer_for_schema/_inline.py
@@ -250,7 +250,7 @@ def infer_constraints_by_class(
         )
 
         for prop in symbol.properties:
-            # NOTE (mristin, 2022-03-3):
+            # NOTE (mristin, 2022-03-03):
             # We need to go beneath ``Optional`` as the constraints are applied even
             # if a property is optional. In cases where cardinality is affected by
             # ``Optional``, the client code needs to cover them separately.
@@ -295,7 +295,7 @@ def infer_constraints_by_class(
                 len_constraint_from_type is not None
                 and len_constraint_from_invariants is not None
             ):
-                # NOTE (mristin, 2022-03-2):
+                # NOTE (mristin, 2022-03-02):
                 # We have to make the bounds *stricter* since both
                 # the type constraints and the invariant(s) need to be satisfied.
 

--- a/aas_core_codegen/infer_for_schema/_len.py
+++ b/aas_core_codegen/infer_for_schema/_len.py
@@ -205,7 +205,7 @@ def min_with_none(*args: Optional[int]) -> Optional[int]:
 
     >>> min_with_none(None, None)
     """
-    # NOTE (mristin, 2022-03-2):
+    # NOTE (mristin, 2022-03-02):
     # There is no one-liner in Python for this.
     # See: https://stackoverflow.com/questions/2295461/list-minimum-in-python-with-none
     minimum = None  # type: Optional[int]
@@ -228,7 +228,7 @@ def max_with_none(*args: Optional[int]) -> Optional[int]:
 
     >>> max_with_none(None, None)
     """
-    # NOTE (mristin, 2022-03-2):
+    # NOTE (mristin, 2022-03-02):
     # There is no one-liner in Python for this.
     # See: https://stackoverflow.com/questions/2295461/list-minimum-in-python-with-none
     maximum = None  # type: Optional[int]

--- a/aas_core_codegen/intermediate/_types.py
+++ b/aas_core_codegen/intermediate/_types.py
@@ -624,7 +624,7 @@ class Snapshot:
 class Contracts:
     """Represent the set of contracts for a method or a function."""
 
-    # NOTE (mristin, 2022-04-7):
+    # NOTE (mristin, 2022-04-07):
     # Common programming languages which work with contracts usually implement
     # pre-conditions in a disjunctive normal form, *i.e.* as a disjunction of
     # conjunctions, where at least one conjunction needs to hold. The individual


### PR DESCRIPTION
I had an error in my live template where the day of the note was written
without a preceding zero in the days.

This patch makes the note comments uniform again.