### PR TITLE
Fix indention in snippets of C# jsonization

### DIFF
--- a/aas_core_codegen/csharp/jsonization/_generate.py
+++ b/aas_core_codegen/csharp/jsonization/_generate.py
@@ -138,24 +138,20 @@ def _generate_from_method_for_interface(
         model_type = naming.json_model_type(implementer.name)
         implementer_name = csharp_naming.class_name(implementer.name)
         switch_writer.write(
-            textwrap.dedent(
-                f"""\
-                {I}case {csharp_common.string_literal(model_type)}:
-                {II}return {implementer_name}From(
-                {III}node, out error);
-                """
-            )
+            f"""\
+{I}case {csharp_common.string_literal(model_type)}:
+{II}return {implementer_name}From(
+{III}node, out error);
+"""
         )
 
     switch_writer.write(
-        textwrap.dedent(
-            f"""\
-            {I}default:
-            {II}error = new Reporting.Error(
-            {III}$"Unexpected model type for {name}: {{modelType}}");
-            {II}return null;
-            }}"""
-        )
+        f"""\
+{I}default:
+{II}error = new Reporting.Error(
+{III}$"Unexpected model type for {name}: {{modelType}}");
+{II}return null;
+}}"""
     )
     blocks.append(Stripped(switch_writer.getvalue()))
 

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/jsonization.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/jsonization.cs
@@ -313,57 +313,57 @@ namespace AasCore.Aas3
 
                 switch (modelType)
                 {
-                case "AnnotatedRelationshipElement":
-                    return AnnotatedRelationshipElementFrom(
-                        node, out error);
-                case "BasicEventElement":
-                    return BasicEventElementFrom(
-                        node, out error);
-                case "Blob":
-                    return BlobFrom(
-                        node, out error);
-                case "Capability":
-                    return CapabilityFrom(
-                        node, out error);
-                case "Entity":
-                    return EntityFrom(
-                        node, out error);
-                case "Extension":
-                    return ExtensionFrom(
-                        node, out error);
-                case "File":
-                    return FileFrom(
-                        node, out error);
-                case "IdentifierKeyValuePair":
-                    return IdentifierKeyValuePairFrom(
-                        node, out error);
-                case "MultiLanguageProperty":
-                    return MultiLanguagePropertyFrom(
-                        node, out error);
-                case "Operation":
-                    return OperationFrom(
-                        node, out error);
-                case "Property":
-                    return PropertyFrom(
-                        node, out error);
-                case "Qualifier":
-                    return QualifierFrom(
-                        node, out error);
-                case "Range":
-                    return RangeFrom(
-                        node, out error);
-                case "ReferenceElement":
-                    return ReferenceElementFrom(
-                        node, out error);
-                case "Submodel":
-                    return SubmodelFrom(
-                        node, out error);
-                case "SubmodelElementList":
-                    return SubmodelElementListFrom(
-                        node, out error);
-                case "SubmodelElementStruct":
-                    return SubmodelElementStructFrom(
-                        node, out error);
+                    case "AnnotatedRelationshipElement":
+                        return AnnotatedRelationshipElementFrom(
+                            node, out error);
+                    case "BasicEventElement":
+                        return BasicEventElementFrom(
+                            node, out error);
+                    case "Blob":
+                        return BlobFrom(
+                            node, out error);
+                    case "Capability":
+                        return CapabilityFrom(
+                            node, out error);
+                    case "Entity":
+                        return EntityFrom(
+                            node, out error);
+                    case "Extension":
+                        return ExtensionFrom(
+                            node, out error);
+                    case "File":
+                        return FileFrom(
+                            node, out error);
+                    case "IdentifierKeyValuePair":
+                        return IdentifierKeyValuePairFrom(
+                            node, out error);
+                    case "MultiLanguageProperty":
+                        return MultiLanguagePropertyFrom(
+                            node, out error);
+                    case "Operation":
+                        return OperationFrom(
+                            node, out error);
+                    case "Property":
+                        return PropertyFrom(
+                            node, out error);
+                    case "Qualifier":
+                        return QualifierFrom(
+                            node, out error);
+                    case "Range":
+                        return RangeFrom(
+                            node, out error);
+                    case "ReferenceElement":
+                        return ReferenceElementFrom(
+                            node, out error);
+                    case "Submodel":
+                        return SubmodelFrom(
+                            node, out error);
+                    case "SubmodelElementList":
+                        return SubmodelElementListFrom(
+                            node, out error);
+                    case "SubmodelElementStruct":
+                        return SubmodelElementStructFrom(
+                            node, out error);
                     default:
                         error = new Reporting.Error(
                             $"Unexpected model type for IHasSemantics: {modelType}");
@@ -553,54 +553,54 @@ namespace AasCore.Aas3
 
                 switch (modelType)
                 {
-                case "AnnotatedRelationshipElement":
-                    return AnnotatedRelationshipElementFrom(
-                        node, out error);
-                case "AssetAdministrationShell":
-                    return AssetAdministrationShellFrom(
-                        node, out error);
-                case "BasicEventElement":
-                    return BasicEventElementFrom(
-                        node, out error);
-                case "Blob":
-                    return BlobFrom(
-                        node, out error);
-                case "Capability":
-                    return CapabilityFrom(
-                        node, out error);
-                case "ConceptDescription":
-                    return ConceptDescriptionFrom(
-                        node, out error);
-                case "Entity":
-                    return EntityFrom(
-                        node, out error);
-                case "File":
-                    return FileFrom(
-                        node, out error);
-                case "MultiLanguageProperty":
-                    return MultiLanguagePropertyFrom(
-                        node, out error);
-                case "Operation":
-                    return OperationFrom(
-                        node, out error);
-                case "Property":
-                    return PropertyFrom(
-                        node, out error);
-                case "Range":
-                    return RangeFrom(
-                        node, out error);
-                case "ReferenceElement":
-                    return ReferenceElementFrom(
-                        node, out error);
-                case "Submodel":
-                    return SubmodelFrom(
-                        node, out error);
-                case "SubmodelElementList":
-                    return SubmodelElementListFrom(
-                        node, out error);
-                case "SubmodelElementStruct":
-                    return SubmodelElementStructFrom(
-                        node, out error);
+                    case "AnnotatedRelationshipElement":
+                        return AnnotatedRelationshipElementFrom(
+                            node, out error);
+                    case "AssetAdministrationShell":
+                        return AssetAdministrationShellFrom(
+                            node, out error);
+                    case "BasicEventElement":
+                        return BasicEventElementFrom(
+                            node, out error);
+                    case "Blob":
+                        return BlobFrom(
+                            node, out error);
+                    case "Capability":
+                        return CapabilityFrom(
+                            node, out error);
+                    case "ConceptDescription":
+                        return ConceptDescriptionFrom(
+                            node, out error);
+                    case "Entity":
+                        return EntityFrom(
+                            node, out error);
+                    case "File":
+                        return FileFrom(
+                            node, out error);
+                    case "MultiLanguageProperty":
+                        return MultiLanguagePropertyFrom(
+                            node, out error);
+                    case "Operation":
+                        return OperationFrom(
+                            node, out error);
+                    case "Property":
+                        return PropertyFrom(
+                            node, out error);
+                    case "Range":
+                        return RangeFrom(
+                            node, out error);
+                    case "ReferenceElement":
+                        return ReferenceElementFrom(
+                            node, out error);
+                    case "Submodel":
+                        return SubmodelFrom(
+                            node, out error);
+                    case "SubmodelElementList":
+                        return SubmodelElementListFrom(
+                            node, out error);
+                    case "SubmodelElementStruct":
+                        return SubmodelElementStructFrom(
+                            node, out error);
                     default:
                         error = new Reporting.Error(
                             $"Unexpected model type for IHasExtensions: {modelType}");
@@ -654,54 +654,54 @@ namespace AasCore.Aas3
 
                 switch (modelType)
                 {
-                case "AnnotatedRelationshipElement":
-                    return AnnotatedRelationshipElementFrom(
-                        node, out error);
-                case "AssetAdministrationShell":
-                    return AssetAdministrationShellFrom(
-                        node, out error);
-                case "BasicEventElement":
-                    return BasicEventElementFrom(
-                        node, out error);
-                case "Blob":
-                    return BlobFrom(
-                        node, out error);
-                case "Capability":
-                    return CapabilityFrom(
-                        node, out error);
-                case "ConceptDescription":
-                    return ConceptDescriptionFrom(
-                        node, out error);
-                case "Entity":
-                    return EntityFrom(
-                        node, out error);
-                case "File":
-                    return FileFrom(
-                        node, out error);
-                case "MultiLanguageProperty":
-                    return MultiLanguagePropertyFrom(
-                        node, out error);
-                case "Operation":
-                    return OperationFrom(
-                        node, out error);
-                case "Property":
-                    return PropertyFrom(
-                        node, out error);
-                case "Range":
-                    return RangeFrom(
-                        node, out error);
-                case "ReferenceElement":
-                    return ReferenceElementFrom(
-                        node, out error);
-                case "Submodel":
-                    return SubmodelFrom(
-                        node, out error);
-                case "SubmodelElementList":
-                    return SubmodelElementListFrom(
-                        node, out error);
-                case "SubmodelElementStruct":
-                    return SubmodelElementStructFrom(
-                        node, out error);
+                    case "AnnotatedRelationshipElement":
+                        return AnnotatedRelationshipElementFrom(
+                            node, out error);
+                    case "AssetAdministrationShell":
+                        return AssetAdministrationShellFrom(
+                            node, out error);
+                    case "BasicEventElement":
+                        return BasicEventElementFrom(
+                            node, out error);
+                    case "Blob":
+                        return BlobFrom(
+                            node, out error);
+                    case "Capability":
+                        return CapabilityFrom(
+                            node, out error);
+                    case "ConceptDescription":
+                        return ConceptDescriptionFrom(
+                            node, out error);
+                    case "Entity":
+                        return EntityFrom(
+                            node, out error);
+                    case "File":
+                        return FileFrom(
+                            node, out error);
+                    case "MultiLanguageProperty":
+                        return MultiLanguagePropertyFrom(
+                            node, out error);
+                    case "Operation":
+                        return OperationFrom(
+                            node, out error);
+                    case "Property":
+                        return PropertyFrom(
+                            node, out error);
+                    case "Range":
+                        return RangeFrom(
+                            node, out error);
+                    case "ReferenceElement":
+                        return ReferenceElementFrom(
+                            node, out error);
+                    case "Submodel":
+                        return SubmodelFrom(
+                            node, out error);
+                    case "SubmodelElementList":
+                        return SubmodelElementListFrom(
+                            node, out error);
+                    case "SubmodelElementStruct":
+                        return SubmodelElementStructFrom(
+                            node, out error);
                     default:
                         error = new Reporting.Error(
                             $"Unexpected model type for IReferable: {modelType}");
@@ -755,15 +755,15 @@ namespace AasCore.Aas3
 
                 switch (modelType)
                 {
-                case "AssetAdministrationShell":
-                    return AssetAdministrationShellFrom(
-                        node, out error);
-                case "ConceptDescription":
-                    return ConceptDescriptionFrom(
-                        node, out error);
-                case "Submodel":
-                    return SubmodelFrom(
-                        node, out error);
+                    case "AssetAdministrationShell":
+                        return AssetAdministrationShellFrom(
+                            node, out error);
+                    case "ConceptDescription":
+                        return ConceptDescriptionFrom(
+                            node, out error);
+                    case "Submodel":
+                        return SubmodelFrom(
+                            node, out error);
                     default:
                         error = new Reporting.Error(
                             $"Unexpected model type for IIdentifiable: {modelType}");
@@ -847,48 +847,48 @@ namespace AasCore.Aas3
 
                 switch (modelType)
                 {
-                case "AnnotatedRelationshipElement":
-                    return AnnotatedRelationshipElementFrom(
-                        node, out error);
-                case "BasicEventElement":
-                    return BasicEventElementFrom(
-                        node, out error);
-                case "Blob":
-                    return BlobFrom(
-                        node, out error);
-                case "Capability":
-                    return CapabilityFrom(
-                        node, out error);
-                case "Entity":
-                    return EntityFrom(
-                        node, out error);
-                case "File":
-                    return FileFrom(
-                        node, out error);
-                case "MultiLanguageProperty":
-                    return MultiLanguagePropertyFrom(
-                        node, out error);
-                case "Operation":
-                    return OperationFrom(
-                        node, out error);
-                case "Property":
-                    return PropertyFrom(
-                        node, out error);
-                case "Range":
-                    return RangeFrom(
-                        node, out error);
-                case "ReferenceElement":
-                    return ReferenceElementFrom(
-                        node, out error);
-                case "Submodel":
-                    return SubmodelFrom(
-                        node, out error);
-                case "SubmodelElementList":
-                    return SubmodelElementListFrom(
-                        node, out error);
-                case "SubmodelElementStruct":
-                    return SubmodelElementStructFrom(
-                        node, out error);
+                    case "AnnotatedRelationshipElement":
+                        return AnnotatedRelationshipElementFrom(
+                            node, out error);
+                    case "BasicEventElement":
+                        return BasicEventElementFrom(
+                            node, out error);
+                    case "Blob":
+                        return BlobFrom(
+                            node, out error);
+                    case "Capability":
+                        return CapabilityFrom(
+                            node, out error);
+                    case "Entity":
+                        return EntityFrom(
+                            node, out error);
+                    case "File":
+                        return FileFrom(
+                            node, out error);
+                    case "MultiLanguageProperty":
+                        return MultiLanguagePropertyFrom(
+                            node, out error);
+                    case "Operation":
+                        return OperationFrom(
+                            node, out error);
+                    case "Property":
+                        return PropertyFrom(
+                            node, out error);
+                    case "Range":
+                        return RangeFrom(
+                            node, out error);
+                    case "ReferenceElement":
+                        return ReferenceElementFrom(
+                            node, out error);
+                    case "Submodel":
+                        return SubmodelFrom(
+                            node, out error);
+                    case "SubmodelElementList":
+                        return SubmodelElementListFrom(
+                            node, out error);
+                    case "SubmodelElementStruct":
+                        return SubmodelElementStructFrom(
+                            node, out error);
                     default:
                         error = new Reporting.Error(
                             $"Unexpected model type for IHasKind: {modelType}");
@@ -942,57 +942,57 @@ namespace AasCore.Aas3
 
                 switch (modelType)
                 {
-                case "AdministrativeInformation":
-                    return AdministrativeInformationFrom(
-                        node, out error);
-                case "AnnotatedRelationshipElement":
-                    return AnnotatedRelationshipElementFrom(
-                        node, out error);
-                case "AssetAdministrationShell":
-                    return AssetAdministrationShellFrom(
-                        node, out error);
-                case "BasicEventElement":
-                    return BasicEventElementFrom(
-                        node, out error);
-                case "Blob":
-                    return BlobFrom(
-                        node, out error);
-                case "Capability":
-                    return CapabilityFrom(
-                        node, out error);
-                case "ConceptDescription":
-                    return ConceptDescriptionFrom(
-                        node, out error);
-                case "Entity":
-                    return EntityFrom(
-                        node, out error);
-                case "File":
-                    return FileFrom(
-                        node, out error);
-                case "MultiLanguageProperty":
-                    return MultiLanguagePropertyFrom(
-                        node, out error);
-                case "Operation":
-                    return OperationFrom(
-                        node, out error);
-                case "Property":
-                    return PropertyFrom(
-                        node, out error);
-                case "Range":
-                    return RangeFrom(
-                        node, out error);
-                case "ReferenceElement":
-                    return ReferenceElementFrom(
-                        node, out error);
-                case "Submodel":
-                    return SubmodelFrom(
-                        node, out error);
-                case "SubmodelElementList":
-                    return SubmodelElementListFrom(
-                        node, out error);
-                case "SubmodelElementStruct":
-                    return SubmodelElementStructFrom(
-                        node, out error);
+                    case "AdministrativeInformation":
+                        return AdministrativeInformationFrom(
+                            node, out error);
+                    case "AnnotatedRelationshipElement":
+                        return AnnotatedRelationshipElementFrom(
+                            node, out error);
+                    case "AssetAdministrationShell":
+                        return AssetAdministrationShellFrom(
+                            node, out error);
+                    case "BasicEventElement":
+                        return BasicEventElementFrom(
+                            node, out error);
+                    case "Blob":
+                        return BlobFrom(
+                            node, out error);
+                    case "Capability":
+                        return CapabilityFrom(
+                            node, out error);
+                    case "ConceptDescription":
+                        return ConceptDescriptionFrom(
+                            node, out error);
+                    case "Entity":
+                        return EntityFrom(
+                            node, out error);
+                    case "File":
+                        return FileFrom(
+                            node, out error);
+                    case "MultiLanguageProperty":
+                        return MultiLanguagePropertyFrom(
+                            node, out error);
+                    case "Operation":
+                        return OperationFrom(
+                            node, out error);
+                    case "Property":
+                        return PropertyFrom(
+                            node, out error);
+                    case "Range":
+                        return RangeFrom(
+                            node, out error);
+                    case "ReferenceElement":
+                        return ReferenceElementFrom(
+                            node, out error);
+                    case "Submodel":
+                        return SubmodelFrom(
+                            node, out error);
+                    case "SubmodelElementList":
+                        return SubmodelElementListFrom(
+                            node, out error);
+                    case "SubmodelElementStruct":
+                        return SubmodelElementStructFrom(
+                            node, out error);
                     default:
                         error = new Reporting.Error(
                             $"Unexpected model type for IHasDataSpecification: {modelType}");
@@ -1164,48 +1164,48 @@ namespace AasCore.Aas3
 
                 switch (modelType)
                 {
-                case "AnnotatedRelationshipElement":
-                    return AnnotatedRelationshipElementFrom(
-                        node, out error);
-                case "BasicEventElement":
-                    return BasicEventElementFrom(
-                        node, out error);
-                case "Blob":
-                    return BlobFrom(
-                        node, out error);
-                case "Capability":
-                    return CapabilityFrom(
-                        node, out error);
-                case "Entity":
-                    return EntityFrom(
-                        node, out error);
-                case "File":
-                    return FileFrom(
-                        node, out error);
-                case "MultiLanguageProperty":
-                    return MultiLanguagePropertyFrom(
-                        node, out error);
-                case "Operation":
-                    return OperationFrom(
-                        node, out error);
-                case "Property":
-                    return PropertyFrom(
-                        node, out error);
-                case "Range":
-                    return RangeFrom(
-                        node, out error);
-                case "ReferenceElement":
-                    return ReferenceElementFrom(
-                        node, out error);
-                case "Submodel":
-                    return SubmodelFrom(
-                        node, out error);
-                case "SubmodelElementList":
-                    return SubmodelElementListFrom(
-                        node, out error);
-                case "SubmodelElementStruct":
-                    return SubmodelElementStructFrom(
-                        node, out error);
+                    case "AnnotatedRelationshipElement":
+                        return AnnotatedRelationshipElementFrom(
+                            node, out error);
+                    case "BasicEventElement":
+                        return BasicEventElementFrom(
+                            node, out error);
+                    case "Blob":
+                        return BlobFrom(
+                            node, out error);
+                    case "Capability":
+                        return CapabilityFrom(
+                            node, out error);
+                    case "Entity":
+                        return EntityFrom(
+                            node, out error);
+                    case "File":
+                        return FileFrom(
+                            node, out error);
+                    case "MultiLanguageProperty":
+                        return MultiLanguagePropertyFrom(
+                            node, out error);
+                    case "Operation":
+                        return OperationFrom(
+                            node, out error);
+                    case "Property":
+                        return PropertyFrom(
+                            node, out error);
+                    case "Range":
+                        return RangeFrom(
+                            node, out error);
+                    case "ReferenceElement":
+                        return ReferenceElementFrom(
+                            node, out error);
+                    case "Submodel":
+                        return SubmodelFrom(
+                            node, out error);
+                    case "SubmodelElementList":
+                        return SubmodelElementListFrom(
+                            node, out error);
+                    case "SubmodelElementStruct":
+                        return SubmodelElementStructFrom(
+                            node, out error);
                     default:
                         error = new Reporting.Error(
                             $"Unexpected model type for IQualifiable: {modelType}");
@@ -2477,45 +2477,45 @@ namespace AasCore.Aas3
 
                 switch (modelType)
                 {
-                case "AnnotatedRelationshipElement":
-                    return AnnotatedRelationshipElementFrom(
-                        node, out error);
-                case "BasicEventElement":
-                    return BasicEventElementFrom(
-                        node, out error);
-                case "Blob":
-                    return BlobFrom(
-                        node, out error);
-                case "Capability":
-                    return CapabilityFrom(
-                        node, out error);
-                case "Entity":
-                    return EntityFrom(
-                        node, out error);
-                case "File":
-                    return FileFrom(
-                        node, out error);
-                case "MultiLanguageProperty":
-                    return MultiLanguagePropertyFrom(
-                        node, out error);
-                case "Operation":
-                    return OperationFrom(
-                        node, out error);
-                case "Property":
-                    return PropertyFrom(
-                        node, out error);
-                case "Range":
-                    return RangeFrom(
-                        node, out error);
-                case "ReferenceElement":
-                    return ReferenceElementFrom(
-                        node, out error);
-                case "SubmodelElementList":
-                    return SubmodelElementListFrom(
-                        node, out error);
-                case "SubmodelElementStruct":
-                    return SubmodelElementStructFrom(
-                        node, out error);
+                    case "AnnotatedRelationshipElement":
+                        return AnnotatedRelationshipElementFrom(
+                            node, out error);
+                    case "BasicEventElement":
+                        return BasicEventElementFrom(
+                            node, out error);
+                    case "Blob":
+                        return BlobFrom(
+                            node, out error);
+                    case "Capability":
+                        return CapabilityFrom(
+                            node, out error);
+                    case "Entity":
+                        return EntityFrom(
+                            node, out error);
+                    case "File":
+                        return FileFrom(
+                            node, out error);
+                    case "MultiLanguageProperty":
+                        return MultiLanguagePropertyFrom(
+                            node, out error);
+                    case "Operation":
+                        return OperationFrom(
+                            node, out error);
+                    case "Property":
+                        return PropertyFrom(
+                            node, out error);
+                    case "Range":
+                        return RangeFrom(
+                            node, out error);
+                    case "ReferenceElement":
+                        return ReferenceElementFrom(
+                            node, out error);
+                    case "SubmodelElementList":
+                        return SubmodelElementListFrom(
+                            node, out error);
+                    case "SubmodelElementStruct":
+                        return SubmodelElementStructFrom(
+                            node, out error);
                     default:
                         error = new Reporting.Error(
                             $"Unexpected model type for ISubmodelElement: {modelType}");
@@ -2569,9 +2569,9 @@ namespace AasCore.Aas3
 
                 switch (modelType)
                 {
-                case "AnnotatedRelationshipElement":
-                    return AnnotatedRelationshipElementFrom(
-                        node, out error);
+                    case "AnnotatedRelationshipElement":
+                        return AnnotatedRelationshipElementFrom(
+                            node, out error);
                     default:
                         error = new Reporting.Error(
                             $"Unexpected model type for IRelationshipElement: {modelType}");
@@ -3485,24 +3485,24 @@ namespace AasCore.Aas3
 
                 switch (modelType)
                 {
-                case "Blob":
-                    return BlobFrom(
-                        node, out error);
-                case "File":
-                    return FileFrom(
-                        node, out error);
-                case "MultiLanguageProperty":
-                    return MultiLanguagePropertyFrom(
-                        node, out error);
-                case "Property":
-                    return PropertyFrom(
-                        node, out error);
-                case "Range":
-                    return RangeFrom(
-                        node, out error);
-                case "ReferenceElement":
-                    return ReferenceElementFrom(
-                        node, out error);
+                    case "Blob":
+                        return BlobFrom(
+                            node, out error);
+                    case "File":
+                        return FileFrom(
+                            node, out error);
+                    case "MultiLanguageProperty":
+                        return MultiLanguagePropertyFrom(
+                            node, out error);
+                    case "Property":
+                        return PropertyFrom(
+                            node, out error);
+                    case "Range":
+                        return RangeFrom(
+                            node, out error);
+                    case "ReferenceElement":
+                        return ReferenceElementFrom(
+                            node, out error);
                     default:
                         error = new Reporting.Error(
                             $"Unexpected model type for IDataElement: {modelType}");
@@ -7040,9 +7040,9 @@ namespace AasCore.Aas3
 
                 switch (modelType)
                 {
-                case "BasicEventElement":
-                    return BasicEventElementFrom(
-                        node, out error);
+                    case "BasicEventElement":
+                        return BasicEventElementFrom(
+                            node, out error);
                     default:
                         error = new Reporting.Error(
                             $"Unexpected model type for IEventElement: {modelType}");
@@ -8820,12 +8820,12 @@ namespace AasCore.Aas3
 
                 switch (modelType)
                 {
-                case "GlobalReference":
-                    return GlobalReferenceFrom(
-                        node, out error);
-                case "ModelReference":
-                    return ModelReferenceFrom(
-                        node, out error);
+                    case "GlobalReference":
+                        return GlobalReferenceFrom(
+                            node, out error);
+                    case "ModelReference":
+                        return ModelReferenceFrom(
+                            node, out error);
                     default:
                         error = new Reporting.Error(
                             $"Unexpected model type for IReference: {modelType}");


### PR DESCRIPTION
There was a bug related to ``textwrap.dedent`` where we start the
template with an indention (``{I}``) which is later "eaten" by
``textwrap.dedent``.

We remove ``textwrap.dedent`` for these cases so that the formatting in
the generated code becomes correct.