### PR TITLE
Fix unspecified indentions in C#

### DIFF
--- a/aas_core_codegen/csharp/structure/_generate.py
+++ b/aas_core_codegen/csharp/structure/_generate.py
@@ -1073,41 +1073,41 @@ def generate(
         /// </summary>
         public interface IClass
         {{
-            /// <summary>
-            /// Iterate over all the class instances referenced from this instance
-            /// without further recursion.
-            /// </summary>
-            public IEnumerable<IClass> DescendOnce();
+        {I}/// <summary>
+        {I}/// Iterate over all the class instances referenced from this instance
+        {I}/// without further recursion.
+        {I}/// </summary>
+        {I}public IEnumerable<IClass> DescendOnce();
 
-            /// <summary>
-            /// Iterate recursively over all the class instances referenced from this instance.
-            /// </summary>
-            public IEnumerable<IClass> Descend();
+        {I}/// <summary>
+        {I}/// Iterate recursively over all the class instances referenced from this instance.
+        {I}/// </summary>
+        {I}public IEnumerable<IClass> Descend();
 
-            /// <summary>
-            /// Accept the <paramref name="visitor" /> to visit this instance
-            /// for double dispatch.
-            /// </summary>
-            public void Accept(Visitation.IVisitor visitor);
+        {I}/// <summary>
+        {I}/// Accept the <paramref name="visitor" /> to visit this instance
+        {I}/// for double dispatch.
+        {I}/// </summary>
+        {I}public void Accept(Visitation.IVisitor visitor);
 
-            /// <summary>
-            /// Accept the visitor to visit this instance for double dispatch
-            /// with the <paramref name="context" />.
-            /// </summary>
-            public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context);
+        {I}/// <summary>
+        {I}/// Accept the visitor to visit this instance for double dispatch
+        {I}/// with the <paramref name="context" />.
+        {I}/// </summary>
+        {I}public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context);
 
-            /// <summary>
-            /// Accept the <paramref name="transformer" /> to transform this instance
-            /// for double dispatch.
-            /// </summary>
-            public T Transform<T>(Visitation.ITransformer<T> transformer);
+        {I}/// <summary>
+        {I}/// Accept the <paramref name="transformer" /> to transform this instance
+        {I}/// for double dispatch.
+        {I}/// </summary>
+        {I}public T Transform<T>(Visitation.ITransformer<T> transformer);
 
-            /// <summary>
-            /// Accept the <paramref name="transformer" /> to visit this instance
-            /// for double dispatch with the <paramref name="context" />.
-            /// </summary>
-            public T Transform<C, T>(
-            {I}Visitation.ITransformerWithContext<C, T> transformer, C context);
+        {I}/// <summary>
+        {I}/// Accept the <paramref name="transformer" /> to visit this instance
+        {I}/// for double dispatch with the <paramref name="context" />.
+        {I}/// </summary>
+        {I}public T Transform<C, T>(
+        {II}Visitation.ITransformerWithContext<C, T> transformer, C context);
         }}"""
                 ),
                 I,

--- a/aas_core_codegen/csharp/visitation/_generate.py
+++ b/aas_core_codegen/csharp/visitation/_generate.py
@@ -43,13 +43,13 @@ def _generate_ivisitor(symbol_table: intermediate.SymbolTable) -> Stripped:
     writer = io.StringIO()
     writer.write(
         textwrap.dedent(
-            """\
+            f"""\
             /// <summary>
             /// Define the interface for a visitor which visits the instances of the model.
             /// </summary>
             public interface IVisitor
-            {
-                public void Visit(IClass that);
+            {{
+            {I}public void Visit(IClass that);
             """
         )
     )
@@ -97,11 +97,11 @@ public void Visit(IClass that)
                     f"""\
 public void Visit({cls_name} that)
 {{
-    // Just descend through, do nothing with <c>that</c>
-    foreach (var something in that.DescendOnce())
-    {{
-        Visit(something);
-    }}
+{I}// Just descend through, do nothing with <c>that</c>
+{I}foreach (var something in that.DescendOnce())
+{I}{{
+{II}Visit(something);
+{I}}}
 }}"""
                 )
             )
@@ -216,14 +216,14 @@ def _generate_ivisitor_with_context(symbol_table: intermediate.SymbolTable) -> S
     writer = io.StringIO()
     writer.write(
         textwrap.dedent(
-            """\
+            f"""\
             /// <summary>
             /// Define the interface for a visitor which visits the instances of the model.
             /// </summary>
             /// <typeparam name="C">Context type</typeparam>
             public interface IVisitorWithContext<C>
-            {
-                public void Visit(IClass that, C context);
+            {{
+            {I}public void Visit(IClass that, C context);
             """
         )
     )
@@ -327,15 +327,15 @@ def _generate_itransformer(symbol_table: intermediate.SymbolTable) -> Stripped:
     writer = io.StringIO()
     writer.write(
         textwrap.dedent(
-            """\
+            f"""\
             /// <summary>
             /// Define the interface for a transformer which transforms recursively
             /// the instances into something else.
             /// </summary>
             /// <typeparam name="T">The type of the transformation result</typeparam>
             public interface ITransformer<T>
-            {
-                public T Transform(IClass that);
+            {{
+            {I}public T Transform(IClass that);
             """
         )
     )
@@ -440,7 +440,7 @@ def _generate_itransformer_with_context(
     writer = io.StringIO()
     writer.write(
         textwrap.dedent(
-            """\
+            f"""\
             /// <summary>
             /// Define the interface for a transformer which recursively transforms
             /// the instances into something else while the context is passed along.
@@ -448,8 +448,8 @@ def _generate_itransformer_with_context(
             /// <typeparam name="C">Type of the transformation context</typeparam>
             /// <typeparam name="T">The type of the transformation result</typeparam>
             public interface ITransformerWithContext<C, T>
-            {
-                public T Transform(IClass that, C context);
+            {{
+            {I}public T Transform(IClass that, C context);
             """
         )
     )


### PR DESCRIPTION
At a couple of spots we did not specify the indentions in C# code
generations, but just left four spaces in the templates (``    ``).

We replace the indentions with the explicit snippet (``{I}``, ``{II}``
*etc.*).