### PR TITLE
Allow for subclass checks in intermediate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /venv39/
 /venv310/
 /deleteme.py
+/deleteme*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.idea/dictionaries/rist.xml
+++ b/.idea/dictionaries/rist.xml
@@ -90,6 +90,7 @@
       <w>stringified</w>
       <w>subscripted</w>
       <w>tchar</w>
+      <w>testgen</w>
       <w>todos</w>
       <w>transformator</w>
       <w>transpilation</w>

--- a/aas_core_codegen/intermediate/_types.py
+++ b/aas_core_codegen/intermediate/_types.py
@@ -14,6 +14,7 @@ from typing import (
     Set,
     Tuple,
     OrderedDict,
+    List,
 )
 
 import docutils.nodes
@@ -1218,6 +1219,29 @@ class Class(DBC):
     def inheritance_id_set(self) -> FrozenSet[int]:
         """Collect IDs (with :py:func:`id`) of the inheritance objects in a set."""
         return self._inheritance_id_set
+
+    def is_subclass_of(self, cls: "ClassUnion") -> bool:
+        """
+        Check recursively whether this class is a sub-class of ``cls``.
+
+        Every class is a sub-class of itself.
+        """
+        # NOTE (mristin, 2022-05-13):
+        # This function is not used by the aas-core-codegen, but by downstream clients
+        # such as aas-core3.0rc02-testgen.
+
+        if id(cls) == id(self):
+            return True
+
+        queue = [self]  # type: List[Class]
+        while len(queue) > 0:
+            top = queue.pop()
+            if id(cls) in top.inheritance_id_set:
+                return True
+
+            queue.extend(top.inheritances)
+
+        return False
 
     # endregion
 

--- a/tests/intermediate/test_types.py
+++ b/tests/intermediate/test_types.py
@@ -1,0 +1,174 @@
+# pylint: disable=missing-docstring
+
+import textwrap
+import unittest
+
+import tests.common
+from aas_core_codegen import intermediate
+from aas_core_codegen.common import Identifier
+
+
+class TestIsSubclassOf(unittest.TestCase):
+    def test_no_inheritances(self) -> None:
+        source = textwrap.dedent(
+            """\
+            class Concrete:
+                pass
+
+
+            class AnotherConcrete:
+                pass
+
+
+            __book_url__ = "dummy"
+            __book_version__ = "dummy"
+            """
+        )
+
+        symbol_table, error = tests.common.translate_source_to_intermediate(
+            source=source
+        )
+        assert error is None, tests.common.most_underlying_messages(error)
+
+        assert symbol_table is not None
+
+        concrete = symbol_table.must_find(Identifier("Concrete"))
+        assert isinstance(concrete, intermediate.ConcreteClass)
+
+        another_concrete = symbol_table.must_find(Identifier("AnotherConcrete"))
+        assert isinstance(another_concrete, intermediate.ConcreteClass)
+
+        self.assertTrue(concrete.is_subclass_of(cls=concrete))
+        self.assertFalse(concrete.is_subclass_of(cls=another_concrete))
+
+    def test_one_level_ancestor(self) -> None:
+        source = textwrap.dedent(
+            """\
+            class Parent:
+                pass
+
+
+            class Concrete(Parent):
+                pass
+
+
+            class AnotherConcrete:
+                pass
+
+
+            __book_url__ = "dummy"
+            __book_version__ = "dummy"
+            """
+        )
+
+        symbol_table, error = tests.common.translate_source_to_intermediate(
+            source=source
+        )
+        assert error is None, tests.common.most_underlying_messages(error)
+
+        assert symbol_table is not None
+
+        parent = symbol_table.must_find(Identifier("Parent"))
+        assert isinstance(parent, intermediate.ConcreteClass)
+
+        concrete = symbol_table.must_find(Identifier("Concrete"))
+        assert isinstance(concrete, intermediate.ConcreteClass)
+
+        another_concrete = symbol_table.must_find(Identifier("AnotherConcrete"))
+        assert isinstance(another_concrete, intermediate.ConcreteClass)
+
+        self.assertTrue(concrete.is_subclass_of(cls=concrete))
+        self.assertTrue(concrete.is_subclass_of(cls=parent))
+        self.assertFalse(concrete.is_subclass_of(cls=another_concrete))
+
+    def test_two_level_ancestor(self) -> None:
+        source = textwrap.dedent(
+            """\
+            class GrandParent:
+                pass
+
+
+            class Parent(GrandParent):
+                pass
+
+
+            class Concrete(Parent):
+                pass
+
+
+            class AnotherConcrete:
+                pass
+
+
+            __book_url__ = "dummy"
+            __book_version__ = "dummy"
+            """
+        )
+
+        symbol_table, error = tests.common.translate_source_to_intermediate(
+            source=source
+        )
+        assert error is None, tests.common.most_underlying_messages(error)
+
+        assert symbol_table is not None
+
+        grand_parent = symbol_table.must_find(Identifier("GrandParent"))
+        assert isinstance(grand_parent, intermediate.ConcreteClass)
+
+        parent = symbol_table.must_find(Identifier("Parent"))
+        assert isinstance(parent, intermediate.ConcreteClass)
+
+        concrete = symbol_table.must_find(Identifier("Concrete"))
+        assert isinstance(concrete, intermediate.ConcreteClass)
+
+        another_concrete = symbol_table.must_find(Identifier("AnotherConcrete"))
+        assert isinstance(another_concrete, intermediate.ConcreteClass)
+
+        self.assertTrue(concrete.is_subclass_of(cls=concrete))
+        self.assertTrue(concrete.is_subclass_of(cls=parent))
+        self.assertTrue(concrete.is_subclass_of(cls=grand_parent))
+        self.assertFalse(concrete.is_subclass_of(cls=another_concrete))
+
+    def test_common_ancestor_but_no_subclass(self) -> None:
+        source = textwrap.dedent(
+            """\
+            class Parent:
+                pass
+
+
+            class Concrete(Parent):
+                pass
+
+
+            class AnotherConcrete(Parent):
+                pass
+
+
+            __book_url__ = "dummy"
+            __book_version__ = "dummy"
+            """
+        )
+
+        symbol_table, error = tests.common.translate_source_to_intermediate(
+            source=source
+        )
+        assert error is None, tests.common.most_underlying_messages(error)
+
+        assert symbol_table is not None
+
+        parent = symbol_table.must_find(Identifier("Parent"))
+        assert isinstance(parent, intermediate.ConcreteClass)
+
+        concrete = symbol_table.must_find(Identifier("Concrete"))
+        assert isinstance(concrete, intermediate.ConcreteClass)
+
+        another_concrete = symbol_table.must_find(Identifier("AnotherConcrete"))
+        assert isinstance(another_concrete, intermediate.ConcreteClass)
+
+        self.assertTrue(concrete.is_subclass_of(cls=concrete))
+        self.assertTrue(concrete.is_subclass_of(cls=parent))
+        self.assertFalse(concrete.is_subclass_of(cls=another_concrete))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
We introduce a function to check for subclassing between two classes in
the intermediate layer to simplify the life of the downstream clients.