### PR TITLE
Allow null enums in C# stringification

### DIFF
--- a/aas_core_codegen/csharp/stringification/_generate.py
+++ b/aas_core_codegen/csharp/stringification/_generate.py
@@ -10,7 +10,7 @@ from icontract import ensure
 from aas_core_codegen import intermediate
 from aas_core_codegen.common import Error, Stripped, Identifier
 from aas_core_codegen.csharp import common as csharp_common, naming as csharp_naming
-from aas_core_codegen.csharp.common import INDENT as I, INDENT2 as II
+from aas_core_codegen.csharp.common import INDENT as I, INDENT2 as II, INDENT3 as III
 
 
 def _generate_enum_to_and_from_string(
@@ -66,15 +66,22 @@ def _generate_enum_to_and_from_string(
         /// <remarks>
         /// If <paramref name="that" /> is not a valid literal, return <c>null</c>.
         /// </remarks>
-        public static string? {to_str_name}(Aas.{name} that)
+        public static string? {to_str_name}(Aas.{name}? that)
         {{
-        {I}if ({to_str_map_name}.TryGetValue(that, out string? value))
+        {I}if (!that.HasValue)
         {I}{{
-        {II}return value;
+        {II}return null;
         {I}}}
         {I}else
         {I}{{
-        {II}return null;
+        {II}if ({to_str_map_name}.TryGetValue(that.Value, out string? value))
+        {II}{{
+        {III}return value;
+        {II}}}
+        {II}else
+        {II}{{
+        {III}return null;
+        {II}}}
         {I}}}
         }}"""
         )

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/stringification.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/stringification.cs
@@ -24,15 +24,22 @@ namespace AasCore.Aas3
         /// <remarks>
         /// If <paramref name="that" /> is not a valid literal, return <c>null</c>.
         /// </remarks>
-        public static string? ToString(Aas.ModelingKind that)
+        public static string? ToString(Aas.ModelingKind? that)
         {
-            if (_modelingKindToString.TryGetValue(that, out string? value))
+            if (!that.HasValue)
             {
-                return value;
+                return null;
             }
             else
             {
-                return null;
+                if (_modelingKindToString.TryGetValue(that.Value, out string? value))
+                {
+                    return value;
+                }
+                else
+                {
+                    return null;
+                }
             }
         }
 
@@ -76,15 +83,22 @@ namespace AasCore.Aas3
         /// <remarks>
         /// If <paramref name="that" /> is not a valid literal, return <c>null</c>.
         /// </remarks>
-        public static string? ToString(Aas.AssetKind that)
+        public static string? ToString(Aas.AssetKind? that)
         {
-            if (_assetKindToString.TryGetValue(that, out string? value))
+            if (!that.HasValue)
             {
-                return value;
+                return null;
             }
             else
             {
-                return null;
+                if (_assetKindToString.TryGetValue(that.Value, out string? value))
+                {
+                    return value;
+                }
+                else
+                {
+                    return null;
+                }
             }
         }
 
@@ -128,15 +142,22 @@ namespace AasCore.Aas3
         /// <remarks>
         /// If <paramref name="that" /> is not a valid literal, return <c>null</c>.
         /// </remarks>
-        public static string? ToString(Aas.EntityType that)
+        public static string? ToString(Aas.EntityType? that)
         {
-            if (_entityTypeToString.TryGetValue(that, out string? value))
+            if (!that.HasValue)
             {
-                return value;
+                return null;
             }
             else
             {
-                return null;
+                if (_entityTypeToString.TryGetValue(that.Value, out string? value))
+                {
+                    return value;
+                }
+                else
+                {
+                    return null;
+                }
             }
         }
 
@@ -180,15 +201,22 @@ namespace AasCore.Aas3
         /// <remarks>
         /// If <paramref name="that" /> is not a valid literal, return <c>null</c>.
         /// </remarks>
-        public static string? ToString(Aas.Direction that)
+        public static string? ToString(Aas.Direction? that)
         {
-            if (_directionToString.TryGetValue(that, out string? value))
+            if (!that.HasValue)
             {
-                return value;
+                return null;
             }
             else
             {
-                return null;
+                if (_directionToString.TryGetValue(that.Value, out string? value))
+                {
+                    return value;
+                }
+                else
+                {
+                    return null;
+                }
             }
         }
 
@@ -232,15 +260,22 @@ namespace AasCore.Aas3
         /// <remarks>
         /// If <paramref name="that" /> is not a valid literal, return <c>null</c>.
         /// </remarks>
-        public static string? ToString(Aas.StateOfEvent that)
+        public static string? ToString(Aas.StateOfEvent? that)
         {
-            if (_stateOfEventToString.TryGetValue(that, out string? value))
+            if (!that.HasValue)
             {
-                return value;
+                return null;
             }
             else
             {
-                return null;
+                if (_stateOfEventToString.TryGetValue(that.Value, out string? value))
+                {
+                    return value;
+                }
+                else
+                {
+                    return null;
+                }
             }
         }
 
@@ -285,15 +320,22 @@ namespace AasCore.Aas3
         /// <remarks>
         /// If <paramref name="that" /> is not a valid literal, return <c>null</c>.
         /// </remarks>
-        public static string? ToString(Aas.IdentifiableElements that)
+        public static string? ToString(Aas.IdentifiableElements? that)
         {
-            if (_identifiableElementsToString.TryGetValue(that, out string? value))
+            if (!that.HasValue)
             {
-                return value;
+                return null;
             }
             else
             {
-                return null;
+                if (_identifiableElementsToString.TryGetValue(that.Value, out string? value))
+                {
+                    return value;
+                }
+                else
+                {
+                    return null;
+                }
             }
         }
 
@@ -353,15 +395,22 @@ namespace AasCore.Aas3
         /// <remarks>
         /// If <paramref name="that" /> is not a valid literal, return <c>null</c>.
         /// </remarks>
-        public static string? ToString(Aas.SubmodelElementElements that)
+        public static string? ToString(Aas.SubmodelElementElements? that)
         {
-            if (_submodelElementElementsToString.TryGetValue(that, out string? value))
+            if (!that.HasValue)
             {
-                return value;
+                return null;
             }
             else
             {
-                return null;
+                if (_submodelElementElementsToString.TryGetValue(that.Value, out string? value))
+                {
+                    return value;
+                }
+                else
+                {
+                    return null;
+                }
             }
         }
 
@@ -438,15 +487,22 @@ namespace AasCore.Aas3
         /// <remarks>
         /// If <paramref name="that" /> is not a valid literal, return <c>null</c>.
         /// </remarks>
-        public static string? ToString(Aas.ReferableElements that)
+        public static string? ToString(Aas.ReferableElements? that)
         {
-            if (_referableElementsToString.TryGetValue(that, out string? value))
+            if (!that.HasValue)
             {
-                return value;
+                return null;
             }
             else
             {
-                return null;
+                if (_referableElementsToString.TryGetValue(that.Value, out string? value))
+                {
+                    return value;
+                }
+                else
+                {
+                    return null;
+                }
             }
         }
 
@@ -528,15 +584,22 @@ namespace AasCore.Aas3
         /// <remarks>
         /// If <paramref name="that" /> is not a valid literal, return <c>null</c>.
         /// </remarks>
-        public static string? ToString(Aas.KeyElements that)
+        public static string? ToString(Aas.KeyElements? that)
         {
-            if (_keyElementsToString.TryGetValue(that, out string? value))
+            if (!that.HasValue)
             {
-                return value;
+                return null;
             }
             else
             {
-                return null;
+                if (_keyElementsToString.TryGetValue(that.Value, out string? value))
+                {
+                    return value;
+                }
+                else
+                {
+                    return null;
+                }
             }
         }
 
@@ -631,15 +694,22 @@ namespace AasCore.Aas3
         /// <remarks>
         /// If <paramref name="that" /> is not a valid literal, return <c>null</c>.
         /// </remarks>
-        public static string? ToString(Aas.DataTypeDefXsd that)
+        public static string? ToString(Aas.DataTypeDefXsd? that)
         {
-            if (_dataTypeDefXsdToString.TryGetValue(that, out string? value))
+            if (!that.HasValue)
             {
-                return value;
+                return null;
             }
             else
             {
-                return null;
+                if (_dataTypeDefXsdToString.TryGetValue(that.Value, out string? value))
+                {
+                    return value;
+                }
+                else
+                {
+                    return null;
+                }
             }
         }
 
@@ -713,15 +783,22 @@ namespace AasCore.Aas3
         /// <remarks>
         /// If <paramref name="that" /> is not a valid literal, return <c>null</c>.
         /// </remarks>
-        public static string? ToString(Aas.DataTypeDefRdf that)
+        public static string? ToString(Aas.DataTypeDefRdf? that)
         {
-            if (_dataTypeDefRdfToString.TryGetValue(that, out string? value))
+            if (!that.HasValue)
             {
-                return value;
+                return null;
             }
             else
             {
-                return null;
+                if (_dataTypeDefRdfToString.TryGetValue(that.Value, out string? value))
+                {
+                    return value;
+                }
+                else
+                {
+                    return null;
+                }
             }
         }
 
@@ -796,15 +873,22 @@ namespace AasCore.Aas3
         /// <remarks>
         /// If <paramref name="that" /> is not a valid literal, return <c>null</c>.
         /// </remarks>
-        public static string? ToString(Aas.DataTypeDef that)
+        public static string? ToString(Aas.DataTypeDef? that)
         {
-            if (_dataTypeDefToString.TryGetValue(that, out string? value))
+            if (!that.HasValue)
             {
-                return value;
+                return null;
             }
             else
             {
-                return null;
+                if (_dataTypeDefToString.TryGetValue(that.Value, out string? value))
+                {
+                    return value;
+                }
+                else
+                {
+                    return null;
+                }
             }
         }
 


### PR DESCRIPTION
Since we are going to return a nullable string anyhow, we accept just as
well nullable enum literals. This makes the client code a bit easier to
manage.

Additionally, C# is kind of peculiar about nullable value types. See
this StackOverflow answer for more information: [1].

[1]: https://stackoverflow.com/questions/54593923/nullable-reference-types-with-generic-return-type/54594285#54594285