### PR TITLE
Verify the limitedness of type annotations

### DIFF
--- a/aas_core_codegen/csharp/jsonization/_generate.py
+++ b/aas_core_codegen/csharp/jsonization/_generate.py
@@ -243,53 +243,7 @@ def _generate_deserialize_property(
     prop: intermediate.Property,
 ) -> Tuple[Optional[Stripped], Optional[Error]]:
     """Generate the code snippet for de-serializing the property ``prop``."""
-    # NOTE (mristin, 2022-03-10):
-    # Instead of writing here a complex but general solution with unrolling we choose
-    # to provide a simple, but limited, solution. First, the meta-model is quite
-    # limited itself at the moment, so the complexity of the general solution is not
-    # warranted. Second, we hope that there will be fewer bugs in the simple solution
-    # which is particularly important at this early adoption stage.
-    #
-    # We anticipate that in the future we will indeed need a general and complex
-    # solution. Here are just some thoughts on how to approach it:
-    # * Leave the pattern matching to produce more readable code for simple cases,
-    # * Unroll only in case of composite types and optional composite types.
-
-    type_anno = (
-        prop.type_annotation
-        if not isinstance(prop.type_annotation, intermediate.OptionalTypeAnnotation)
-        else prop.type_annotation.value
-    )
-
-    if isinstance(type_anno, intermediate.OptionalTypeAnnotation):
-        return None, Error(
-            prop.parsed.node,
-            "We currently implemented deserialization based on a very limited "
-            "pattern matching due to code simplicity. We did not handle "
-            "the case of nested optional values. Please contact "
-            "the developers if you need this functionality.",
-        )
-    elif isinstance(type_anno, intermediate.ListTypeAnnotation):
-        if isinstance(type_anno.items, intermediate.OptionalTypeAnnotation):
-            return None, Error(
-                prop.parsed.node,
-                "We currently implemented deserialization based on a very limited "
-                "pattern matching due to code simplicity. We did not handle "
-                "the case of lists of optional values. Please contact "
-                "the developers if you need this functionality.",
-            )
-        elif isinstance(type_anno.items, intermediate.ListTypeAnnotation):
-            return None, Error(
-                prop.parsed.node,
-                "We currently implemented deserialization based on a very limited "
-                "pattern matching due to code simplicity. We did not handle "
-                "the case of lists of lists. Please contact "
-                "the developers if you need this functionality.",
-            )
-        else:
-            pass
-    else:
-        pass
+    type_anno = intermediate.beneath_optional(prop.type_annotation)
 
     # Prefix the variables to avoid naming conflicts
     target_var = csharp_naming.variable_name(Identifier(f"the_{prop.name}"))
@@ -360,7 +314,7 @@ def _generate_deserialize_property(
             (intermediate.OptionalTypeAnnotation, intermediate.ListTypeAnnotation),
         ), (
             "We chose to implement only a very limited pattern matching; "
-            "see the note above in the code."
+            "see intermediate._translate_._verify_only_simple_type_patterns"
         )
 
         item_type = csharp_common.generate_type(type_anno.items)
@@ -1100,53 +1054,7 @@ def _generate_transform_property(
     prop: intermediate.Property,
 ) -> Tuple[Optional[Stripped], Optional[Error]]:
     """Generate the snippet to transform a property into a JSON node."""
-    # NOTE (mristin, 2022-03-10):
-    # Instead of writing here a complex but general solution with unrolling we choose
-    # to provide a simple, but limited, solution. First, the meta-model is quite
-    # limited itself at the moment, so the complexity of the general solution is not
-    # warranted. Second, we hope that there will be fewer bugs in the simple solution
-    # which is particularly important at this early adoption stage.
-    #
-    # We anticipate that in the future we will indeed need a general and complex
-    # solution. Here are just some thoughts on how to approach it:
-    # * Leave the pattern matching to produce more readable code for simple cases,
-    # * Unroll only in case of composite types and optional composite types.
-
-    type_anno = (
-        prop.type_annotation
-        if not isinstance(prop.type_annotation, intermediate.OptionalTypeAnnotation)
-        else prop.type_annotation.value
-    )
-
-    if isinstance(type_anno, intermediate.OptionalTypeAnnotation):
-        return None, Error(
-            prop.parsed.node,
-            "We currently implemented serialization based on a very limited "
-            "pattern matching due to code simplicity. We did not handle "
-            "the case of nested optional values. Please contact "
-            "the developers if you need this functionality.",
-        )
-    elif isinstance(type_anno, intermediate.ListTypeAnnotation):
-        if isinstance(type_anno.items, intermediate.OptionalTypeAnnotation):
-            return None, Error(
-                prop.parsed.node,
-                "We currently implemented serialization based on a very limited "
-                "pattern matching due to code simplicity. We did not handle "
-                "the case of lists of optional values. Please contact "
-                "the developers if you need this functionality.",
-            )
-        elif isinstance(type_anno.items, intermediate.ListTypeAnnotation):
-            return None, Error(
-                prop.parsed.node,
-                "We currently implemented serialization based on a very limited "
-                "pattern matching due to code simplicity. We did not handle "
-                "the case of lists of lists. Please contact "
-                "the developers if you need this functionality.",
-            )
-        else:
-            pass
-    else:
-        pass
+    type_anno = intermediate.beneath_optional(prop.type_annotation)
 
     stmts = []  # type: List[Stripped]
 
@@ -1183,7 +1091,7 @@ def _generate_transform_property(
             (intermediate.OptionalTypeAnnotation, intermediate.ListTypeAnnotation),
         ), (
             "We chose to implement only a very limited pattern matching; "
-            "see the note above in the code."
+            "see intermediate._translate._verify_only_simple_type_patterns."
         )
 
         item_type = csharp_common.generate_type(type_anno.items)

--- a/test_data/intermediate/expected/type_annotation/subscripted/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/type_annotation/subscripted/expected_symbol_table.txt
@@ -1,7 +1,44 @@
 SymbolTable(
   symbols=[
     ConcreteClass(
-      name='Concrete',
+      name='SomeConcreteClass',
+      inheritances=[],
+      inheritance_id_set=...,
+      is_implementation_specific=False,
+      interface=None,
+      descendant_id_set=...,
+      concrete_descendants=[],
+      properties=[],
+      methods=[],
+      constructor=Constructor(
+        name='__init__',
+        arguments=[],
+        returns=None,
+        description=None,
+        contracts=Contracts(
+          preconditions=[],
+          snapshots=[],
+          postconditions=[]),
+        parsed=None,
+        arguments_by_name=...,
+        is_implementation_specific=False,
+        statements=[]),
+      invariants=[],
+      serialization=Serialization(
+        with_model_type=False),
+      reference_in_the_book=None,
+      description=SymbolDescription(
+        summary='<paragraph>Represent something.</paragraph>',
+        remarks=[],
+        constraints_by_identifier=[],
+        parsed=...),
+      parsed=...,
+      properties_by_name=...,
+      property_id_set=...,
+      methods_by_name=...,
+      invariant_id_set=...),
+    ConcreteClass(
+      name='SomeContainerClass',
       inheritances=[],
       inheritance_id_set=...,
       is_implementation_specific=False,
@@ -12,12 +49,12 @@ SymbolTable(
         Property(
           name='x',
           type_annotation=ListTypeAnnotation(
-            items=PrimitiveTypeAnnotation(
-              a_type='INT',
+            items=OurTypeAnnotation(
+              symbol='Reference to symbol SomeConcreteClass',
               parsed=...),
             parsed=...),
           description=None,
-          specified_for='Reference to ConcreteClass Concrete',
+          specified_for='Reference to ConcreteClass SomeContainerClass',
           parsed=...)],
       methods=[],
       constructor=Constructor(
@@ -26,8 +63,8 @@ SymbolTable(
           Argument(
             name='x',
             type_annotation=ListTypeAnnotation(
-              items=PrimitiveTypeAnnotation(
-                a_type='INT',
+              items=OurTypeAnnotation(
+                symbol='Reference to symbol SomeConcreteClass',
                 parsed=...),
               parsed=...),
             default=None,
@@ -54,7 +91,8 @@ SymbolTable(
       methods_by_name=...,
       invariant_id_set=...)],
   symbols_topologically_sorted=[
-    'Reference to symbol Concrete'],
+    'Reference to symbol SomeConcreteClass',
+    'Reference to symbol SomeContainerClass'],
   verification_functions=[],
   verification_functions_by_name=...,
   meta_model=MetaModel(

--- a/test_data/intermediate/expected/type_annotation/subscripted/meta_model.py
+++ b/test_data/intermediate/expected/type_annotation/subscripted/meta_model.py
@@ -1,7 +1,11 @@
-class Concrete:
-    x: List[int]
+class SomeConcreteClass:
+    """Represent something."""
 
-    def __init__(self, x: List[int]) -> None:
+
+class SomeContainerClass:
+    x: List[SomeConcreteClass]
+
+    def __init__(self, x: List[SomeConcreteClass]) -> None:
         self.x = x
 
 


### PR DESCRIPTION
We check at the intermediate stage that only a limited set of type
annotation patterns is used. This greately simplifies the generators.

However, we anticipate that more complex type patterns are going to be
used in the meta-models in the future. At the moment, we stick to the
simple generators, and explicitly check for these simplifying
assumptions.