### PR TITLE
Adapt RDF and SHACL to match aas-specs V3RC02

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Our own ignores
+/deleteme.sh
 /deleteme/
 /venv/
 /venv39/

--- a/test_data/rdf_shacl/test_main/aas_core_meta.v3rc1/expected_output/rdf-ontology.ttl
+++ b/test_data/rdf_shacl/test_main/aas_core_meta.v3rc1/expected_output/rdf-ontology.ttl
@@ -30,28 +30,12 @@ aas:AccessControl rdf:type owl:Class ;
     rdfs:comment "Access permission rules of the AAS describing the rights assigned to (already authenticated) subjects to access elements of the AAS."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC01/AccessControl/selectableSubjectAttributes
-<https://admin-shell.io/aas/3/0/RC01/AccessControl/selectableSubjectAttributes> rdf:type owl:ObjectProperty ;
-    rdfs:label "has selectable subject attributes"^^xsd:string ;
+###  https://admin-shell.io/aas/3/0/RC01/AccessControl/defaultEnvironmentAttributes
+<https://admin-shell.io/aas/3/0/RC01/AccessControl/defaultEnvironmentAttributes> rdf:type owl:ObjectProperty ;
+    rdfs:label "has default environment attributes"^^xsd:string ;
     rdfs:domain aas:AccessControl ;
     rdfs:range aas:Reference ;
-    rdfs:comment "Reference to a submodel defining the authenticated subjects that are configured for the AAS. They are selectable by the access permission rules to assign permissions to the subjects."@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/AccessControl/defaultSubjectAttributes
-<https://admin-shell.io/aas/3/0/RC01/AccessControl/defaultSubjectAttributes> rdf:type owl:ObjectProperty ;
-    rdfs:label "has default subject attributes"^^xsd:string ;
-    rdfs:domain aas:AccessControl ;
-    rdfs:range aas:Reference ;
-    rdfs:comment "Reference to a submodel defining the default subjects’ attributes for the AAS that can be used to describe access permission rules."@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/AccessControl/selectablePermissions
-<https://admin-shell.io/aas/3/0/RC01/AccessControl/selectablePermissions> rdf:type owl:ObjectProperty ;
-    rdfs:label "has selectable permissions"^^xsd:string ;
-    rdfs:domain aas:AccessControl ;
-    rdfs:range aas:Reference ;
-    rdfs:comment "Reference to a submodel defining which permissions can be assigned to the subjects."@en ;
+    rdfs:comment "Reference to a submodel defining default environment attributes, i.e. attributes that are not describing the asset itself."@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/AccessControl/defaultPermissions
@@ -62,6 +46,14 @@ aas:AccessControl rdf:type owl:Class ;
     rdfs:comment "Reference to a submodel defining the default permissions for the AAS."@en ;
 .
 
+###  https://admin-shell.io/aas/3/0/RC01/AccessControl/defaultSubjectAttributes
+<https://admin-shell.io/aas/3/0/RC01/AccessControl/defaultSubjectAttributes> rdf:type owl:ObjectProperty ;
+    rdfs:label "has default subject attributes"^^xsd:string ;
+    rdfs:domain aas:AccessControl ;
+    rdfs:range aas:Reference ;
+    rdfs:comment "Reference to a submodel defining the default subjects’ attributes for the AAS that can be used to describe access permission rules."@en ;
+.
+
 ###  https://admin-shell.io/aas/3/0/RC01/AccessControl/selectableEnvironmentAttributes
 <https://admin-shell.io/aas/3/0/RC01/AccessControl/selectableEnvironmentAttributes> rdf:type owl:ObjectProperty ;
     rdfs:label "has selectable environment attributes"^^xsd:string ;
@@ -70,12 +62,20 @@ aas:AccessControl rdf:type owl:Class ;
     rdfs:comment "Reference to a submodel defining which environment attributes can be accessed via the permission rules defined for the AAS, i.e. attributes that are not describing the asset itself."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC01/AccessControl/defaultEnvironmentAttributes
-<https://admin-shell.io/aas/3/0/RC01/AccessControl/defaultEnvironmentAttributes> rdf:type owl:ObjectProperty ;
-    rdfs:label "has default environment attributes"^^xsd:string ;
+###  https://admin-shell.io/aas/3/0/RC01/AccessControl/selectablePermissions
+<https://admin-shell.io/aas/3/0/RC01/AccessControl/selectablePermissions> rdf:type owl:ObjectProperty ;
+    rdfs:label "has selectable permissions"^^xsd:string ;
     rdfs:domain aas:AccessControl ;
     rdfs:range aas:Reference ;
-    rdfs:comment "Reference to a submodel defining default environment attributes, i.e. attributes that are not describing the asset itself."@en ;
+    rdfs:comment "Reference to a submodel defining which permissions can be assigned to the subjects."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/AccessControl/selectableSubjectAttributes
+<https://admin-shell.io/aas/3/0/RC01/AccessControl/selectableSubjectAttributes> rdf:type owl:ObjectProperty ;
+    rdfs:label "has selectable subject attributes"^^xsd:string ;
+    rdfs:domain aas:AccessControl ;
+    rdfs:range aas:Reference ;
+    rdfs:comment "Reference to a submodel defining the authenticated subjects that are configured for the AAS. They are selectable by the access permission rules to assign permissions to the subjects."@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/AccessControlPolicyPoints
@@ -124,20 +124,20 @@ aas:AccessPermissionRule rdf:type owl:Class ;
     rdfs:comment "Table that defines access permissions per authenticated subject for a set of objects (referable elements)."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC01/AccessPermissionRule/targetSubjectAttributes
-<https://admin-shell.io/aas/3/0/RC01/AccessPermissionRule/targetSubjectAttributes> rdf:type owl:ObjectProperty ;
-    rdfs:label "has target subject attributes"^^xsd:string ;
-    rdfs:domain aas:AccessPermissionRule ;
-    rdfs:range aas:SubjectAttributes ;
-    rdfs:comment "Target subject attributes that need to be fulfilled by accessing subject to get the permissions defined by this rule."@en ;
-.
-
 ###  https://admin-shell.io/aas/3/0/RC01/AccessPermissionRule/permissionsPerObject
 <https://admin-shell.io/aas/3/0/RC01/AccessPermissionRule/permissionsPerObject> rdf:type owl:ObjectProperty ;
     rdfs:label "has permissions per object"^^xsd:string ;
     rdfs:domain aas:AccessPermissionRule ;
     rdfs:range aas:PermissionsPerObject ;
     rdfs:comment "Set of object-permission pairs that define the permissions per object within the access permission rule."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/AccessPermissionRule/targetSubjectAttributes
+<https://admin-shell.io/aas/3/0/RC01/AccessPermissionRule/targetSubjectAttributes> rdf:type owl:ObjectProperty ;
+    rdfs:label "has target subject attributes"^^xsd:string ;
+    rdfs:domain aas:AccessPermissionRule ;
+    rdfs:range aas:SubjectAttributes ;
+    rdfs:comment "Target subject attributes that need to be fulfilled by accessing subject to get the permissions defined by this rule."@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/AdministrativeInformation
@@ -147,20 +147,20 @@ aas:AdministrativeInformation rdf:type owl:Class ;
     rdfs:comment "Administrative meta-information for an element like version information."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC01/AdministrativeInformation/version
-<https://admin-shell.io/aas/3/0/RC01/AdministrativeInformation/version> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has version"^^xsd:string ;
-    rdfs:domain aas:AdministrativeInformation ;
-    rdfs:range xsd:string ;
-    rdfs:comment "Version of the element."@en ;
-.
-
 ###  https://admin-shell.io/aas/3/0/RC01/AdministrativeInformation/revision
 <https://admin-shell.io/aas/3/0/RC01/AdministrativeInformation/revision> rdf:type owl:DatatypeProperty ;
     rdfs:label "has revision"^^xsd:string ;
     rdfs:domain aas:AdministrativeInformation ;
     rdfs:range xsd:string ;
     rdfs:comment "Revision of the element."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/AdministrativeInformation/version
+<https://admin-shell.io/aas/3/0/RC01/AdministrativeInformation/version> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has version"^^xsd:string ;
+    rdfs:domain aas:AdministrativeInformation ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Version of the element."@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/AnnotatedRelationshipElement
@@ -194,6 +194,14 @@ aas:AssetAdministrationShell rdf:type owl:Class ;
     rdfs:comment "Structure a digital representation of an 'Asset'."@en ;
 .
 
+###  https://admin-shell.io/aas/3/0/RC01/AssetAdministrationShell/assetInformation
+<https://admin-shell.io/aas/3/0/RC01/AssetAdministrationShell/assetInformation> rdf:type owl:ObjectProperty ;
+    rdfs:label "has asset information"^^xsd:string ;
+    rdfs:domain aas:AssetAdministrationShell ;
+    rdfs:range aas:AssetInformation ;
+    rdfs:comment "Meta-information about the asset the AAS is representing."@en ;
+.
+
 ###  https://admin-shell.io/aas/3/0/RC01/AssetAdministrationShell/derivedFrom
 <https://admin-shell.io/aas/3/0/RC01/AssetAdministrationShell/derivedFrom> rdf:type owl:ObjectProperty ;
     rdfs:label "has derived from"^^xsd:string ;
@@ -208,14 +216,6 @@ aas:AssetAdministrationShell rdf:type owl:Class ;
     rdfs:domain aas:AssetAdministrationShell ;
     rdfs:range aas:Security ;
     rdfs:comment "Definition of the security relevant aspects of the AAS."@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/AssetAdministrationShell/assetInformation
-<https://admin-shell.io/aas/3/0/RC01/AssetAdministrationShell/assetInformation> rdf:type owl:ObjectProperty ;
-    rdfs:label "has asset information"^^xsd:string ;
-    rdfs:domain aas:AssetAdministrationShell ;
-    rdfs:range aas:AssetInformation ;
-    rdfs:comment "Meta-information about the asset the AAS is representing."@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/AssetAdministrationShell/submodels
@@ -254,18 +254,18 @@ aas:AssetAdministrationShellEnvironment rdf:type owl:Class ;
     rdfs:range aas:Asset ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC01/AssetAdministrationShellEnvironment/submodels
-<https://admin-shell.io/aas/3/0/RC01/AssetAdministrationShellEnvironment/submodels> rdf:type owl:ObjectProperty ;
-    rdfs:label "has submodels"^^xsd:string ;
-    rdfs:domain aas:AssetAdministrationShellEnvironment ;
-    rdfs:range aas:Submodel ;
-.
-
 ###  https://admin-shell.io/aas/3/0/RC01/AssetAdministrationShellEnvironment/conceptDescriptions
 <https://admin-shell.io/aas/3/0/RC01/AssetAdministrationShellEnvironment/conceptDescriptions> rdf:type owl:ObjectProperty ;
     rdfs:label "has concept descriptions"^^xsd:string ;
     rdfs:domain aas:AssetAdministrationShellEnvironment ;
     rdfs:range aas:ConceptDescription ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/AssetAdministrationShellEnvironment/submodels
+<https://admin-shell.io/aas/3/0/RC01/AssetAdministrationShellEnvironment/submodels> rdf:type owl:ObjectProperty ;
+    rdfs:label "has submodels"^^xsd:string ;
+    rdfs:domain aas:AssetAdministrationShellEnvironment ;
+    rdfs:range aas:Submodel ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/AssetInformation
@@ -280,22 +280,6 @@ aas:AssetInformation rdf:type owl:Class ;
     rdfs:domain aas:AssetInformation ;
     rdfs:range aas:AssetKind ;
     rdfs:comment "Denotes whether the Asset is of kind \"Type\" or \"Instance\"."@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/AssetInformation/globalAssetId
-<https://admin-shell.io/aas/3/0/RC01/AssetInformation/globalAssetId> rdf:type owl:ObjectProperty ;
-    rdfs:label "has global asset id"^^xsd:string ;
-    rdfs:domain aas:AssetInformation ;
-    rdfs:range aas:Reference ;
-    rdfs:comment "Reference to either an Asset object or a global reference to the asset the AAS is representing."@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/AssetInformation/specificAssetIds
-<https://admin-shell.io/aas/3/0/RC01/AssetInformation/specificAssetIds> rdf:type owl:ObjectProperty ;
-    rdfs:label "has specific asset ids"^^xsd:string ;
-    rdfs:domain aas:AssetInformation ;
-    rdfs:range aas:IdentifierKeyValuePair ;
-    rdfs:comment "Additional domain-specific, typically proprietary, Identifier for the asset."@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/AssetInformation/billOfMaterial
@@ -314,26 +298,42 @@ aas:AssetInformation rdf:type owl:Class ;
     rdfs:comment "Thumbnail of the asset represented by the asset administration shell."@en ;
 .
 
+###  https://admin-shell.io/aas/3/0/RC01/AssetInformation/globalAssetId
+<https://admin-shell.io/aas/3/0/RC01/AssetInformation/globalAssetId> rdf:type owl:ObjectProperty ;
+    rdfs:label "has global asset id"^^xsd:string ;
+    rdfs:domain aas:AssetInformation ;
+    rdfs:range aas:Reference ;
+    rdfs:comment "Reference to either an Asset object or a global reference to the asset the AAS is representing."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/AssetInformation/specificAssetIds
+<https://admin-shell.io/aas/3/0/RC01/AssetInformation/specificAssetIds> rdf:type owl:ObjectProperty ;
+    rdfs:label "has specific asset ids"^^xsd:string ;
+    rdfs:domain aas:AssetInformation ;
+    rdfs:range aas:IdentifierKeyValuePair ;
+    rdfs:comment "Additional domain-specific, typically proprietary, Identifier for the asset."@en ;
+.
+
 ###  https://admin-shell.io/aas/3/0/RC01/AssetKind
 aas:AssetKind rdf:type owl:Class ;
     rdfs:label "Asset Kind"^^xsd:string ;
     rdfs:comment "Enumeration for denoting whether an element is a type or an instance."@en ;
     owl:oneOf (
-        <https://admin-shell.io/aas/3/0/RC01/AssetKind/Type>
         <https://admin-shell.io/aas/3/0/RC01/AssetKind/Instance>
+        <https://admin-shell.io/aas/3/0/RC01/AssetKind/Type>
     ) ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/AssetKind/Type
-<https://admin-shell.io/aas/3/0/RC01/AssetKind/Type> rdf:type aas:AssetKind ;
-    rdfs:label "Type"^^xsd:string ;
-    rdfs:comment "hardware or software element which specifies the common attributes shared by all instances of the type"@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/AssetKind/Instance
 <https://admin-shell.io/aas/3/0/RC01/AssetKind/Instance> rdf:type aas:AssetKind ;
     rdfs:label "Instance"^^xsd:string ;
     rdfs:comment "concrete, clearly identifiable component of a certain type"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/AssetKind/Type
+<https://admin-shell.io/aas/3/0/RC01/AssetKind/Type> rdf:type aas:AssetKind ;
+    rdfs:label "Type"^^xsd:string ;
+    rdfs:comment "hardware or software element which specifies the common attributes shared by all instances of the type"@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/BasicEvent
@@ -389,20 +389,20 @@ aas:BlobCertificate rdf:type owl:Class ;
     rdfs:comment "Certificate as BLOB."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC01/BlobCertificate/lastCertificate
-<https://admin-shell.io/aas/3/0/RC01/BlobCertificate/lastCertificate> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has last certificate"^^xsd:string ;
-    rdfs:domain aas:BlobCertificate ;
-    rdfs:range xsd:boolean ;
-    rdfs:comment "Denotes whether this certificate is the certificated that fast added last."@en ;
-.
-
 ###  https://admin-shell.io/aas/3/0/RC01/BlobCertificate/containedExtensions
 <https://admin-shell.io/aas/3/0/RC01/BlobCertificate/containedExtensions> rdf:type owl:ObjectProperty ;
     rdfs:label "has contained extensions"^^xsd:string ;
     rdfs:domain aas:BlobCertificate ;
     rdfs:range aas:Reference ;
     rdfs:comment "Extensions contained in the certificate."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/BlobCertificate/lastCertificate
+<https://admin-shell.io/aas/3/0/RC01/BlobCertificate/lastCertificate> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has last certificate"^^xsd:string ;
+    rdfs:domain aas:BlobCertificate ;
+    rdfs:range xsd:boolean ;
+    rdfs:comment "Denotes whether this certificate is the certificated that fast added last."@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/Capability
@@ -467,6 +467,30 @@ aas:DataSpecificationIEC61360 rdf:type owl:Class ;
     rdfs:comment "Content of data specification template for concept descriptions conformant to IEC 61360. Although the IEC61360 attributes listed in this template are defined for properties and values and value lists only it is also possible to use the template for other definition This is shown in the tables Table 7, Table 8, Table 9 and Table 10."@en ;
 .
 
+###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/dataType
+<https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/dataType> rdf:type owl:ObjectProperty ;
+    rdfs:label "has data type"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationIEC61360 ;
+    rdfs:range aas:DataTypeIEC61360 ;
+    rdfs:comment "Data Type"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/definition
+<https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/definition> rdf:type owl:ObjectProperty ;
+    rdfs:label "has definition"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationIEC61360 ;
+    rdfs:range rdf:langString ;
+    rdfs:comment "Definition in different languages"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/levelType
+<https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/levelType> rdf:type owl:ObjectProperty ;
+    rdfs:label "has level type"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationIEC61360 ;
+    rdfs:range aas:LevelType ;
+    rdfs:comment "Set of levels."@en ;
+.
+
 ###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/preferredName
 <https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/preferredName> rdf:type owl:ObjectProperty ;
     rdfs:label "has preferred name"^^xsd:string ;
@@ -481,22 +505,6 @@ aas:DataSpecificationIEC61360 rdf:type owl:Class ;
     rdfs:domain aas:DataSpecificationIEC61360 ;
     rdfs:range rdf:langString ;
     rdfs:comment "Short name"@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/unit
-<https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/unit> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has unit"^^xsd:string ;
-    rdfs:domain aas:DataSpecificationIEC61360 ;
-    rdfs:range xsd:string ;
-    rdfs:comment "Unit"@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/unitId
-<https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/unitId> rdf:type owl:ObjectProperty ;
-    rdfs:label "has unit id"^^xsd:string ;
-    rdfs:domain aas:DataSpecificationIEC61360 ;
-    rdfs:range aas:Reference ;
-    rdfs:comment "Unique unit id"@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/sourceOfDefinition
@@ -515,36 +523,20 @@ aas:DataSpecificationIEC61360 rdf:type owl:Class ;
     rdfs:comment "Symbol"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/dataType
-<https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/dataType> rdf:type owl:ObjectProperty ;
-    rdfs:label "has data type"^^xsd:string ;
-    rdfs:domain aas:DataSpecificationIEC61360 ;
-    rdfs:range aas:DataTypeIEC61360 ;
-    rdfs:comment "Data Type"@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/definition
-<https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/definition> rdf:type owl:ObjectProperty ;
-    rdfs:label "has definition"^^xsd:string ;
-    rdfs:domain aas:DataSpecificationIEC61360 ;
-    rdfs:range rdf:langString ;
-    rdfs:comment "Definition in different languages"@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/valueFormat
-<https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/valueFormat> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has value format"^^xsd:string ;
+###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/unit
+<https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/unit> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has unit"^^xsd:string ;
     rdfs:domain aas:DataSpecificationIEC61360 ;
     rdfs:range xsd:string ;
-    rdfs:comment "Value Format"@en ;
+    rdfs:comment "Unit"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/valueList
-<https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/valueList> rdf:type owl:ObjectProperty ;
-    rdfs:label "has value list"^^xsd:string ;
+###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/unitId
+<https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/unitId> rdf:type owl:ObjectProperty ;
+    rdfs:label "has unit id"^^xsd:string ;
     rdfs:domain aas:DataSpecificationIEC61360 ;
-    rdfs:range aas:ValueList ;
-    rdfs:comment "List of allowed values"@en ;
+    rdfs:range aas:Reference ;
+    rdfs:comment "Unique unit id"@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/value
@@ -555,6 +547,14 @@ aas:DataSpecificationIEC61360 rdf:type owl:Class ;
     rdfs:comment "Value"@en ;
 .
 
+###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/valueFormat
+<https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/valueFormat> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has value format"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationIEC61360 ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Value Format"@en ;
+.
+
 ###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/valueId
 <https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/valueId> rdf:type owl:ObjectProperty ;
     rdfs:label "has value id"^^xsd:string ;
@@ -563,18 +563,106 @@ aas:DataSpecificationIEC61360 rdf:type owl:Class ;
     rdfs:comment "Unique value id"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/levelType
-<https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/levelType> rdf:type owl:ObjectProperty ;
-    rdfs:label "has level type"^^xsd:string ;
+###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/valueList
+<https://admin-shell.io/aas/3/0/RC01/DataSpecificationIEC61360/valueList> rdf:type owl:ObjectProperty ;
+    rdfs:label "has value list"^^xsd:string ;
     rdfs:domain aas:DataSpecificationIEC61360 ;
-    rdfs:range aas:LevelType ;
-    rdfs:comment "Set of levels."@en ;
+    rdfs:range aas:ValueList ;
+    rdfs:comment "List of allowed values"@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit
 aas:DataSpecificationPhysicalUnit rdf:type owl:Class ;
     rdfs:subClassOf aas:DataSpecificationContent ;
     rdfs:label "Data Specification Physical Unit"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/conversionFactor
+<https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/conversionFactor> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has conversion factor"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationPhysicalUnit ;
+    rdfs:range xsd:string ;
+    rdfs:comment "TODO"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/definition
+<https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/definition> rdf:type owl:ObjectProperty ;
+    rdfs:label "has definition"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationPhysicalUnit ;
+    rdfs:range rdf:langString ;
+    rdfs:comment "TODO"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/dinNotation
+<https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/dinNotation> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has din notation"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationPhysicalUnit ;
+    rdfs:range xsd:string ;
+    rdfs:comment "TODO"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/eceCode
+<https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/eceCode> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has ece code"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationPhysicalUnit ;
+    rdfs:range xsd:string ;
+    rdfs:comment "TODO"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/eceName
+<https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/eceName> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has ece name"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationPhysicalUnit ;
+    rdfs:range xsd:string ;
+    rdfs:comment "TODO"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/nistName
+<https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/nistName> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has nist name"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationPhysicalUnit ;
+    rdfs:range xsd:string ;
+    rdfs:comment "TODO"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/registrationAuthorityId
+<https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/registrationAuthorityId> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has registration authority id"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationPhysicalUnit ;
+    rdfs:range xsd:string ;
+    rdfs:comment "TODO"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/siName
+<https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/siName> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has si name"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationPhysicalUnit ;
+    rdfs:range xsd:string ;
+    rdfs:comment "TODO"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/siNotation
+<https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/siNotation> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has si notation"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationPhysicalUnit ;
+    rdfs:range xsd:string ;
+    rdfs:comment "TODO"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/sourceOfDefinition
+<https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/sourceOfDefinition> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has source of definition"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationPhysicalUnit ;
+    rdfs:range xsd:string ;
+    rdfs:comment "TODO"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/supplier
+<https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/supplier> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has supplier"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationPhysicalUnit ;
+    rdfs:range xsd:string ;
+    rdfs:comment "TODO"@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/unitName
@@ -593,94 +681,6 @@ aas:DataSpecificationPhysicalUnit rdf:type owl:Class ;
     rdfs:comment "TODO"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/definition
-<https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/definition> rdf:type owl:ObjectProperty ;
-    rdfs:label "has definition"^^xsd:string ;
-    rdfs:domain aas:DataSpecificationPhysicalUnit ;
-    rdfs:range rdf:langString ;
-    rdfs:comment "TODO"@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/siNotation
-<https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/siNotation> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has si notation"^^xsd:string ;
-    rdfs:domain aas:DataSpecificationPhysicalUnit ;
-    rdfs:range xsd:string ;
-    rdfs:comment "TODO"@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/siName
-<https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/siName> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has si name"^^xsd:string ;
-    rdfs:domain aas:DataSpecificationPhysicalUnit ;
-    rdfs:range xsd:string ;
-    rdfs:comment "TODO"@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/dinNotation
-<https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/dinNotation> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has din notation"^^xsd:string ;
-    rdfs:domain aas:DataSpecificationPhysicalUnit ;
-    rdfs:range xsd:string ;
-    rdfs:comment "TODO"@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/eceName
-<https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/eceName> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has ece name"^^xsd:string ;
-    rdfs:domain aas:DataSpecificationPhysicalUnit ;
-    rdfs:range xsd:string ;
-    rdfs:comment "TODO"@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/eceCode
-<https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/eceCode> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has ece code"^^xsd:string ;
-    rdfs:domain aas:DataSpecificationPhysicalUnit ;
-    rdfs:range xsd:string ;
-    rdfs:comment "TODO"@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/nistName
-<https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/nistName> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has nist name"^^xsd:string ;
-    rdfs:domain aas:DataSpecificationPhysicalUnit ;
-    rdfs:range xsd:string ;
-    rdfs:comment "TODO"@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/sourceOfDefinition
-<https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/sourceOfDefinition> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has source of definition"^^xsd:string ;
-    rdfs:domain aas:DataSpecificationPhysicalUnit ;
-    rdfs:range xsd:string ;
-    rdfs:comment "TODO"@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/conversionFactor
-<https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/conversionFactor> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has conversion factor"^^xsd:string ;
-    rdfs:domain aas:DataSpecificationPhysicalUnit ;
-    rdfs:range xsd:string ;
-    rdfs:comment "TODO"@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/registrationAuthorityId
-<https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/registrationAuthorityId> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has registration authority id"^^xsd:string ;
-    rdfs:domain aas:DataSpecificationPhysicalUnit ;
-    rdfs:range xsd:string ;
-    rdfs:comment "TODO"@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/supplier
-<https://admin-shell.io/aas/3/0/RC01/DataSpecificationPhysicalUnit/supplier> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has supplier"^^xsd:string ;
-    rdfs:domain aas:DataSpecificationPhysicalUnit ;
-    rdfs:range xsd:string ;
-    rdfs:comment "TODO"@en ;
-.
-
 ###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef
 aas:DataTypeDef rdf:type owl:Class ;
     rdfs:label "Data Type Def"^^xsd:string ;
@@ -688,27 +688,15 @@ aas:DataTypeDef rdf:type owl:Class ;
         <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/AnyUri>
         <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Base64Binary>
         <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Boolean>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Byte>
         <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Date>
         <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Datetime>
         <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/DatetimeStamp>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/DayTimeDuration>
         <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Decimal>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Integer>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Long>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Int>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Short>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Byte>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NonNegativeInteger>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/PositiveInteger>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/UnsignedLong>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/UnsignedInt>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/UnsignedShort>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/UnsignedByte>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NonPositiveInteger>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NegativeInteger>
         <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Double>
         <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Duration>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/DayTimeDuration>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/YearMonthDuration>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Entity>
         <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Float>
         <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/GDay>
         <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/GMonth>
@@ -716,19 +704,31 @@ aas:DataTypeDef rdf:type owl:Class ;
         <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/GYear>
         <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/GYearMonth>
         <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/HexBinary>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Notation>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/QName>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/String>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NormalizedString>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Token>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Language>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Name>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NCName>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Entity>
         <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Id>
         <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Idref>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Int>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Integer>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Language>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Long>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NCName>
         <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NMToken>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Name>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NegativeInteger>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NonNegativeInteger>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NonPositiveInteger>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NormalizedString>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Notation>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/PositiveInteger>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/QName>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Short>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/String>
         <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Time>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Token>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/UnsignedByte>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/UnsignedInt>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/UnsignedLong>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/UnsignedShort>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/YearMonthDuration>
     ) ;
 .
 
@@ -747,6 +747,11 @@ aas:DataTypeDef rdf:type owl:Class ;
     rdfs:label "Boolean"^^xsd:string ;
 .
 
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Byte
+<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Byte> rdf:type aas:DataTypeDef ;
+    rdfs:label "Byte"^^xsd:string ;
+.
+
 ###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Date
 <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Date> rdf:type aas:DataTypeDef ;
     rdfs:label "Date"^^xsd:string ;
@@ -762,74 +767,14 @@ aas:DataTypeDef rdf:type owl:Class ;
     rdfs:label "Datetime Stamp"^^xsd:string ;
 .
 
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/DayTimeDuration
+<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/DayTimeDuration> rdf:type aas:DataTypeDef ;
+    rdfs:label "Day Time Duration"^^xsd:string ;
+.
+
 ###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Decimal
 <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Decimal> rdf:type aas:DataTypeDef ;
     rdfs:label "Decimal"^^xsd:string ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Integer
-<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Integer> rdf:type aas:DataTypeDef ;
-    rdfs:label "Integer"^^xsd:string ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Long
-<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Long> rdf:type aas:DataTypeDef ;
-    rdfs:label "Long"^^xsd:string ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Int
-<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Int> rdf:type aas:DataTypeDef ;
-    rdfs:label "Int"^^xsd:string ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Short
-<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Short> rdf:type aas:DataTypeDef ;
-    rdfs:label "Short"^^xsd:string ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Byte
-<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Byte> rdf:type aas:DataTypeDef ;
-    rdfs:label "Byte"^^xsd:string ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NonNegativeInteger
-<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NonNegativeInteger> rdf:type aas:DataTypeDef ;
-    rdfs:label "Non Negative Integer"^^xsd:string ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/PositiveInteger
-<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/PositiveInteger> rdf:type aas:DataTypeDef ;
-    rdfs:label "Positive Integer"^^xsd:string ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/UnsignedLong
-<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/UnsignedLong> rdf:type aas:DataTypeDef ;
-    rdfs:label "Unsigned Long"^^xsd:string ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/UnsignedInt
-<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/UnsignedInt> rdf:type aas:DataTypeDef ;
-    rdfs:label "Unsigned Int"^^xsd:string ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/UnsignedShort
-<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/UnsignedShort> rdf:type aas:DataTypeDef ;
-    rdfs:label "Unsigned Short"^^xsd:string ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/UnsignedByte
-<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/UnsignedByte> rdf:type aas:DataTypeDef ;
-    rdfs:label "Unsigned Byte"^^xsd:string ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NonPositiveInteger
-<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NonPositiveInteger> rdf:type aas:DataTypeDef ;
-    rdfs:label "Non Positive Integer"^^xsd:string ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NegativeInteger
-<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NegativeInteger> rdf:type aas:DataTypeDef ;
-    rdfs:label "Negative Integer"^^xsd:string ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Double
@@ -842,14 +787,9 @@ aas:DataTypeDef rdf:type owl:Class ;
     rdfs:label "Duration"^^xsd:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/DayTimeDuration
-<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/DayTimeDuration> rdf:type aas:DataTypeDef ;
-    rdfs:label "Day Time Duration"^^xsd:string ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/YearMonthDuration
-<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/YearMonthDuration> rdf:type aas:DataTypeDef ;
-    rdfs:label "Year Month Duration"^^xsd:string ;
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Entity
+<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Entity> rdf:type aas:DataTypeDef ;
+    rdfs:label "Entity"^^xsd:string ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Float
@@ -887,51 +827,6 @@ aas:DataTypeDef rdf:type owl:Class ;
     rdfs:label "Hex Binary"^^xsd:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Notation
-<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Notation> rdf:type aas:DataTypeDef ;
-    rdfs:label "Notation"^^xsd:string ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/QName
-<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/QName> rdf:type aas:DataTypeDef ;
-    rdfs:label "Q Name"^^xsd:string ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/String
-<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/String> rdf:type aas:DataTypeDef ;
-    rdfs:label "String"^^xsd:string ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NormalizedString
-<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NormalizedString> rdf:type aas:DataTypeDef ;
-    rdfs:label "Normalized String"^^xsd:string ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Token
-<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Token> rdf:type aas:DataTypeDef ;
-    rdfs:label "Token"^^xsd:string ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Language
-<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Language> rdf:type aas:DataTypeDef ;
-    rdfs:label "Language"^^xsd:string ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Name
-<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Name> rdf:type aas:DataTypeDef ;
-    rdfs:label "Name"^^xsd:string ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NCName
-<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NCName> rdf:type aas:DataTypeDef ;
-    rdfs:label "N C Name"^^xsd:string ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Entity
-<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Entity> rdf:type aas:DataTypeDef ;
-    rdfs:label "Entity"^^xsd:string ;
-.
-
 ###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Id
 <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Id> rdf:type aas:DataTypeDef ;
     rdfs:label "Id"^^xsd:string ;
@@ -942,9 +837,84 @@ aas:DataTypeDef rdf:type owl:Class ;
     rdfs:label "Idref"^^xsd:string ;
 .
 
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Int
+<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Int> rdf:type aas:DataTypeDef ;
+    rdfs:label "Int"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Integer
+<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Integer> rdf:type aas:DataTypeDef ;
+    rdfs:label "Integer"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Language
+<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Language> rdf:type aas:DataTypeDef ;
+    rdfs:label "Language"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Long
+<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Long> rdf:type aas:DataTypeDef ;
+    rdfs:label "Long"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NCName
+<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NCName> rdf:type aas:DataTypeDef ;
+    rdfs:label "N C Name"^^xsd:string ;
+.
+
 ###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NMToken
 <https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NMToken> rdf:type aas:DataTypeDef ;
     rdfs:label "N M Token"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Name
+<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Name> rdf:type aas:DataTypeDef ;
+    rdfs:label "Name"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NegativeInteger
+<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NegativeInteger> rdf:type aas:DataTypeDef ;
+    rdfs:label "Negative Integer"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NonNegativeInteger
+<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NonNegativeInteger> rdf:type aas:DataTypeDef ;
+    rdfs:label "Non Negative Integer"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NonPositiveInteger
+<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NonPositiveInteger> rdf:type aas:DataTypeDef ;
+    rdfs:label "Non Positive Integer"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NormalizedString
+<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/NormalizedString> rdf:type aas:DataTypeDef ;
+    rdfs:label "Normalized String"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Notation
+<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Notation> rdf:type aas:DataTypeDef ;
+    rdfs:label "Notation"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/PositiveInteger
+<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/PositiveInteger> rdf:type aas:DataTypeDef ;
+    rdfs:label "Positive Integer"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/QName
+<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/QName> rdf:type aas:DataTypeDef ;
+    rdfs:label "Q Name"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Short
+<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Short> rdf:type aas:DataTypeDef ;
+    rdfs:label "Short"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/String
+<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/String> rdf:type aas:DataTypeDef ;
+    rdfs:label "String"^^xsd:string ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Time
@@ -952,46 +922,66 @@ aas:DataTypeDef rdf:type owl:Class ;
     rdfs:label "Time"^^xsd:string ;
 .
 
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Token
+<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/Token> rdf:type aas:DataTypeDef ;
+    rdfs:label "Token"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/UnsignedByte
+<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/UnsignedByte> rdf:type aas:DataTypeDef ;
+    rdfs:label "Unsigned Byte"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/UnsignedInt
+<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/UnsignedInt> rdf:type aas:DataTypeDef ;
+    rdfs:label "Unsigned Int"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/UnsignedLong
+<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/UnsignedLong> rdf:type aas:DataTypeDef ;
+    rdfs:label "Unsigned Long"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/UnsignedShort
+<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/UnsignedShort> rdf:type aas:DataTypeDef ;
+    rdfs:label "Unsigned Short"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeDef/YearMonthDuration
+<https://admin-shell.io/aas/3/0/RC01/DataTypeDef/YearMonthDuration> rdf:type aas:DataTypeDef ;
+    rdfs:label "Year Month Duration"^^xsd:string ;
+.
+
 ###  https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360
 aas:DataTypeIEC61360 rdf:type owl:Class ;
     rdfs:label "Data Type IEC 61360"^^xsd:string ;
     owl:oneOf (
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/Boolean>
         <https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/Date>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/String>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/StringTranslatable>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/IntegerMeasure>
         <https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/IntegerCount>
         <https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/IntegerCurrency>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/RealMeasure>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/RealCount>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/RealCurrency>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/Boolean>
-        <https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/Url>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/IntegerMeasure>
         <https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/Rational>
         <https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/RationalMeasure>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/RealCount>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/RealCurrency>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/RealMeasure>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/String>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/StringTranslatable>
         <https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/Time>
         <https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/Timestamp>
+        <https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/Url>
     ) ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/Boolean
+<https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/Boolean> rdf:type aas:DataTypeIEC61360 ;
+    rdfs:label "Boolean"^^xsd:string ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/Date
 <https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/Date> rdf:type aas:DataTypeIEC61360 ;
     rdfs:label "Date"^^xsd:string ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/String
-<https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/String> rdf:type aas:DataTypeIEC61360 ;
-    rdfs:label "String"^^xsd:string ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/StringTranslatable
-<https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/StringTranslatable> rdf:type aas:DataTypeIEC61360 ;
-    rdfs:label "String Translatable"^^xsd:string ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/IntegerMeasure
-<https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/IntegerMeasure> rdf:type aas:DataTypeIEC61360 ;
-    rdfs:label "Integer Measure"^^xsd:string ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/IntegerCount
@@ -1004,29 +994,9 @@ aas:DataTypeIEC61360 rdf:type owl:Class ;
     rdfs:label "Integer Currency"^^xsd:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/RealMeasure
-<https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/RealMeasure> rdf:type aas:DataTypeIEC61360 ;
-    rdfs:label "Real Measure"^^xsd:string ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/RealCount
-<https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/RealCount> rdf:type aas:DataTypeIEC61360 ;
-    rdfs:label "Real Count"^^xsd:string ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/RealCurrency
-<https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/RealCurrency> rdf:type aas:DataTypeIEC61360 ;
-    rdfs:label "Real Currency"^^xsd:string ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/Boolean
-<https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/Boolean> rdf:type aas:DataTypeIEC61360 ;
-    rdfs:label "Boolean"^^xsd:string ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/Url
-<https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/Url> rdf:type aas:DataTypeIEC61360 ;
-    rdfs:label "URL"^^xsd:string ;
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/IntegerMeasure
+<https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/IntegerMeasure> rdf:type aas:DataTypeIEC61360 ;
+    rdfs:label "Integer Measure"^^xsd:string ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/Rational
@@ -1039,6 +1009,31 @@ aas:DataTypeIEC61360 rdf:type owl:Class ;
     rdfs:label "Rational Measure"^^xsd:string ;
 .
 
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/RealCount
+<https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/RealCount> rdf:type aas:DataTypeIEC61360 ;
+    rdfs:label "Real Count"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/RealCurrency
+<https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/RealCurrency> rdf:type aas:DataTypeIEC61360 ;
+    rdfs:label "Real Currency"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/RealMeasure
+<https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/RealMeasure> rdf:type aas:DataTypeIEC61360 ;
+    rdfs:label "Real Measure"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/String
+<https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/String> rdf:type aas:DataTypeIEC61360 ;
+    rdfs:label "String"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/StringTranslatable
+<https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/StringTranslatable> rdf:type aas:DataTypeIEC61360 ;
+    rdfs:label "String Translatable"^^xsd:string ;
+.
+
 ###  https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/Time
 <https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/Time> rdf:type aas:DataTypeIEC61360 ;
     rdfs:label "Time"^^xsd:string ;
@@ -1047,6 +1042,11 @@ aas:DataTypeIEC61360 rdf:type owl:Class ;
 ###  https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/Timestamp
 <https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/Timestamp> rdf:type aas:DataTypeIEC61360 ;
     rdfs:label "Timestamp"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/Url
+<https://admin-shell.io/aas/3/0/RC01/DataTypeIEC61360/Url> rdf:type aas:DataTypeIEC61360 ;
+    rdfs:label "URL"^^xsd:string ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/Entity
@@ -1064,14 +1064,6 @@ aas:Entity rdf:type owl:Class ;
     rdfs:comment "Describes whether the entity is a co- managed entity or a self-managed entity."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC01/Entity/statements
-<https://admin-shell.io/aas/3/0/RC01/Entity/statements> rdf:type owl:ObjectProperty ;
-    rdfs:label "has statements"^^xsd:string ;
-    rdfs:domain aas:Entity ;
-    rdfs:range aas:SubmodelElement ;
-    rdfs:comment "Describes statements applicable to the entity by a set of submodel elements, typically with a qualified value."@en ;
-.
-
 ###  https://admin-shell.io/aas/3/0/RC01/Entity/globalAssetId
 <https://admin-shell.io/aas/3/0/RC01/Entity/globalAssetId> rdf:type owl:ObjectProperty ;
     rdfs:label "has global asset id"^^xsd:string ;
@@ -1086,6 +1078,14 @@ aas:Entity rdf:type owl:Class ;
     rdfs:domain aas:Entity ;
     rdfs:range aas:IdentifierKeyValuePair ;
     rdfs:comment "Reference to an identifier key value pair representing a specific identifier of the asset represented by the asset administration shell. See Constraint AASd-014"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/Entity/statements
+<https://admin-shell.io/aas/3/0/RC01/Entity/statements> rdf:type owl:ObjectProperty ;
+    rdfs:label "has statements"^^xsd:string ;
+    rdfs:domain aas:Entity ;
+    rdfs:range aas:SubmodelElement ;
+    rdfs:comment "Describes statements applicable to the entity by a set of submodel elements, typically with a qualified value."@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/EntityType
@@ -1132,12 +1132,12 @@ aas:Extension rdf:type owl:Class ;
     rdfs:comment "Name of the extension."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC01/Extension/valueType
-<https://admin-shell.io/aas/3/0/RC01/Extension/valueType> rdf:type owl:ObjectProperty ;
-    rdfs:label "has value type"^^xsd:string ;
+###  https://admin-shell.io/aas/3/0/RC01/Extension/refersTo
+<https://admin-shell.io/aas/3/0/RC01/Extension/refersTo> rdf:type owl:ObjectProperty ;
+    rdfs:label "has refers to"^^xsd:string ;
     rdfs:domain aas:Extension ;
-    rdfs:range aas:DataTypeDef ;
-    rdfs:comment "Type of the value of the extension."@en ;
+    rdfs:range aas:Reference ;
+    rdfs:comment "Reference to an element the extension refers to."@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/Extension/value
@@ -1148,12 +1148,12 @@ aas:Extension rdf:type owl:Class ;
     rdfs:comment "Value of the extension"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC01/Extension/refersTo
-<https://admin-shell.io/aas/3/0/RC01/Extension/refersTo> rdf:type owl:ObjectProperty ;
-    rdfs:label "has refers to"^^xsd:string ;
+###  https://admin-shell.io/aas/3/0/RC01/Extension/valueType
+<https://admin-shell.io/aas/3/0/RC01/Extension/valueType> rdf:type owl:ObjectProperty ;
+    rdfs:label "has value type"^^xsd:string ;
     rdfs:domain aas:Extension ;
-    rdfs:range aas:Reference ;
-    rdfs:comment "Reference to an element the extension refers to."@en ;
+    rdfs:range aas:DataTypeDef ;
+    rdfs:comment "Type of the value of the extension."@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/File
@@ -1311,14 +1311,6 @@ aas:Identifier rdf:type owl:Class ;
     rdfs:comment "Used to uniquely identify an entity by using an identifier."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC01/Identifier/idType
-<https://admin-shell.io/aas/3/0/RC01/Identifier/idType> rdf:type owl:ObjectProperty ;
-    rdfs:label "has id type"^^xsd:string ;
-    rdfs:domain aas:Identifier ;
-    rdfs:range aas:IdentifierType ;
-    rdfs:comment "Type of the  Identifier, e.g. IRI, IRDI etc. The supported Identifier types are defined in the enumeration 'IdentifierType'."@en ;
-.
-
 ###  https://admin-shell.io/aas/3/0/RC01/Identifier/id
 <https://admin-shell.io/aas/3/0/RC01/Identifier/id> rdf:type owl:DatatypeProperty ;
     rdfs:label "has id"^^xsd:string ;
@@ -1327,11 +1319,27 @@ aas:Identifier rdf:type owl:Class ;
     rdfs:comment "Globally unique identifier of the element."@en ;
 .
 
+###  https://admin-shell.io/aas/3/0/RC01/Identifier/idType
+<https://admin-shell.io/aas/3/0/RC01/Identifier/idType> rdf:type owl:ObjectProperty ;
+    rdfs:label "has id type"^^xsd:string ;
+    rdfs:domain aas:Identifier ;
+    rdfs:range aas:IdentifierType ;
+    rdfs:comment "Type of the  Identifier, e.g. IRI, IRDI etc. The supported Identifier types are defined in the enumeration 'IdentifierType'."@en ;
+.
+
 ###  https://admin-shell.io/aas/3/0/RC01/IdentifierKeyValuePair
 aas:IdentifierKeyValuePair rdf:type owl:Class ;
     rdfs:subClassOf aas:HasSemantics ;
     rdfs:label "Identifier Key Value Pair"^^xsd:string ;
     rdfs:comment "An IdentifierKeyValuePair describes a generic identifier as key-value pair."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/IdentifierKeyValuePair/externalSubjectId
+<https://admin-shell.io/aas/3/0/RC01/IdentifierKeyValuePair/externalSubjectId> rdf:type owl:ObjectProperty ;
+    rdfs:label "has external subject id"^^xsd:string ;
+    rdfs:domain aas:IdentifierKeyValuePair ;
+    rdfs:range aas:Reference ;
+    rdfs:comment "The (external) subject the key belongs to or has meaning to."@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/IdentifierKeyValuePair/key
@@ -1350,23 +1358,21 @@ aas:IdentifierKeyValuePair rdf:type owl:Class ;
     rdfs:comment "The value of the identifier with the corresponding key."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC01/IdentifierKeyValuePair/externalSubjectId
-<https://admin-shell.io/aas/3/0/RC01/IdentifierKeyValuePair/externalSubjectId> rdf:type owl:ObjectProperty ;
-    rdfs:label "has external subject id"^^xsd:string ;
-    rdfs:domain aas:IdentifierKeyValuePair ;
-    rdfs:range aas:Reference ;
-    rdfs:comment "The (external) subject the key belongs to or has meaning to."@en ;
-.
-
 ###  https://admin-shell.io/aas/3/0/RC01/IdentifierType
 aas:IdentifierType rdf:type owl:Class ;
     rdfs:label "Identifier Type"^^xsd:string ;
     rdfs:comment "Enumeration of different types of Identifiers for global identification"@en ;
     owl:oneOf (
+        <https://admin-shell.io/aas/3/0/RC01/IdentifierType/Custom>
         <https://admin-shell.io/aas/3/0/RC01/IdentifierType/Irdi>
         <https://admin-shell.io/aas/3/0/RC01/IdentifierType/Iri>
-        <https://admin-shell.io/aas/3/0/RC01/IdentifierType/Custom>
     ) ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/IdentifierType/Custom
+<https://admin-shell.io/aas/3/0/RC01/IdentifierType/Custom> rdf:type aas:IdentifierType ;
+    rdfs:label "Custom"^^xsd:string ;
+    rdfs:comment "Custom identifiers like GUIDs (globally unique identifiers)"@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/IdentifierType/Irdi
@@ -1381,16 +1387,18 @@ aas:IdentifierType rdf:type owl:Class ;
     rdfs:comment "IRI according to Rfc 3987. Every URIis an IRI"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC01/IdentifierType/Custom
-<https://admin-shell.io/aas/3/0/RC01/IdentifierType/Custom> rdf:type aas:IdentifierType ;
-    rdfs:label "Custom"^^xsd:string ;
-    rdfs:comment "Custom identifiers like GUIDs (globally unique identifiers)"@en ;
-.
-
 ###  https://admin-shell.io/aas/3/0/RC01/Key
 aas:Key rdf:type owl:Class ;
     rdfs:label "Key"^^xsd:string ;
     rdfs:comment "A key is a reference to an element by its id."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/Key/idType
+<https://admin-shell.io/aas/3/0/RC01/Key/idType> rdf:type owl:ObjectProperty ;
+    rdfs:label "has id type"^^xsd:string ;
+    rdfs:domain aas:Key ;
+    rdfs:range aas:KeyType ;
+    rdfs:comment "Type of the key value."@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/Key/type
@@ -1409,21 +1417,11 @@ aas:Key rdf:type owl:Class ;
     rdfs:comment "The key value, for example an IRDI if the 'idType' is IRDI."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC01/Key/idType
-<https://admin-shell.io/aas/3/0/RC01/Key/idType> rdf:type owl:ObjectProperty ;
-    rdfs:label "has id type"^^xsd:string ;
-    rdfs:domain aas:Key ;
-    rdfs:range aas:KeyType ;
-    rdfs:comment "Type of the key value."@en ;
-.
-
 ###  https://admin-shell.io/aas/3/0/RC01/KeyElements
 aas:KeyElements rdf:type owl:Class ;
     rdfs:label "Key Elements"^^xsd:string ;
     rdfs:comment "Enumeration of different key value types within a key."@en ;
     owl:oneOf (
-        <https://admin-shell.io/aas/3/0/RC01/KeyElements/GlobalReference>
-        <https://admin-shell.io/aas/3/0/RC01/KeyElements/FragmentReference>
         <https://admin-shell.io/aas/3/0/RC01/KeyElements/AccessPermissionRule>
         <https://admin-shell.io/aas/3/0/RC01/KeyElements/AnnotatedRelationshipElement>
         <https://admin-shell.io/aas/3/0/RC01/KeyElements/Asset>
@@ -1437,6 +1435,8 @@ aas:KeyElements rdf:type owl:Class ;
         <https://admin-shell.io/aas/3/0/RC01/KeyElements/Entity>
         <https://admin-shell.io/aas/3/0/RC01/KeyElements/Event>
         <https://admin-shell.io/aas/3/0/RC01/KeyElements/File>
+        <https://admin-shell.io/aas/3/0/RC01/KeyElements/FragmentReference>
+        <https://admin-shell.io/aas/3/0/RC01/KeyElements/GlobalReference>
         <https://admin-shell.io/aas/3/0/RC01/KeyElements/MultiLanguageProperty>
         <https://admin-shell.io/aas/3/0/RC01/KeyElements/Operation>
         <https://admin-shell.io/aas/3/0/RC01/KeyElements/Property>
@@ -1448,18 +1448,6 @@ aas:KeyElements rdf:type owl:Class ;
         <https://admin-shell.io/aas/3/0/RC01/KeyElements/SubmodelElementCollection>
         <https://admin-shell.io/aas/3/0/RC01/KeyElements/View>
     ) ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/KeyElements/GlobalReference
-<https://admin-shell.io/aas/3/0/RC01/KeyElements/GlobalReference> rdf:type aas:KeyElements ;
-    rdfs:label "Global Reference"^^xsd:string ;
-    rdfs:comment "reference to an element not belonging to an asset administration shell"@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/KeyElements/FragmentReference
-<https://admin-shell.io/aas/3/0/RC01/KeyElements/FragmentReference> rdf:type aas:KeyElements ;
-    rdfs:label "Fragment Reference"^^xsd:string ;
-    rdfs:comment "unique reference to an element within a file."@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/KeyElements/AccessPermissionRule
@@ -1529,6 +1517,18 @@ aas:KeyElements rdf:type owl:Class ;
     rdfs:label "File"^^xsd:string ;
 .
 
+###  https://admin-shell.io/aas/3/0/RC01/KeyElements/FragmentReference
+<https://admin-shell.io/aas/3/0/RC01/KeyElements/FragmentReference> rdf:type aas:KeyElements ;
+    rdfs:label "Fragment Reference"^^xsd:string ;
+    rdfs:comment "unique reference to an element within a file."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/KeyElements/GlobalReference
+<https://admin-shell.io/aas/3/0/RC01/KeyElements/GlobalReference> rdf:type aas:KeyElements ;
+    rdfs:label "Global Reference"^^xsd:string ;
+    rdfs:comment "reference to an element not belonging to an asset administration shell"@en ;
+.
+
 ###  https://admin-shell.io/aas/3/0/RC01/KeyElements/MultiLanguageProperty
 <https://admin-shell.io/aas/3/0/RC01/KeyElements/MultiLanguageProperty> rdf:type aas:KeyElements ;
     rdfs:label "Multi Language Property"^^xsd:string ;
@@ -1587,24 +1587,30 @@ aas:KeyType rdf:type owl:Class ;
     rdfs:label "Key Type"^^xsd:string ;
     rdfs:comment "Enumeration of different key value types within a key."@en ;
     owl:oneOf (
-        <https://admin-shell.io/aas/3/0/RC01/KeyType/IdShort>
+        <https://admin-shell.io/aas/3/0/RC01/KeyType/Custom>
         <https://admin-shell.io/aas/3/0/RC01/KeyType/FragmentId>
+        <https://admin-shell.io/aas/3/0/RC01/KeyType/IdShort>
         <https://admin-shell.io/aas/3/0/RC01/KeyType/Irdi>
         <https://admin-shell.io/aas/3/0/RC01/KeyType/Iri>
-        <https://admin-shell.io/aas/3/0/RC01/KeyType/Custom>
     ) ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC01/KeyType/IdShort
-<https://admin-shell.io/aas/3/0/RC01/KeyType/IdShort> rdf:type aas:KeyType ;
-    rdfs:label "Id Short"^^xsd:string ;
-    rdfs:comment "idShort of a referable element"@en ;
+###  https://admin-shell.io/aas/3/0/RC01/KeyType/Custom
+<https://admin-shell.io/aas/3/0/RC01/KeyType/Custom> rdf:type aas:KeyType ;
+    rdfs:label "Custom"^^xsd:string ;
+    rdfs:comment "Custom identifiers like GUIDs (globally unique identifiers)"@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/KeyType/FragmentId
 <https://admin-shell.io/aas/3/0/RC01/KeyType/FragmentId> rdf:type aas:KeyType ;
     rdfs:label "Fragment Id"^^xsd:string ;
     rdfs:comment "Identifier of a fragment within a file"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/KeyType/IdShort
+<https://admin-shell.io/aas/3/0/RC01/KeyType/IdShort> rdf:type aas:KeyType ;
+    rdfs:label "Id Short"^^xsd:string ;
+    rdfs:comment "idShort of a referable element"@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/KeyType/Irdi
@@ -1619,33 +1625,27 @@ aas:KeyType rdf:type owl:Class ;
     rdfs:comment "IRI according to Rfc 3987. Every URI is an IRI."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC01/KeyType/Custom
-<https://admin-shell.io/aas/3/0/RC01/KeyType/Custom> rdf:type aas:KeyType ;
-    rdfs:label "Custom"^^xsd:string ;
-    rdfs:comment "Custom identifiers like GUIDs (globally unique identifiers)"@en ;
-.
-
 # The class LangStringSet is implicitly defined in RDF through rdf:langString.
 
 ###  https://admin-shell.io/aas/3/0/RC01/LevelType
 aas:LevelType rdf:type owl:Class ;
     rdfs:label "Level Type"^^xsd:string ;
     owl:oneOf (
-        <https://admin-shell.io/aas/3/0/RC01/LevelType/Min>
         <https://admin-shell.io/aas/3/0/RC01/LevelType/Max>
+        <https://admin-shell.io/aas/3/0/RC01/LevelType/Min>
         <https://admin-shell.io/aas/3/0/RC01/LevelType/Nom>
         <https://admin-shell.io/aas/3/0/RC01/LevelType/Typ>
     ) ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC01/LevelType/Min
-<https://admin-shell.io/aas/3/0/RC01/LevelType/Min> rdf:type aas:LevelType ;
-    rdfs:label "Min"^^xsd:string ;
-.
-
 ###  https://admin-shell.io/aas/3/0/RC01/LevelType/Max
 <https://admin-shell.io/aas/3/0/RC01/LevelType/Max> rdf:type aas:LevelType ;
     rdfs:label "Max"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/LevelType/Min
+<https://admin-shell.io/aas/3/0/RC01/LevelType/Min> rdf:type aas:LevelType ;
+    rdfs:label "Min"^^xsd:string ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/LevelType/Nom
@@ -1663,15 +1663,9 @@ aas:LocalKeyType rdf:type owl:Class ;
     rdfs:label "Local Key Type"^^xsd:string ;
     rdfs:comment "Enumeration of different key value types within a key."@en ;
     owl:oneOf (
-        <https://admin-shell.io/aas/3/0/RC01/LocalKeyType/IdShort>
         <https://admin-shell.io/aas/3/0/RC01/LocalKeyType/FragmentId>
+        <https://admin-shell.io/aas/3/0/RC01/LocalKeyType/IdShort>
     ) ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/LocalKeyType/IdShort
-<https://admin-shell.io/aas/3/0/RC01/LocalKeyType/IdShort> rdf:type aas:LocalKeyType ;
-    rdfs:label "Id Short"^^xsd:string ;
-    rdfs:comment "idShort of a referable element"@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/LocalKeyType/FragmentId
@@ -1680,26 +1674,32 @@ aas:LocalKeyType rdf:type owl:Class ;
     rdfs:comment "Identifier of a fragment within a file"@en ;
 .
 
+###  https://admin-shell.io/aas/3/0/RC01/LocalKeyType/IdShort
+<https://admin-shell.io/aas/3/0/RC01/LocalKeyType/IdShort> rdf:type aas:LocalKeyType ;
+    rdfs:label "Id Short"^^xsd:string ;
+    rdfs:comment "idShort of a referable element"@en ;
+.
+
 ###  https://admin-shell.io/aas/3/0/RC01/ModelingKind
 aas:ModelingKind rdf:type owl:Class ;
     rdfs:label "Modeling Kind"^^xsd:string ;
     rdfs:comment "Enumeration for denoting whether an element is a template or an instance."@en ;
     owl:oneOf (
-        <https://admin-shell.io/aas/3/0/RC01/ModelingKind/Template>
         <https://admin-shell.io/aas/3/0/RC01/ModelingKind/Instance>
+        <https://admin-shell.io/aas/3/0/RC01/ModelingKind/Template>
     ) ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/ModelingKind/Template
-<https://admin-shell.io/aas/3/0/RC01/ModelingKind/Template> rdf:type aas:ModelingKind ;
-    rdfs:label "Template"^^xsd:string ;
-    rdfs:comment "Software element which specifies the common attributes shared by all instances of the template."@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/ModelingKind/Instance
 <https://admin-shell.io/aas/3/0/RC01/ModelingKind/Instance> rdf:type aas:ModelingKind ;
     rdfs:label "Instance"^^xsd:string ;
     rdfs:comment "Concrete, clearly identifiable component of a certain template."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/ModelingKind/Template
+<https://admin-shell.io/aas/3/0/RC01/ModelingKind/Template> rdf:type aas:ModelingKind ;
+    rdfs:label "Template"^^xsd:string ;
+    rdfs:comment "Software element which specifies the common attributes shared by all instances of the template."@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/MultiLanguageProperty
@@ -1746,6 +1746,14 @@ aas:Operation rdf:type owl:Class ;
     rdfs:comment "An operation is a submodel element with input and output variables."@en ;
 .
 
+###  https://admin-shell.io/aas/3/0/RC01/Operation/inoutputVariables
+<https://admin-shell.io/aas/3/0/RC01/Operation/inoutputVariables> rdf:type owl:ObjectProperty ;
+    rdfs:label "has inoutput variables"^^xsd:string ;
+    rdfs:domain aas:Operation ;
+    rdfs:range aas:OperationVariable ;
+    rdfs:comment "Parameter that is input and output of the operation."@en ;
+.
+
 ###  https://admin-shell.io/aas/3/0/RC01/Operation/inputVariables
 <https://admin-shell.io/aas/3/0/RC01/Operation/inputVariables> rdf:type owl:ObjectProperty ;
     rdfs:label "has input variables"^^xsd:string ;
@@ -1760,14 +1768,6 @@ aas:Operation rdf:type owl:Class ;
     rdfs:domain aas:Operation ;
     rdfs:range aas:OperationVariable ;
     rdfs:comment "Output parameter of the operation."@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/Operation/inoutputVariables
-<https://admin-shell.io/aas/3/0/RC01/Operation/inoutputVariables> rdf:type owl:ObjectProperty ;
-    rdfs:label "has inoutput variables"^^xsd:string ;
-    rdfs:domain aas:Operation ;
-    rdfs:range aas:OperationVariable ;
-    rdfs:comment "Parameter that is input and output of the operation."@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/OperationVariable
@@ -1790,20 +1790,20 @@ aas:Permission rdf:type owl:Class ;
     rdfs:comment "Description of a single permission."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC01/Permission/permission
-<https://admin-shell.io/aas/3/0/RC01/Permission/permission> rdf:type owl:ObjectProperty ;
-    rdfs:label "has permission"^^xsd:string ;
-    rdfs:domain aas:Permission ;
-    rdfs:range aas:Reference ;
-    rdfs:comment "Reference to a property that defines the semantics of the permission."@en ;
-.
-
 ###  https://admin-shell.io/aas/3/0/RC01/Permission/kindOfPermission
 <https://admin-shell.io/aas/3/0/RC01/Permission/kindOfPermission> rdf:type owl:ObjectProperty ;
     rdfs:label "has kind of permission"^^xsd:string ;
     rdfs:domain aas:Permission ;
     rdfs:range aas:PermissionKind ;
     rdfs:comment "Description of the kind of permission. Possible kind of permission also include the denial of the permission."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/Permission/permission
+<https://admin-shell.io/aas/3/0/RC01/Permission/permission> rdf:type owl:ObjectProperty ;
+    rdfs:label "has permission"^^xsd:string ;
+    rdfs:domain aas:Permission ;
+    rdfs:range aas:Reference ;
+    rdfs:comment "Reference to a property that defines the semantics of the permission."@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/PermissionKind
@@ -1856,20 +1856,20 @@ aas:PermissionsPerObject rdf:type owl:Class ;
     rdfs:comment "Element to which permission shall be assigned."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC01/PermissionsPerObject/targetObjectAttributes
-<https://admin-shell.io/aas/3/0/RC01/PermissionsPerObject/targetObjectAttributes> rdf:type owl:ObjectProperty ;
-    rdfs:label "has target object attributes"^^xsd:string ;
-    rdfs:domain aas:PermissionsPerObject ;
-    rdfs:range aas:ObjectAttributes ;
-    rdfs:comment "Target object attributes that need to be fulfilled so that the access permissions apply to the accessing subject."@en ;
-.
-
 ###  https://admin-shell.io/aas/3/0/RC01/PermissionsPerObject/permissions
 <https://admin-shell.io/aas/3/0/RC01/PermissionsPerObject/permissions> rdf:type owl:ObjectProperty ;
     rdfs:label "has permissions"^^xsd:string ;
     rdfs:domain aas:PermissionsPerObject ;
     rdfs:range aas:Permission ;
     rdfs:comment "Permissions assigned to the object. The permissions hold for all subjects as specified in the access permission rule.\""@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/PermissionsPerObject/targetObjectAttributes
+<https://admin-shell.io/aas/3/0/RC01/PermissionsPerObject/targetObjectAttributes> rdf:type owl:ObjectProperty ;
+    rdfs:label "has target object attributes"^^xsd:string ;
+    rdfs:domain aas:PermissionsPerObject ;
+    rdfs:range aas:ObjectAttributes ;
+    rdfs:comment "Target object attributes that need to be fulfilled so that the access permissions apply to the accessing subject."@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/PolicyAdministrationPoint
@@ -1951,14 +1951,6 @@ aas:Property rdf:type owl:Class ;
     rdfs:comment "A property is a data element that has a single value."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC01/Property/valueType
-<https://admin-shell.io/aas/3/0/RC01/Property/valueType> rdf:type owl:ObjectProperty ;
-    rdfs:label "has value type"^^xsd:string ;
-    rdfs:domain aas:Property ;
-    rdfs:range aas:DataTypeDef ;
-    rdfs:comment "Data type of the value"@en ;
-.
-
 ###  https://admin-shell.io/aas/3/0/RC01/Property/value
 <https://admin-shell.io/aas/3/0/RC01/Property/value> rdf:type owl:DatatypeProperty ;
     rdfs:label "has value"^^xsd:string ;
@@ -1973,6 +1965,14 @@ aas:Property rdf:type owl:Class ;
     rdfs:domain aas:Property ;
     rdfs:range aas:Reference ;
     rdfs:comment "Reference to the global unique id of a coded value."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/Property/valueType
+<https://admin-shell.io/aas/3/0/RC01/Property/valueType> rdf:type owl:ObjectProperty ;
+    rdfs:label "has value type"^^xsd:string ;
+    rdfs:domain aas:Property ;
+    rdfs:range aas:DataTypeDef ;
+    rdfs:comment "Data type of the value"@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/Qualifiable
@@ -2005,14 +2005,6 @@ aas:Qualifier rdf:type owl:Class ;
     rdfs:comment "The qualifier type describes the type of the qualifier that is applied to the element."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC01/Qualifier/valueType
-<https://admin-shell.io/aas/3/0/RC01/Qualifier/valueType> rdf:type owl:ObjectProperty ;
-    rdfs:label "has value type"^^xsd:string ;
-    rdfs:domain aas:Qualifier ;
-    rdfs:range aas:DataTypeDef ;
-    rdfs:comment "Data type of the qualifier value."@en ;
-.
-
 ###  https://admin-shell.io/aas/3/0/RC01/Qualifier/value
 <https://admin-shell.io/aas/3/0/RC01/Qualifier/value> rdf:type owl:DatatypeProperty ;
     rdfs:label "has value"^^xsd:string ;
@@ -2029,27 +2021,19 @@ aas:Qualifier rdf:type owl:Class ;
     rdfs:comment "Reference to the global unique ID of a coded value."@en ;
 .
 
+###  https://admin-shell.io/aas/3/0/RC01/Qualifier/valueType
+<https://admin-shell.io/aas/3/0/RC01/Qualifier/valueType> rdf:type owl:ObjectProperty ;
+    rdfs:label "has value type"^^xsd:string ;
+    rdfs:domain aas:Qualifier ;
+    rdfs:range aas:DataTypeDef ;
+    rdfs:comment "Data type of the qualifier value."@en ;
+.
+
 ###  https://admin-shell.io/aas/3/0/RC01/Range
 aas:Range rdf:type owl:Class ;
     rdfs:subClassOf aas:DataElement ;
     rdfs:label "Range"^^xsd:string ;
     rdfs:comment "A range data element is a data element that defines a range with min and max."@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/Range/valueType
-<https://admin-shell.io/aas/3/0/RC01/Range/valueType> rdf:type owl:ObjectProperty ;
-    rdfs:label "has value type"^^xsd:string ;
-    rdfs:domain aas:Range ;
-    rdfs:range aas:DataTypeDef ;
-    rdfs:comment "Data type of the min und max"@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/Range/min
-<https://admin-shell.io/aas/3/0/RC01/Range/min> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has min"^^xsd:string ;
-    rdfs:domain aas:Range ;
-    rdfs:range xsd:string ;
-    rdfs:comment "The minimum value of the range. If the min value is missing, then the value is assumed to be negative infinite."@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/Range/max
@@ -2060,27 +2044,27 @@ aas:Range rdf:type owl:Class ;
     rdfs:comment "The maximum value of the range. If the max value is missing,  then the value is assumed to be positive infinite."@en ;
 .
 
+###  https://admin-shell.io/aas/3/0/RC01/Range/min
+<https://admin-shell.io/aas/3/0/RC01/Range/min> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has min"^^xsd:string ;
+    rdfs:domain aas:Range ;
+    rdfs:range xsd:string ;
+    rdfs:comment "The minimum value of the range. If the min value is missing, then the value is assumed to be negative infinite."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/Range/valueType
+<https://admin-shell.io/aas/3/0/RC01/Range/valueType> rdf:type owl:ObjectProperty ;
+    rdfs:label "has value type"^^xsd:string ;
+    rdfs:domain aas:Range ;
+    rdfs:range aas:DataTypeDef ;
+    rdfs:comment "Data type of the min und max"@en ;
+.
+
 ###  https://admin-shell.io/aas/3/0/RC01/Referable
 aas:Referable rdf:type owl:Class ;
     rdfs:subClassOf aas:HasExtensions ;
     rdfs:label "Referable"^^xsd:string ;
     rdfs:comment "An element that is referable by its 'idShort'."@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/Referable/idShort
-<https://admin-shell.io/aas/3/0/RC01/Referable/idShort> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has id short"^^xsd:string ;
-    rdfs:domain aas:Referable ;
-    rdfs:range xsd:string ;
-    rdfs:comment "In case of identifiable this attribute is a short name of the element. In case of referable this ID is an identifying string of the element within its name space."@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC01/Referable/displayName
-<https://admin-shell.io/aas/3/0/RC01/Referable/displayName> rdf:type owl:ObjectProperty ;
-    rdfs:label "has display name"^^xsd:string ;
-    rdfs:domain aas:Referable ;
-    rdfs:range rdf:langString ;
-    rdfs:comment "Display name. Can be provided in several languages."@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/Referable/category
@@ -2097,6 +2081,22 @@ aas:Referable rdf:type owl:Class ;
     rdfs:domain aas:Referable ;
     rdfs:range rdf:langString ;
     rdfs:comment "Description or comments on the element."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/Referable/displayName
+<https://admin-shell.io/aas/3/0/RC01/Referable/displayName> rdf:type owl:ObjectProperty ;
+    rdfs:label "has display name"^^xsd:string ;
+    rdfs:domain aas:Referable ;
+    rdfs:range rdf:langString ;
+    rdfs:comment "Display name. Can be provided in several languages."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC01/Referable/idShort
+<https://admin-shell.io/aas/3/0/RC01/Referable/idShort> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has id short"^^xsd:string ;
+    rdfs:domain aas:Referable ;
+    rdfs:range xsd:string ;
+    rdfs:comment "In case of identifiable this attribute is a short name of the element. In case of referable this ID is an identifying string of the element within its name space."@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/ReferableElements
@@ -2381,12 +2381,12 @@ aas:SubmodelElementCollection rdf:type owl:Class ;
     rdfs:comment "A submodel element collection is a set or list of submodel elements."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC01/SubmodelElementCollection/value
-<https://admin-shell.io/aas/3/0/RC01/SubmodelElementCollection/value> rdf:type owl:ObjectProperty ;
-    rdfs:label "has value"^^xsd:string ;
+###  https://admin-shell.io/aas/3/0/RC01/SubmodelElementCollection/allowDuplicates
+<https://admin-shell.io/aas/3/0/RC01/SubmodelElementCollection/allowDuplicates> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has allow duplicates"^^xsd:string ;
     rdfs:domain aas:SubmodelElementCollection ;
-    rdfs:range aas:SubmodelElement ;
-    rdfs:comment "Submodel element contained in the collection."@en ;
+    rdfs:range xsd:boolean ;
+    rdfs:comment "If allowDuplicates==true, then it is allowed that the collection contains several elements with the same semantics (i.e. the same semanticId)."@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/SubmodelElementCollection/ordered
@@ -2397,12 +2397,12 @@ aas:SubmodelElementCollection rdf:type owl:Class ;
     rdfs:comment "If ordered=false, then the elements in the collection are not ordered. If ordered=true, then the elements in the collection are ordered. Default = false"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC01/SubmodelElementCollection/allowDuplicates
-<https://admin-shell.io/aas/3/0/RC01/SubmodelElementCollection/allowDuplicates> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has allow duplicates"^^xsd:string ;
+###  https://admin-shell.io/aas/3/0/RC01/SubmodelElementCollection/value
+<https://admin-shell.io/aas/3/0/RC01/SubmodelElementCollection/value> rdf:type owl:ObjectProperty ;
+    rdfs:label "has value"^^xsd:string ;
     rdfs:domain aas:SubmodelElementCollection ;
-    rdfs:range xsd:boolean ;
-    rdfs:comment "If allowDuplicates==true, then it is allowed that the collection contains several elements with the same semantics (i.e. the same semanticId)."@en ;
+    rdfs:range aas:SubmodelElement ;
+    rdfs:comment "Submodel element contained in the collection."@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC01/ValueList

--- a/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/expected_output/rdf-ontology.ttl
+++ b/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/expected_output/rdf-ontology.ttl
@@ -1,0 +1,2024 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@base <https://admin-shell.io/aas/3/0/RC02/> .
+
+<https://admin-shell.io/aas/3/0/RC02/> rdf:type owl:Ontology ;
+    vann:preferredNamespaceUri "https://admin-shell.io/aas/3/0/RC02/"^^xsd:anyURI ;
+    owl:versionInfo "3.0.RC02" ;
+    rdfs:comment "This ontology represents the data model for the Asset Administration Shell according to the specification 'Details of the Asset Administration Shell - Part 1 - Version 3.0.RC02'."@en ;
+    vann:preferredNamespacePrefix "aas"^^xsd:string ;
+    rdfs:isDefinedBy <https://admin-shell.io/aas/3/0/RC02/> ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/AdministrativeInformation
+aas:AdministrativeInformation rdf:type owl:Class ;
+    rdfs:subClassOf aas:HasDataSpecification ;
+    rdfs:label "Administrative Information"^^xsd:string ;
+    rdfs:comment "Administrative meta-information for an element like version information."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/AdministrativeInformation/revision
+<https://admin-shell.io/aas/3/0/RC02/AdministrativeInformation/revision> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has revision"^^xsd:string ;
+    rdfs:domain aas:AdministrativeInformation ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Revision of the element."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/AdministrativeInformation/version
+<https://admin-shell.io/aas/3/0/RC02/AdministrativeInformation/version> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has version"^^xsd:string ;
+    rdfs:domain aas:AdministrativeInformation ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Version of the element."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/AnnotatedRelationshipElement
+aas:AnnotatedRelationshipElement rdf:type owl:Class ;
+    rdfs:subClassOf aas:RelationshipElement ;
+    rdfs:label "Annotated Relationship Element"^^xsd:string ;
+    rdfs:comment "An annotated relationship element is a relationship element that can be annotated with additional data elements."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/AnnotatedRelationshipElement/annotation
+<https://admin-shell.io/aas/3/0/RC02/AnnotatedRelationshipElement/annotation> rdf:type owl:ObjectProperty ;
+    rdfs:label "has annotation"^^xsd:string ;
+    rdfs:domain aas:AnnotatedRelationshipElement ;
+    rdfs:range aas:DataElement ;
+    rdfs:comment "A data element that represents an annotation that holds for the relationship between the two elements"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/AssetAdministrationShell
+aas:AssetAdministrationShell rdf:type owl:Class ;
+    rdfs:subClassOf aas:Identifiable ;
+    rdfs:subClassOf aas:HasDataSpecification ;
+    rdfs:label "Asset Administration Shell"^^xsd:string ;
+    rdfs:comment "An asset administration shell."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/AssetAdministrationShell/assetInformation
+<https://admin-shell.io/aas/3/0/RC02/AssetAdministrationShell/assetInformation> rdf:type owl:ObjectProperty ;
+    rdfs:label "has asset information"^^xsd:string ;
+    rdfs:domain aas:AssetAdministrationShell ;
+    rdfs:range aas:AssetInformation ;
+    rdfs:comment "Meta-information about the asset the AAS is representing."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/AssetAdministrationShell/derivedFrom
+<https://admin-shell.io/aas/3/0/RC02/AssetAdministrationShell/derivedFrom> rdf:type owl:ObjectProperty ;
+    rdfs:label "has derived from"^^xsd:string ;
+    rdfs:domain aas:AssetAdministrationShell ;
+    rdfs:range aas:ModelReference ;
+    rdfs:comment "The reference to the AAS the AAS was derived from."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/AssetAdministrationShell/submodels
+<https://admin-shell.io/aas/3/0/RC02/AssetAdministrationShell/submodels> rdf:type owl:ObjectProperty ;
+    rdfs:label "has submodels"^^xsd:string ;
+    rdfs:domain aas:AssetAdministrationShell ;
+    rdfs:range aas:ModelReference ;
+    rdfs:comment "References to submodels of the AAS."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/AssetInformation
+aas:AssetInformation rdf:type owl:Class ;
+    rdfs:label "Asset Information"^^xsd:string ;
+    rdfs:comment "In 'AssetInformation' identifying meta data of the asset that is represented by an AAS is defined."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/AssetInformation/assetKind
+<https://admin-shell.io/aas/3/0/RC02/AssetInformation/assetKind> rdf:type owl:ObjectProperty ;
+    rdfs:label "has asset kind"^^xsd:string ;
+    rdfs:domain aas:AssetInformation ;
+    rdfs:range aas:AssetKind ;
+    rdfs:comment "Denotes whether the Asset is of kind \"Type\" or \"Instance\"."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/AssetInformation/defaultThumbnail
+<https://admin-shell.io/aas/3/0/RC02/AssetInformation/defaultThumbnail> rdf:type owl:ObjectProperty ;
+    rdfs:label "has default thumbnail"^^xsd:string ;
+    rdfs:domain aas:AssetInformation ;
+    rdfs:range aas:Resource ;
+    rdfs:comment "Thumbnail of the asset represented by the asset administration shell."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/AssetInformation/globalAssetId
+<https://admin-shell.io/aas/3/0/RC02/AssetInformation/globalAssetId> rdf:type owl:ObjectProperty ;
+    rdfs:label "has global asset id"^^xsd:string ;
+    rdfs:domain aas:AssetInformation ;
+    rdfs:range aas:GlobalReference ;
+    rdfs:comment "Reference to either an Asset object or a global reference to the asset the AAS is representing."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/AssetInformation/specificAssetId
+<https://admin-shell.io/aas/3/0/RC02/AssetInformation/specificAssetId> rdf:type owl:ObjectProperty ;
+    rdfs:label "has specific asset id"^^xsd:string ;
+    rdfs:domain aas:AssetInformation ;
+    rdfs:range aas:IdentifierKeyValuePair ;
+    rdfs:comment "Additional domain-specific, typically proprietary, Identifier for the asset."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/AssetKind
+aas:AssetKind rdf:type owl:Class ;
+    rdfs:label "Asset Kind"^^xsd:string ;
+    rdfs:comment "Enumeration for denoting whether an element is a type or an instance."@en ;
+    owl:oneOf (
+        <https://admin-shell.io/aas/3/0/RC02/AssetKind/Instance>
+        <https://admin-shell.io/aas/3/0/RC02/AssetKind/Type>
+    ) ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/AssetKind/Instance
+<https://admin-shell.io/aas/3/0/RC02/AssetKind/Instance> rdf:type aas:AssetKind ;
+    rdfs:label "Instance"^^xsd:string ;
+    rdfs:comment "concrete, clearly identifiable component of a certain type"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/AssetKind/Type
+<https://admin-shell.io/aas/3/0/RC02/AssetKind/Type> rdf:type aas:AssetKind ;
+    rdfs:label "Type"^^xsd:string ;
+    rdfs:comment "hardware or software element which specifies the common attributes shared by all instances of the type"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/BasicEventElement
+aas:BasicEventElement rdf:type owl:Class ;
+    rdfs:subClassOf aas:EventElement ;
+    rdfs:label "Basic Event Element"^^xsd:string ;
+    rdfs:comment "A basic event element."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/BasicEventElement/direction
+<https://admin-shell.io/aas/3/0/RC02/BasicEventElement/direction> rdf:type owl:ObjectProperty ;
+    rdfs:label "has direction"^^xsd:string ;
+    rdfs:domain aas:BasicEventElement ;
+    rdfs:range aas:Direction ;
+    rdfs:comment "Direction of event. Can be { Input, Output }."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/BasicEventElement/lastUpdate
+<https://admin-shell.io/aas/3/0/RC02/BasicEventElement/lastUpdate> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has last update"^^xsd:string ;
+    rdfs:domain aas:BasicEventElement ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Timestamp in UTC, when the last event was received (input direction) or sent (output direction)."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/BasicEventElement/maxInterval
+<https://admin-shell.io/aas/3/0/RC02/BasicEventElement/maxInterval> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has max interval"^^xsd:string ;
+    rdfs:domain aas:BasicEventElement ;
+    rdfs:range xsd:string ;
+    rdfs:comment "For input direction: not applicable. For output direction: maximum interval in time, the respective Referable shall send an update of the status of the event, even if no other trigger condition for the event was not met. Might be not specified, that is, there is no maximum interval."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/BasicEventElement/messageBroker
+<https://admin-shell.io/aas/3/0/RC02/BasicEventElement/messageBroker> rdf:type owl:ObjectProperty ;
+    rdfs:label "has message broker"^^xsd:string ;
+    rdfs:domain aas:BasicEventElement ;
+    rdfs:range aas:ModelReference ;
+    rdfs:comment "Information, which outer message infrastructure shall handle messages for the 'EventElement'."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/BasicEventElement/messageTopic
+<https://admin-shell.io/aas/3/0/RC02/BasicEventElement/messageTopic> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has message topic"^^xsd:string ;
+    rdfs:domain aas:BasicEventElement ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Information for the outer message infrastructure for scheduling the event to the respective communication channel."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/BasicEventElement/minInterval
+<https://admin-shell.io/aas/3/0/RC02/BasicEventElement/minInterval> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has min interval"^^xsd:string ;
+    rdfs:domain aas:BasicEventElement ;
+    rdfs:range xsd:string ;
+    rdfs:comment "For input direction, reports on the maximum frequency, the software entity behind the respective Referable can handle input events. For output events, specifies the maximum frequency of outputting this event to an outer infrastructure. Might be not specified, that is, there is no minimum interval."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/BasicEventElement/observed
+<https://admin-shell.io/aas/3/0/RC02/BasicEventElement/observed> rdf:type owl:ObjectProperty ;
+    rdfs:label "has observed"^^xsd:string ;
+    rdfs:domain aas:BasicEventElement ;
+    rdfs:range aas:ModelReference ;
+    rdfs:comment "Reference to the 'Referable', which defines the scope of the event. Can be 'AssetAdministrationShell', 'Submodel', or 'SubmodelElement'. Reference to a referable, e.g. a data element or a submodel, that is being observed."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/BasicEventElement/state
+<https://admin-shell.io/aas/3/0/RC02/BasicEventElement/state> rdf:type owl:ObjectProperty ;
+    rdfs:label "has state"^^xsd:string ;
+    rdfs:domain aas:BasicEventElement ;
+    rdfs:range aas:StateOfEvent ;
+    rdfs:comment "State of event. Can be { On, Off }."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Blob
+aas:Blob rdf:type owl:Class ;
+    rdfs:subClassOf aas:DataElement ;
+    rdfs:label "Blob"^^xsd:string ;
+    rdfs:comment "A 'Blob' is a data element that represents a file that is contained with its source code in the value attribute."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Blob/mimeType
+<https://admin-shell.io/aas/3/0/RC02/Blob/mimeType> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has mime type"^^xsd:string ;
+    rdfs:domain aas:Blob ;
+    rdfs:range xsd:string ;
+    rdfs:comment "MIME type of the content of the 'Blob'."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Blob/value
+<https://admin-shell.io/aas/3/0/RC02/Blob/value> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has value"^^xsd:string ;
+    rdfs:domain aas:Blob ;
+    rdfs:range xsd:byte ;
+    rdfs:comment "The value of the 'Blob' instance of a blob data element."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Capability
+aas:Capability rdf:type owl:Class ;
+    rdfs:subClassOf aas:SubmodelElement ;
+    rdfs:label "Capability"^^xsd:string ;
+    rdfs:comment "A capability is the implementation-independent description of the potential of an asset to achieve a certain effect in the physical or virtual world."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ConceptDescription
+aas:ConceptDescription rdf:type owl:Class ;
+    rdfs:subClassOf aas:Identifiable ;
+    rdfs:subClassOf aas:HasDataSpecification ;
+    rdfs:label "Concept Description"^^xsd:string ;
+    rdfs:comment "The semantics of a property or other elements that may have a semantic description is defined by a concept description. The description of the concept should follow a standardized schema (realized as data specification template)."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ConceptDescription/isCaseOf
+<https://admin-shell.io/aas/3/0/RC02/ConceptDescription/isCaseOf> rdf:type owl:ObjectProperty ;
+    rdfs:label "has is case of"^^xsd:string ;
+    rdfs:domain aas:ConceptDescription ;
+    rdfs:range aas:GlobalReference ;
+    rdfs:comment "Reference to an external definition the concept is compatible to or was derived from"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataElement
+aas:DataElement rdf:type owl:Class ;
+    rdfs:subClassOf aas:SubmodelElement ;
+    rdfs:label "Data Element"^^xsd:string ;
+    rdfs:comment "A data element is a submodel element that is not further composed out of other submodel elements."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef
+aas:DataTypeDef rdf:type owl:Class ;
+    rdfs:label "Data Type Def"^^xsd:string ;
+    rdfs:comment "string with values of enumerations 'DataTypeDefXsd', 'DataTypeDefRdf'"@en ;
+    owl:oneOf (
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/AnyUri>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Base64Binary>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Boolean>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Byte>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Date>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/DateTime>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/DateTimeStamp>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/DayTimeDuration>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Decimal>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Double>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Duration>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Float>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/GDay>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/GMonth>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/GMonthDay>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/GYear>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/GYearMonth>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/HexBinary>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Int>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Integer>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/LangString>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Long>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/NegativeInteger>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/NonNegativeInteger>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/NonPositiveInteger>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/PositiveInteger>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Short>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/String>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Time>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/UnsignedByte>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/UnsignedInt>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/UnsignedLong>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/UnsignedShort>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDef/YearMonthDuration>
+    ) ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/AnyUri
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/AnyUri> rdf:type aas:DataTypeDef ;
+    rdfs:label "Any Uri"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Base64Binary
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Base64Binary> rdf:type aas:DataTypeDef ;
+    rdfs:label "Base 64 Binary"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Boolean
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Boolean> rdf:type aas:DataTypeDef ;
+    rdfs:label "Boolean"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Byte
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Byte> rdf:type aas:DataTypeDef ;
+    rdfs:label "Byte"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Date
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Date> rdf:type aas:DataTypeDef ;
+    rdfs:label "Date"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/DateTime
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/DateTime> rdf:type aas:DataTypeDef ;
+    rdfs:label "Date Time"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/DateTimeStamp
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/DateTimeStamp> rdf:type aas:DataTypeDef ;
+    rdfs:label "Date Time Stamp"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/DayTimeDuration
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/DayTimeDuration> rdf:type aas:DataTypeDef ;
+    rdfs:label "Day Time Duration"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Decimal
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Decimal> rdf:type aas:DataTypeDef ;
+    rdfs:label "Decimal"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Double
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Double> rdf:type aas:DataTypeDef ;
+    rdfs:label "Double"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Duration
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Duration> rdf:type aas:DataTypeDef ;
+    rdfs:label "Duration"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Float
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Float> rdf:type aas:DataTypeDef ;
+    rdfs:label "Float"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/GDay
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/GDay> rdf:type aas:DataTypeDef ;
+    rdfs:label "G Day"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/GMonth
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/GMonth> rdf:type aas:DataTypeDef ;
+    rdfs:label "G Month"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/GMonthDay
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/GMonthDay> rdf:type aas:DataTypeDef ;
+    rdfs:label "G Month Day"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/GYear
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/GYear> rdf:type aas:DataTypeDef ;
+    rdfs:label "G Year"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/GYearMonth
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/GYearMonth> rdf:type aas:DataTypeDef ;
+    rdfs:label "G Year Month"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/HexBinary
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/HexBinary> rdf:type aas:DataTypeDef ;
+    rdfs:label "Hex Binary"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Int
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Int> rdf:type aas:DataTypeDef ;
+    rdfs:label "Int"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Integer
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Integer> rdf:type aas:DataTypeDef ;
+    rdfs:label "Integer"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/LangString
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/LangString> rdf:type aas:DataTypeDef ;
+    rdfs:label "Lang String"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Long
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Long> rdf:type aas:DataTypeDef ;
+    rdfs:label "Long"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/NegativeInteger
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/NegativeInteger> rdf:type aas:DataTypeDef ;
+    rdfs:label "Negative Integer"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/NonNegativeInteger
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/NonNegativeInteger> rdf:type aas:DataTypeDef ;
+    rdfs:label "Non Negative Integer"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/NonPositiveInteger
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/NonPositiveInteger> rdf:type aas:DataTypeDef ;
+    rdfs:label "Non Positive Integer"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/PositiveInteger
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/PositiveInteger> rdf:type aas:DataTypeDef ;
+    rdfs:label "Positive Integer"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Short
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Short> rdf:type aas:DataTypeDef ;
+    rdfs:label "Short"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/String
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/String> rdf:type aas:DataTypeDef ;
+    rdfs:label "String"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Time
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/Time> rdf:type aas:DataTypeDef ;
+    rdfs:label "Time"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/UnsignedByte
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/UnsignedByte> rdf:type aas:DataTypeDef ;
+    rdfs:label "Unsigned Byte"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/UnsignedInt
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/UnsignedInt> rdf:type aas:DataTypeDef ;
+    rdfs:label "Unsigned Int"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/UnsignedLong
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/UnsignedLong> rdf:type aas:DataTypeDef ;
+    rdfs:label "Unsigned Long"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/UnsignedShort
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/UnsignedShort> rdf:type aas:DataTypeDef ;
+    rdfs:label "Unsigned Short"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDef/YearMonthDuration
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDef/YearMonthDuration> rdf:type aas:DataTypeDef ;
+    rdfs:label "Year Month Duration"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefRdf
+aas:DataTypeDefRdf rdf:type owl:Class ;
+    rdfs:label "Data Type Def Rdf"^^xsd:string ;
+    rdfs:comment "Enumeration listing all RDF types"@en ;
+    owl:oneOf (
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefRdf/LangString>
+    ) ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefRdf/LangString
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefRdf/LangString> rdf:type aas:DataTypeDefRdf ;
+    rdfs:label "Lang String"^^xsd:string ;
+    rdfs:comment "String with a language tag"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd
+aas:DataTypeDefXsd rdf:type owl:Class ;
+    rdfs:label "Data Type Def Xsd"^^xsd:string ;
+    rdfs:comment "Enumeration listing all xsd anySimpleTypes"@en ;
+    owl:oneOf (
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/AnyUri>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Base64Binary>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Boolean>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Byte>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Date>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTime>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTimeStamp>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DayTimeDuration>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Decimal>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Double>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Duration>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Float>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/GDay>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/GMonth>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/GMonthDay>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/GYear>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/GYearMonth>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/HexBinary>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Int>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Integer>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Long>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/NegativeInteger>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/NonNegativeInteger>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/NonPositiveInteger>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/PositiveInteger>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Short>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/String>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Time>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/UnsignedByte>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/UnsignedInt>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/UnsignedLong>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/UnsignedShort>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/YearMonthDuration>
+    ) ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/AnyUri
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/AnyUri> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "Any Uri"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Base64Binary
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Base64Binary> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "Base 64 Binary"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Boolean
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Boolean> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "Boolean"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Byte
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Byte> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "Byte"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Date
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Date> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "Date"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTime
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTime> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "Date Time"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTimeStamp
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DateTimeStamp> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "Date Time Stamp"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DayTimeDuration
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/DayTimeDuration> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "Day Time Duration"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Decimal
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Decimal> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "Decimal"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Double
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Double> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "Double"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Duration
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Duration> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "Duration"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Float
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Float> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "Float"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/GDay
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/GDay> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "G Day"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/GMonth
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/GMonth> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "G Month"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/GMonthDay
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/GMonthDay> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "G Month Day"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/GYear
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/GYear> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "G Year"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/GYearMonth
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/GYearMonth> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "G Year Month"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/HexBinary
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/HexBinary> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "Hex Binary"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Int
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Int> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "Int"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Integer
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Integer> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "Integer"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Long
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Long> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "Long"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/NegativeInteger
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/NegativeInteger> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "Negative Integer"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/NonNegativeInteger
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/NonNegativeInteger> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "Non Negative Integer"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/NonPositiveInteger
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/NonPositiveInteger> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "Non Positive Integer"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/PositiveInteger
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/PositiveInteger> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "Positive Integer"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Short
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Short> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "Short"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/String
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/String> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "String"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Time
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/Time> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "Time"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/UnsignedByte
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/UnsignedByte> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "Unsigned Byte"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/UnsignedInt
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/UnsignedInt> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "Unsigned Int"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/UnsignedLong
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/UnsignedLong> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "Unsigned Long"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/UnsignedShort
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/UnsignedShort> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "Unsigned Short"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/YearMonthDuration
+<https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd/YearMonthDuration> rdf:type aas:DataTypeDefXsd ;
+    rdfs:label "Year Month Duration"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Direction
+aas:Direction rdf:type owl:Class ;
+    rdfs:label "Direction"^^xsd:string ;
+    rdfs:comment "Direction"@en ;
+    owl:oneOf (
+        <https://admin-shell.io/aas/3/0/RC02/Direction/Input>
+        <https://admin-shell.io/aas/3/0/RC02/Direction/Output>
+    ) ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Direction/Input
+<https://admin-shell.io/aas/3/0/RC02/Direction/Input> rdf:type aas:Direction ;
+    rdfs:label "Input"^^xsd:string ;
+    rdfs:comment "Input direction."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Direction/Output
+<https://admin-shell.io/aas/3/0/RC02/Direction/Output> rdf:type aas:Direction ;
+    rdfs:label "Output"^^xsd:string ;
+    rdfs:comment "Output direction"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Entity
+aas:Entity rdf:type owl:Class ;
+    rdfs:subClassOf aas:SubmodelElement ;
+    rdfs:label "Entity"^^xsd:string ;
+    rdfs:comment "An entity is a submodel element that is used to model entities."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Entity/entityType
+<https://admin-shell.io/aas/3/0/RC02/Entity/entityType> rdf:type owl:ObjectProperty ;
+    rdfs:label "has entity type"^^xsd:string ;
+    rdfs:domain aas:Entity ;
+    rdfs:range aas:EntityType ;
+    rdfs:comment "Describes whether the entity is a co- managed entity or a self-managed entity."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Entity/globalAssetId
+<https://admin-shell.io/aas/3/0/RC02/Entity/globalAssetId> rdf:type owl:ObjectProperty ;
+    rdfs:label "has global asset id"^^xsd:string ;
+    rdfs:domain aas:Entity ;
+    rdfs:range aas:Reference ;
+    rdfs:comment "Reference to the asset the entity is representing."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Entity/specificAssetId
+<https://admin-shell.io/aas/3/0/RC02/Entity/specificAssetId> rdf:type owl:ObjectProperty ;
+    rdfs:label "has specific asset id"^^xsd:string ;
+    rdfs:domain aas:Entity ;
+    rdfs:range aas:IdentifierKeyValuePair ;
+    rdfs:comment "Reference to an identifier key value pair representing a specific identifier of the asset represented by the asset administration shell."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Entity/statements
+<https://admin-shell.io/aas/3/0/RC02/Entity/statements> rdf:type owl:ObjectProperty ;
+    rdfs:label "has statements"^^xsd:string ;
+    rdfs:domain aas:Entity ;
+    rdfs:range aas:SubmodelElement ;
+    rdfs:comment "Describes statements applicable to the entity by a set of submodel elements, typically with a qualified value."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/EntityType
+aas:EntityType rdf:type owl:Class ;
+    rdfs:label "Entity Type"^^xsd:string ;
+    rdfs:comment "Enumeration for denoting whether an entity is a self-managed entity or a co-managed entity."@en ;
+    owl:oneOf (
+        <https://admin-shell.io/aas/3/0/RC02/EntityType/CoManagedEntity>
+        <https://admin-shell.io/aas/3/0/RC02/EntityType/SelfManagedEntity>
+    ) ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/EntityType/CoManagedEntity
+<https://admin-shell.io/aas/3/0/RC02/EntityType/CoManagedEntity> rdf:type aas:EntityType ;
+    rdfs:label "Co Managed Entity"^^xsd:string ;
+    rdfs:comment "For co-managed entities there is no separate AAS. Co-managed entities need to be part of a self-managed entity."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/EntityType/SelfManagedEntity
+<https://admin-shell.io/aas/3/0/RC02/EntityType/SelfManagedEntity> rdf:type aas:EntityType ;
+    rdfs:label "Self Managed Entity"^^xsd:string ;
+    rdfs:comment "Self-Managed Entities have their own AAS but can be part of the bill of material of a composite self-managed entity. The asset of an I4.0 Component is a self-managed entity per definition.\""@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Environment
+aas:Environment rdf:type owl:Class ;
+    rdfs:label "Environment"^^xsd:string ;
+    rdfs:comment "Container for the sets of different identifiables."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Environment/assetAdministrationShells
+<https://admin-shell.io/aas/3/0/RC02/Environment/assetAdministrationShells> rdf:type owl:ObjectProperty ;
+    rdfs:label "has asset administration shells"^^xsd:string ;
+    rdfs:domain aas:Environment ;
+    rdfs:range aas:AssetAdministrationShell ;
+    rdfs:comment "Asset administration shell"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Environment/conceptDescriptions
+<https://admin-shell.io/aas/3/0/RC02/Environment/conceptDescriptions> rdf:type owl:ObjectProperty ;
+    rdfs:label "has concept descriptions"^^xsd:string ;
+    rdfs:domain aas:Environment ;
+    rdfs:range aas:ConceptDescription ;
+    rdfs:comment "Concept description"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Environment/submodels
+<https://admin-shell.io/aas/3/0/RC02/Environment/submodels> rdf:type owl:ObjectProperty ;
+    rdfs:label "has submodels"^^xsd:string ;
+    rdfs:domain aas:Environment ;
+    rdfs:range aas:Submodel ;
+    rdfs:comment "Submodel"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/EventElement
+aas:EventElement rdf:type owl:Class ;
+    rdfs:subClassOf aas:SubmodelElement ;
+    rdfs:label "Event Element"^^xsd:string ;
+    rdfs:comment "An event element."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/EventPayload
+aas:EventPayload rdf:type owl:Class ;
+    rdfs:label "Event Payload"^^xsd:string ;
+    rdfs:comment "Defines the necessary information of an event instance sent out or received."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/EventPayload/observableReference
+<https://admin-shell.io/aas/3/0/RC02/EventPayload/observableReference> rdf:type owl:ObjectProperty ;
+    rdfs:label "has observable reference"^^xsd:string ;
+    rdfs:domain aas:EventPayload ;
+    rdfs:range aas:ModelReference ;
+    rdfs:comment "Reference to the referable, which defines the scope of the event."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/EventPayload/observableSemanticId
+<https://admin-shell.io/aas/3/0/RC02/EventPayload/observableSemanticId> rdf:type owl:ObjectProperty ;
+    rdfs:label "has observable semantic id"^^xsd:string ;
+    rdfs:domain aas:EventPayload ;
+    rdfs:range aas:GlobalReference ;
+    rdfs:comment "'semanticId' of the referable which defines the scope of the event, if available."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/EventPayload/payload
+<https://admin-shell.io/aas/3/0/RC02/EventPayload/payload> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has payload"^^xsd:string ;
+    rdfs:domain aas:EventPayload ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Event specific payload."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/EventPayload/source
+<https://admin-shell.io/aas/3/0/RC02/EventPayload/source> rdf:type owl:ObjectProperty ;
+    rdfs:label "has source"^^xsd:string ;
+    rdfs:domain aas:EventPayload ;
+    rdfs:range aas:ModelReference ;
+    rdfs:comment "Reference to the source event element, including identification of 'AssetAdministrationShell', 'Submodel', 'SubmodelElement''s."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/EventPayload/sourceSemanticId
+<https://admin-shell.io/aas/3/0/RC02/EventPayload/sourceSemanticId> rdf:type owl:ObjectProperty ;
+    rdfs:label "has source semantic id"^^xsd:string ;
+    rdfs:domain aas:EventPayload ;
+    rdfs:range aas:GlobalReference ;
+    rdfs:comment "'semanticId' of the source event element, if available"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/EventPayload/subjectId
+<https://admin-shell.io/aas/3/0/RC02/EventPayload/subjectId> rdf:type owl:ObjectProperty ;
+    rdfs:label "has subject id"^^xsd:string ;
+    rdfs:domain aas:EventPayload ;
+    rdfs:range aas:GlobalReference ;
+    rdfs:comment "Subject, who/which initiated the creation."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/EventPayload/timeStamp
+<https://admin-shell.io/aas/3/0/RC02/EventPayload/timeStamp> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has time stamp"^^xsd:string ;
+    rdfs:domain aas:EventPayload ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Timestamp in UTC, when this event was triggered."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/EventPayload/topic
+<https://admin-shell.io/aas/3/0/RC02/EventPayload/topic> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has topic"^^xsd:string ;
+    rdfs:domain aas:EventPayload ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Information for the outer message infrastructure for scheduling the event to the respective communication channel."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Extension
+aas:Extension rdf:type owl:Class ;
+    rdfs:subClassOf aas:HasSemantics ;
+    rdfs:label "Extension"^^xsd:string ;
+    rdfs:comment "Single extension of an element."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Extension/name
+<https://admin-shell.io/aas/3/0/RC02/Extension/name> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has name"^^xsd:string ;
+    rdfs:domain aas:Extension ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Name of the extension."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Extension/refersTo
+<https://admin-shell.io/aas/3/0/RC02/Extension/refersTo> rdf:type owl:ObjectProperty ;
+    rdfs:label "has refers to"^^xsd:string ;
+    rdfs:domain aas:Extension ;
+    rdfs:range aas:ModelReference ;
+    rdfs:comment "Reference to an element the extension refers to."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Extension/value
+<https://admin-shell.io/aas/3/0/RC02/Extension/value> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has value"^^xsd:string ;
+    rdfs:domain aas:Extension ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Value of the extension"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Extension/valueType
+<https://admin-shell.io/aas/3/0/RC02/Extension/valueType> rdf:type owl:ObjectProperty ;
+    rdfs:label "has value type"^^xsd:string ;
+    rdfs:domain aas:Extension ;
+    rdfs:range aas:DataTypeDefXsd ;
+    rdfs:comment "Type of the value of the extension."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/File
+aas:File rdf:type owl:Class ;
+    rdfs:subClassOf aas:DataElement ;
+    rdfs:label "File"^^xsd:string ;
+    rdfs:comment "A File is a data element that represents an address to a file."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/File/contentType
+<https://admin-shell.io/aas/3/0/RC02/File/contentType> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has content type"^^xsd:string ;
+    rdfs:domain aas:File ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Content type of the content of the file."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/File/value
+<https://admin-shell.io/aas/3/0/RC02/File/value> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has value"^^xsd:string ;
+    rdfs:domain aas:File ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Path and name of the referenced file (with file extension). The path can be absolute or relative."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/GlobalReference
+aas:GlobalReference rdf:type owl:Class ;
+    rdfs:subClassOf aas:Reference ;
+    rdfs:label "Global Reference"^^xsd:string ;
+    rdfs:comment "Reference to an external entity."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/GlobalReference/value
+<https://admin-shell.io/aas/3/0/RC02/GlobalReference/value> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has value"^^xsd:string ;
+    rdfs:domain aas:GlobalReference ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Unique identifier"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/HasDataSpecification
+aas:HasDataSpecification rdf:type owl:Class ;
+    rdfs:label "Has Data Specification"^^xsd:string ;
+    rdfs:comment "Element that can be extended by using data specification templates."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/HasDataSpecification/dataSpecifications
+<https://admin-shell.io/aas/3/0/RC02/HasDataSpecification/dataSpecifications> rdf:type owl:ObjectProperty ;
+    rdfs:label "has data specifications"^^xsd:string ;
+    rdfs:domain aas:HasDataSpecification ;
+    rdfs:range aas:GlobalReference ;
+    rdfs:comment "Global reference to the data specification template used by the element."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/HasExtensions
+aas:HasExtensions rdf:type owl:Class ;
+    rdfs:label "Has Extensions"^^xsd:string ;
+    rdfs:comment "Element that can be extended by proprietary extensions."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/HasExtensions/extensions
+<https://admin-shell.io/aas/3/0/RC02/HasExtensions/extensions> rdf:type owl:ObjectProperty ;
+    rdfs:label "has extensions"^^xsd:string ;
+    rdfs:domain aas:HasExtensions ;
+    rdfs:range aas:Extension ;
+    rdfs:comment "An extension of the element."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/HasKind
+aas:HasKind rdf:type owl:Class ;
+    rdfs:label "Has Kind"^^xsd:string ;
+    rdfs:comment "An element with a kind is an element that can either represent a template or an instance."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/HasKind/kind
+<https://admin-shell.io/aas/3/0/RC02/HasKind/kind> rdf:type owl:ObjectProperty ;
+    rdfs:label "has kind"^^xsd:string ;
+    rdfs:domain aas:HasKind ;
+    rdfs:range aas:ModelingKind ;
+    rdfs:comment "Kind of the element: either type or instance."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/HasSemantics
+aas:HasSemantics rdf:type owl:Class ;
+    rdfs:label "Has Semantics"^^xsd:string ;
+    rdfs:comment "Element that can have a semantic definition."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/HasSemantics/semanticId
+<https://admin-shell.io/aas/3/0/RC02/HasSemantics/semanticId> rdf:type owl:ObjectProperty ;
+    rdfs:label "has semantic id"^^xsd:string ;
+    rdfs:domain aas:HasSemantics ;
+    rdfs:range aas:GlobalReference ;
+    rdfs:comment "Identifier of the semantic definition of the element. It is called semantic ID of the element."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Identifiable
+aas:Identifiable rdf:type owl:Class ;
+    rdfs:subClassOf aas:Referable ;
+    rdfs:label "Identifiable"^^xsd:string ;
+    rdfs:comment "An element that has a globally unique identifier."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Identifiable/administration
+<https://admin-shell.io/aas/3/0/RC02/Identifiable/administration> rdf:type owl:ObjectProperty ;
+    rdfs:label "has administration"^^xsd:string ;
+    rdfs:domain aas:Identifiable ;
+    rdfs:range aas:AdministrativeInformation ;
+    rdfs:comment "Administrative information of an identifiable element."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Identifiable/id
+<https://admin-shell.io/aas/3/0/RC02/Identifiable/id> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has id"^^xsd:string ;
+    rdfs:domain aas:Identifiable ;
+    rdfs:range xsd:string ;
+    rdfs:comment "The globally unique identification of the element."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/IdentifiableElements
+aas:IdentifiableElements rdf:type owl:Class ;
+    rdfs:label "Identifiable Elements"^^xsd:string ;
+    rdfs:comment "Enumeration of all identifiable elements within an asset administration shell."@en ;
+    owl:oneOf (
+        <https://admin-shell.io/aas/3/0/RC02/IdentifiableElements/AssetAdministrationShell>
+        <https://admin-shell.io/aas/3/0/RC02/IdentifiableElements/ConceptDescription>
+        <https://admin-shell.io/aas/3/0/RC02/IdentifiableElements/Submodel>
+    ) ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/IdentifiableElements/AssetAdministrationShell
+<https://admin-shell.io/aas/3/0/RC02/IdentifiableElements/AssetAdministrationShell> rdf:type aas:IdentifiableElements ;
+    rdfs:label "Asset Administration Shell"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/IdentifiableElements/ConceptDescription
+<https://admin-shell.io/aas/3/0/RC02/IdentifiableElements/ConceptDescription> rdf:type aas:IdentifiableElements ;
+    rdfs:label "Concept Description"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/IdentifiableElements/Submodel
+<https://admin-shell.io/aas/3/0/RC02/IdentifiableElements/Submodel> rdf:type aas:IdentifiableElements ;
+    rdfs:label "Submodel"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/IdentifierKeyValuePair
+aas:IdentifierKeyValuePair rdf:type owl:Class ;
+    rdfs:subClassOf aas:HasSemantics ;
+    rdfs:label "Identifier Key Value Pair"^^xsd:string ;
+    rdfs:comment "An 'IdentifierKeyValuePair' describes a generic identifier as key-value pair."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/IdentifierKeyValuePair/externalSubjectId
+<https://admin-shell.io/aas/3/0/RC02/IdentifierKeyValuePair/externalSubjectId> rdf:type owl:ObjectProperty ;
+    rdfs:label "has external subject id"^^xsd:string ;
+    rdfs:domain aas:IdentifierKeyValuePair ;
+    rdfs:range aas:GlobalReference ;
+    rdfs:comment "The (external) subject the key belongs to or has meaning to."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/IdentifierKeyValuePair/key
+<https://admin-shell.io/aas/3/0/RC02/IdentifierKeyValuePair/key> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has key"^^xsd:string ;
+    rdfs:domain aas:IdentifierKeyValuePair ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Key of the identifier"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/IdentifierKeyValuePair/value
+<https://admin-shell.io/aas/3/0/RC02/IdentifierKeyValuePair/value> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has value"^^xsd:string ;
+    rdfs:domain aas:IdentifierKeyValuePair ;
+    rdfs:range xsd:string ;
+    rdfs:comment "The value of the identifier with the corresponding key."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Key
+aas:Key rdf:type owl:Class ;
+    rdfs:label "Key"^^xsd:string ;
+    rdfs:comment "A key is a reference to an element by its ID."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Key/type
+<https://admin-shell.io/aas/3/0/RC02/Key/type> rdf:type owl:ObjectProperty ;
+    rdfs:label "has type"^^xsd:string ;
+    rdfs:domain aas:Key ;
+    rdfs:range aas:KeyElements ;
+    rdfs:comment "Denote which kind of entity is referenced."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Key/value
+<https://admin-shell.io/aas/3/0/RC02/Key/value> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has value"^^xsd:string ;
+    rdfs:domain aas:Key ;
+    rdfs:range xsd:string ;
+    rdfs:comment "The key value, for example an IRDI or an URI"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/KeyElements
+aas:KeyElements rdf:type owl:Class ;
+    rdfs:label "Key Elements"^^xsd:string ;
+    rdfs:comment "Enumeration of different key value types within a key."@en ;
+    owl:oneOf (
+        <https://admin-shell.io/aas/3/0/RC02/KeyElements/AnnotatedRelationshipElement>
+        <https://admin-shell.io/aas/3/0/RC02/KeyElements/AssetAdministrationShell>
+        <https://admin-shell.io/aas/3/0/RC02/KeyElements/BasicEventElement>
+        <https://admin-shell.io/aas/3/0/RC02/KeyElements/Blob>
+        <https://admin-shell.io/aas/3/0/RC02/KeyElements/Capability>
+        <https://admin-shell.io/aas/3/0/RC02/KeyElements/ConceptDescription>
+        <https://admin-shell.io/aas/3/0/RC02/KeyElements/DataElement>
+        <https://admin-shell.io/aas/3/0/RC02/KeyElements/Entity>
+        <https://admin-shell.io/aas/3/0/RC02/KeyElements/EventElement>
+        <https://admin-shell.io/aas/3/0/RC02/KeyElements/File>
+        <https://admin-shell.io/aas/3/0/RC02/KeyElements/FragmentReference>
+        <https://admin-shell.io/aas/3/0/RC02/KeyElements/GlobalReference>
+        <https://admin-shell.io/aas/3/0/RC02/KeyElements/MultiLanguageProperty>
+        <https://admin-shell.io/aas/3/0/RC02/KeyElements/Operation>
+        <https://admin-shell.io/aas/3/0/RC02/KeyElements/Property>
+        <https://admin-shell.io/aas/3/0/RC02/KeyElements/Range>
+        <https://admin-shell.io/aas/3/0/RC02/KeyElements/ReferenceElement>
+        <https://admin-shell.io/aas/3/0/RC02/KeyElements/RelationshipElement>
+        <https://admin-shell.io/aas/3/0/RC02/KeyElements/Submodel>
+        <https://admin-shell.io/aas/3/0/RC02/KeyElements/SubmodelElement>
+        <https://admin-shell.io/aas/3/0/RC02/KeyElements/SubmodelElementList>
+        <https://admin-shell.io/aas/3/0/RC02/KeyElements/SubmodelElementStruct>
+    ) ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/KeyElements/AnnotatedRelationshipElement
+<https://admin-shell.io/aas/3/0/RC02/KeyElements/AnnotatedRelationshipElement> rdf:type aas:KeyElements ;
+    rdfs:label "Annotated Relationship Element"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/KeyElements/AssetAdministrationShell
+<https://admin-shell.io/aas/3/0/RC02/KeyElements/AssetAdministrationShell> rdf:type aas:KeyElements ;
+    rdfs:label "Asset Administration Shell"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/KeyElements/BasicEventElement
+<https://admin-shell.io/aas/3/0/RC02/KeyElements/BasicEventElement> rdf:type aas:KeyElements ;
+    rdfs:label "Basic Event Element"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/KeyElements/Blob
+<https://admin-shell.io/aas/3/0/RC02/KeyElements/Blob> rdf:type aas:KeyElements ;
+    rdfs:label "Blob"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/KeyElements/Capability
+<https://admin-shell.io/aas/3/0/RC02/KeyElements/Capability> rdf:type aas:KeyElements ;
+    rdfs:label "Capability"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/KeyElements/ConceptDescription
+<https://admin-shell.io/aas/3/0/RC02/KeyElements/ConceptDescription> rdf:type aas:KeyElements ;
+    rdfs:label "Concept Description"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/KeyElements/DataElement
+<https://admin-shell.io/aas/3/0/RC02/KeyElements/DataElement> rdf:type aas:KeyElements ;
+    rdfs:label "Data Element"^^xsd:string ;
+    rdfs:comment "Data element."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/KeyElements/Entity
+<https://admin-shell.io/aas/3/0/RC02/KeyElements/Entity> rdf:type aas:KeyElements ;
+    rdfs:label "Entity"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/KeyElements/EventElement
+<https://admin-shell.io/aas/3/0/RC02/KeyElements/EventElement> rdf:type aas:KeyElements ;
+    rdfs:label "Event Element"^^xsd:string ;
+    rdfs:comment "Event."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/KeyElements/File
+<https://admin-shell.io/aas/3/0/RC02/KeyElements/File> rdf:type aas:KeyElements ;
+    rdfs:label "File"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/KeyElements/FragmentReference
+<https://admin-shell.io/aas/3/0/RC02/KeyElements/FragmentReference> rdf:type aas:KeyElements ;
+    rdfs:label "Fragment Reference"^^xsd:string ;
+    rdfs:comment "Bookmark or a similar local identifier of a subordinate part of a primary resource"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/KeyElements/GlobalReference
+<https://admin-shell.io/aas/3/0/RC02/KeyElements/GlobalReference> rdf:type aas:KeyElements ;
+    rdfs:label "Global Reference"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/KeyElements/MultiLanguageProperty
+<https://admin-shell.io/aas/3/0/RC02/KeyElements/MultiLanguageProperty> rdf:type aas:KeyElements ;
+    rdfs:label "Multi Language Property"^^xsd:string ;
+    rdfs:comment "Property with a value that can be provided in multiple languages"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/KeyElements/Operation
+<https://admin-shell.io/aas/3/0/RC02/KeyElements/Operation> rdf:type aas:KeyElements ;
+    rdfs:label "Operation"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/KeyElements/Property
+<https://admin-shell.io/aas/3/0/RC02/KeyElements/Property> rdf:type aas:KeyElements ;
+    rdfs:label "Property"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/KeyElements/Range
+<https://admin-shell.io/aas/3/0/RC02/KeyElements/Range> rdf:type aas:KeyElements ;
+    rdfs:label "Range"^^xsd:string ;
+    rdfs:comment "Range with min and max"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/KeyElements/ReferenceElement
+<https://admin-shell.io/aas/3/0/RC02/KeyElements/ReferenceElement> rdf:type aas:KeyElements ;
+    rdfs:label "Reference Element"^^xsd:string ;
+    rdfs:comment "Reference"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/KeyElements/RelationshipElement
+<https://admin-shell.io/aas/3/0/RC02/KeyElements/RelationshipElement> rdf:type aas:KeyElements ;
+    rdfs:label "Relationship Element"^^xsd:string ;
+    rdfs:comment "Relationship"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/KeyElements/Submodel
+<https://admin-shell.io/aas/3/0/RC02/KeyElements/Submodel> rdf:type aas:KeyElements ;
+    rdfs:label "Submodel"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/KeyElements/SubmodelElement
+<https://admin-shell.io/aas/3/0/RC02/KeyElements/SubmodelElement> rdf:type aas:KeyElements ;
+    rdfs:label "Submodel Element"^^xsd:string ;
+    rdfs:comment "Submodel Element"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/KeyElements/SubmodelElementList
+<https://admin-shell.io/aas/3/0/RC02/KeyElements/SubmodelElementList> rdf:type aas:KeyElements ;
+    rdfs:label "Submodel Element List"^^xsd:string ;
+    rdfs:comment "List of Submodel Elements"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/KeyElements/SubmodelElementStruct
+<https://admin-shell.io/aas/3/0/RC02/KeyElements/SubmodelElementStruct> rdf:type aas:KeyElements ;
+    rdfs:label "Submodel Element Struct"^^xsd:string ;
+    rdfs:comment "Struct of Submodel Elements"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/LangString
+aas:LangString rdf:type owl:Class ;
+    rdfs:label "Lang String"^^xsd:string ;
+    rdfs:comment "Strings with language tags"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/LangString/language
+<https://admin-shell.io/aas/3/0/RC02/LangString/language> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has language"^^xsd:string ;
+    rdfs:domain aas:LangString ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Language tag conforming to BCP 47"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/LangString/text
+<https://admin-shell.io/aas/3/0/RC02/LangString/text> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has text"^^xsd:string ;
+    rdfs:domain aas:LangString ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Text in the 'language'"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/LangStringSet
+aas:LangStringSet rdf:type owl:Class ;
+    rdfs:label "Lang String Set"^^xsd:string ;
+    rdfs:comment "Array of elements of type langString"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/LangStringSet/langStrings
+<https://admin-shell.io/aas/3/0/RC02/LangStringSet/langStrings> rdf:type owl:ObjectProperty ;
+    rdfs:label "has lang strings"^^xsd:string ;
+    rdfs:domain aas:LangStringSet ;
+    rdfs:range aas:LangString ;
+    rdfs:comment "Strings in different languages"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ModelReference
+aas:ModelReference rdf:type owl:Class ;
+    rdfs:subClassOf aas:Reference ;
+    rdfs:label "Model Reference"^^xsd:string ;
+    rdfs:comment "Reference to a model element of the same or another AAS."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ModelReference/keys
+<https://admin-shell.io/aas/3/0/RC02/ModelReference/keys> rdf:type owl:ObjectProperty ;
+    rdfs:label "has keys"^^xsd:string ;
+    rdfs:domain aas:ModelReference ;
+    rdfs:range aas:Key ;
+    rdfs:comment "Unique references in their name space."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ModelReference/referredSemanticId
+<https://admin-shell.io/aas/3/0/RC02/ModelReference/referredSemanticId> rdf:type owl:ObjectProperty ;
+    rdfs:label "has referred semantic id"^^xsd:string ;
+    rdfs:domain aas:ModelReference ;
+    rdfs:range aas:GlobalReference ;
+    rdfs:comment "'semanticId' of the referenced model element."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ModelingKind
+aas:ModelingKind rdf:type owl:Class ;
+    rdfs:label "Modeling Kind"^^xsd:string ;
+    rdfs:comment "Enumeration for denoting whether an element is a template or an instance."@en ;
+    owl:oneOf (
+        <https://admin-shell.io/aas/3/0/RC02/ModelingKind/Instance>
+        <https://admin-shell.io/aas/3/0/RC02/ModelingKind/Template>
+    ) ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ModelingKind/Instance
+<https://admin-shell.io/aas/3/0/RC02/ModelingKind/Instance> rdf:type aas:ModelingKind ;
+    rdfs:label "Instance"^^xsd:string ;
+    rdfs:comment "Concrete, clearly identifiable component of a certain template."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ModelingKind/Template
+<https://admin-shell.io/aas/3/0/RC02/ModelingKind/Template> rdf:type aas:ModelingKind ;
+    rdfs:label "Template"^^xsd:string ;
+    rdfs:comment "Software element which specifies the common attributes shared by all instances of the template."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/MultiLanguageProperty
+aas:MultiLanguageProperty rdf:type owl:Class ;
+    rdfs:subClassOf aas:DataElement ;
+    rdfs:label "Multi Language Property"^^xsd:string ;
+    rdfs:comment "A property is a data element that has a multi-language value."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/MultiLanguageProperty/value
+<https://admin-shell.io/aas/3/0/RC02/MultiLanguageProperty/value> rdf:type owl:ObjectProperty ;
+    rdfs:label "has value"^^xsd:string ;
+    rdfs:domain aas:MultiLanguageProperty ;
+    rdfs:range aas:LangStringSet ;
+    rdfs:comment "The value of the property instance."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/MultiLanguageProperty/valueId
+<https://admin-shell.io/aas/3/0/RC02/MultiLanguageProperty/valueId> rdf:type owl:ObjectProperty ;
+    rdfs:label "has value id"^^xsd:string ;
+    rdfs:domain aas:MultiLanguageProperty ;
+    rdfs:range aas:GlobalReference ;
+    rdfs:comment "Reference to the global unique ID of a coded value."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Operation
+aas:Operation rdf:type owl:Class ;
+    rdfs:subClassOf aas:SubmodelElement ;
+    rdfs:label "Operation"^^xsd:string ;
+    rdfs:comment "An operation is a submodel element with input and output variables."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Operation/inoutputVariables
+<https://admin-shell.io/aas/3/0/RC02/Operation/inoutputVariables> rdf:type owl:ObjectProperty ;
+    rdfs:label "has inoutput variables"^^xsd:string ;
+    rdfs:domain aas:Operation ;
+    rdfs:range aas:OperationVariable ;
+    rdfs:comment "Parameter that is input and output of the operation."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Operation/inputVariables
+<https://admin-shell.io/aas/3/0/RC02/Operation/inputVariables> rdf:type owl:ObjectProperty ;
+    rdfs:label "has input variables"^^xsd:string ;
+    rdfs:domain aas:Operation ;
+    rdfs:range aas:OperationVariable ;
+    rdfs:comment "Input parameter of the operation."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Operation/outputVariables
+<https://admin-shell.io/aas/3/0/RC02/Operation/outputVariables> rdf:type owl:ObjectProperty ;
+    rdfs:label "has output variables"^^xsd:string ;
+    rdfs:domain aas:Operation ;
+    rdfs:range aas:OperationVariable ;
+    rdfs:comment "Output parameter of the operation."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/OperationVariable
+aas:OperationVariable rdf:type owl:Class ;
+    rdfs:label "Operation Variable"^^xsd:string ;
+    rdfs:comment "An operation variable is a submodel element that is used as input or output variable of an operation."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/OperationVariable/value
+<https://admin-shell.io/aas/3/0/RC02/OperationVariable/value> rdf:type owl:ObjectProperty ;
+    rdfs:label "has value"^^xsd:string ;
+    rdfs:domain aas:OperationVariable ;
+    rdfs:range aas:SubmodelElement ;
+    rdfs:comment "Describes the needed argument for an operation via a submodel element"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Property
+aas:Property rdf:type owl:Class ;
+    rdfs:subClassOf aas:DataElement ;
+    rdfs:label "Property"^^xsd:string ;
+    rdfs:comment "A property is a data element that has a single value."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Property/value
+<https://admin-shell.io/aas/3/0/RC02/Property/value> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has value"^^xsd:string ;
+    rdfs:domain aas:Property ;
+    rdfs:range xsd:string ;
+    rdfs:comment "The value of the property instance."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Property/valueId
+<https://admin-shell.io/aas/3/0/RC02/Property/valueId> rdf:type owl:ObjectProperty ;
+    rdfs:label "has value id"^^xsd:string ;
+    rdfs:domain aas:Property ;
+    rdfs:range aas:GlobalReference ;
+    rdfs:comment "Reference to the global unique ID of a coded value."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Property/valueType
+<https://admin-shell.io/aas/3/0/RC02/Property/valueType> rdf:type owl:ObjectProperty ;
+    rdfs:label "has value type"^^xsd:string ;
+    rdfs:domain aas:Property ;
+    rdfs:range aas:DataTypeDefXsd ;
+    rdfs:comment "Data type of the value"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Qualifiable
+aas:Qualifiable rdf:type owl:Class ;
+    rdfs:label "Qualifiable"^^xsd:string ;
+    rdfs:comment "The value of a qualifiable element may be further qualified by one or more qualifiers or complex formulas."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Qualifiable/qualifiers
+<https://admin-shell.io/aas/3/0/RC02/Qualifiable/qualifiers> rdf:type owl:ObjectProperty ;
+    rdfs:label "has qualifiers"^^xsd:string ;
+    rdfs:domain aas:Qualifiable ;
+    rdfs:range aas:Qualifier ;
+    rdfs:comment "Additional qualification of a qualifiable element."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Qualifier
+aas:Qualifier rdf:type owl:Class ;
+    rdfs:subClassOf aas:HasSemantics ;
+    rdfs:label "Qualifier"^^xsd:string ;
+    rdfs:comment "A qualifier is a type-value-pair that makes additional statements w.r.t.  the value of the element."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Qualifier/type
+<https://admin-shell.io/aas/3/0/RC02/Qualifier/type> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has type"^^xsd:string ;
+    rdfs:domain aas:Qualifier ;
+    rdfs:range xsd:string ;
+    rdfs:comment "The qualifier type describes the type of the qualifier that is applied to the element."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Qualifier/value
+<https://admin-shell.io/aas/3/0/RC02/Qualifier/value> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has value"^^xsd:string ;
+    rdfs:domain aas:Qualifier ;
+    rdfs:range xsd:string ;
+    rdfs:comment "The qualifier value is the value of the qualifier."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Qualifier/valueId
+<https://admin-shell.io/aas/3/0/RC02/Qualifier/valueId> rdf:type owl:ObjectProperty ;
+    rdfs:label "has value id"^^xsd:string ;
+    rdfs:domain aas:Qualifier ;
+    rdfs:range aas:GlobalReference ;
+    rdfs:comment "Reference to the global unique ID of a coded value."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Qualifier/valueType
+<https://admin-shell.io/aas/3/0/RC02/Qualifier/valueType> rdf:type owl:ObjectProperty ;
+    rdfs:label "has value type"^^xsd:string ;
+    rdfs:domain aas:Qualifier ;
+    rdfs:range aas:DataTypeDefXsd ;
+    rdfs:comment "Data type of the qualifier value."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Range
+aas:Range rdf:type owl:Class ;
+    rdfs:subClassOf aas:DataElement ;
+    rdfs:label "Range"^^xsd:string ;
+    rdfs:comment "A range data element is a data element that defines a range with min and max."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Range/max
+<https://admin-shell.io/aas/3/0/RC02/Range/max> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has max"^^xsd:string ;
+    rdfs:domain aas:Range ;
+    rdfs:range xsd:string ;
+    rdfs:comment "The maximum value of the range. If the max value is missing,  then the value is assumed to be positive infinite."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Range/min
+<https://admin-shell.io/aas/3/0/RC02/Range/min> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has min"^^xsd:string ;
+    rdfs:domain aas:Range ;
+    rdfs:range xsd:string ;
+    rdfs:comment "The minimum value of the range. If the min value is missing, then the value is assumed to be negative infinite."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Range/valueType
+<https://admin-shell.io/aas/3/0/RC02/Range/valueType> rdf:type owl:ObjectProperty ;
+    rdfs:label "has value type"^^xsd:string ;
+    rdfs:domain aas:Range ;
+    rdfs:range aas:DataTypeDefXsd ;
+    rdfs:comment "Data type of the min und max"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Referable
+aas:Referable rdf:type owl:Class ;
+    rdfs:subClassOf aas:HasExtensions ;
+    rdfs:label "Referable"^^xsd:string ;
+    rdfs:comment "An element that is referable by its 'idShort'."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Referable/category
+<https://admin-shell.io/aas/3/0/RC02/Referable/category> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has category"^^xsd:string ;
+    rdfs:domain aas:Referable ;
+    rdfs:range xsd:string ;
+    rdfs:comment "The category is a value that gives further meta information w.r.t. to the class of the element. It affects the expected existence of attributes and the applicability of constraints."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Referable/checksum
+<https://admin-shell.io/aas/3/0/RC02/Referable/checksum> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has checksum"^^xsd:string ;
+    rdfs:domain aas:Referable ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Checksum to be used to determine if an Referable (including its aggregated child elements) has changed."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Referable/description
+<https://admin-shell.io/aas/3/0/RC02/Referable/description> rdf:type owl:ObjectProperty ;
+    rdfs:label "has description"^^xsd:string ;
+    rdfs:domain aas:Referable ;
+    rdfs:range aas:LangStringSet ;
+    rdfs:comment "Description or comments on the element."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Referable/displayName
+<https://admin-shell.io/aas/3/0/RC02/Referable/displayName> rdf:type owl:ObjectProperty ;
+    rdfs:label "has display name"^^xsd:string ;
+    rdfs:domain aas:Referable ;
+    rdfs:range aas:LangStringSet ;
+    rdfs:comment "Display name. Can be provided in several languages."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Referable/idShort
+<https://admin-shell.io/aas/3/0/RC02/Referable/idShort> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has id short"^^xsd:string ;
+    rdfs:domain aas:Referable ;
+    rdfs:range xsd:string ;
+    rdfs:comment "In case of identifiables this attribute is a short name of the element. In case of referable this ID is an identifying string of the element within its name space."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ReferableElements
+aas:ReferableElements rdf:type owl:Class ;
+    rdfs:label "Referable Elements"^^xsd:string ;
+    rdfs:comment "Enumeration of all referable elements within an asset administration shell"@en ;
+    owl:oneOf (
+        <https://admin-shell.io/aas/3/0/RC02/ReferableElements/AnnotatedRelationshipElement>
+        <https://admin-shell.io/aas/3/0/RC02/ReferableElements/AssetAdministrationShell>
+        <https://admin-shell.io/aas/3/0/RC02/ReferableElements/BasicEventElement>
+        <https://admin-shell.io/aas/3/0/RC02/ReferableElements/Blob>
+        <https://admin-shell.io/aas/3/0/RC02/ReferableElements/Capability>
+        <https://admin-shell.io/aas/3/0/RC02/ReferableElements/ConceptDescription>
+        <https://admin-shell.io/aas/3/0/RC02/ReferableElements/DataElement>
+        <https://admin-shell.io/aas/3/0/RC02/ReferableElements/Entity>
+        <https://admin-shell.io/aas/3/0/RC02/ReferableElements/EventElement>
+        <https://admin-shell.io/aas/3/0/RC02/ReferableElements/File>
+        <https://admin-shell.io/aas/3/0/RC02/ReferableElements/MultiLanguageProperty>
+        <https://admin-shell.io/aas/3/0/RC02/ReferableElements/Operation>
+        <https://admin-shell.io/aas/3/0/RC02/ReferableElements/Property>
+        <https://admin-shell.io/aas/3/0/RC02/ReferableElements/Range>
+        <https://admin-shell.io/aas/3/0/RC02/ReferableElements/ReferenceElement>
+        <https://admin-shell.io/aas/3/0/RC02/ReferableElements/RelationshipElement>
+        <https://admin-shell.io/aas/3/0/RC02/ReferableElements/Submodel>
+        <https://admin-shell.io/aas/3/0/RC02/ReferableElements/SubmodelElement>
+        <https://admin-shell.io/aas/3/0/RC02/ReferableElements/SubmodelElementList>
+        <https://admin-shell.io/aas/3/0/RC02/ReferableElements/SubmodelElementStruct>
+    ) ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ReferableElements/AnnotatedRelationshipElement
+<https://admin-shell.io/aas/3/0/RC02/ReferableElements/AnnotatedRelationshipElement> rdf:type aas:ReferableElements ;
+    rdfs:label "Annotated Relationship Element"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ReferableElements/AssetAdministrationShell
+<https://admin-shell.io/aas/3/0/RC02/ReferableElements/AssetAdministrationShell> rdf:type aas:ReferableElements ;
+    rdfs:label "Asset Administration Shell"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ReferableElements/BasicEventElement
+<https://admin-shell.io/aas/3/0/RC02/ReferableElements/BasicEventElement> rdf:type aas:ReferableElements ;
+    rdfs:label "Basic Event Element"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ReferableElements/Blob
+<https://admin-shell.io/aas/3/0/RC02/ReferableElements/Blob> rdf:type aas:ReferableElements ;
+    rdfs:label "Blob"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ReferableElements/Capability
+<https://admin-shell.io/aas/3/0/RC02/ReferableElements/Capability> rdf:type aas:ReferableElements ;
+    rdfs:label "Capability"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ReferableElements/ConceptDescription
+<https://admin-shell.io/aas/3/0/RC02/ReferableElements/ConceptDescription> rdf:type aas:ReferableElements ;
+    rdfs:label "Concept Description"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ReferableElements/DataElement
+<https://admin-shell.io/aas/3/0/RC02/ReferableElements/DataElement> rdf:type aas:ReferableElements ;
+    rdfs:label "Data Element"^^xsd:string ;
+    rdfs:comment "Data element."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ReferableElements/Entity
+<https://admin-shell.io/aas/3/0/RC02/ReferableElements/Entity> rdf:type aas:ReferableElements ;
+    rdfs:label "Entity"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ReferableElements/EventElement
+<https://admin-shell.io/aas/3/0/RC02/ReferableElements/EventElement> rdf:type aas:ReferableElements ;
+    rdfs:label "Event Element"^^xsd:string ;
+    rdfs:comment "Event."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ReferableElements/File
+<https://admin-shell.io/aas/3/0/RC02/ReferableElements/File> rdf:type aas:ReferableElements ;
+    rdfs:label "File"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ReferableElements/MultiLanguageProperty
+<https://admin-shell.io/aas/3/0/RC02/ReferableElements/MultiLanguageProperty> rdf:type aas:ReferableElements ;
+    rdfs:label "Multi Language Property"^^xsd:string ;
+    rdfs:comment "Property with a value that can be provided in multiple languages"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ReferableElements/Operation
+<https://admin-shell.io/aas/3/0/RC02/ReferableElements/Operation> rdf:type aas:ReferableElements ;
+    rdfs:label "Operation"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ReferableElements/Property
+<https://admin-shell.io/aas/3/0/RC02/ReferableElements/Property> rdf:type aas:ReferableElements ;
+    rdfs:label "Property"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ReferableElements/Range
+<https://admin-shell.io/aas/3/0/RC02/ReferableElements/Range> rdf:type aas:ReferableElements ;
+    rdfs:label "Range"^^xsd:string ;
+    rdfs:comment "Range with min and max"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ReferableElements/ReferenceElement
+<https://admin-shell.io/aas/3/0/RC02/ReferableElements/ReferenceElement> rdf:type aas:ReferableElements ;
+    rdfs:label "Reference Element"^^xsd:string ;
+    rdfs:comment "Reference"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ReferableElements/RelationshipElement
+<https://admin-shell.io/aas/3/0/RC02/ReferableElements/RelationshipElement> rdf:type aas:ReferableElements ;
+    rdfs:label "Relationship Element"^^xsd:string ;
+    rdfs:comment "Relationship"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ReferableElements/Submodel
+<https://admin-shell.io/aas/3/0/RC02/ReferableElements/Submodel> rdf:type aas:ReferableElements ;
+    rdfs:label "Submodel"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ReferableElements/SubmodelElement
+<https://admin-shell.io/aas/3/0/RC02/ReferableElements/SubmodelElement> rdf:type aas:ReferableElements ;
+    rdfs:label "Submodel Element"^^xsd:string ;
+    rdfs:comment "Submodel Element"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ReferableElements/SubmodelElementList
+<https://admin-shell.io/aas/3/0/RC02/ReferableElements/SubmodelElementList> rdf:type aas:ReferableElements ;
+    rdfs:label "Submodel Element List"^^xsd:string ;
+    rdfs:comment "List of Submodel Elements"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ReferableElements/SubmodelElementStruct
+<https://admin-shell.io/aas/3/0/RC02/ReferableElements/SubmodelElementStruct> rdf:type aas:ReferableElements ;
+    rdfs:label "Submodel Element Struct"^^xsd:string ;
+    rdfs:comment "Struct of Submodel Elements"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Reference
+aas:Reference rdf:type owl:Class ;
+    rdfs:label "Reference"^^xsd:string ;
+    rdfs:comment "Reference to either a model element of the same or another AAs or to an external entity."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ReferenceElement
+aas:ReferenceElement rdf:type owl:Class ;
+    rdfs:subClassOf aas:DataElement ;
+    rdfs:label "Reference Element"^^xsd:string ;
+    rdfs:comment "A reference element is a data element that defines a logical reference to another element within the same or another AAS or a reference to an external object or entity."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ReferenceElement/value
+<https://admin-shell.io/aas/3/0/RC02/ReferenceElement/value> rdf:type owl:ObjectProperty ;
+    rdfs:label "has value"^^xsd:string ;
+    rdfs:domain aas:ReferenceElement ;
+    rdfs:range aas:Reference ;
+    rdfs:comment "Global reference to an external object or entity or a logical reference to another element within the same or another AAS (i.e. a model reference to a Referable)."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/RelationshipElement
+aas:RelationshipElement rdf:type owl:Class ;
+    rdfs:subClassOf aas:SubmodelElement ;
+    rdfs:label "Relationship Element"^^xsd:string ;
+    rdfs:comment "A relationship element is used to define a relationship between two elements being either referable (model reference) or external (global reference)."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/RelationshipElement/first
+<https://admin-shell.io/aas/3/0/RC02/RelationshipElement/first> rdf:type owl:ObjectProperty ;
+    rdfs:label "has first"^^xsd:string ;
+    rdfs:domain aas:RelationshipElement ;
+    rdfs:range aas:Reference ;
+    rdfs:comment "Reference to the first element in the relationship taking the role of the subject."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/RelationshipElement/second
+<https://admin-shell.io/aas/3/0/RC02/RelationshipElement/second> rdf:type owl:ObjectProperty ;
+    rdfs:label "has second"^^xsd:string ;
+    rdfs:domain aas:RelationshipElement ;
+    rdfs:range aas:Reference ;
+    rdfs:comment "Reference to the second element in the relationship taking the role of the object."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Resource
+aas:Resource rdf:type owl:Class ;
+    rdfs:label "Resource"^^xsd:string ;
+    rdfs:comment "Resource represents an address to a file (a locator). The value is an URI that can represent an absolute or relative path"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Resource/contentType
+<https://admin-shell.io/aas/3/0/RC02/Resource/contentType> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has content type"^^xsd:string ;
+    rdfs:domain aas:Resource ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Content type of the content of the file. The content type states which file extensions the file can have."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Resource/path
+<https://admin-shell.io/aas/3/0/RC02/Resource/path> rdf:type owl:ObjectProperty ;
+    rdfs:label "has path"^^xsd:string ;
+    rdfs:domain aas:Resource ;
+    rdfs:range aas:AssetKind ;
+    rdfs:comment "Path and name of the resource (with file extension). The path can be absolute or relative."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/StateOfEvent
+aas:StateOfEvent rdf:type owl:Class ;
+    rdfs:label "State Of Event"^^xsd:string ;
+    rdfs:comment "State of an event"@en ;
+    owl:oneOf (
+        <https://admin-shell.io/aas/3/0/RC02/StateOfEvent/Off>
+        <https://admin-shell.io/aas/3/0/RC02/StateOfEvent/On>
+    ) ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/StateOfEvent/Off
+<https://admin-shell.io/aas/3/0/RC02/StateOfEvent/Off> rdf:type aas:StateOfEvent ;
+    rdfs:label "Off"^^xsd:string ;
+    rdfs:comment "Event is off."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/StateOfEvent/On
+<https://admin-shell.io/aas/3/0/RC02/StateOfEvent/On> rdf:type aas:StateOfEvent ;
+    rdfs:label "On"^^xsd:string ;
+    rdfs:comment "Event is on"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Submodel
+aas:Submodel rdf:type owl:Class ;
+    rdfs:subClassOf aas:Identifiable ;
+    rdfs:subClassOf aas:HasKind ;
+    rdfs:subClassOf aas:HasSemantics ;
+    rdfs:subClassOf aas:Qualifiable ;
+    rdfs:subClassOf aas:HasDataSpecification ;
+    rdfs:label "Submodel"^^xsd:string ;
+    rdfs:comment "A submodel defines a specific aspect of the asset represented by the AAS."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/Submodel/submodelElements
+<https://admin-shell.io/aas/3/0/RC02/Submodel/submodelElements> rdf:type owl:ObjectProperty ;
+    rdfs:label "has submodel elements"^^xsd:string ;
+    rdfs:domain aas:Submodel ;
+    rdfs:range aas:SubmodelElement ;
+    rdfs:comment "A submodel consists of zero or more submodel elements."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/SubmodelElement
+aas:SubmodelElement rdf:type owl:Class ;
+    rdfs:subClassOf aas:Referable ;
+    rdfs:subClassOf aas:HasKind ;
+    rdfs:subClassOf aas:HasSemantics ;
+    rdfs:subClassOf aas:Qualifiable ;
+    rdfs:subClassOf aas:HasDataSpecification ;
+    rdfs:label "Submodel Element"^^xsd:string ;
+    rdfs:comment "A submodel element is an element suitable for the description and differentiation of assets."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements
+aas:SubmodelElementElements rdf:type owl:Class ;
+    rdfs:label "Submodel Element Elements"^^xsd:string ;
+    rdfs:comment "Enumeration of all referable elements within an asset administration shell."@en ;
+    owl:oneOf (
+        <https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/AnnotatedRelationshipElement>
+        <https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/BasicEventElement>
+        <https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/Blob>
+        <https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/Capability>
+        <https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/DataElement>
+        <https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/Entity>
+        <https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/EventElement>
+        <https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/File>
+        <https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/MultiLanguageProperty>
+        <https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/Operation>
+        <https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/Property>
+        <https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/Range>
+        <https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/ReferenceElement>
+        <https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/RelationshipElement>
+        <https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/SubmodelElement>
+        <https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/SubmodelElementList>
+        <https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/SubmodelElementStruct>
+    ) ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/AnnotatedRelationshipElement
+<https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/AnnotatedRelationshipElement> rdf:type aas:SubmodelElementElements ;
+    rdfs:label "Annotated Relationship Element"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/BasicEventElement
+<https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/BasicEventElement> rdf:type aas:SubmodelElementElements ;
+    rdfs:label "Basic Event Element"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/Blob
+<https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/Blob> rdf:type aas:SubmodelElementElements ;
+    rdfs:label "Blob"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/Capability
+<https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/Capability> rdf:type aas:SubmodelElementElements ;
+    rdfs:label "Capability"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/DataElement
+<https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/DataElement> rdf:type aas:SubmodelElementElements ;
+    rdfs:label "Data Element"^^xsd:string ;
+    rdfs:comment "Data Element."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/Entity
+<https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/Entity> rdf:type aas:SubmodelElementElements ;
+    rdfs:label "Entity"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/EventElement
+<https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/EventElement> rdf:type aas:SubmodelElementElements ;
+    rdfs:label "Event Element"^^xsd:string ;
+    rdfs:comment "Event element"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/File
+<https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/File> rdf:type aas:SubmodelElementElements ;
+    rdfs:label "File"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/MultiLanguageProperty
+<https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/MultiLanguageProperty> rdf:type aas:SubmodelElementElements ;
+    rdfs:label "Multi Language Property"^^xsd:string ;
+    rdfs:comment "Property with a value that can be provided in multiple languages"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/Operation
+<https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/Operation> rdf:type aas:SubmodelElementElements ;
+    rdfs:label "Operation"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/Property
+<https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/Property> rdf:type aas:SubmodelElementElements ;
+    rdfs:label "Property"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/Range
+<https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/Range> rdf:type aas:SubmodelElementElements ;
+    rdfs:label "Range"^^xsd:string ;
+    rdfs:comment "Range with min and max"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/ReferenceElement
+<https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/ReferenceElement> rdf:type aas:SubmodelElementElements ;
+    rdfs:label "Reference Element"^^xsd:string ;
+    rdfs:comment "Reference"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/RelationshipElement
+<https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/RelationshipElement> rdf:type aas:SubmodelElementElements ;
+    rdfs:label "Relationship Element"^^xsd:string ;
+    rdfs:comment "Relationship"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/SubmodelElement
+<https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/SubmodelElement> rdf:type aas:SubmodelElementElements ;
+    rdfs:label "Submodel Element"^^xsd:string ;
+    rdfs:comment "Submodel Element"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/SubmodelElementList
+<https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/SubmodelElementList> rdf:type aas:SubmodelElementElements ;
+    rdfs:label "Submodel Element List"^^xsd:string ;
+    rdfs:comment "List of Submodel Elements"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/SubmodelElementStruct
+<https://admin-shell.io/aas/3/0/RC02/SubmodelElementElements/SubmodelElementStruct> rdf:type aas:SubmodelElementElements ;
+    rdfs:label "Submodel Element Struct"^^xsd:string ;
+    rdfs:comment "Struct of Submodel Elements"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/SubmodelElementList
+aas:SubmodelElementList rdf:type owl:Class ;
+    rdfs:subClassOf aas:SubmodelElement ;
+    rdfs:label "Submodel Element List"^^xsd:string ;
+    rdfs:comment "A submodel element list is an ordered collection of submodel elements."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/SubmodelElementList/orderRelevant
+<https://admin-shell.io/aas/3/0/RC02/SubmodelElementList/orderRelevant> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has order relevant"^^xsd:string ;
+    rdfs:domain aas:SubmodelElementList ;
+    rdfs:range xsd:boolean ;
+    rdfs:comment "Defines whether order in list is relevant. If 'orderRelevant' = False then the list is representing a set or a bag."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/SubmodelElementList/semanticIdListElement
+<https://admin-shell.io/aas/3/0/RC02/SubmodelElementList/semanticIdListElement> rdf:type owl:ObjectProperty ;
+    rdfs:label "has semantic id list element"^^xsd:string ;
+    rdfs:domain aas:SubmodelElementList ;
+    rdfs:range aas:GlobalReference ;
+    rdfs:comment "The submodel element type of the submodel elements contained in the list."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/SubmodelElementList/typeValueListElement
+<https://admin-shell.io/aas/3/0/RC02/SubmodelElementList/typeValueListElement> rdf:type owl:ObjectProperty ;
+    rdfs:label "has type value list element"^^xsd:string ;
+    rdfs:domain aas:SubmodelElementList ;
+    rdfs:range aas:SubmodelElementElements ;
+    rdfs:comment "The submodel element type of the submodel elements contained in the list."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/SubmodelElementList/value
+<https://admin-shell.io/aas/3/0/RC02/SubmodelElementList/value> rdf:type owl:ObjectProperty ;
+    rdfs:label "has value"^^xsd:string ;
+    rdfs:domain aas:SubmodelElementList ;
+    rdfs:range aas:SubmodelElement ;
+    rdfs:comment "Submodel element contained in the list. The list is ordered."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/SubmodelElementList/valueTypeListElement
+<https://admin-shell.io/aas/3/0/RC02/SubmodelElementList/valueTypeListElement> rdf:type owl:ObjectProperty ;
+    rdfs:label "has value type list element"^^xsd:string ;
+    rdfs:domain aas:SubmodelElementList ;
+    rdfs:range aas:DataTypeDefXsd ;
+    rdfs:comment "The value type of the submodel element contained in the list."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/SubmodelElementStruct
+aas:SubmodelElementStruct rdf:type owl:Class ;
+    rdfs:subClassOf aas:SubmodelElement ;
+    rdfs:label "Submodel Element Struct"^^xsd:string ;
+    rdfs:comment "A submodel element struct is is a logical encapsulation of multiple values. It has a number of of submodel elements."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/SubmodelElementStruct/value
+<https://admin-shell.io/aas/3/0/RC02/SubmodelElementStruct/value> rdf:type owl:ObjectProperty ;
+    rdfs:label "has value"^^xsd:string ;
+    rdfs:domain aas:SubmodelElementStruct ;
+    rdfs:range aas:SubmodelElement ;
+    rdfs:comment "Submodel element contained in the struct."@en ;
+.

--- a/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/expected_output/shacl-schema.ttl
+++ b/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/expected_output/shacl-schema.ttl
@@ -1,0 +1,1031 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix iec61360: <https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0/RC02/> .
+@prefix phys_unit: <https://admin-shell.io/DataSpecificationTemplates/DataSpecificationPhysicalUnit/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Metadata
+<https://admin-shell.io/aas/3/0/RC02/> a owl:Ontology ;
+    owl:imports <http://datashapes.org/dash> ;
+    owl:imports sh: ;
+    sh:declare [
+        a sh:PrefixDeclaration ;
+        sh:namespace "https://admin-shell.io/aas/3/0/RC02/"^^xsd:anyURI ;
+        sh:prefix "aas"^^xsd:string ;
+    ] ;
+.
+
+aas:AdministrativeInformationShape a sh:NodeShape ;
+    sh:targetClass aas:AdministrativeInformation ;
+    rdfs:subClassOf aas:HasDataSpecificationShape ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/AdministrativeInformation/version> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/AdministrativeInformation/revision> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] ;
+.
+
+aas:AnnotatedRelationshipElementShape a sh:NodeShape ;
+    sh:targetClass aas:AnnotatedRelationshipElement ;
+    rdfs:subClassOf aas:RelationshipElementShape ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/AnnotatedRelationshipElement/annotation> ;
+        sh:class aas:DataElement ;
+        sh:minCount 0 ;
+    ] ;
+.
+
+aas:AssetAdministrationShellShape a sh:NodeShape ;
+    sh:targetClass aas:AssetAdministrationShell ;
+    rdfs:subClassOf aas:IdentifiableShape ;
+    rdfs:subClassOf aas:HasDataSpecificationShape ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/AssetAdministrationShell/assetInformation> ;
+        sh:class aas:AssetInformation ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/AssetAdministrationShell/submodels> ;
+        sh:class aas:ModelReference ;
+        sh:minCount 0 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/AssetAdministrationShell/derivedFrom> ;
+        sh:class aas:ModelReference ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+.
+
+aas:AssetInformationShape a sh:NodeShape ;
+    sh:targetClass aas:AssetInformation ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/AssetInformation/assetKind> ;
+        sh:class aas:AssetKind ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/AssetInformation/globalAssetId> ;
+        sh:class aas:GlobalReference ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/AssetInformation/specificAssetId> ;
+        sh:class aas:IdentifierKeyValuePair ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/AssetInformation/defaultThumbnail> ;
+        sh:class aas:Resource ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+.
+
+aas:BasicEventElementShape a sh:NodeShape ;
+    sh:targetClass aas:BasicEventElement ;
+    rdfs:subClassOf aas:EventElementShape ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/BasicEventElement/observed> ;
+        sh:class aas:ModelReference ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/BasicEventElement/direction> ;
+        sh:class aas:Direction ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/BasicEventElement/state> ;
+        sh:class aas:StateOfEvent ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/BasicEventElement/messageTopic> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/BasicEventElement/messageBroker> ;
+        sh:class aas:ModelReference ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/BasicEventElement/lastUpdate> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:pattern "^-?(([1-9][0-9][0-9][0-9]+)|(0[0-9][0-9][0-9]))-((0[1-9])|(1[0-2]))-((0[1-9])|([12][0-9])|(3[01]))T(((([01][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.[0-9]+)?)|24:00:00(\\.0+)?)Z$" ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/BasicEventElement/minInterval> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:pattern "^-?(([1-9][0-9][0-9][0-9]+)|(0[0-9][0-9][0-9]))-((0[1-9])|(1[0-2]))-((0[1-9])|([12][0-9])|(3[01]))T(((([01][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.[0-9]+)?)|24:00:00(\\.0+)?)Z$" ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/BasicEventElement/maxInterval> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:pattern "^-?(([1-9][0-9][0-9][0-9]+)|(0[0-9][0-9][0-9]))-((0[1-9])|(1[0-2]))-((0[1-9])|([12][0-9])|(3[01]))T(((([01][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.[0-9]+)?)|24:00:00(\\.0+)?)Z$" ;
+    ] ;
+.
+
+aas:BlobShape a sh:NodeShape ;
+    sh:targetClass aas:Blob ;
+    rdfs:subClassOf aas:DataElementShape ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Blob/mimeType> ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+        sh:pattern "^([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+/([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+([ 	]*;[ 	]*([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+=(([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+|\"(([	 !#-\\[\\]-~]|[\\x80-\\xff])|\\\\([	 !-~]|[\\x80-\\xff]))*\"))*$" ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Blob/value> ;
+        sh:datatype xsd:byte ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+.
+
+aas:CapabilityShape a sh:NodeShape ;
+    sh:targetClass aas:Capability ;
+    rdfs:subClassOf aas:SubmodelElementShape ;
+.
+
+aas:ConceptDescriptionShape a sh:NodeShape ;
+    sh:targetClass aas:ConceptDescription ;
+    rdfs:subClassOf aas:IdentifiableShape ;
+    rdfs:subClassOf aas:HasDataSpecificationShape ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/ConceptDescription/isCaseOf> ;
+        sh:class aas:GlobalReference ;
+        sh:minCount 0 ;
+    ] ;
+.
+
+aas:DataElementShape a sh:NodeShape ;
+    sh:targetClass aas:DataElement ;
+    rdfs:subClassOf aas:SubmodelElementShape ;
+    sh:sparql [
+        a sh:SPARQLConstraint ;
+        sh:message "(DataElementShape): An aas:DataElement is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+        sh:prefixes aas: ;
+        sh:select """
+            SELECT ?this ?type
+            WHERE {
+                ?this rdf:type ?type .
+                FILTER (?type = aas:DataElement)
+            }
+        """ ;
+    ] ;
+.
+
+aas:EntityShape a sh:NodeShape ;
+    sh:targetClass aas:Entity ;
+    rdfs:subClassOf aas:SubmodelElementShape ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Entity/entityType> ;
+        sh:class aas:EntityType ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Entity/statements> ;
+        sh:class aas:SubmodelElement ;
+        sh:minCount 0 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Entity/globalAssetId> ;
+        sh:class aas:Reference ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Entity/specificAssetId> ;
+        sh:class aas:IdentifierKeyValuePair ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+.
+
+aas:EnvironmentShape a sh:NodeShape ;
+    sh:targetClass aas:Environment ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Environment/assetAdministrationShells> ;
+        sh:class aas:AssetAdministrationShell ;
+        sh:minCount 0 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Environment/submodels> ;
+        sh:class aas:Submodel ;
+        sh:minCount 0 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Environment/conceptDescriptions> ;
+        sh:class aas:ConceptDescription ;
+        sh:minCount 0 ;
+    ] ;
+.
+
+aas:EventElementShape a sh:NodeShape ;
+    sh:targetClass aas:EventElement ;
+    rdfs:subClassOf aas:SubmodelElementShape ;
+    sh:sparql [
+        a sh:SPARQLConstraint ;
+        sh:message "(EventElementShape): An aas:EventElement is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+        sh:prefixes aas: ;
+        sh:select """
+            SELECT ?this ?type
+            WHERE {
+                ?this rdf:type ?type .
+                FILTER (?type = aas:EventElement)
+            }
+        """ ;
+    ] ;
+.
+
+aas:EventPayloadShape a sh:NodeShape ;
+    sh:targetClass aas:EventPayload ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/EventPayload/source> ;
+        sh:class aas:ModelReference ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/EventPayload/sourceSemanticId> ;
+        sh:class aas:GlobalReference ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/EventPayload/observableReference> ;
+        sh:class aas:ModelReference ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/EventPayload/observableSemanticId> ;
+        sh:class aas:GlobalReference ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/EventPayload/topic> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/EventPayload/subjectId> ;
+        sh:class aas:GlobalReference ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/EventPayload/timeStamp> ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:pattern "^-?(([1-9][0-9][0-9][0-9]+)|(0[0-9][0-9][0-9]))-((0[1-9])|(1[0-2]))-((0[1-9])|([12][0-9])|(3[01]))T(((([01][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.[0-9]+)?)|24:00:00(\\.0+)?)Z$" ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/EventPayload/payload> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] ;
+.
+
+aas:ExtensionShape a sh:NodeShape ;
+    sh:targetClass aas:Extension ;
+    rdfs:subClassOf aas:HasSemanticsShape ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Extension/name> ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Extension/valueType> ;
+        sh:class aas:DataTypeDefXsd ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Extension/value> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Extension/refersTo> ;
+        sh:class aas:ModelReference ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+.
+
+aas:FileShape a sh:NodeShape ;
+    sh:targetClass aas:File ;
+    rdfs:subClassOf aas:DataElementShape ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/File/contentType> ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+        sh:pattern "^([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+/([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+([ 	]*;[ 	]*([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+=(([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+|\"(([	 !#-\\[\\]-~]|[\\x80-\\xff])|\\\\([	 !-~]|[\\x80-\\xff]))*\"))*$" ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/File/value> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+        sh:pattern "^file:(//((localhost|(\\[((([0-9A-Fa-f]{1,4}:){6}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|::([0-9A-Fa-f]{1,4}:){5}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|([0-9A-Fa-f]{1,4})?::([0-9A-Fa-f]{1,4}:){4}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:)?[0-9A-Fa-f]{1,4})?::([0-9A-Fa-f]{1,4}:){3}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:){2}[0-9A-Fa-f]{1,4})?::([0-9A-Fa-f]{1,4}:){2}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:){3}[0-9A-Fa-f]{1,4})?::[0-9A-Fa-f]{1,4}:([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:){4}[0-9A-Fa-f]{1,4})?::([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:){5}[0-9A-Fa-f]{1,4})?::[0-9A-Fa-f]{1,4}|(([0-9A-Fa-f]{1,4}:){6}[0-9A-Fa-f]{1,4})?::)|[vV][0-9A-Fa-f]+\\.([a-zA-Z0-9\\-._~]|[!$&'()*+,;=]|:)+)\\]|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])|([a-zA-Z0-9\\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&'()*+,;=])*)))?/((([a-zA-Z0-9\\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&'()*+,;=]|[:@]))+(/(([a-zA-Z0-9\\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&'()*+,;=]|[:@]))*)*)?|/((([a-zA-Z0-9\\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&'()*+,;=]|[:@]))+(/(([a-zA-Z0-9\\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&'()*+,;=]|[:@]))*)*)?)$" ;
+    ] ;
+.
+
+aas:GlobalReferenceShape a sh:NodeShape ;
+    sh:targetClass aas:GlobalReference ;
+    rdfs:subClassOf aas:ReferenceShape ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/GlobalReference/value> ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] ;
+.
+
+aas:HasDataSpecificationShape a sh:NodeShape ;
+    sh:targetClass aas:HasDataSpecification ;
+    sh:sparql [
+        a sh:SPARQLConstraint ;
+        sh:message "(HasDataSpecificationShape): An aas:HasDataSpecification is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+        sh:prefixes aas: ;
+        sh:select """
+            SELECT ?this ?type
+            WHERE {
+                ?this rdf:type ?type .
+                FILTER (?type = aas:HasDataSpecification)
+            }
+        """ ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/HasDataSpecification/dataSpecifications> ;
+        sh:class aas:GlobalReference ;
+        sh:minCount 0 ;
+    ] ;
+.
+
+aas:HasExtensionsShape a sh:NodeShape ;
+    sh:targetClass aas:HasExtensions ;
+    sh:sparql [
+        a sh:SPARQLConstraint ;
+        sh:message "(HasExtensionsShape): An aas:HasExtensions is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+        sh:prefixes aas: ;
+        sh:select """
+            SELECT ?this ?type
+            WHERE {
+                ?this rdf:type ?type .
+                FILTER (?type = aas:HasExtensions)
+            }
+        """ ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/HasExtensions/extensions> ;
+        sh:class aas:Extension ;
+        sh:minCount 0 ;
+    ] ;
+.
+
+aas:HasKindShape a sh:NodeShape ;
+    sh:targetClass aas:HasKind ;
+    sh:sparql [
+        a sh:SPARQLConstraint ;
+        sh:message "(HasKindShape): An aas:HasKind is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+        sh:prefixes aas: ;
+        sh:select """
+            SELECT ?this ?type
+            WHERE {
+                ?this rdf:type ?type .
+                FILTER (?type = aas:HasKind)
+            }
+        """ ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/HasKind/kind> ;
+        sh:class aas:ModelingKind ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+.
+
+aas:HasSemanticsShape a sh:NodeShape ;
+    sh:targetClass aas:HasSemantics ;
+    sh:sparql [
+        a sh:SPARQLConstraint ;
+        sh:message "(HasSemanticsShape): An aas:HasSemantics is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+        sh:prefixes aas: ;
+        sh:select """
+            SELECT ?this ?type
+            WHERE {
+                ?this rdf:type ?type .
+                FILTER (?type = aas:HasSemantics)
+            }
+        """ ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/HasSemantics/semanticId> ;
+        sh:class aas:GlobalReference ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+.
+
+aas:IdentifiableShape a sh:NodeShape ;
+    sh:targetClass aas:Identifiable ;
+    rdfs:subClassOf aas:ReferableShape ;
+    sh:sparql [
+        a sh:SPARQLConstraint ;
+        sh:message "(IdentifiableShape): An aas:Identifiable is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+        sh:prefixes aas: ;
+        sh:select """
+            SELECT ?this ?type
+            WHERE {
+                ?this rdf:type ?type .
+                FILTER (?type = aas:Identifiable)
+            }
+        """ ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Identifiable/id> ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Identifiable/administration> ;
+        sh:class aas:AdministrativeInformation ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+.
+
+aas:IdentifierKeyValuePairShape a sh:NodeShape ;
+    sh:targetClass aas:IdentifierKeyValuePair ;
+    rdfs:subClassOf aas:HasSemanticsShape ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/IdentifierKeyValuePair/key> ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/IdentifierKeyValuePair/value> ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/IdentifierKeyValuePair/externalSubjectId> ;
+        sh:class aas:GlobalReference ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+.
+
+aas:KeyShape a sh:NodeShape ;
+    sh:targetClass aas:Key ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Key/type> ;
+        sh:class aas:KeyElements ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Key/value> ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] ;
+.
+
+aas:LangStringShape a sh:NodeShape ;
+    sh:targetClass aas:LangString ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/LangString/language> ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:pattern "^(([a-zA-Z]{2,3}(-[a-zA-Z]{3}(-[a-zA-Z]{3}){2})?|[a-zA-Z]{4}|[a-zA-Z]{5,8})(-[a-zA-Z]{4})?(-([a-zA-Z]{2}|[0-9]{3}))?(-(([a-zA-Z0-9]){5,8}|[0-9]([a-zA-Z0-9]){3}))*(-[0-9A-WY-Za-wy-z](-([a-zA-Z0-9]){2,8})+)*(-[xX](-([a-zA-Z0-9]){1,8})+)?|[xX](-([a-zA-Z0-9]){1,8})+|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$" ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/LangString/text> ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+.
+
+aas:LangStringSetShape a sh:NodeShape ;
+    sh:targetClass aas:LangStringSet ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/LangStringSet/langStrings> ;
+        sh:class aas:LangString ;
+        sh:minCount 1 ;
+    ] ;
+.
+
+aas:ModelReferenceShape a sh:NodeShape ;
+    sh:targetClass aas:ModelReference ;
+    rdfs:subClassOf aas:ReferenceShape ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/ModelReference/keys> ;
+        sh:class aas:Key ;
+        sh:minCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/ModelReference/referredSemanticId> ;
+        sh:class aas:GlobalReference ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+.
+
+aas:MultiLanguagePropertyShape a sh:NodeShape ;
+    sh:targetClass aas:MultiLanguageProperty ;
+    rdfs:subClassOf aas:DataElementShape ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/MultiLanguageProperty/value> ;
+        sh:class aas:LangStringSet ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/MultiLanguageProperty/valueId> ;
+        sh:class aas:GlobalReference ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+.
+
+aas:OperationShape a sh:NodeShape ;
+    sh:targetClass aas:Operation ;
+    rdfs:subClassOf aas:SubmodelElementShape ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Operation/inputVariables> ;
+        sh:class aas:OperationVariable ;
+        sh:minCount 0 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Operation/outputVariables> ;
+        sh:class aas:OperationVariable ;
+        sh:minCount 0 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Operation/inoutputVariables> ;
+        sh:class aas:OperationVariable ;
+        sh:minCount 0 ;
+    ] ;
+.
+
+aas:OperationVariableShape a sh:NodeShape ;
+    sh:targetClass aas:OperationVariable ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/OperationVariable/value> ;
+        sh:class aas:SubmodelElement ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+.
+
+aas:PropertyShape a sh:NodeShape ;
+    sh:targetClass aas:Property ;
+    rdfs:subClassOf aas:DataElementShape ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Property/valueType> ;
+        sh:class aas:DataTypeDefXsd ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Property/value> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Property/valueId> ;
+        sh:class aas:GlobalReference ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+.
+
+aas:QualifiableShape a sh:NodeShape ;
+    sh:targetClass aas:Qualifiable ;
+    sh:sparql [
+        a sh:SPARQLConstraint ;
+        sh:message "(QualifiableShape): An aas:Qualifiable is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+        sh:prefixes aas: ;
+        sh:select """
+            SELECT ?this ?type
+            WHERE {
+                ?this rdf:type ?type .
+                FILTER (?type = aas:Qualifiable)
+            }
+        """ ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Qualifiable/qualifiers> ;
+        sh:class aas:Qualifier ;
+        sh:minCount 0 ;
+    ] ;
+.
+
+aas:QualifierShape a sh:NodeShape ;
+    sh:targetClass aas:Qualifier ;
+    rdfs:subClassOf aas:HasSemanticsShape ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Qualifier/type> ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Qualifier/valueType> ;
+        sh:class aas:DataTypeDefXsd ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Qualifier/value> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Qualifier/valueId> ;
+        sh:class aas:GlobalReference ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+.
+
+aas:RangeShape a sh:NodeShape ;
+    sh:targetClass aas:Range ;
+    rdfs:subClassOf aas:DataElementShape ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Range/valueType> ;
+        sh:class aas:DataTypeDefXsd ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Range/min> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Range/max> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+.
+
+aas:ReferableShape a sh:NodeShape ;
+    sh:targetClass aas:Referable ;
+    rdfs:subClassOf aas:HasExtensionsShape ;
+    sh:sparql [
+        a sh:SPARQLConstraint ;
+        sh:message "(ReferableShape): An aas:Referable is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+        sh:prefixes aas: ;
+        sh:select """
+            SELECT ?this ?type
+            WHERE {
+                ?this rdf:type ?type .
+                FILTER (?type = aas:Referable)
+            }
+        """ ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Referable/idShort> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+        sh:maxLength 128 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Referable/displayName> ;
+        sh:class aas:LangStringSet ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Referable/category> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Referable/description> ;
+        sh:class aas:LangStringSet ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Referable/checksum> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] ;
+.
+
+aas:ReferenceShape a sh:NodeShape ;
+    sh:targetClass aas:Reference ;
+    sh:sparql [
+        a sh:SPARQLConstraint ;
+        sh:message "(ReferenceShape): An aas:Reference is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+        sh:prefixes aas: ;
+        sh:select """
+            SELECT ?this ?type
+            WHERE {
+                ?this rdf:type ?type .
+                FILTER (?type = aas:Reference)
+            }
+        """ ;
+    ] ;
+.
+
+aas:ReferenceElementShape a sh:NodeShape ;
+    sh:targetClass aas:ReferenceElement ;
+    rdfs:subClassOf aas:DataElementShape ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/ReferenceElement/value> ;
+        sh:class aas:Reference ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+.
+
+aas:RelationshipElementShape a sh:NodeShape ;
+    sh:targetClass aas:RelationshipElement ;
+    rdfs:subClassOf aas:SubmodelElementShape ;
+    sh:sparql [
+        a sh:SPARQLConstraint ;
+        sh:message "(RelationshipElementShape): An aas:RelationshipElement is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+        sh:prefixes aas: ;
+        sh:select """
+            SELECT ?this ?type
+            WHERE {
+                ?this rdf:type ?type .
+                FILTER (?type = aas:RelationshipElement)
+            }
+        """ ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/RelationshipElement/first> ;
+        sh:class aas:Reference ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/RelationshipElement/second> ;
+        sh:class aas:Reference ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+.
+
+aas:ResourceShape a sh:NodeShape ;
+    sh:targetClass aas:Resource ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Resource/path> ;
+        sh:class aas:AssetKind ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Resource/contentType> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+        sh:pattern "^([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+/([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+([ 	]*;[ 	]*([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+=(([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+|\"(([	 !#-\\[\\]-~]|[\\x80-\\xff])|\\\\([	 !-~]|[\\x80-\\xff]))*\"))*$" ;
+    ] ;
+.
+
+aas:SubmodelShape a sh:NodeShape ;
+    sh:targetClass aas:Submodel ;
+    rdfs:subClassOf aas:IdentifiableShape ;
+    rdfs:subClassOf aas:HasKindShape ;
+    rdfs:subClassOf aas:HasSemanticsShape ;
+    rdfs:subClassOf aas:QualifiableShape ;
+    rdfs:subClassOf aas:HasDataSpecificationShape ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/Submodel/submodelElements> ;
+        sh:class aas:SubmodelElement ;
+        sh:minCount 0 ;
+    ] ;
+.
+
+aas:SubmodelElementShape a sh:NodeShape ;
+    sh:targetClass aas:SubmodelElement ;
+    rdfs:subClassOf aas:ReferableShape ;
+    rdfs:subClassOf aas:HasKindShape ;
+    rdfs:subClassOf aas:HasSemanticsShape ;
+    rdfs:subClassOf aas:QualifiableShape ;
+    rdfs:subClassOf aas:HasDataSpecificationShape ;
+    sh:sparql [
+        a sh:SPARQLConstraint ;
+        sh:message "(SubmodelElementShape): An aas:SubmodelElement is a abstract class. Please use one of the subclasses for the generation of instances."@en ;
+        sh:prefixes aas: ;
+        sh:select """
+            SELECT ?this ?type
+            WHERE {
+                ?this rdf:type ?type .
+                FILTER (?type = aas:SubmodelElement)
+            }
+        """ ;
+    ] ;
+.
+
+aas:SubmodelElementListShape a sh:NodeShape ;
+    sh:targetClass aas:SubmodelElementList ;
+    rdfs:subClassOf aas:SubmodelElementShape ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/SubmodelElementList/typeValueListElement> ;
+        sh:class aas:SubmodelElementElements ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/SubmodelElementList/orderRelevant> ;
+        sh:datatype xsd:boolean ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/SubmodelElementList/value> ;
+        sh:class aas:SubmodelElement ;
+        sh:minCount 0 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/SubmodelElementList/semanticIdListElement> ;
+        sh:class aas:GlobalReference ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/SubmodelElementList/valueTypeListElement> ;
+        sh:class aas:DataTypeDefXsd ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+.
+
+aas:SubmodelElementStructShape a sh:NodeShape ;
+    sh:targetClass aas:SubmodelElementStruct ;
+    rdfs:subClassOf aas:SubmodelElementShape ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/SubmodelElementStruct/value> ;
+        sh:class aas:SubmodelElement ;
+        sh:minCount 0 ;
+    ] ;
+.

--- a/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/expected_output/stdout.txt
+++ b/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/expected_output/stdout.txt
@@ -1,0 +1,1 @@
+Code generated to: <output dir>

--- a/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/input/snippets/rdf/preamble.ttl
+++ b/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/input/snippets/rdf/preamble.ttl
@@ -1,0 +1,15 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@base <https://admin-shell.io/aas/3/0/RC02/> .
+
+<https://admin-shell.io/aas/3/0/RC02/> rdf:type owl:Ontology ;
+    vann:preferredNamespaceUri "https://admin-shell.io/aas/3/0/RC02/"^^xsd:anyURI ;
+    owl:versionInfo "3.0.RC02" ;
+    rdfs:comment "This ontology represents the data model for the Asset Administration Shell according to the specification 'Details of the Asset Administration Shell - Part 1 - Version 3.0.RC02'."@en ;
+    vann:preferredNamespacePrefix "aas"^^xsd:string ;
+    rdfs:isDefinedBy <https://admin-shell.io/aas/3/0/RC02/> ;
+.

--- a/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/input/snippets/shacl/preamble.ttl
+++ b/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/input/snippets/shacl/preamble.ttl
@@ -1,0 +1,19 @@
+@prefix aas: <https://admin-shell.io/aas/3/0/RC02/> .
+@prefix iec61360: <https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0/RC02/> .
+@prefix phys_unit: <https://admin-shell.io/DataSpecificationTemplates/DataSpecificationPhysicalUnit/3/0/RC02/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Metadata
+<https://admin-shell.io/aas/3/0/RC02/> a owl:Ontology ;
+    owl:imports <http://datashapes.org/dash> ;
+    owl:imports sh: ;
+    sh:declare [
+        a sh:PrefixDeclaration ;
+        sh:namespace "https://admin-shell.io/aas/3/0/RC02/"^^xsd:anyURI ;
+        sh:prefix "aas"^^xsd:string ;
+    ] ;
+.

--- a/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/input/snippets/url_prefix.txt
+++ b/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/input/snippets/url_prefix.txt
@@ -1,0 +1,1 @@
+https://admin-shell.io/aas/3/0/RC02

--- a/tests/rdf_shacl/test_main.py
+++ b/tests/rdf_shacl/test_main.py
@@ -8,6 +8,7 @@ import tempfile
 import unittest
 
 import aas_core_meta.v3rc1
+import aas_core_meta.v3rc2
 
 import aas_core_codegen.main
 
@@ -25,7 +26,7 @@ class Test_against_recorded(unittest.TestCase):
         parent_case_dir = repo_dir / "test_data" / "rdf_shacl" / "test_main"
         assert parent_case_dir.exists() and parent_case_dir.is_dir(), parent_case_dir
 
-        for module in [aas_core_meta.v3rc1]:
+        for module in [aas_core_meta.v3rc1, aas_core_meta.v3rc2]:
             case_dir = parent_case_dir / module.__name__
             assert case_dir.is_dir(), case_dir
 


### PR DESCRIPTION
We make changes to RDF and SHACL generation so that our generated
schemas are as similar as possible to the schemas in
admin-shell-io/aas-specs repository for the version V3RC02 on the branch
[feature/rdf/updateToV3.0RC02].

[feature/rdf/updateToV3.0RC02]: https://github.com/admin-shell-io/aas-specs/tree/feature/rdf/updateToV3.0RC02