### PR TITLE
Fix documentation about classes in C# jsonization

### DIFF
--- a/aas_core_codegen/csharp/jsonization/_generate.py
+++ b/aas_core_codegen/csharp/jsonization/_generate.py
@@ -1583,7 +1583,7 @@ def generate(
             namespace {namespace}
             {{
             {I}/// <summary>
-            {I}/// Provide de/serialization of meta-model entities to/from JSON.
+            {I}/// Provide de/serialization of meta-model classes to/from JSON.
             {I}/// </summary>
             {I}/// <remarks>
             {I}/// We can not use one-pass deserialization for JSON since the object

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/jsonization.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/jsonization.cs
@@ -11,7 +11,7 @@ using Aas = AasCore.Aas3;
 namespace AasCore.Aas3
 {
     /// <summary>
-    /// Provide de/serialization of meta-model entities to/from JSON.
+    /// Provide de/serialization of meta-model classes to/from JSON.
     /// </summary>
     /// <remarks>
     /// We can not use one-pass deserialization for JSON since the object


### PR DESCRIPTION
We fix the documentation comment and replace "entities" with "classes"
to avoid confusing the reader. There is indeed a meta-model class
"Entity", so this can be indeed misleading.