### PR TITLE
Render the descriptions with smoke at intermediate

### DIFF
--- a/test_data/intermediate/unexpected/documentation/unexpected_documentation_elements/expected_error.txt
+++ b/test_data/intermediate/unexpected/documentation/unexpected_documentation_elements/expected_error.txt
@@ -1,0 +1,4 @@
+Handling of the element of a description with type <class 'docutils.nodes.block_quote'> has not been implemented: <block_quote><paragraph>0: An unexpected block quote.</paragraph></block_quote>
+Handling of the element of a description with type <class 'docutils.nodes.block_quote'> has not been implemented: <block_quote><paragraph>3: An unexpected block quote.</paragraph></block_quote>
+Handling of the element of a description with type <class 'docutils.nodes.block_quote'> has not been implemented: <block_quote><paragraph>2: An unexpected block quote.</paragraph></block_quote>
+Handling of the element of a description with type <class 'docutils.nodes.block_quote'> has not been implemented: <block_quote><paragraph>1: An unexpected block quote.</paragraph></block_quote>

--- a/test_data/intermediate/unexpected/documentation/unexpected_documentation_elements/meta_model.py
+++ b/test_data/intermediate/unexpected/documentation/unexpected_documentation_elements/meta_model.py
@@ -1,0 +1,34 @@
+"""
+Do something.
+
+    0: An unexpected block quote.
+"""
+
+
+class Something:
+    """
+    Represent something.
+
+        1: An unexpected block quote.
+    """
+
+    something: str
+    """
+    Capture something.
+    
+        2: An unexpected block quote.
+    """
+
+    def __init__(self, something: str) -> None:
+        self.something = something
+
+    def do_something(self) -> None:
+        """
+        Do something.
+
+            3: An unexpected block quote.
+        """
+
+
+__book_url__ = "dummy"
+__book_version__ = "dummy"


### PR DESCRIPTION
We introduce an additional verification at the intermediate stage to
check that all documentation elements can be rendered using a dummy
smoke renderer. This is necessary since we had bad suprises over at
aas-core-meta, so we want to catch these issues as soon as possible.