### PR TITLE
Make stringify output multi-line string

### DIFF
--- a/aas_core_codegen/stringify.py
+++ b/aas_core_codegen/stringify.py
@@ -71,8 +71,21 @@ class Entity:
 
 def dump(stringifiable: Stringifiable) -> str:
     """Produce a string representation of ``stringifiable`` for debugging or testing."""
-    if isinstance(stringifiable, (bool, int, float, str)):
+    if isinstance(stringifiable, (bool, int, float)):
         return repr(stringifiable)
+
+    elif isinstance(stringifiable, str):
+        if "\n" not in stringifiable or "\r" in stringifiable or '"""' in stringifiable:
+            return repr(stringifiable)
+
+        # NOTE (mristin, 2022-05-18):
+        # A multi-line string literal is much more readable when it comes to diffing.
+
+        escaped = stringifiable.replace("\\", "\\\\")
+
+        indented = "\n".join(f"  {line}" for line in escaped.splitlines())
+
+        return f'textwrap.dedent("""\\\n{indented}""")'
 
     elif isinstance(stringifiable, Entity):
         if len(stringifiable.properties) == 0:

--- a/test_data/intermediate/expected/class/inheritance/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/class/inheritance/expected_symbol_table.txt
@@ -89,7 +89,16 @@ SymbolTable(
               args=[
                 'some_property'],
               description=None,
-              body="Comparison(\n  left=Name(\n    identifier='some_property',\n    original_node=...),\n  op='GT',\n  right=Constant(\n    value=0,\n    original_node=...),\n  original_node=...)",
+              body=textwrap.dedent("""\
+                Comparison(
+                  left=Name(
+                    identifier='some_property',
+                    original_node=...),
+                  op='GT',
+                  right=Constant(
+                    value=0,
+                    original_node=...),
+                  original_node=...)"""),
               parsed=...)],
           snapshots=[],
           postconditions=[]),
@@ -97,7 +106,11 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='some_property',\n  argument='some_property',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='some_property',
+              argument='some_property',
+              default=None)""")]),
       invariants=[],
       serialization=Serialization(
         with_model_type=False),
@@ -255,7 +268,16 @@ SymbolTable(
               args=[
                 'another_property'],
               description=None,
-              body="Comparison(\n  left=Name(\n    identifier='another_property',\n    original_node=...),\n  op='GT',\n  right=Constant(\n    value=0,\n    original_node=...),\n  original_node=...)",
+              body=textwrap.dedent("""\
+                Comparison(
+                  left=Name(
+                    identifier='another_property',
+                    original_node=...),
+                  op='GT',
+                  right=Constant(
+                    value=0,
+                    original_node=...),
+                  original_node=...)"""),
               parsed=...)],
           snapshots=[],
           postconditions=[]),
@@ -263,8 +285,16 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='some_property',\n  argument='some_property',\n  default=None)",
-          "AssignArgument(\n  name='another_property',\n  argument='another_property',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='some_property',
+              argument='some_property',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='another_property',
+              argument='another_property',
+              default=None)""")]),
       invariants=[],
       serialization=Serialization(
         with_model_type=False),
@@ -393,7 +423,16 @@ SymbolTable(
               args=[
                 'yet_another_property'],
               description=None,
-              body="Comparison(\n  left=Name(\n    identifier='yet_another_property',\n    original_node=...),\n  op='GT',\n  right=Constant(\n    value=0,\n    original_node=...),\n  original_node=...)",
+              body=textwrap.dedent("""\
+                Comparison(
+                  left=Name(
+                    identifier='yet_another_property',
+                    original_node=...),
+                  op='GT',
+                  right=Constant(
+                    value=0,
+                    original_node=...),
+                  original_node=...)"""),
               parsed=...)],
           snapshots=[],
           postconditions=[]),
@@ -401,9 +440,21 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='some_property',\n  argument='some_property',\n  default=None)",
-          "AssignArgument(\n  name='another_property',\n  argument='another_property',\n  default=None)",
-          "AssignArgument(\n  name='yet_another_property',\n  argument='yet_another_property',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='some_property',
+              argument='some_property',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='another_property',
+              argument='another_property',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='yet_another_property',
+              argument='yet_another_property',
+              default=None)""")]),
       invariants=[],
       serialization=Serialization(
         with_model_type=False),

--- a/test_data/intermediate/expected/class/methods_with_contracts/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/class/methods_with_contracts/expected_symbol_table.txt
@@ -43,13 +43,34 @@ SymbolTable(
                 args=[
                   'number'],
                 description=None,
-                body="Comparison(\n  left=Name(\n    identifier='number',\n    original_node=...),\n  op='GT',\n  right=Constant(\n    value=0,\n    original_node=...),\n  original_node=...)",
+                body=textwrap.dedent("""\
+                  Comparison(
+                    left=Name(
+                      identifier='number',
+                      original_node=...),
+                    op='GT',
+                    right=Constant(
+                      value=0,
+                      original_node=...),
+                    original_node=...)"""),
                 parsed=...),
               Contract(
                 args=[
                   'self'],
                 description=None,
-                body="Comparison(\n  left=Member(\n    instance=Name(\n      identifier='self',\n      original_node=...),\n    name='x',\n    original_node=...),\n  op='GT',\n  right=Constant(\n    value=2,\n    original_node=...),\n  original_node=...)",
+                body=textwrap.dedent("""\
+                  Comparison(
+                    left=Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='x',
+                      original_node=...),
+                    op='GT',
+                    right=Constant(
+                      value=2,
+                      original_node=...),
+                    original_node=...)"""),
                 parsed=...)],
             snapshots=[],
             postconditions=[]),
@@ -74,7 +95,16 @@ SymbolTable(
               args=[
                 'x'],
               description=None,
-              body="Comparison(\n  left=Name(\n    identifier='x',\n    original_node=...),\n  op='GT',\n  right=Constant(\n    value=0,\n    original_node=...),\n  original_node=...)",
+              body=textwrap.dedent("""\
+                Comparison(
+                  left=Name(
+                    identifier='x',
+                    original_node=...),
+                  op='GT',
+                  right=Constant(
+                    value=0,
+                    original_node=...),
+                  original_node=...)"""),
               parsed=...)],
           snapshots=[],
           postconditions=[]),
@@ -82,7 +112,11 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='x',\n  argument='x',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='x',
+              argument='x',
+              default=None)""")]),
       invariants=[],
       serialization=Serialization(
         with_model_type=False),

--- a/test_data/intermediate/expected/class/only_property_no_method/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/class/only_property_no_method/expected_symbol_table.txt
@@ -38,7 +38,11 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='x',\n  argument='x',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='x',
+              argument='x',
+              default=None)""")]),
       invariants=[],
       serialization=Serialization(
         with_model_type=False),

--- a/test_data/intermediate/expected/interface/basic/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/interface/basic/expected_symbol_table.txt
@@ -77,7 +77,16 @@ SymbolTable(
               args=[
                 'some_property'],
               description=None,
-              body="Comparison(\n  left=Name(\n    identifier='some_property',\n    original_node=...),\n  op='GT',\n  right=Constant(\n    value=0,\n    original_node=...),\n  original_node=...)",
+              body=textwrap.dedent("""\
+                Comparison(
+                  left=Name(
+                    identifier='some_property',
+                    original_node=...),
+                  op='GT',
+                  right=Constant(
+                    value=0,
+                    original_node=...),
+                  original_node=...)"""),
               parsed=...)],
           snapshots=[],
           postconditions=[]),
@@ -85,7 +94,11 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='some_property',\n  argument='some_property',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='some_property',
+              argument='some_property',
+              default=None)""")]),
       invariants=[],
       serialization=Serialization(
         with_model_type=False),

--- a/test_data/intermediate/expected/interface/inheritance/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/interface/inheritance/expected_symbol_table.txt
@@ -77,7 +77,16 @@ SymbolTable(
               args=[
                 'some_property'],
               description=None,
-              body="Comparison(\n  left=Name(\n    identifier='some_property',\n    original_node=...),\n  op='GT',\n  right=Constant(\n    value=0,\n    original_node=...),\n  original_node=...)",
+              body=textwrap.dedent("""\
+                Comparison(
+                  left=Name(
+                    identifier='some_property',
+                    original_node=...),
+                  op='GT',
+                  right=Constant(
+                    value=0,
+                    original_node=...),
+                  original_node=...)"""),
               parsed=...)],
           snapshots=[],
           postconditions=[]),
@@ -85,7 +94,11 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='some_property',\n  argument='some_property',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='some_property',
+              argument='some_property',
+              default=None)""")]),
       invariants=[],
       serialization=Serialization(
         with_model_type=False),
@@ -221,7 +234,16 @@ SymbolTable(
               args=[
                 'another_property'],
               description=None,
-              body="Comparison(\n  left=Name(\n    identifier='another_property',\n    original_node=...),\n  op='GT',\n  right=Constant(\n    value=0,\n    original_node=...),\n  original_node=...)",
+              body=textwrap.dedent("""\
+                Comparison(
+                  left=Name(
+                    identifier='another_property',
+                    original_node=...),
+                  op='GT',
+                  right=Constant(
+                    value=0,
+                    original_node=...),
+                  original_node=...)"""),
               parsed=...)],
           snapshots=[],
           postconditions=[]),
@@ -229,8 +251,16 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='some_property',\n  argument='some_property',\n  default=None)",
-          "AssignArgument(\n  name='another_property',\n  argument='another_property',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='some_property',
+              argument='some_property',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='another_property',
+              argument='another_property',
+              default=None)""")]),
       invariants=[],
       serialization=Serialization(
         with_model_type=False),

--- a/test_data/intermediate/expected/interface/method_signature/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/interface/method_signature/expected_symbol_table.txt
@@ -32,7 +32,16 @@ SymbolTable(
                   args=[
                     'x'],
                   description=None,
-                  body="Comparison(\n  left=Name(\n    identifier='x',\n    original_node=...),\n  op='GT',\n  right=Constant(\n    value=0,\n    original_node=...),\n  original_node=...)",
+                  body=textwrap.dedent("""\
+                    Comparison(
+                      left=Name(
+                        identifier='x',
+                        original_node=...),
+                      op='GT',
+                      right=Constant(
+                        value=0,
+                        original_node=...),
+                      original_node=...)"""),
                   parsed=...)],
               snapshots=[],
               postconditions=[]),
@@ -66,7 +75,16 @@ SymbolTable(
                 args=[
                   'x'],
                 description=None,
-                body="Comparison(\n  left=Name(\n    identifier='x',\n    original_node=...),\n  op='GT',\n  right=Constant(\n    value=0,\n    original_node=...),\n  original_node=...)",
+                body=textwrap.dedent("""\
+                  Comparison(
+                    left=Name(
+                      identifier='x',
+                      original_node=...),
+                    op='GT',
+                    right=Constant(
+                      value=0,
+                      original_node=...),
+                    original_node=...)"""),
                 parsed=...)],
             snapshots=[],
             postconditions=[]),

--- a/test_data/intermediate/expected/interface/only_constructor/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/interface/only_constructor/expected_symbol_table.txt
@@ -56,7 +56,11 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='x',\n  argument='x',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='x',
+              argument='x',
+              default=None)""")]),
       invariants=[],
       serialization=Serialization(
         with_model_type=False),

--- a/test_data/intermediate/expected/type_annotation/atomic/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/type_annotation/atomic/expected_symbol_table.txt
@@ -38,7 +38,11 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='x',\n  argument='x',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='x',
+              argument='x',
+              default=None)""")]),
       invariants=[],
       serialization=Serialization(
         with_model_type=False),

--- a/test_data/intermediate/expected/type_annotation/subscripted/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/type_annotation/subscripted/expected_symbol_table.txt
@@ -79,7 +79,11 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='x',\n  argument='x',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='x',
+              argument='x',
+              default=None)""")]),
       invariants=[],
       serialization=Serialization(
         with_model_type=False),

--- a/test_data/intermediate/real_meta_models/aas_core_meta.v3rc2/expected_symbol_table.txt
+++ b/test_data/intermediate/real_meta_models/aas_core_meta.v3rc2/expected_symbol_table.txt
@@ -10,7 +10,20 @@ SymbolTable(
       invariants=[
         Invariant(
           description=None,
-          body="Comparison(\n  left=FunctionCall(\n    name='len',\n    args=[\n      Name(\n        identifier='self',\n        original_node=...)],\n    original_node=...),\n  op='GE',\n  right=Constant(\n    value=1,\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Comparison(
+              left=FunctionCall(
+                name='len',
+                args=[
+                  Name(
+                    identifier='self',
+                    original_node=...)],
+                original_node=...),
+              op='GE',
+              right=Constant(
+                value=1,
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to ConstrainedPrimitive Non_empty_string',
           parsed=...)],
       invariant_id_set=...,
@@ -31,12 +44,26 @@ SymbolTable(
       invariants=[
         Invariant(
           description=None,
-          body="FunctionCall(\n  name='matches_xs_date_time_stamp_utc',\n  args=[\n    Name(\n      identifier='self',\n      original_node=...)],\n  original_node=...)",
+          body=textwrap.dedent("""\
+            FunctionCall(
+              name='matches_xs_date_time_stamp_utc',
+              args=[
+                Name(
+                  identifier='self',
+                  original_node=...)],
+              original_node=...)"""),
           specified_for='Reference to ConstrainedPrimitive Date_time_stamp_UTC',
           parsed=...),
         Invariant(
           description=None,
-          body="FunctionCall(\n  name='is_xs_date_time_stamp_utc',\n  args=[\n    Name(\n      identifier='self',\n      original_node=...)],\n  original_node=...)",
+          body=textwrap.dedent("""\
+            FunctionCall(
+              name='is_xs_date_time_stamp_utc',
+              args=[
+                Name(
+                  identifier='self',
+                  original_node=...)],
+              original_node=...)"""),
           specified_for='Reference to ConstrainedPrimitive Date_time_stamp_UTC',
           parsed=...)],
       invariant_id_set=...,
@@ -81,7 +108,20 @@ SymbolTable(
       invariants=[
         Invariant(
           description=None,
-          body="Comparison(\n  left=FunctionCall(\n    name='len',\n    args=[\n      Name(\n        identifier='self',\n        original_node=...)],\n    original_node=...),\n  op='GE',\n  right=Constant(\n    value=1,\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Comparison(
+              left=FunctionCall(
+                name='len',
+                args=[
+                  Name(
+                    identifier='self',
+                    original_node=...)],
+                original_node=...),
+              op='GE',
+              right=Constant(
+                value=1,
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to ConstrainedPrimitive Non_empty_string',
           parsed=...)],
       invariant_id_set=...,
@@ -109,7 +149,14 @@ SymbolTable(
       invariants=[
         Invariant(
           description=None,
-          body="FunctionCall(\n  name='matches_BCP_47',\n  args=[\n    Name(\n      identifier='self',\n      original_node=...)],\n  original_node=...)",
+          body=textwrap.dedent("""\
+            FunctionCall(
+              name='matches_BCP_47',
+              args=[
+                Name(
+                  identifier='self',
+                  original_node=...)],
+              original_node=...)"""),
           specified_for='Reference to ConstrainedPrimitive BCP_47_language_tag',
           parsed=...)],
       invariant_id_set=...,
@@ -132,12 +179,32 @@ SymbolTable(
       invariants=[
         Invariant(
           description=None,
-          body="Comparison(\n  left=FunctionCall(\n    name='len',\n    args=[\n      Name(\n        identifier='self',\n        original_node=...)],\n    original_node=...),\n  op='GE',\n  right=Constant(\n    value=1,\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Comparison(
+              left=FunctionCall(
+                name='len',
+                args=[
+                  Name(
+                    identifier='self',
+                    original_node=...)],
+                original_node=...),
+              op='GE',
+              right=Constant(
+                value=1,
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to ConstrainedPrimitive Non_empty_string',
           parsed=...),
         Invariant(
           description=None,
-          body="FunctionCall(\n  name='matches_MIME_type',\n  args=[\n    Name(\n      identifier='self',\n      original_node=...)],\n  original_node=...)",
+          body=textwrap.dedent("""\
+            FunctionCall(
+              name='matches_MIME_type',
+              args=[
+                Name(
+                  identifier='self',
+                  original_node=...)],
+              original_node=...)"""),
           specified_for='Reference to ConstrainedPrimitive Content_type',
           parsed=...)],
       invariant_id_set=...,
@@ -153,7 +220,15 @@ SymbolTable(
         summary='<paragraph>string</paragraph>',
         remarks=[
           '<note><paragraph>Any content type as in RFC2046.</paragraph></note>',
-          '<paragraph>A media type (also MIME type and content type) […] is a two-part\nidentifier for file formats and format contents transmitted on\nthe Internet. The Internet Assigned Numbers Authority (IANA) is\nthe official authority for the standardization and publication of\nthese classifications. Media types were originally defined in\nRequest for Comments 2045 in November 1996 as a part of MIME\n(Multipurpose Internet Mail Extensions) specification, for denoting\ntype of email message content and attachments.</paragraph>'],
+          textwrap.dedent("""\
+            <paragraph>A media type (also MIME type and content type) […] is a two-part
+            identifier for file formats and format contents transmitted on
+            the Internet. The Internet Assigned Numbers Authority (IANA) is
+            the official authority for the standardization and publication of
+            these classifications. Media types were originally defined in
+            Request for Comments 2045 in November 1996 as a part of MIME
+            (Multipurpose Internet Mail Extensions) specification, for denoting
+            type of email message content and attachments.</paragraph>""")],
         constraints_by_identifier=[],
         parsed=...),
       parsed=...),
@@ -168,12 +243,32 @@ SymbolTable(
       invariants=[
         Invariant(
           description=None,
-          body="Comparison(\n  left=FunctionCall(\n    name='len',\n    args=[\n      Name(\n        identifier='self',\n        original_node=...)],\n    original_node=...),\n  op='GE',\n  right=Constant(\n    value=1,\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Comparison(
+              left=FunctionCall(
+                name='len',
+                args=[
+                  Name(
+                    identifier='self',
+                    original_node=...)],
+                original_node=...),
+              op='GE',
+              right=Constant(
+                value=1,
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to ConstrainedPrimitive Non_empty_string',
           parsed=...),
         Invariant(
           description=None,
-          body="FunctionCall(\n  name='matches_RFC_8089_path',\n  args=[\n    Name(\n      identifier='self',\n      original_node=...)],\n  original_node=...)",
+          body=textwrap.dedent("""\
+            FunctionCall(
+              name='matches_RFC_8089_path',
+              args=[
+                Name(
+                  identifier='self',
+                  original_node=...)],
+              original_node=...)"""),
           specified_for='Reference to ConstrainedPrimitive Path_type',
           parsed=...)],
       invariant_id_set=...,
@@ -188,7 +283,9 @@ SymbolTable(
       description=SymbolDescription(
         summary='<paragraph>string</paragraph>',
         remarks=[
-          '<note><paragraph>Any string conformant to RFC8089 , the “file” URI scheme (for\nrelative and absolute file paths)</paragraph></note>'],
+          textwrap.dedent("""\
+            <note><paragraph>Any string conformant to RFC8089 , the “file” URI scheme (for
+            relative and absolute file paths)</paragraph></note>""")],
         constraints_by_identifier=[],
         parsed=...),
       parsed=...),
@@ -203,7 +300,20 @@ SymbolTable(
       invariants=[
         Invariant(
           description=None,
-          body="Comparison(\n  left=FunctionCall(\n    name='len',\n    args=[\n      Name(\n        identifier='self',\n        original_node=...)],\n    original_node=...),\n  op='GE',\n  right=Constant(\n    value=1,\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Comparison(
+              left=FunctionCall(
+                name='len',
+                args=[
+                  Name(
+                    identifier='self',
+                    original_node=...)],
+                original_node=...),
+              op='GE',
+              right=Constant(
+                value=1,
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to ConstrainedPrimitive Non_empty_string',
           parsed=...)],
       invariant_id_set=...,
@@ -252,7 +362,9 @@ SymbolTable(
             symbol='Reference to symbol Asset_kind',
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Path and name of the resource (with file extension).\nThe path can be absolute or relative.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Path and name of the resource (with file extension).
+              The path can be absolute or relative.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -266,7 +378,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Content type of the content of the file.\nThe content type states which file extensions the file can have.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Content type of the content of the file.
+              The content type states which file extensions the file can have.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -304,14 +418,24 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='path',\n  argument='path',\n  default=None)",
-          "AssignArgument(\n  name='content_type',\n  argument='content_type',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='path',
+              argument='path',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='content_type',
+              argument='content_type',
+              default=None)""")]),
       invariants=[],
       serialization=Serialization(
         with_model_type=False),
       reference_in_the_book=None,
       description=SymbolDescription(
-        summary='<paragraph>Resource represents an address to a file (a locator). The value is an URI that\ncan represent an absolute or relative path</paragraph>',
+        summary=textwrap.dedent("""\
+          <paragraph>Resource represents an address to a file (a locator). The value is an URI that
+          can represent an absolute or relative path</paragraph>"""),
         remarks=[],
         constraints_by_identifier=[],
         parsed=...),
@@ -356,7 +480,9 @@ SymbolTable(
                 parsed=...),
               parsed=...),
             description=PropertyDescription(
-              summary='<paragraph>Identifier of the semantic definition of the element. It is called semantic ID\nof the element.</paragraph>',
+              summary=textwrap.dedent("""\
+                <paragraph>Identifier of the semantic definition of the element. It is called semantic ID
+                of the element.</paragraph>"""),
               remarks=[],
               constraints_by_identifier=[],
               parsed=...),
@@ -399,7 +525,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Identifier of the semantic definition of the element. It is called semantic ID\nof the element.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Identifier of the semantic definition of the element. It is called semantic ID
+              of the element.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -430,7 +558,11 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='semantic_id',\n  argument='semantic_id',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='semantic_id',
+              argument='semantic_id',
+              default=None)""")]),
       invariants=[],
       serialization=Serialization(
         with_model_type=False),
@@ -470,7 +602,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Identifier of the semantic definition of the element. It is called semantic ID\nof the element.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Identifier of the semantic definition of the element. It is called semantic ID
+              of the element.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -599,11 +733,31 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='semantic_id',\n  argument='semantic_id',\n  default=None)",
-          "AssignArgument(\n  name='name',\n  argument='name',\n  default=None)",
-          "AssignArgument(\n  name='value_type',\n  argument='value_type',\n  default=None)",
-          "AssignArgument(\n  name='value',\n  argument='value',\n  default=None)",
-          "AssignArgument(\n  name='refers_to',\n  argument='refers_to',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='semantic_id',
+              argument='semantic_id',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='name',
+              argument='name',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='value_type',
+              argument='value_type',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='value',
+              argument='value',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='refers_to',
+              argument='refers_to',
+              default=None)""")]),
       invariants=[],
       serialization=Serialization(
         with_model_type=False),
@@ -740,11 +894,35 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='extensions',\n  argument='extensions',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='extensions',
+              argument='extensions',
+              default=None)""")]),
       invariants=[
         Invariant(
           description='Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='extensions',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='extension_names_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='extensions',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='extension_names_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='extensions',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...)],
       serialization=Serialization(
@@ -821,13 +999,21 @@ SymbolTable(
                 parsed=...),
               parsed=...),
             description=PropertyDescription(
-              summary='<paragraph>In case of identifiables this attribute is a short name of the element.\nIn case of referable this ID is an identifying string of\nthe element within its name space.</paragraph>',
+              summary=textwrap.dedent("""\
+                <paragraph>In case of identifiables this attribute is a short name of the element.
+                In case of referable this ID is an identifying string of
+                the element within its name space.</paragraph>"""),
               remarks=[
-                '<note><paragraph>In case the element is a property and the property has a semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>\nis typically identical to the short name in English.</paragraph></note>'],
+                textwrap.dedent("""\
+                  <note><paragraph>In case the element is a property and the property has a semantic definition
+                  (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>
+                  is typically identical to the short name in English.</paragraph></note>""")],
               constraints_by_identifier=[
                 [
                   'AASd-027',
-                  '<field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>\'s shall have a maximum length\nof 128 characters.</paragraph></field_body>']],
+                  textwrap.dedent("""\
+                    <field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>'s shall have a maximum length
+                    of 128 characters.</paragraph></field_body>""")]],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
             parsed=...),
@@ -841,8 +1027,15 @@ SymbolTable(
             description=PropertyDescription(
               summary='<paragraph>Display name. Can be provided in several languages.</paragraph>',
               remarks=[
-                '<paragraph>If no display name is defined in the language requested by the application,\nthen the display name is selected in the following order if available:</paragraph>',
-                '<bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,\nthen the corresponding preferred name in the language is chosen\naccording to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>'],
+                textwrap.dedent("""\
+                  <paragraph>If no display name is defined in the language requested by the application,
+                  then the display name is selected in the following order if available:</paragraph>"""),
+                textwrap.dedent("""\
+                  <bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining
+                  the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
+                  then the corresponding preferred name in the language is chosen
+                  according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
+                  the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -855,9 +1048,18 @@ SymbolTable(
                 parsed=...),
               parsed=...),
             description=PropertyDescription(
-              summary='<paragraph>The category is a value that gives further meta information\nw.r.t. to the class of the element.\nIt affects the expected existence of attributes and the applicability of\nconstraints.</paragraph>',
+              summary=textwrap.dedent("""\
+                <paragraph>The category is a value that gives further meta information
+                w.r.t. to the class of the element.
+                It affects the expected existence of attributes and the applicability of
+                constraints.</paragraph>"""),
               remarks=[
-                '<note><paragraph>The category is not identical to the semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category\n<emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the\nsemantic definition of the element would\ndenote that it is the measured temperature.</paragraph></note>'],
+                textwrap.dedent("""\
+                  <note><paragraph>The category is not identical to the semantic definition
+                  (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category
+                  <emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the
+                  semantic definition of the element would
+                  denote that it is the measured temperature.</paragraph></note>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -873,8 +1075,14 @@ SymbolTable(
               summary='<paragraph>Description or comments on the element.</paragraph>',
               remarks=[
                 '<paragraph>The description can be provided in several languages.</paragraph>',
-                '<paragraph>If no description is defined, then the definition of the concept\ndescription that defines the semantics of the element is used.</paragraph>',
-                '<paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is\nqualified and which qualifier types can be expected in which\ncontext or which additional data specification templates are\nprovided.</paragraph>'],
+                textwrap.dedent("""\
+                  <paragraph>If no description is defined, then the definition of the concept
+                  description that defines the semantics of the element is used.</paragraph>"""),
+                textwrap.dedent("""\
+                  <paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is
+                  qualified and which qualifier types can be expected in which
+                  context or which additional data specification templates are
+                  provided.</paragraph>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -887,9 +1095,15 @@ SymbolTable(
                 parsed=...),
               parsed=...),
             description=PropertyDescription(
-              summary='<paragraph>Checksum to be used to determine if an Referable (including its\naggregated child elements) has changed.</paragraph>',
+              summary=textwrap.dedent("""\
+                <paragraph>Checksum to be used to determine if an Referable (including its
+                aggregated child elements) has changed.</paragraph>"""),
               remarks=[
-                "<paragraph>The checksum is calculated by the user's tool environment.\nThe checksum has no semantic meaning for an asset administration\nshell model and there is no requirement for asset administration\nshell tools to manage the checksum</paragraph>"],
+                textwrap.dedent("""\
+                  <paragraph>The checksum is calculated by the user's tool environment.
+                  The checksum has no semantic meaning for an asset administration
+                  shell model and there is no requirement for asset administration
+                  shell tools to manage the checksum</paragraph>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -898,7 +1112,9 @@ SymbolTable(
         description=SymbolDescription(
           summary='<paragraph>An element that is referable by its <AttributeReference refuri="~id_short">~id_short</AttributeReference>.</paragraph>',
           remarks=[
-            '<paragraph>This identifier is not globally unique.\nThis identifier is unique within the name space of the element.</paragraph>'],
+            textwrap.dedent("""\
+              <paragraph>This identifier is not globally unique.
+              This identifier is unique within the name space of the element.</paragraph>""")],
           constraints_by_identifier=[],
           parsed=...),
         parsed=...,
@@ -947,13 +1163,21 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>In case of identifiables this attribute is a short name of the element.\nIn case of referable this ID is an identifying string of\nthe element within its name space.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>In case of identifiables this attribute is a short name of the element.
+              In case of referable this ID is an identifying string of
+              the element within its name space.</paragraph>"""),
             remarks=[
-              '<note><paragraph>In case the element is a property and the property has a semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>\nis typically identical to the short name in English.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>In case the element is a property and the property has a semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>
+                is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[
               [
                 'AASd-027',
-                '<field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>\'s shall have a maximum length\nof 128 characters.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>'s shall have a maximum length
+                  of 128 characters.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
@@ -967,8 +1191,15 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>Display name. Can be provided in several languages.</paragraph>',
             remarks=[
-              '<paragraph>If no display name is defined in the language requested by the application,\nthen the display name is selected in the following order if available:</paragraph>',
-              '<bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,\nthen the corresponding preferred name in the language is chosen\naccording to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>'],
+              textwrap.dedent("""\
+                <paragraph>If no display name is defined in the language requested by the application,
+                then the display name is selected in the following order if available:</paragraph>"""),
+              textwrap.dedent("""\
+                <bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
+                then the corresponding preferred name in the language is chosen
+                according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -981,9 +1212,18 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>The category is a value that gives further meta information\nw.r.t. to the class of the element.\nIt affects the expected existence of attributes and the applicability of\nconstraints.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>The category is a value that gives further meta information
+              w.r.t. to the class of the element.
+              It affects the expected existence of attributes and the applicability of
+              constraints.</paragraph>"""),
             remarks=[
-              '<note><paragraph>The category is not identical to the semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category\n<emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the\nsemantic definition of the element would\ndenote that it is the measured temperature.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>The category is not identical to the semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category
+                <emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the
+                semantic definition of the element would
+                denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -999,8 +1239,14 @@ SymbolTable(
             summary='<paragraph>Description or comments on the element.</paragraph>',
             remarks=[
               '<paragraph>The description can be provided in several languages.</paragraph>',
-              '<paragraph>If no description is defined, then the definition of the concept\ndescription that defines the semantics of the element is used.</paragraph>',
-              '<paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is\nqualified and which qualifier types can be expected in which\ncontext or which additional data specification templates are\nprovided.</paragraph>'],
+              textwrap.dedent("""\
+                <paragraph>If no description is defined, then the definition of the concept
+                description that defines the semantics of the element is used.</paragraph>"""),
+              textwrap.dedent("""\
+                <paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is
+                qualified and which qualifier types can be expected in which
+                context or which additional data specification templates are
+                provided.</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -1013,9 +1259,15 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Checksum to be used to determine if an Referable (including its\naggregated child elements) has changed.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Checksum to be used to determine if an Referable (including its
+              aggregated child elements) has changed.</paragraph>"""),
             remarks=[
-              "<paragraph>The checksum is calculated by the user's tool environment.\nThe checksum has no semantic meaning for an asset administration\nshell model and there is no requirement for asset administration\nshell tools to manage the checksum</paragraph>"],
+              textwrap.dedent("""\
+                <paragraph>The checksum is calculated by the user's tool environment.
+                The checksum has no semantic meaning for an asset administration
+                shell model and there is no requirement for asset administration
+                shell tools to manage the checksum</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -1102,21 +1354,91 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='extensions',\n  argument='extensions',\n  default=None)",
-          "AssignArgument(\n  name='id_short',\n  argument='id_short',\n  default=None)",
-          "AssignArgument(\n  name='display_name',\n  argument='display_name',\n  default=None)",
-          "AssignArgument(\n  name='category',\n  argument='category',\n  default=None)",
-          "AssignArgument(\n  name='description',\n  argument='description',\n  default=None)",
-          "AssignArgument(\n  name='checksum',\n  argument='checksum',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='extensions',
+              argument='extensions',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='id_short',
+              argument='id_short',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='display_name',
+              argument='display_name',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='category',
+              argument='category',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='description',
+              argument='description',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='checksum',
+              argument='checksum',
+              default=None)""")]),
       invariants=[
         Invariant(
           description='Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='extensions',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='extension_names_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='extensions',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='extension_names_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='extensions',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
           description='Constraint AASd-027: ID-short shall have a maximum length of 128 characters.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='id_short',\n      original_node=...),\n    original_node=...),\n  consequent=Comparison(\n    left=FunctionCall(\n      name='len',\n      args=[\n        Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='id_short',\n          original_node=...)],\n      original_node=...),\n    op='LE',\n    right=Constant(\n      value=128,\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='id_short',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='id_short',
+                      original_node=...)],
+                  original_node=...),
+                op='LE',
+                right=Constant(
+                  value=128,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Referable',
           parsed=...)],
       serialization=Serialization(
@@ -1132,7 +1454,9 @@ SymbolTable(
       description=SymbolDescription(
         summary='<paragraph>An element that is referable by its <AttributeReference refuri="~id_short">~id_short</AttributeReference>.</paragraph>',
         remarks=[
-          '<paragraph>This identifier is not globally unique.\nThis identifier is unique within the name space of the element.</paragraph>'],
+          textwrap.dedent("""\
+            <paragraph>This identifier is not globally unique.
+            This identifier is unique within the name space of the element.</paragraph>""")],
         constraints_by_identifier=[],
         parsed=...),
       parsed=...,
@@ -1180,13 +1504,21 @@ SymbolTable(
                 parsed=...),
               parsed=...),
             description=PropertyDescription(
-              summary='<paragraph>In case of identifiables this attribute is a short name of the element.\nIn case of referable this ID is an identifying string of\nthe element within its name space.</paragraph>',
+              summary=textwrap.dedent("""\
+                <paragraph>In case of identifiables this attribute is a short name of the element.
+                In case of referable this ID is an identifying string of
+                the element within its name space.</paragraph>"""),
               remarks=[
-                '<note><paragraph>In case the element is a property and the property has a semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>\nis typically identical to the short name in English.</paragraph></note>'],
+                textwrap.dedent("""\
+                  <note><paragraph>In case the element is a property and the property has a semantic definition
+                  (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>
+                  is typically identical to the short name in English.</paragraph></note>""")],
               constraints_by_identifier=[
                 [
                   'AASd-027',
-                  '<field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>\'s shall have a maximum length\nof 128 characters.</paragraph></field_body>']],
+                  textwrap.dedent("""\
+                    <field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>'s shall have a maximum length
+                    of 128 characters.</paragraph></field_body>""")]],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
             parsed=...),
@@ -1200,8 +1532,15 @@ SymbolTable(
             description=PropertyDescription(
               summary='<paragraph>Display name. Can be provided in several languages.</paragraph>',
               remarks=[
-                '<paragraph>If no display name is defined in the language requested by the application,\nthen the display name is selected in the following order if available:</paragraph>',
-                '<bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,\nthen the corresponding preferred name in the language is chosen\naccording to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>'],
+                textwrap.dedent("""\
+                  <paragraph>If no display name is defined in the language requested by the application,
+                  then the display name is selected in the following order if available:</paragraph>"""),
+                textwrap.dedent("""\
+                  <bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining
+                  the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
+                  then the corresponding preferred name in the language is chosen
+                  according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
+                  the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -1214,9 +1553,18 @@ SymbolTable(
                 parsed=...),
               parsed=...),
             description=PropertyDescription(
-              summary='<paragraph>The category is a value that gives further meta information\nw.r.t. to the class of the element.\nIt affects the expected existence of attributes and the applicability of\nconstraints.</paragraph>',
+              summary=textwrap.dedent("""\
+                <paragraph>The category is a value that gives further meta information
+                w.r.t. to the class of the element.
+                It affects the expected existence of attributes and the applicability of
+                constraints.</paragraph>"""),
               remarks=[
-                '<note><paragraph>The category is not identical to the semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category\n<emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the\nsemantic definition of the element would\ndenote that it is the measured temperature.</paragraph></note>'],
+                textwrap.dedent("""\
+                  <note><paragraph>The category is not identical to the semantic definition
+                  (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category
+                  <emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the
+                  semantic definition of the element would
+                  denote that it is the measured temperature.</paragraph></note>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -1232,8 +1580,14 @@ SymbolTable(
               summary='<paragraph>Description or comments on the element.</paragraph>',
               remarks=[
                 '<paragraph>The description can be provided in several languages.</paragraph>',
-                '<paragraph>If no description is defined, then the definition of the concept\ndescription that defines the semantics of the element is used.</paragraph>',
-                '<paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is\nqualified and which qualifier types can be expected in which\ncontext or which additional data specification templates are\nprovided.</paragraph>'],
+                textwrap.dedent("""\
+                  <paragraph>If no description is defined, then the definition of the concept
+                  description that defines the semantics of the element is used.</paragraph>"""),
+                textwrap.dedent("""\
+                  <paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is
+                  qualified and which qualifier types can be expected in which
+                  context or which additional data specification templates are
+                  provided.</paragraph>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -1246,9 +1600,15 @@ SymbolTable(
                 parsed=...),
               parsed=...),
             description=PropertyDescription(
-              summary='<paragraph>Checksum to be used to determine if an Referable (including its\naggregated child elements) has changed.</paragraph>',
+              summary=textwrap.dedent("""\
+                <paragraph>Checksum to be used to determine if an Referable (including its
+                aggregated child elements) has changed.</paragraph>"""),
               remarks=[
-                "<paragraph>The checksum is calculated by the user's tool environment.\nThe checksum has no semantic meaning for an asset administration\nshell model and there is no requirement for asset administration\nshell tools to manage the checksum</paragraph>"],
+                textwrap.dedent("""\
+                  <paragraph>The checksum is calculated by the user's tool environment.
+                  The checksum has no semantic meaning for an asset administration
+                  shell model and there is no requirement for asset administration
+                  shell tools to manage the checksum</paragraph>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -1275,7 +1635,9 @@ SymbolTable(
             description=PropertyDescription(
               summary='<paragraph>Administrative information of an identifiable element.</paragraph>',
               remarks=[
-                '<note><paragraph>Some of the administrative information like the version number might need to\nbe part of the identification.</paragraph></note>'],
+                textwrap.dedent("""\
+                  <note><paragraph>Some of the administrative information like the version number might need to
+                  be part of the identification.</paragraph></note>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Identifiable',
@@ -1319,13 +1681,21 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>In case of identifiables this attribute is a short name of the element.\nIn case of referable this ID is an identifying string of\nthe element within its name space.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>In case of identifiables this attribute is a short name of the element.
+              In case of referable this ID is an identifying string of
+              the element within its name space.</paragraph>"""),
             remarks=[
-              '<note><paragraph>In case the element is a property and the property has a semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>\nis typically identical to the short name in English.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>In case the element is a property and the property has a semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>
+                is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[
               [
                 'AASd-027',
-                '<field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>\'s shall have a maximum length\nof 128 characters.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>'s shall have a maximum length
+                  of 128 characters.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
@@ -1339,8 +1709,15 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>Display name. Can be provided in several languages.</paragraph>',
             remarks=[
-              '<paragraph>If no display name is defined in the language requested by the application,\nthen the display name is selected in the following order if available:</paragraph>',
-              '<bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,\nthen the corresponding preferred name in the language is chosen\naccording to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>'],
+              textwrap.dedent("""\
+                <paragraph>If no display name is defined in the language requested by the application,
+                then the display name is selected in the following order if available:</paragraph>"""),
+              textwrap.dedent("""\
+                <bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
+                then the corresponding preferred name in the language is chosen
+                according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -1353,9 +1730,18 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>The category is a value that gives further meta information\nw.r.t. to the class of the element.\nIt affects the expected existence of attributes and the applicability of\nconstraints.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>The category is a value that gives further meta information
+              w.r.t. to the class of the element.
+              It affects the expected existence of attributes and the applicability of
+              constraints.</paragraph>"""),
             remarks=[
-              '<note><paragraph>The category is not identical to the semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category\n<emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the\nsemantic definition of the element would\ndenote that it is the measured temperature.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>The category is not identical to the semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category
+                <emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the
+                semantic definition of the element would
+                denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -1371,8 +1757,14 @@ SymbolTable(
             summary='<paragraph>Description or comments on the element.</paragraph>',
             remarks=[
               '<paragraph>The description can be provided in several languages.</paragraph>',
-              '<paragraph>If no description is defined, then the definition of the concept\ndescription that defines the semantics of the element is used.</paragraph>',
-              '<paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is\nqualified and which qualifier types can be expected in which\ncontext or which additional data specification templates are\nprovided.</paragraph>'],
+              textwrap.dedent("""\
+                <paragraph>If no description is defined, then the definition of the concept
+                description that defines the semantics of the element is used.</paragraph>"""),
+              textwrap.dedent("""\
+                <paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is
+                qualified and which qualifier types can be expected in which
+                context or which additional data specification templates are
+                provided.</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -1385,9 +1777,15 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Checksum to be used to determine if an Referable (including its\naggregated child elements) has changed.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Checksum to be used to determine if an Referable (including its
+              aggregated child elements) has changed.</paragraph>"""),
             remarks=[
-              "<paragraph>The checksum is calculated by the user's tool environment.\nThe checksum has no semantic meaning for an asset administration\nshell model and there is no requirement for asset administration\nshell tools to manage the checksum</paragraph>"],
+              textwrap.dedent("""\
+                <paragraph>The checksum is calculated by the user's tool environment.
+                The checksum has no semantic meaning for an asset administration
+                shell model and there is no requirement for asset administration
+                shell tools to manage the checksum</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -1414,7 +1812,9 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>Administrative information of an identifiable element.</paragraph>',
             remarks=[
-              '<note><paragraph>Some of the administrative information like the version number might need to\nbe part of the identification.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>Some of the administrative information like the version number might need to
+                be part of the identification.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Identifiable',
@@ -1519,23 +1919,101 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='extensions',\n  argument='extensions',\n  default=None)",
-          "AssignArgument(\n  name='id_short',\n  argument='id_short',\n  default=None)",
-          "AssignArgument(\n  name='display_name',\n  argument='display_name',\n  default=None)",
-          "AssignArgument(\n  name='category',\n  argument='category',\n  default=None)",
-          "AssignArgument(\n  name='description',\n  argument='description',\n  default=None)",
-          "AssignArgument(\n  name='checksum',\n  argument='checksum',\n  default=None)",
-          "AssignArgument(\n  name='ID',\n  argument='ID',\n  default=None)",
-          "AssignArgument(\n  name='administration',\n  argument='administration',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='extensions',
+              argument='extensions',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='id_short',
+              argument='id_short',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='display_name',
+              argument='display_name',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='category',
+              argument='category',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='description',
+              argument='description',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='checksum',
+              argument='checksum',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='ID',
+              argument='ID',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='administration',
+              argument='administration',
+              default=None)""")]),
       invariants=[
         Invariant(
           description='Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='extensions',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='extension_names_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='extensions',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='extension_names_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='extensions',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
           description='Constraint AASd-027: ID-short shall have a maximum length of 128 characters.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='id_short',\n      original_node=...),\n    original_node=...),\n  consequent=Comparison(\n    left=FunctionCall(\n      name='len',\n      args=[\n        Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='id_short',\n          original_node=...)],\n      original_node=...),\n    op='LE',\n    right=Constant(\n      value=128,\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='id_short',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='id_short',
+                      original_node=...)],
+                  original_node=...),
+                op='LE',
+                right=Constant(
+                  value=128,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Referable',
           parsed=...)],
       serialization=Serialization(
@@ -1565,7 +2043,9 @@ SymbolTable(
           name='Template',
           value='TEMPLATE',
           description=EnumerationLiteralDescription(
-            summary='<paragraph>Software element which specifies the common attributes shared by all instances of\nthe template.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Software element which specifies the common attributes shared by all instances of
+              the template.</paragraph>"""),
             remarks=[
               '<paragraph>[SOURCE: IEC TR 62390:2005-01, 3.1.25] modified</paragraph>'],
             parsed=...),
@@ -1576,8 +2056,12 @@ SymbolTable(
           description=EnumerationLiteralDescription(
             summary='<paragraph>Concrete, clearly identifiable component of a certain template.</paragraph>',
             remarks=[
-              '<note><paragraph>It becomes an individual entity of a  template,  for example a\ndevice model, by defining specific property values.</paragraph></note>',
-              '<note><paragraph>In an object oriented view,  an instance denotes an object of a\ntemplate (class).</paragraph></note>',
+              textwrap.dedent("""\
+                <note><paragraph>It becomes an individual entity of a  template,  for example a
+                device model, by defining specific property values.</paragraph></note>"""),
+              textwrap.dedent("""\
+                <note><paragraph>In an object oriented view,  an instance denotes an object of a
+                template (class).</paragraph></note>"""),
               '<paragraph>[SOURCE: IEC 62890:2016, 3.1.16 65/617/CDV]  modified</paragraph>'],
             parsed=...),
           parsed=...)],
@@ -1640,7 +2124,9 @@ SymbolTable(
             parsed=...)],
         signatures=[],
         description=SymbolDescription(
-          summary='<paragraph>An element with a kind is an element that can either represent a template or an\ninstance.</paragraph>',
+          summary=textwrap.dedent("""\
+            <paragraph>An element with a kind is an element that can either represent a template or an
+            instance.</paragraph>"""),
           remarks=[
             '<paragraph>Default for an element is that it is representing an instance.</paragraph>'],
           constraints_by_identifier=[],
@@ -1705,7 +2191,14 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='kind',\n  argument='kind',\n  default=DefaultEnumLiteral(\n    node=...,\n    enum='Reference to Enumeration Modeling_kind',\n    literal='Reference to EnumerationLiteral Instance'))"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='kind',
+              argument='kind',
+              default=DefaultEnumLiteral(
+                node=...,
+                enum='Reference to Enumeration Modeling_kind',
+                literal='Reference to EnumerationLiteral Instance'))""")]),
       invariants=[],
       serialization=Serialization(
         with_model_type=False),
@@ -1718,7 +2211,9 @@ SymbolTable(
         index=0,
         fragment=None),
       description=SymbolDescription(
-        summary='<paragraph>An element with a kind is an element that can either represent a template or an\ninstance.</paragraph>',
+        summary=textwrap.dedent("""\
+          <paragraph>An element with a kind is an element that can either represent a template or an
+          instance.</paragraph>"""),
         remarks=[
           '<paragraph>Default for an element is that it is representing an instance.</paragraph>'],
         constraints_by_identifier=[],
@@ -1776,7 +2271,10 @@ SymbolTable(
         description=SymbolDescription(
           summary='<paragraph>Element that can be extended by using data specification templates.</paragraph>',
           remarks=[
-            '<paragraph>A data specification template defines a named set of additional attributes an\nelement may or shall have. The data specifications used are explicitly specified\nwith their global ID.</paragraph>'],
+            textwrap.dedent("""\
+              <paragraph>A data specification template defines a named set of additional attributes an
+              element may or shall have. The data specifications used are explicitly specified
+              with their global ID.</paragraph>""")],
           constraints_by_identifier=[],
           parsed=...),
         parsed=...,
@@ -1845,7 +2343,11 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='data_specifications',\n  argument='data_specifications',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='data_specifications',
+              argument='data_specifications',
+              default=None)""")]),
       invariants=[],
       serialization=Serialization(
         with_model_type=False),
@@ -1860,7 +2362,10 @@ SymbolTable(
       description=SymbolDescription(
         summary='<paragraph>Element that can be extended by using data specification templates.</paragraph>',
         remarks=[
-          '<paragraph>A data specification template defines a named set of additional attributes an\nelement may or shall have. The data specifications used are explicitly specified\nwith their global ID.</paragraph>'],
+          textwrap.dedent("""\
+            <paragraph>A data specification template defines a named set of additional attributes an
+            element may or shall have. The data specifications used are explicitly specified
+            with their global ID.</paragraph>""")],
         constraints_by_identifier=[],
         parsed=...),
       parsed=...,
@@ -1971,13 +2476,43 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='data_specifications',\n  argument='data_specifications',\n  default=None)",
-          "AssignArgument(\n  name='version',\n  argument='version',\n  default=None)",
-          "AssignArgument(\n  name='revision',\n  argument='revision',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='data_specifications',
+              argument='data_specifications',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='version',
+              argument='version',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='revision',
+              argument='revision',
+              default=None)""")]),
       invariants=[
         Invariant(
           description='Constraint AASd-005: If version is not specified than also revision shall be unspecified. This means, a revision requires a version. If there is no version there is no revision neither. Revision is optional.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='revision',\n      original_node=...),\n    original_node=...),\n  consequent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='version',\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='revision',
+                  original_node=...),
+                original_node=...),
+              consequent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='version',
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to ConcreteClass Administrative_information',
           parsed=...)],
       serialization=Serialization(
@@ -1991,12 +2526,17 @@ SymbolTable(
         index=0,
         fragment=None),
       description=SymbolDescription(
-        summary='<paragraph>Administrative meta-information for an element like version\ninformation.</paragraph>',
+        summary=textwrap.dedent("""\
+          <paragraph>Administrative meta-information for an element like version
+          information.</paragraph>"""),
         remarks=[],
         constraints_by_identifier=[
           [
             'AASd-005',
-            '<field_body><paragraph>If <AttributeReference refuri="~version">~version</AttributeReference> is not specified than also <AttributeReference refuri="~revision">~revision</AttributeReference> shall be\nunspecified. This means, a revision requires a version. If there is no version\nthere is no revision neither. Revision is optional.</paragraph></field_body>']],
+            textwrap.dedent("""\
+              <field_body><paragraph>If <AttributeReference refuri="~version">~version</AttributeReference> is not specified than also <AttributeReference refuri="~revision">~revision</AttributeReference> shall be
+              unspecified. This means, a revision requires a version. If there is no version
+              there is no revision neither. Revision is optional.</paragraph></field_body>""")]],
         parsed=...),
       parsed=...,
       properties_by_name=...,
@@ -2043,13 +2583,17 @@ SymbolTable(
               constraints_by_identifier=[
                 [
                   'AASd-021',
-                  '<field_body><paragraph>Every qualifiable can only have one qualifier with the same\n<AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>']],
+                  textwrap.dedent("""\
+                    <field_body><paragraph>Every qualifiable can only have one qualifier with the same
+                    <AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>""")]],
               parsed=...),
             specified_for='Reference to AbstractClass Qualifiable',
             parsed=...)],
         signatures=[],
         description=SymbolDescription(
-          summary='<paragraph>The value of a qualifiable element may be further qualified by one or more\nqualifiers or complex formulas.</paragraph>',
+          summary=textwrap.dedent("""\
+            <paragraph>The value of a qualifiable element may be further qualified by one or more
+            qualifiers or complex formulas.</paragraph>"""),
           remarks=[],
           constraints_by_identifier=[],
           parsed=...),
@@ -2088,7 +2632,9 @@ SymbolTable(
             constraints_by_identifier=[
               [
                 'AASd-021',
-                '<field_body><paragraph>Every qualifiable can only have one qualifier with the same\n<AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph>Every qualifiable can only have one qualifier with the same
+                  <AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...)],
@@ -2119,11 +2665,35 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='qualifiers',\n  argument='qualifiers',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='qualifiers',
+              argument='qualifiers',
+              default=None)""")]),
       invariants=[
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='qualifiers',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='qualifier_types_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='qualifiers',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='qualifier_types_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='qualifiers',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...)],
       serialization=Serialization(
@@ -2137,7 +2707,9 @@ SymbolTable(
         index=0,
         fragment=None),
       description=SymbolDescription(
-        summary='<paragraph>The value of a qualifiable element may be further qualified by one or more\nqualifiers or complex formulas.</paragraph>',
+        summary=textwrap.dedent("""\
+          <paragraph>The value of a qualifiable element may be further qualified by one or more
+          qualifiers or complex formulas.</paragraph>"""),
         remarks=[],
         constraints_by_identifier=[],
         parsed=...),
@@ -2164,7 +2736,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Identifier of the semantic definition of the element. It is called semantic ID\nof the element.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Identifier of the semantic definition of the element. It is called semantic ID
+              of the element.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -2176,7 +2750,9 @@ SymbolTable(
             symbol='Reference to symbol Qualifier_type',
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>The qualifier type describes the type of the qualifier that is applied to\nthe element.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>The qualifier type describes the type of the qualifier that is applied to
+              the element.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -2283,15 +2859,61 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='semantic_id',\n  argument='semantic_id',\n  default=None)",
-          "AssignArgument(\n  name='type',\n  argument='type',\n  default=None)",
-          "AssignArgument(\n  name='value_type',\n  argument='value_type',\n  default=None)",
-          "AssignArgument(\n  name='value',\n  argument='value',\n  default=None)",
-          "AssignArgument(\n  name='value_id',\n  argument='value_id',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='semantic_id',
+              argument='semantic_id',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='type',
+              argument='type',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='value_type',
+              argument='value_type',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='value',
+              argument='value',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='value_id',
+              argument='value_id',
+              default=None)""")]),
       invariants=[
         Invariant(
           description='Constraint AASd-020: The value shall be consistent to the data type as defined in value_type.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='value',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='value_consistent_with_xsd_type',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='value',\n        original_node=...),\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='value_type',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='value',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='value_consistent_with_xsd_type',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='value',
+                    original_node=...),
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='value_type',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to ConcreteClass Qualifier',
           parsed=...)],
       serialization=Serialization(
@@ -2305,15 +2927,23 @@ SymbolTable(
         index=0,
         fragment=None),
       description=SymbolDescription(
-        summary='<paragraph>A qualifier is a type-value-pair that makes additional statements w.r.t.  the value\nof the element.</paragraph>',
+        summary=textwrap.dedent("""\
+          <paragraph>A qualifier is a type-value-pair that makes additional statements w.r.t.  the value
+          of the element.</paragraph>"""),
         remarks=[],
         constraints_by_identifier=[
           [
             'AASd-006',
-            '<field_body><paragraph>If both the <AttributeReference refuri="~value">~value</AttributeReference> and the <AttributeReference refuri="~value_id">~value_id</AttributeReference> of\na <SymbolReference refuri=".Qualifier">.Qualifier</SymbolReference> are present then the <AttributeReference refuri="~value">~value</AttributeReference> needs\nto be identical to the value of the referenced coded value\nin <AttributeReference refuri="~value_id">~value_id</AttributeReference>.</paragraph></field_body>'],
+            textwrap.dedent("""\
+              <field_body><paragraph>If both the <AttributeReference refuri="~value">~value</AttributeReference> and the <AttributeReference refuri="~value_id">~value_id</AttributeReference> of
+              a <SymbolReference refuri=".Qualifier">.Qualifier</SymbolReference> are present then the <AttributeReference refuri="~value">~value</AttributeReference> needs
+              to be identical to the value of the referenced coded value
+              in <AttributeReference refuri="~value_id">~value_id</AttributeReference>.</paragraph></field_body>""")],
           [
             'AASd-020',
-            '<field_body><paragraph>The value of <AttributeReference refuri="~value">~value</AttributeReference> shall be consistent to the data type as\ndefined in <AttributeReference refuri="~value_type">~value_type</AttributeReference>.</paragraph></field_body>']],
+            textwrap.dedent("""\
+              <field_body><paragraph>The value of <AttributeReference refuri="~value">~value</AttributeReference> shall be consistent to the data type as
+              defined in <AttributeReference refuri="~value_type">~value_type</AttributeReference>.</paragraph></field_body>""")]],
         parsed=...),
       parsed=...,
       properties_by_name=...,
@@ -2355,13 +2985,21 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>In case of identifiables this attribute is a short name of the element.\nIn case of referable this ID is an identifying string of\nthe element within its name space.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>In case of identifiables this attribute is a short name of the element.
+              In case of referable this ID is an identifying string of
+              the element within its name space.</paragraph>"""),
             remarks=[
-              '<note><paragraph>In case the element is a property and the property has a semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>\nis typically identical to the short name in English.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>In case the element is a property and the property has a semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>
+                is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[
               [
                 'AASd-027',
-                '<field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>\'s shall have a maximum length\nof 128 characters.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>'s shall have a maximum length
+                  of 128 characters.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
@@ -2375,8 +3013,15 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>Display name. Can be provided in several languages.</paragraph>',
             remarks=[
-              '<paragraph>If no display name is defined in the language requested by the application,\nthen the display name is selected in the following order if available:</paragraph>',
-              '<bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,\nthen the corresponding preferred name in the language is chosen\naccording to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>'],
+              textwrap.dedent("""\
+                <paragraph>If no display name is defined in the language requested by the application,
+                then the display name is selected in the following order if available:</paragraph>"""),
+              textwrap.dedent("""\
+                <bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
+                then the corresponding preferred name in the language is chosen
+                according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -2389,9 +3034,18 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>The category is a value that gives further meta information\nw.r.t. to the class of the element.\nIt affects the expected existence of attributes and the applicability of\nconstraints.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>The category is a value that gives further meta information
+              w.r.t. to the class of the element.
+              It affects the expected existence of attributes and the applicability of
+              constraints.</paragraph>"""),
             remarks=[
-              '<note><paragraph>The category is not identical to the semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category\n<emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the\nsemantic definition of the element would\ndenote that it is the measured temperature.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>The category is not identical to the semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category
+                <emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the
+                semantic definition of the element would
+                denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -2407,8 +3061,14 @@ SymbolTable(
             summary='<paragraph>Description or comments on the element.</paragraph>',
             remarks=[
               '<paragraph>The description can be provided in several languages.</paragraph>',
-              '<paragraph>If no description is defined, then the definition of the concept\ndescription that defines the semantics of the element is used.</paragraph>',
-              '<paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is\nqualified and which qualifier types can be expected in which\ncontext or which additional data specification templates are\nprovided.</paragraph>'],
+              textwrap.dedent("""\
+                <paragraph>If no description is defined, then the definition of the concept
+                description that defines the semantics of the element is used.</paragraph>"""),
+              textwrap.dedent("""\
+                <paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is
+                qualified and which qualifier types can be expected in which
+                context or which additional data specification templates are
+                provided.</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -2421,9 +3081,15 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Checksum to be used to determine if an Referable (including its\naggregated child elements) has changed.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Checksum to be used to determine if an Referable (including its
+              aggregated child elements) has changed.</paragraph>"""),
             remarks=[
-              "<paragraph>The checksum is calculated by the user's tool environment.\nThe checksum has no semantic meaning for an asset administration\nshell model and there is no requirement for asset administration\nshell tools to manage the checksum</paragraph>"],
+              textwrap.dedent("""\
+                <paragraph>The checksum is calculated by the user's tool environment.
+                The checksum has no semantic meaning for an asset administration
+                shell model and there is no requirement for asset administration
+                shell tools to manage the checksum</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -2450,7 +3116,9 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>Administrative information of an identifiable element.</paragraph>',
             remarks=[
-              '<note><paragraph>Some of the administrative information like the version number might need to\nbe part of the identification.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>Some of the administrative information like the version number might need to
+                be part of the identification.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Identifiable',
@@ -2495,7 +3163,10 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>References to submodels of the AAS.</paragraph>',
             remarks=[
-              '<paragraph>A submodel is a description of an aspect of the asset the AAS is representing.\nThe asset of an AAS is typically described by one or more submodels.\nTemporarily no submodel might be assigned to the AAS.</paragraph>'],
+              textwrap.dedent("""\
+                <paragraph>A submodel is a description of an aspect of the asset the AAS is representing.
+                The asset of an AAS is typically described by one or more submodels.
+                Temporarily no submodel might be assigned to the AAS.</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to ConcreteClass Asset_administration_shell',
@@ -2658,37 +3329,193 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='extensions',\n  argument='extensions',\n  default=None)",
-          "AssignArgument(\n  name='id_short',\n  argument='id_short',\n  default=None)",
-          "AssignArgument(\n  name='display_name',\n  argument='display_name',\n  default=None)",
-          "AssignArgument(\n  name='category',\n  argument='category',\n  default=None)",
-          "AssignArgument(\n  name='description',\n  argument='description',\n  default=None)",
-          "AssignArgument(\n  name='checksum',\n  argument='checksum',\n  default=None)",
-          "AssignArgument(\n  name='ID',\n  argument='ID',\n  default=None)",
-          "AssignArgument(\n  name='administration',\n  argument='administration',\n  default=None)",
-          "AssignArgument(\n  name='data_specifications',\n  argument='data_specifications',\n  default=None)",
-          "AssignArgument(\n  name='derived_from',\n  argument='derived_from',\n  default=None)",
-          "AssignArgument(\n  name='asset_information',\n  argument='asset_information',\n  default=None)",
-          "AssignArgument(\n  name='submodels',\n  argument='submodels',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='extensions',
+              argument='extensions',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='id_short',
+              argument='id_short',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='display_name',
+              argument='display_name',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='category',
+              argument='category',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='description',
+              argument='description',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='checksum',
+              argument='checksum',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='ID',
+              argument='ID',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='administration',
+              argument='administration',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='data_specifications',
+              argument='data_specifications',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='derived_from',
+              argument='derived_from',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='asset_information',
+              argument='asset_information',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='submodels',
+              argument='submodels',
+              default=None)""")]),
       invariants=[
         Invariant(
           description='Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='extensions',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='extension_names_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='extensions',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='extension_names_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='extensions',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
           description='Constraint AASd-027: ID-short shall have a maximum length of 128 characters.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='id_short',\n      original_node=...),\n    original_node=...),\n  consequent=Comparison(\n    left=FunctionCall(\n      name='len',\n      args=[\n        Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='id_short',\n          original_node=...)],\n      original_node=...),\n    op='LE',\n    right=Constant(\n      value=128,\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='id_short',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='id_short',
+                      original_node=...)],
+                  original_node=...),
+                op='LE',
+                right=Constant(
+                  value=128,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
         Invariant(
           description=None,
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='derived_from',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='is_model_reference_to',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='derived_from',\n        original_node=...),\n      Member(\n        instance=Name(\n          identifier='Key_elements',\n          original_node=...),\n        name='Asset_administration_shell',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='derived_from',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='is_model_reference_to',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='derived_from',
+                    original_node=...),
+                  Member(
+                    instance=Name(
+                      identifier='Key_elements',
+                      original_node=...),
+                    name='Asset_administration_shell',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to ConcreteClass Asset_administration_shell',
           parsed=...),
         Invariant(
           description=None,
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='submodels',\n      original_node=...),\n    original_node=...),\n  consequent=All(\n    for_each=ForEach(\n      variable=Name(\n        identifier='reference',\n        original_node=...),\n      iteration=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='submodels',\n        original_node=...),\n      original_node=...),\n    condition=FunctionCall(\n      name='is_model_reference_to',\n      args=[\n        Name(\n          identifier='reference',\n          original_node=...),\n        Member(\n          instance=Name(\n            identifier='Key_elements',\n            original_node=...),\n          name='Submodel',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='submodels',
+                  original_node=...),
+                original_node=...),
+              consequent=All(
+                for_each=ForEach(
+                  variable=Name(
+                    identifier='reference',
+                    original_node=...),
+                  iteration=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='submodels',
+                    original_node=...),
+                  original_node=...),
+                condition=FunctionCall(
+                  name='is_model_reference_to',
+                  args=[
+                    Name(
+                      identifier='reference',
+                      original_node=...),
+                    Member(
+                      instance=Name(
+                        identifier='Key_elements',
+                        original_node=...),
+                      name='Submodel',
+                      original_node=...)],
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to ConcreteClass Asset_administration_shell',
           parsed=...)],
       serialization=Serialization(
@@ -2739,9 +3566,15 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Reference to either an Asset object or a global reference to the asset the AAS is\nrepresenting.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Reference to either an Asset object or a global reference to the asset the AAS is
+              representing.</paragraph>"""),
             remarks=[
-              '<paragraph>This attribute is required as soon as the AAS is exchanged via partners in the life\ncycle of the asset. In a first phase of the life cycle the asset might not yet have\na global ID but already an internal identifier. The internal identifier would be\nmodelled via <AttributeReference refuri="~specific_asset_id">~specific_asset_id</AttributeReference>.</paragraph>'],
+              textwrap.dedent("""\
+                <paragraph>This attribute is required as soon as the AAS is exchanged via partners in the life
+                cycle of the asset. In a first phase of the life cycle the asset might not yet have
+                a global ID but already an internal identifier. The internal identifier would be
+                modelled via <AttributeReference refuri="~specific_asset_id">~specific_asset_id</AttributeReference>.</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to ConcreteClass Asset_information',
@@ -2830,10 +3663,26 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='asset_kind',\n  argument='asset_kind',\n  default=None)",
-          "AssignArgument(\n  name='global_asset_id',\n  argument='global_asset_id',\n  default=None)",
-          "AssignArgument(\n  name='specific_asset_id',\n  argument='specific_asset_id',\n  default=None)",
-          "AssignArgument(\n  name='default_thumbnail',\n  argument='default_thumbnail',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='asset_kind',
+              argument='asset_kind',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='global_asset_id',
+              argument='global_asset_id',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='specific_asset_id',
+              argument='specific_asset_id',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='default_thumbnail',
+              argument='default_thumbnail',
+              default=None)""")]),
       invariants=[],
       serialization=Serialization(
         with_model_type=False),
@@ -2845,9 +3694,17 @@ SymbolTable(
         index=0,
         fragment=None),
       description=SymbolDescription(
-        summary='<paragraph>In <SymbolReference refuri=".Asset_information">.Asset_information</SymbolReference> identifying meta data of the asset that is\nrepresented by an AAS is defined.</paragraph>',
+        summary=textwrap.dedent("""\
+          <paragraph>In <SymbolReference refuri=".Asset_information">.Asset_information</SymbolReference> identifying meta data of the asset that is
+          represented by an AAS is defined.</paragraph>"""),
         remarks=[
-          '<paragraph>The asset may either represent an asset type or an asset instance.\nThe asset has a globally unique identifier plus – if needed – additional domain\nspecific (proprietary) identifiers. However, to support the corner case of very\nfirst phase of lifecycle where a stabilised/constant global asset identifier does\nnot already exist, the corresponding attribute\n<AttributeReference refuri="~global_asset_id">~global_asset_id</AttributeReference> is optional.</paragraph>'],
+          textwrap.dedent("""\
+            <paragraph>The asset may either represent an asset type or an asset instance.
+            The asset has a globally unique identifier plus – if needed – additional domain
+            specific (proprietary) identifiers. However, to support the corner case of very
+            first phase of lifecycle where a stabilised/constant global asset identifier does
+            not already exist, the corresponding attribute
+            <AttributeReference refuri="~global_asset_id">~global_asset_id</AttributeReference> is optional.</paragraph>""")],
         constraints_by_identifier=[],
         parsed=...),
       parsed=...,
@@ -2862,7 +3719,9 @@ SymbolTable(
           name='Type',
           value='Type',
           description=EnumerationLiteralDescription(
-            summary='<paragraph>hardware or software element which specifies the common attributes shared by all\ninstances of the type</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>hardware or software element which specifies the common attributes shared by all
+              instances of the type</paragraph>"""),
             remarks=[
               '<paragraph>[SOURCE: IEC TR 62390:2005-01, 3.1.25]</paragraph>'],
             parsed=...),
@@ -2873,8 +3732,12 @@ SymbolTable(
           description=EnumerationLiteralDescription(
             summary='<paragraph>concrete, clearly identifiable component of a certain type</paragraph>',
             remarks=[
-              '<note><paragraph>It becomes an individual entity of a type, for example a device, by defining\nspecific property values.</paragraph></note>',
-              '<note><paragraph>In an object oriented view, an instance denotes an object of a class\n(of a type).</paragraph></note>',
+              textwrap.dedent("""\
+                <note><paragraph>It becomes an individual entity of a type, for example a device, by defining
+                specific property values.</paragraph></note>"""),
+              textwrap.dedent("""\
+                <note><paragraph>In an object oriented view, an instance denotes an object of a class
+                (of a type).</paragraph></note>"""),
               '<paragraph>[SOURCE: IEC 62890:2016, 3.1.16] 65/617/CDV</paragraph>'],
             parsed=...),
           parsed=...)],
@@ -2912,7 +3775,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Identifier of the semantic definition of the element. It is called semantic ID\nof the element.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Identifier of the semantic definition of the element. It is called semantic ID
+              of the element.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -3006,10 +3871,26 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='semantic_id',\n  argument='semantic_id',\n  default=None)",
-          "AssignArgument(\n  name='key',\n  argument='key',\n  default=None)",
-          "AssignArgument(\n  name='value',\n  argument='value',\n  default=None)",
-          "AssignArgument(\n  name='external_subject_id',\n  argument='external_subject_id',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='semantic_id',
+              argument='semantic_id',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='key',
+              argument='key',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='value',
+              argument='value',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='external_subject_id',
+              argument='external_subject_id',
+              default=None)""")]),
       invariants=[],
       serialization=Serialization(
         with_model_type=False),
@@ -3021,7 +3902,9 @@ SymbolTable(
         index=3,
         fragment=None),
       description=SymbolDescription(
-        summary='<paragraph>An <SymbolReference refuri=".Identifier_key_value_pair">.Identifier_key_value_pair</SymbolReference> describes a generic identifier as\nkey-value pair.</paragraph>',
+        summary=textwrap.dedent("""\
+          <paragraph>An <SymbolReference refuri=".Identifier_key_value_pair">.Identifier_key_value_pair</SymbolReference> describes a generic identifier as
+          key-value pair.</paragraph>"""),
         remarks=[],
         constraints_by_identifier=[],
         parsed=...),
@@ -3068,13 +3951,21 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>In case of identifiables this attribute is a short name of the element.\nIn case of referable this ID is an identifying string of\nthe element within its name space.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>In case of identifiables this attribute is a short name of the element.
+              In case of referable this ID is an identifying string of
+              the element within its name space.</paragraph>"""),
             remarks=[
-              '<note><paragraph>In case the element is a property and the property has a semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>\nis typically identical to the short name in English.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>In case the element is a property and the property has a semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>
+                is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[
               [
                 'AASd-027',
-                '<field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>\'s shall have a maximum length\nof 128 characters.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>'s shall have a maximum length
+                  of 128 characters.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
@@ -3088,8 +3979,15 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>Display name. Can be provided in several languages.</paragraph>',
             remarks=[
-              '<paragraph>If no display name is defined in the language requested by the application,\nthen the display name is selected in the following order if available:</paragraph>',
-              '<bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,\nthen the corresponding preferred name in the language is chosen\naccording to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>'],
+              textwrap.dedent("""\
+                <paragraph>If no display name is defined in the language requested by the application,
+                then the display name is selected in the following order if available:</paragraph>"""),
+              textwrap.dedent("""\
+                <bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
+                then the corresponding preferred name in the language is chosen
+                according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -3102,9 +4000,18 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>The category is a value that gives further meta information\nw.r.t. to the class of the element.\nIt affects the expected existence of attributes and the applicability of\nconstraints.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>The category is a value that gives further meta information
+              w.r.t. to the class of the element.
+              It affects the expected existence of attributes and the applicability of
+              constraints.</paragraph>"""),
             remarks=[
-              '<note><paragraph>The category is not identical to the semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category\n<emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the\nsemantic definition of the element would\ndenote that it is the measured temperature.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>The category is not identical to the semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category
+                <emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the
+                semantic definition of the element would
+                denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -3120,8 +4027,14 @@ SymbolTable(
             summary='<paragraph>Description or comments on the element.</paragraph>',
             remarks=[
               '<paragraph>The description can be provided in several languages.</paragraph>',
-              '<paragraph>If no description is defined, then the definition of the concept\ndescription that defines the semantics of the element is used.</paragraph>',
-              '<paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is\nqualified and which qualifier types can be expected in which\ncontext or which additional data specification templates are\nprovided.</paragraph>'],
+              textwrap.dedent("""\
+                <paragraph>If no description is defined, then the definition of the concept
+                description that defines the semantics of the element is used.</paragraph>"""),
+              textwrap.dedent("""\
+                <paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is
+                qualified and which qualifier types can be expected in which
+                context or which additional data specification templates are
+                provided.</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -3134,9 +4047,15 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Checksum to be used to determine if an Referable (including its\naggregated child elements) has changed.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Checksum to be used to determine if an Referable (including its
+              aggregated child elements) has changed.</paragraph>"""),
             remarks=[
-              "<paragraph>The checksum is calculated by the user's tool environment.\nThe checksum has no semantic meaning for an asset administration\nshell model and there is no requirement for asset administration\nshell tools to manage the checksum</paragraph>"],
+              textwrap.dedent("""\
+                <paragraph>The checksum is calculated by the user's tool environment.
+                The checksum has no semantic meaning for an asset administration
+                shell model and there is no requirement for asset administration
+                shell tools to manage the checksum</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -3163,7 +4082,9 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>Administrative information of an identifiable element.</paragraph>',
             remarks=[
-              '<note><paragraph>Some of the administrative information like the version number might need to\nbe part of the identification.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>Some of the administrative information like the version number might need to
+                be part of the identification.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Identifiable',
@@ -3191,7 +4112,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Identifier of the semantic definition of the element. It is called semantic ID\nof the element.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Identifier of the semantic definition of the element. It is called semantic ID
+              of the element.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -3212,7 +4135,9 @@ SymbolTable(
             constraints_by_identifier=[
               [
                 'AASd-021',
-                '<field_body><paragraph>Every qualifiable can only have one qualifier with the same\n<AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph>Every qualifiable can only have one qualifier with the same
+                  <AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -3409,43 +4334,215 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='extensions',\n  argument='extensions',\n  default=None)",
-          "AssignArgument(\n  name='id_short',\n  argument='id_short',\n  default=None)",
-          "AssignArgument(\n  name='display_name',\n  argument='display_name',\n  default=None)",
-          "AssignArgument(\n  name='category',\n  argument='category',\n  default=None)",
-          "AssignArgument(\n  name='description',\n  argument='description',\n  default=None)",
-          "AssignArgument(\n  name='checksum',\n  argument='checksum',\n  default=None)",
-          "AssignArgument(\n  name='ID',\n  argument='ID',\n  default=None)",
-          "AssignArgument(\n  name='administration',\n  argument='administration',\n  default=None)",
-          "AssignArgument(\n  name='kind',\n  argument='kind',\n  default=DefaultEnumLiteral(\n    node=...,\n    enum='Reference to Enumeration Modeling_kind',\n    literal='Reference to EnumerationLiteral Instance'))",
-          "AssignArgument(\n  name='semantic_id',\n  argument='semantic_id',\n  default=None)",
-          "AssignArgument(\n  name='qualifiers',\n  argument='qualifiers',\n  default=None)",
-          "AssignArgument(\n  name='data_specifications',\n  argument='data_specifications',\n  default=None)",
-          "AssignArgument(\n  name='submodel_elements',\n  argument='submodel_elements',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='extensions',
+              argument='extensions',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='id_short',
+              argument='id_short',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='display_name',
+              argument='display_name',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='category',
+              argument='category',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='description',
+              argument='description',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='checksum',
+              argument='checksum',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='ID',
+              argument='ID',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='administration',
+              argument='administration',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='kind',
+              argument='kind',
+              default=DefaultEnumLiteral(
+                node=...,
+                enum='Reference to Enumeration Modeling_kind',
+                literal='Reference to EnumerationLiteral Instance'))"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='semantic_id',
+              argument='semantic_id',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='qualifiers',
+              argument='qualifiers',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='data_specifications',
+              argument='data_specifications',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='submodel_elements',
+              argument='submodel_elements',
+              default=None)""")]),
       invariants=[
         Invariant(
           description='Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='extensions',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='extension_names_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='extensions',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='extension_names_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='extensions',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
           description='Constraint AASd-027: ID-short shall have a maximum length of 128 characters.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='id_short',\n      original_node=...),\n    original_node=...),\n  consequent=Comparison(\n    left=FunctionCall(\n      name='len',\n      args=[\n        Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='id_short',\n          original_node=...)],\n      original_node=...),\n    op='LE',\n    right=Constant(\n      value=128,\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='id_short',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='id_short',
+                      original_node=...)],
+                  original_node=...),
+                op='LE',
+                right=Constant(
+                  value=128,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='qualifiers',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='qualifier_types_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='qualifiers',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='qualifier_types_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='qualifiers',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Invariant(
           description='Short IDs need to be defined for all the submodel elements.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='submodel_elements',\n      original_node=...),\n    original_node=...),\n  consequent=All(\n    for_each=ForEach(\n      variable=Name(\n        identifier='element',\n        original_node=...),\n      iteration=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='submodel_elements',\n        original_node=...),\n      original_node=...),\n    condition=IsNotNone(\n      value=Member(\n        instance=Name(\n          identifier='element',\n          original_node=...),\n        name='id_short',\n        original_node=...),\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='submodel_elements',
+                  original_node=...),
+                original_node=...),
+              consequent=All(
+                for_each=ForEach(
+                  variable=Name(
+                    identifier='element',
+                    original_node=...),
+                  iteration=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='submodel_elements',
+                    original_node=...),
+                  original_node=...),
+                condition=IsNotNone(
+                  value=Member(
+                    instance=Name(
+                      identifier='element',
+                      original_node=...),
+                    name='id_short',
+                    original_node=...),
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to ConcreteClass Submodel',
           parsed=...),
         Invariant(
           description=None,
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='submodel_elements',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='id_shorts_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='submodel_elements',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='submodel_elements',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='id_shorts_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='submodel_elements',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to ConcreteClass Submodel',
           parsed=...)],
       serialization=Serialization(
@@ -3460,7 +4557,11 @@ SymbolTable(
       description=SymbolDescription(
         summary='<paragraph>A submodel defines a specific aspect of the asset represented by the AAS.</paragraph>',
         remarks=[
-          '<paragraph>A submodel is used to structure the digital representation and technical\nfunctionality of an Administration Shell into distinguishable parts. Each submodel\nrefers to a well-defined domain or subject matter. Submodels can become\nstandardized and, thus, become submodels templates.</paragraph>'],
+          textwrap.dedent("""\
+            <paragraph>A submodel is used to structure the digital representation and technical
+            functionality of an Administration Shell into distinguishable parts. Each submodel
+            refers to a well-defined domain or subject matter. Submodels can become
+            standardized and, thus, become submodels templates.</paragraph>""")],
         constraints_by_identifier=[],
         parsed=...),
       parsed=...,
@@ -3526,13 +4627,21 @@ SymbolTable(
                 parsed=...),
               parsed=...),
             description=PropertyDescription(
-              summary='<paragraph>In case of identifiables this attribute is a short name of the element.\nIn case of referable this ID is an identifying string of\nthe element within its name space.</paragraph>',
+              summary=textwrap.dedent("""\
+                <paragraph>In case of identifiables this attribute is a short name of the element.
+                In case of referable this ID is an identifying string of
+                the element within its name space.</paragraph>"""),
               remarks=[
-                '<note><paragraph>In case the element is a property and the property has a semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>\nis typically identical to the short name in English.</paragraph></note>'],
+                textwrap.dedent("""\
+                  <note><paragraph>In case the element is a property and the property has a semantic definition
+                  (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>
+                  is typically identical to the short name in English.</paragraph></note>""")],
               constraints_by_identifier=[
                 [
                   'AASd-027',
-                  '<field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>\'s shall have a maximum length\nof 128 characters.</paragraph></field_body>']],
+                  textwrap.dedent("""\
+                    <field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>'s shall have a maximum length
+                    of 128 characters.</paragraph></field_body>""")]],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
             parsed=...),
@@ -3546,8 +4655,15 @@ SymbolTable(
             description=PropertyDescription(
               summary='<paragraph>Display name. Can be provided in several languages.</paragraph>',
               remarks=[
-                '<paragraph>If no display name is defined in the language requested by the application,\nthen the display name is selected in the following order if available:</paragraph>',
-                '<bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,\nthen the corresponding preferred name in the language is chosen\naccording to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>'],
+                textwrap.dedent("""\
+                  <paragraph>If no display name is defined in the language requested by the application,
+                  then the display name is selected in the following order if available:</paragraph>"""),
+                textwrap.dedent("""\
+                  <bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining
+                  the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
+                  then the corresponding preferred name in the language is chosen
+                  according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
+                  the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -3560,9 +4676,18 @@ SymbolTable(
                 parsed=...),
               parsed=...),
             description=PropertyDescription(
-              summary='<paragraph>The category is a value that gives further meta information\nw.r.t. to the class of the element.\nIt affects the expected existence of attributes and the applicability of\nconstraints.</paragraph>',
+              summary=textwrap.dedent("""\
+                <paragraph>The category is a value that gives further meta information
+                w.r.t. to the class of the element.
+                It affects the expected existence of attributes and the applicability of
+                constraints.</paragraph>"""),
               remarks=[
-                '<note><paragraph>The category is not identical to the semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category\n<emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the\nsemantic definition of the element would\ndenote that it is the measured temperature.</paragraph></note>'],
+                textwrap.dedent("""\
+                  <note><paragraph>The category is not identical to the semantic definition
+                  (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category
+                  <emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the
+                  semantic definition of the element would
+                  denote that it is the measured temperature.</paragraph></note>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -3578,8 +4703,14 @@ SymbolTable(
               summary='<paragraph>Description or comments on the element.</paragraph>',
               remarks=[
                 '<paragraph>The description can be provided in several languages.</paragraph>',
-                '<paragraph>If no description is defined, then the definition of the concept\ndescription that defines the semantics of the element is used.</paragraph>',
-                '<paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is\nqualified and which qualifier types can be expected in which\ncontext or which additional data specification templates are\nprovided.</paragraph>'],
+                textwrap.dedent("""\
+                  <paragraph>If no description is defined, then the definition of the concept
+                  description that defines the semantics of the element is used.</paragraph>"""),
+                textwrap.dedent("""\
+                  <paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is
+                  qualified and which qualifier types can be expected in which
+                  context or which additional data specification templates are
+                  provided.</paragraph>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -3592,9 +4723,15 @@ SymbolTable(
                 parsed=...),
               parsed=...),
             description=PropertyDescription(
-              summary='<paragraph>Checksum to be used to determine if an Referable (including its\naggregated child elements) has changed.</paragraph>',
+              summary=textwrap.dedent("""\
+                <paragraph>Checksum to be used to determine if an Referable (including its
+                aggregated child elements) has changed.</paragraph>"""),
               remarks=[
-                "<paragraph>The checksum is calculated by the user's tool environment.\nThe checksum has no semantic meaning for an asset administration\nshell model and there is no requirement for asset administration\nshell tools to manage the checksum</paragraph>"],
+                textwrap.dedent("""\
+                  <paragraph>The checksum is calculated by the user's tool environment.
+                  The checksum has no semantic meaning for an asset administration
+                  shell model and there is no requirement for asset administration
+                  shell tools to manage the checksum</paragraph>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -3622,7 +4759,9 @@ SymbolTable(
                 parsed=...),
               parsed=...),
             description=PropertyDescription(
-              summary='<paragraph>Identifier of the semantic definition of the element. It is called semantic ID\nof the element.</paragraph>',
+              summary=textwrap.dedent("""\
+                <paragraph>Identifier of the semantic definition of the element. It is called semantic ID
+                of the element.</paragraph>"""),
               remarks=[],
               constraints_by_identifier=[],
               parsed=...),
@@ -3643,7 +4782,9 @@ SymbolTable(
               constraints_by_identifier=[
                 [
                   'AASd-021',
-                  '<field_body><paragraph>Every qualifiable can only have one qualifier with the same\n<AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>']],
+                  textwrap.dedent("""\
+                    <field_body><paragraph>Every qualifiable can only have one qualifier with the same
+                    <AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>""")]],
               parsed=...),
             specified_for='Reference to AbstractClass Qualifiable',
             parsed=...),
@@ -3665,7 +4806,9 @@ SymbolTable(
             parsed=...)],
         signatures=[],
         description=SymbolDescription(
-          summary='<paragraph>A submodel element is an element suitable for the description and differentiation of\nassets.</paragraph>',
+          summary=textwrap.dedent("""\
+            <paragraph>A submodel element is an element suitable for the description and differentiation of
+            assets.</paragraph>"""),
           remarks=[
             '<paragraph>It is recommended to add a semantic ID to a submodel element.</paragraph>'],
           constraints_by_identifier=[],
@@ -3713,13 +4856,21 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>In case of identifiables this attribute is a short name of the element.\nIn case of referable this ID is an identifying string of\nthe element within its name space.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>In case of identifiables this attribute is a short name of the element.
+              In case of referable this ID is an identifying string of
+              the element within its name space.</paragraph>"""),
             remarks=[
-              '<note><paragraph>In case the element is a property and the property has a semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>\nis typically identical to the short name in English.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>In case the element is a property and the property has a semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>
+                is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[
               [
                 'AASd-027',
-                '<field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>\'s shall have a maximum length\nof 128 characters.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>'s shall have a maximum length
+                  of 128 characters.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
@@ -3733,8 +4884,15 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>Display name. Can be provided in several languages.</paragraph>',
             remarks=[
-              '<paragraph>If no display name is defined in the language requested by the application,\nthen the display name is selected in the following order if available:</paragraph>',
-              '<bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,\nthen the corresponding preferred name in the language is chosen\naccording to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>'],
+              textwrap.dedent("""\
+                <paragraph>If no display name is defined in the language requested by the application,
+                then the display name is selected in the following order if available:</paragraph>"""),
+              textwrap.dedent("""\
+                <bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
+                then the corresponding preferred name in the language is chosen
+                according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -3747,9 +4905,18 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>The category is a value that gives further meta information\nw.r.t. to the class of the element.\nIt affects the expected existence of attributes and the applicability of\nconstraints.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>The category is a value that gives further meta information
+              w.r.t. to the class of the element.
+              It affects the expected existence of attributes and the applicability of
+              constraints.</paragraph>"""),
             remarks=[
-              '<note><paragraph>The category is not identical to the semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category\n<emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the\nsemantic definition of the element would\ndenote that it is the measured temperature.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>The category is not identical to the semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category
+                <emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the
+                semantic definition of the element would
+                denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -3765,8 +4932,14 @@ SymbolTable(
             summary='<paragraph>Description or comments on the element.</paragraph>',
             remarks=[
               '<paragraph>The description can be provided in several languages.</paragraph>',
-              '<paragraph>If no description is defined, then the definition of the concept\ndescription that defines the semantics of the element is used.</paragraph>',
-              '<paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is\nqualified and which qualifier types can be expected in which\ncontext or which additional data specification templates are\nprovided.</paragraph>'],
+              textwrap.dedent("""\
+                <paragraph>If no description is defined, then the definition of the concept
+                description that defines the semantics of the element is used.</paragraph>"""),
+              textwrap.dedent("""\
+                <paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is
+                qualified and which qualifier types can be expected in which
+                context or which additional data specification templates are
+                provided.</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -3779,9 +4952,15 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Checksum to be used to determine if an Referable (including its\naggregated child elements) has changed.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Checksum to be used to determine if an Referable (including its
+              aggregated child elements) has changed.</paragraph>"""),
             remarks=[
-              "<paragraph>The checksum is calculated by the user's tool environment.\nThe checksum has no semantic meaning for an asset administration\nshell model and there is no requirement for asset administration\nshell tools to manage the checksum</paragraph>"],
+              textwrap.dedent("""\
+                <paragraph>The checksum is calculated by the user's tool environment.
+                The checksum has no semantic meaning for an asset administration
+                shell model and there is no requirement for asset administration
+                shell tools to manage the checksum</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -3809,7 +4988,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Identifier of the semantic definition of the element. It is called semantic ID\nof the element.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Identifier of the semantic definition of the element. It is called semantic ID
+              of the element.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -3830,7 +5011,9 @@ SymbolTable(
             constraints_by_identifier=[
               [
                 'AASd-021',
-                '<field_body><paragraph>Every qualifiable can only have one qualifier with the same\n<AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph>Every qualifiable can only have one qualifier with the same
+                  <AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -3980,30 +5163,139 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='extensions',\n  argument='extensions',\n  default=None)",
-          "AssignArgument(\n  name='id_short',\n  argument='id_short',\n  default=None)",
-          "AssignArgument(\n  name='display_name',\n  argument='display_name',\n  default=None)",
-          "AssignArgument(\n  name='category',\n  argument='category',\n  default=None)",
-          "AssignArgument(\n  name='description',\n  argument='description',\n  default=None)",
-          "AssignArgument(\n  name='checksum',\n  argument='checksum',\n  default=None)",
-          "AssignArgument(\n  name='kind',\n  argument='kind',\n  default=DefaultEnumLiteral(\n    node=...,\n    enum='Reference to Enumeration Modeling_kind',\n    literal='Reference to EnumerationLiteral Instance'))",
-          "AssignArgument(\n  name='semantic_id',\n  argument='semantic_id',\n  default=None)",
-          "AssignArgument(\n  name='qualifiers',\n  argument='qualifiers',\n  default=None)",
-          "AssignArgument(\n  name='data_specifications',\n  argument='data_specifications',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='extensions',
+              argument='extensions',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='id_short',
+              argument='id_short',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='display_name',
+              argument='display_name',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='category',
+              argument='category',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='description',
+              argument='description',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='checksum',
+              argument='checksum',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='kind',
+              argument='kind',
+              default=DefaultEnumLiteral(
+                node=...,
+                enum='Reference to Enumeration Modeling_kind',
+                literal='Reference to EnumerationLiteral Instance'))"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='semantic_id',
+              argument='semantic_id',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='qualifiers',
+              argument='qualifiers',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='data_specifications',
+              argument='data_specifications',
+              default=None)""")]),
       invariants=[
         Invariant(
           description='Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='extensions',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='extension_names_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='extensions',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='extension_names_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='extensions',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
           description='Constraint AASd-027: ID-short shall have a maximum length of 128 characters.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='id_short',\n      original_node=...),\n    original_node=...),\n  consequent=Comparison(\n    left=FunctionCall(\n      name='len',\n      args=[\n        Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='id_short',\n          original_node=...)],\n      original_node=...),\n    op='LE',\n    right=Constant(\n      value=128,\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='id_short',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='id_short',
+                      original_node=...)],
+                  original_node=...),
+                op='LE',
+                right=Constant(
+                  value=128,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='qualifiers',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='qualifier_types_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='qualifiers',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='qualifier_types_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='qualifiers',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...)],
       serialization=Serialization(
@@ -4016,7 +5308,9 @@ SymbolTable(
         index=0,
         fragment=None),
       description=SymbolDescription(
-        summary='<paragraph>A submodel element is an element suitable for the description and differentiation of\nassets.</paragraph>',
+        summary=textwrap.dedent("""\
+          <paragraph>A submodel element is an element suitable for the description and differentiation of
+          assets.</paragraph>"""),
         remarks=[
           '<paragraph>It is recommended to add a semantic ID to a submodel element.</paragraph>'],
         constraints_by_identifier=[],
@@ -4064,13 +5358,21 @@ SymbolTable(
                 parsed=...),
               parsed=...),
             description=PropertyDescription(
-              summary='<paragraph>In case of identifiables this attribute is a short name of the element.\nIn case of referable this ID is an identifying string of\nthe element within its name space.</paragraph>',
+              summary=textwrap.dedent("""\
+                <paragraph>In case of identifiables this attribute is a short name of the element.
+                In case of referable this ID is an identifying string of
+                the element within its name space.</paragraph>"""),
               remarks=[
-                '<note><paragraph>In case the element is a property and the property has a semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>\nis typically identical to the short name in English.</paragraph></note>'],
+                textwrap.dedent("""\
+                  <note><paragraph>In case the element is a property and the property has a semantic definition
+                  (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>
+                  is typically identical to the short name in English.</paragraph></note>""")],
               constraints_by_identifier=[
                 [
                   'AASd-027',
-                  '<field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>\'s shall have a maximum length\nof 128 characters.</paragraph></field_body>']],
+                  textwrap.dedent("""\
+                    <field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>'s shall have a maximum length
+                    of 128 characters.</paragraph></field_body>""")]],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
             parsed=...),
@@ -4084,8 +5386,15 @@ SymbolTable(
             description=PropertyDescription(
               summary='<paragraph>Display name. Can be provided in several languages.</paragraph>',
               remarks=[
-                '<paragraph>If no display name is defined in the language requested by the application,\nthen the display name is selected in the following order if available:</paragraph>',
-                '<bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,\nthen the corresponding preferred name in the language is chosen\naccording to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>'],
+                textwrap.dedent("""\
+                  <paragraph>If no display name is defined in the language requested by the application,
+                  then the display name is selected in the following order if available:</paragraph>"""),
+                textwrap.dedent("""\
+                  <bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining
+                  the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
+                  then the corresponding preferred name in the language is chosen
+                  according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
+                  the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -4098,9 +5407,18 @@ SymbolTable(
                 parsed=...),
               parsed=...),
             description=PropertyDescription(
-              summary='<paragraph>The category is a value that gives further meta information\nw.r.t. to the class of the element.\nIt affects the expected existence of attributes and the applicability of\nconstraints.</paragraph>',
+              summary=textwrap.dedent("""\
+                <paragraph>The category is a value that gives further meta information
+                w.r.t. to the class of the element.
+                It affects the expected existence of attributes and the applicability of
+                constraints.</paragraph>"""),
               remarks=[
-                '<note><paragraph>The category is not identical to the semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category\n<emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the\nsemantic definition of the element would\ndenote that it is the measured temperature.</paragraph></note>'],
+                textwrap.dedent("""\
+                  <note><paragraph>The category is not identical to the semantic definition
+                  (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category
+                  <emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the
+                  semantic definition of the element would
+                  denote that it is the measured temperature.</paragraph></note>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -4116,8 +5434,14 @@ SymbolTable(
               summary='<paragraph>Description or comments on the element.</paragraph>',
               remarks=[
                 '<paragraph>The description can be provided in several languages.</paragraph>',
-                '<paragraph>If no description is defined, then the definition of the concept\ndescription that defines the semantics of the element is used.</paragraph>',
-                '<paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is\nqualified and which qualifier types can be expected in which\ncontext or which additional data specification templates are\nprovided.</paragraph>'],
+                textwrap.dedent("""\
+                  <paragraph>If no description is defined, then the definition of the concept
+                  description that defines the semantics of the element is used.</paragraph>"""),
+                textwrap.dedent("""\
+                  <paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is
+                  qualified and which qualifier types can be expected in which
+                  context or which additional data specification templates are
+                  provided.</paragraph>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -4130,9 +5454,15 @@ SymbolTable(
                 parsed=...),
               parsed=...),
             description=PropertyDescription(
-              summary='<paragraph>Checksum to be used to determine if an Referable (including its\naggregated child elements) has changed.</paragraph>',
+              summary=textwrap.dedent("""\
+                <paragraph>Checksum to be used to determine if an Referable (including its
+                aggregated child elements) has changed.</paragraph>"""),
               remarks=[
-                "<paragraph>The checksum is calculated by the user's tool environment.\nThe checksum has no semantic meaning for an asset administration\nshell model and there is no requirement for asset administration\nshell tools to manage the checksum</paragraph>"],
+                textwrap.dedent("""\
+                  <paragraph>The checksum is calculated by the user's tool environment.
+                  The checksum has no semantic meaning for an asset administration
+                  shell model and there is no requirement for asset administration
+                  shell tools to manage the checksum</paragraph>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -4160,7 +5490,9 @@ SymbolTable(
                 parsed=...),
               parsed=...),
             description=PropertyDescription(
-              summary='<paragraph>Identifier of the semantic definition of the element. It is called semantic ID\nof the element.</paragraph>',
+              summary=textwrap.dedent("""\
+                <paragraph>Identifier of the semantic definition of the element. It is called semantic ID
+                of the element.</paragraph>"""),
               remarks=[],
               constraints_by_identifier=[],
               parsed=...),
@@ -4181,7 +5513,9 @@ SymbolTable(
               constraints_by_identifier=[
                 [
                   'AASd-021',
-                  '<field_body><paragraph>Every qualifiable can only have one qualifier with the same\n<AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>']],
+                  textwrap.dedent("""\
+                    <field_body><paragraph>Every qualifiable can only have one qualifier with the same
+                    <AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>""")]],
               parsed=...),
             specified_for='Reference to AbstractClass Qualifiable',
             parsed=...),
@@ -4227,7 +5561,9 @@ SymbolTable(
             parsed=...)],
         signatures=[],
         description=SymbolDescription(
-          summary='<paragraph>A relationship element is used to define a relationship between two elements\nbeing either referable (model reference) or external (global reference).</paragraph>',
+          summary=textwrap.dedent("""\
+            <paragraph>A relationship element is used to define a relationship between two elements
+            being either referable (model reference) or external (global reference).</paragraph>"""),
           remarks=[],
           constraints_by_identifier=[],
           parsed=...),
@@ -4262,13 +5598,21 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>In case of identifiables this attribute is a short name of the element.\nIn case of referable this ID is an identifying string of\nthe element within its name space.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>In case of identifiables this attribute is a short name of the element.
+              In case of referable this ID is an identifying string of
+              the element within its name space.</paragraph>"""),
             remarks=[
-              '<note><paragraph>In case the element is a property and the property has a semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>\nis typically identical to the short name in English.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>In case the element is a property and the property has a semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>
+                is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[
               [
                 'AASd-027',
-                '<field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>\'s shall have a maximum length\nof 128 characters.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>'s shall have a maximum length
+                  of 128 characters.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
@@ -4282,8 +5626,15 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>Display name. Can be provided in several languages.</paragraph>',
             remarks=[
-              '<paragraph>If no display name is defined in the language requested by the application,\nthen the display name is selected in the following order if available:</paragraph>',
-              '<bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,\nthen the corresponding preferred name in the language is chosen\naccording to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>'],
+              textwrap.dedent("""\
+                <paragraph>If no display name is defined in the language requested by the application,
+                then the display name is selected in the following order if available:</paragraph>"""),
+              textwrap.dedent("""\
+                <bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
+                then the corresponding preferred name in the language is chosen
+                according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -4296,9 +5647,18 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>The category is a value that gives further meta information\nw.r.t. to the class of the element.\nIt affects the expected existence of attributes and the applicability of\nconstraints.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>The category is a value that gives further meta information
+              w.r.t. to the class of the element.
+              It affects the expected existence of attributes and the applicability of
+              constraints.</paragraph>"""),
             remarks=[
-              '<note><paragraph>The category is not identical to the semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category\n<emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the\nsemantic definition of the element would\ndenote that it is the measured temperature.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>The category is not identical to the semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category
+                <emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the
+                semantic definition of the element would
+                denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -4314,8 +5674,14 @@ SymbolTable(
             summary='<paragraph>Description or comments on the element.</paragraph>',
             remarks=[
               '<paragraph>The description can be provided in several languages.</paragraph>',
-              '<paragraph>If no description is defined, then the definition of the concept\ndescription that defines the semantics of the element is used.</paragraph>',
-              '<paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is\nqualified and which qualifier types can be expected in which\ncontext or which additional data specification templates are\nprovided.</paragraph>'],
+              textwrap.dedent("""\
+                <paragraph>If no description is defined, then the definition of the concept
+                description that defines the semantics of the element is used.</paragraph>"""),
+              textwrap.dedent("""\
+                <paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is
+                qualified and which qualifier types can be expected in which
+                context or which additional data specification templates are
+                provided.</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -4328,9 +5694,15 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Checksum to be used to determine if an Referable (including its\naggregated child elements) has changed.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Checksum to be used to determine if an Referable (including its
+              aggregated child elements) has changed.</paragraph>"""),
             remarks=[
-              "<paragraph>The checksum is calculated by the user's tool environment.\nThe checksum has no semantic meaning for an asset administration\nshell model and there is no requirement for asset administration\nshell tools to manage the checksum</paragraph>"],
+              textwrap.dedent("""\
+                <paragraph>The checksum is calculated by the user's tool environment.
+                The checksum has no semantic meaning for an asset administration
+                shell model and there is no requirement for asset administration
+                shell tools to manage the checksum</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -4358,7 +5730,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Identifier of the semantic definition of the element. It is called semantic ID\nof the element.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Identifier of the semantic definition of the element. It is called semantic ID
+              of the element.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -4379,7 +5753,9 @@ SymbolTable(
             constraints_by_identifier=[
               [
                 'AASd-021',
-                '<field_body><paragraph>Every qualifiable can only have one qualifier with the same\n<AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph>Every qualifiable can only have one qualifier with the same
+                  <AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -4567,32 +5943,149 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='extensions',\n  argument='extensions',\n  default=None)",
-          "AssignArgument(\n  name='id_short',\n  argument='id_short',\n  default=None)",
-          "AssignArgument(\n  name='display_name',\n  argument='display_name',\n  default=None)",
-          "AssignArgument(\n  name='category',\n  argument='category',\n  default=None)",
-          "AssignArgument(\n  name='description',\n  argument='description',\n  default=None)",
-          "AssignArgument(\n  name='checksum',\n  argument='checksum',\n  default=None)",
-          "AssignArgument(\n  name='kind',\n  argument='kind',\n  default=DefaultEnumLiteral(\n    node=...,\n    enum='Reference to Enumeration Modeling_kind',\n    literal='Reference to EnumerationLiteral Instance'))",
-          "AssignArgument(\n  name='semantic_id',\n  argument='semantic_id',\n  default=None)",
-          "AssignArgument(\n  name='qualifiers',\n  argument='qualifiers',\n  default=None)",
-          "AssignArgument(\n  name='data_specifications',\n  argument='data_specifications',\n  default=None)",
-          "AssignArgument(\n  name='first',\n  argument='first',\n  default=None)",
-          "AssignArgument(\n  name='second',\n  argument='second',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='extensions',
+              argument='extensions',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='id_short',
+              argument='id_short',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='display_name',
+              argument='display_name',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='category',
+              argument='category',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='description',
+              argument='description',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='checksum',
+              argument='checksum',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='kind',
+              argument='kind',
+              default=DefaultEnumLiteral(
+                node=...,
+                enum='Reference to Enumeration Modeling_kind',
+                literal='Reference to EnumerationLiteral Instance'))"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='semantic_id',
+              argument='semantic_id',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='qualifiers',
+              argument='qualifiers',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='data_specifications',
+              argument='data_specifications',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='first',
+              argument='first',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='second',
+              argument='second',
+              default=None)""")]),
       invariants=[
         Invariant(
           description='Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='extensions',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='extension_names_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='extensions',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='extension_names_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='extensions',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
           description='Constraint AASd-027: ID-short shall have a maximum length of 128 characters.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='id_short',\n      original_node=...),\n    original_node=...),\n  consequent=Comparison(\n    left=FunctionCall(\n      name='len',\n      args=[\n        Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='id_short',\n          original_node=...)],\n      original_node=...),\n    op='LE',\n    right=Constant(\n      value=128,\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='id_short',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='id_short',
+                      original_node=...)],
+                  original_node=...),
+                op='LE',
+                right=Constant(
+                  value=128,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='qualifiers',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='qualifier_types_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='qualifiers',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='qualifier_types_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='qualifiers',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...)],
       serialization=Serialization(
@@ -4606,7 +6099,9 @@ SymbolTable(
         index=0,
         fragment=None),
       description=SymbolDescription(
-        summary='<paragraph>A relationship element is used to define a relationship between two elements\nbeing either referable (model reference) or external (global reference).</paragraph>',
+        summary=textwrap.dedent("""\
+          <paragraph>A relationship element is used to define a relationship between two elements
+          being either referable (model reference) or external (global reference).</paragraph>"""),
         remarks=[],
         constraints_by_identifier=[],
         parsed=...),
@@ -4649,13 +6144,21 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>In case of identifiables this attribute is a short name of the element.\nIn case of referable this ID is an identifying string of\nthe element within its name space.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>In case of identifiables this attribute is a short name of the element.
+              In case of referable this ID is an identifying string of
+              the element within its name space.</paragraph>"""),
             remarks=[
-              '<note><paragraph>In case the element is a property and the property has a semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>\nis typically identical to the short name in English.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>In case the element is a property and the property has a semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>
+                is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[
               [
                 'AASd-027',
-                '<field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>\'s shall have a maximum length\nof 128 characters.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>'s shall have a maximum length
+                  of 128 characters.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
@@ -4669,8 +6172,15 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>Display name. Can be provided in several languages.</paragraph>',
             remarks=[
-              '<paragraph>If no display name is defined in the language requested by the application,\nthen the display name is selected in the following order if available:</paragraph>',
-              '<bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,\nthen the corresponding preferred name in the language is chosen\naccording to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>'],
+              textwrap.dedent("""\
+                <paragraph>If no display name is defined in the language requested by the application,
+                then the display name is selected in the following order if available:</paragraph>"""),
+              textwrap.dedent("""\
+                <bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
+                then the corresponding preferred name in the language is chosen
+                according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -4683,9 +6193,18 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>The category is a value that gives further meta information\nw.r.t. to the class of the element.\nIt affects the expected existence of attributes and the applicability of\nconstraints.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>The category is a value that gives further meta information
+              w.r.t. to the class of the element.
+              It affects the expected existence of attributes and the applicability of
+              constraints.</paragraph>"""),
             remarks=[
-              '<note><paragraph>The category is not identical to the semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category\n<emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the\nsemantic definition of the element would\ndenote that it is the measured temperature.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>The category is not identical to the semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category
+                <emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the
+                semantic definition of the element would
+                denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -4701,8 +6220,14 @@ SymbolTable(
             summary='<paragraph>Description or comments on the element.</paragraph>',
             remarks=[
               '<paragraph>The description can be provided in several languages.</paragraph>',
-              '<paragraph>If no description is defined, then the definition of the concept\ndescription that defines the semantics of the element is used.</paragraph>',
-              '<paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is\nqualified and which qualifier types can be expected in which\ncontext or which additional data specification templates are\nprovided.</paragraph>'],
+              textwrap.dedent("""\
+                <paragraph>If no description is defined, then the definition of the concept
+                description that defines the semantics of the element is used.</paragraph>"""),
+              textwrap.dedent("""\
+                <paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is
+                qualified and which qualifier types can be expected in which
+                context or which additional data specification templates are
+                provided.</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -4715,9 +6240,15 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Checksum to be used to determine if an Referable (including its\naggregated child elements) has changed.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Checksum to be used to determine if an Referable (including its
+              aggregated child elements) has changed.</paragraph>"""),
             remarks=[
-              "<paragraph>The checksum is calculated by the user's tool environment.\nThe checksum has no semantic meaning for an asset administration\nshell model and there is no requirement for asset administration\nshell tools to manage the checksum</paragraph>"],
+              textwrap.dedent("""\
+                <paragraph>The checksum is calculated by the user's tool environment.
+                The checksum has no semantic meaning for an asset administration
+                shell model and there is no requirement for asset administration
+                shell tools to manage the checksum</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -4745,7 +6276,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Identifier of the semantic definition of the element. It is called semantic ID\nof the element.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Identifier of the semantic definition of the element. It is called semantic ID
+              of the element.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -4766,7 +6299,9 @@ SymbolTable(
             constraints_by_identifier=[
               [
                 'AASd-021',
-                '<field_body><paragraph>Every qualifiable can only have one qualifier with the same\n<AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph>Every qualifiable can only have one qualifier with the same
+                  <AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -4806,7 +6341,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Defines whether order in list is relevant. If <AttributeReference refuri="~order_relevant">~order_relevant</AttributeReference> = <literal>False</literal>\nthen the list is representing a set or a bag.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Defines whether order in list is relevant. If <AttributeReference refuri="~order_relevant">~order_relevant</AttributeReference> = <literal>False</literal>
+              then the list is representing a set or a bag.</paragraph>"""),
             remarks=[
               '<paragraph>Default: <literal>True</literal></paragraph>'],
             constraints_by_identifier=[],
@@ -4823,7 +6360,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Submodel element contained in the list.\nThe list is ordered.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Submodel element contained in the list.
+              The list is ordered.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -5040,65 +6579,433 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='extensions',\n  argument='extensions',\n  default=None)",
-          "AssignArgument(\n  name='id_short',\n  argument='id_short',\n  default=None)",
-          "AssignArgument(\n  name='display_name',\n  argument='display_name',\n  default=None)",
-          "AssignArgument(\n  name='category',\n  argument='category',\n  default=None)",
-          "AssignArgument(\n  name='description',\n  argument='description',\n  default=None)",
-          "AssignArgument(\n  name='checksum',\n  argument='checksum',\n  default=None)",
-          "AssignArgument(\n  name='kind',\n  argument='kind',\n  default=DefaultEnumLiteral(\n    node=...,\n    enum='Reference to Enumeration Modeling_kind',\n    literal='Reference to EnumerationLiteral Instance'))",
-          "AssignArgument(\n  name='semantic_id',\n  argument='semantic_id',\n  default=None)",
-          "AssignArgument(\n  name='qualifiers',\n  argument='qualifiers',\n  default=None)",
-          "AssignArgument(\n  name='data_specifications',\n  argument='data_specifications',\n  default=None)",
-          "AssignArgument(\n  name='type_value_list_element',\n  argument='type_value_list_element',\n  default=None)",
-          "AssignArgument(\n  name='order_relevant',\n  argument='order_relevant',\n  default=None)",
-          "AssignArgument(\n  name='value',\n  argument='value',\n  default=None)",
-          "AssignArgument(\n  name='semantic_id_list_element',\n  argument='semantic_id_list_element',\n  default=None)",
-          "AssignArgument(\n  name='value_type_list_element',\n  argument='value_type_list_element',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='extensions',
+              argument='extensions',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='id_short',
+              argument='id_short',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='display_name',
+              argument='display_name',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='category',
+              argument='category',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='description',
+              argument='description',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='checksum',
+              argument='checksum',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='kind',
+              argument='kind',
+              default=DefaultEnumLiteral(
+                node=...,
+                enum='Reference to Enumeration Modeling_kind',
+                literal='Reference to EnumerationLiteral Instance'))"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='semantic_id',
+              argument='semantic_id',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='qualifiers',
+              argument='qualifiers',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='data_specifications',
+              argument='data_specifications',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='type_value_list_element',
+              argument='type_value_list_element',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='order_relevant',
+              argument='order_relevant',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='value',
+              argument='value',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='semantic_id_list_element',
+              argument='semantic_id_list_element',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='value_type_list_element',
+              argument='value_type_list_element',
+              default=None)""")]),
       invariants=[
         Invariant(
           description='Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='extensions',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='extension_names_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='extensions',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='extension_names_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='extensions',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
           description='Constraint AASd-027: ID-short shall have a maximum length of 128 characters.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='id_short',\n      original_node=...),\n    original_node=...),\n  consequent=Comparison(\n    left=FunctionCall(\n      name='len',\n      args=[\n        Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='id_short',\n          original_node=...)],\n      original_node=...),\n    op='LE',\n    right=Constant(\n      value=128,\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='id_short',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='id_short',
+                      original_node=...)],
+                  original_node=...),
+                op='LE',
+                right=Constant(
+                  value=128,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='qualifiers',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='qualifier_types_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='qualifiers',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='qualifier_types_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='qualifiers',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Invariant(
           description='Constraint AASd-107: If a first level child element has a semantic ID it shall be identical to semantic ID list element.',
-          body="Implication(\n  antecedent=And(\n    values=[\n      IsNotNone(\n        value=Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='value',\n          original_node=...),\n        original_node=...),\n      IsNotNone(\n        value=Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='semantic_id_list_element',\n          original_node=...),\n        original_node=...)],\n    original_node=...),\n  consequent=All(\n    for_each=ForEach(\n      variable=Name(\n        identifier='child',\n        original_node=...),\n      iteration=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='value',\n        original_node=...),\n      original_node=...),\n    condition=Implication(\n      antecedent=IsNotNone(\n        value=Member(\n          instance=Name(\n            identifier='child',\n            original_node=...),\n          name='semantic_id',\n          original_node=...),\n        original_node=...),\n      consequent=Comparison(\n        left=Member(\n          instance=Name(\n            identifier='child',\n            original_node=...),\n          name='semantic_id',\n          original_node=...),\n        op='EQ',\n        right=Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='semantic_id_list_element',\n          original_node=...),\n        original_node=...),\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=And(
+                values=[
+                  IsNotNone(
+                    value=Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='value',
+                      original_node=...),
+                    original_node=...),
+                  IsNotNone(
+                    value=Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='semantic_id_list_element',
+                      original_node=...),
+                    original_node=...)],
+                original_node=...),
+              consequent=All(
+                for_each=ForEach(
+                  variable=Name(
+                    identifier='child',
+                    original_node=...),
+                  iteration=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='value',
+                    original_node=...),
+                  original_node=...),
+                condition=Implication(
+                  antecedent=IsNotNone(
+                    value=Member(
+                      instance=Name(
+                        identifier='child',
+                        original_node=...),
+                      name='semantic_id',
+                      original_node=...),
+                    original_node=...),
+                  consequent=Comparison(
+                    left=Member(
+                      instance=Name(
+                        identifier='child',
+                        original_node=...),
+                      name='semantic_id',
+                      original_node=...),
+                    op='EQ',
+                    right=Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='semantic_id_list_element',
+                      original_node=...),
+                    original_node=...),
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to ConcreteClass Submodel_element_list',
           parsed=...),
         Invariant(
           description='Constraint AASd-114: If two first level child elements have a semantic ID then they shall be identical.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='value',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='submodel_elements_have_identical_semantic_ids',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='value',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='value',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='submodel_elements_have_identical_semantic_ids',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='value',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to ConcreteClass Submodel_element_list',
           parsed=...),
         Invariant(
           description='Constraint AASd-108: All first level child elements shall have the same submodel element type as specified in type value list element.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='value',\n      original_node=...),\n    original_node=...),\n  consequent=All(\n    for_each=ForEach(\n      variable=Name(\n        identifier='element',\n        original_node=...),\n      iteration=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='value',\n        original_node=...),\n      original_node=...),\n    condition=FunctionCall(\n      name='submodel_element_is_of_type',\n      args=[\n        Name(\n          identifier='element',\n          original_node=...),\n        Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='type_value_list_element',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='value',
+                  original_node=...),
+                original_node=...),
+              consequent=All(
+                for_each=ForEach(
+                  variable=Name(
+                    identifier='element',
+                    original_node=...),
+                  iteration=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='value',
+                    original_node=...),
+                  original_node=...),
+                condition=FunctionCall(
+                  name='submodel_element_is_of_type',
+                  args=[
+                    Name(
+                      identifier='element',
+                      original_node=...),
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='type_value_list_element',
+                      original_node=...)],
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to ConcreteClass Submodel_element_list',
           parsed=...),
         Invariant(
           description='Constraint AASd-109: If type value list element is equal to Property or Range value type list element shall be set and all first level child elements shall have the value type as specified in value type list element.',
-          body="Implication(\n  antecedent=And(\n    values=[\n      IsNotNone(\n        value=Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='value',\n          original_node=...),\n        original_node=...),\n      Or(\n        values=[\n          Comparison(\n            left=Member(\n              instance=Name(\n                identifier='self',\n                original_node=...),\n              name='type_value_list_element',\n              original_node=...),\n            op='EQ',\n            right=Member(\n              instance=Name(\n                identifier='Submodel_element_elements',\n                original_node=...),\n              name='Property',\n              original_node=...),\n            original_node=...),\n          Comparison(\n            left=Member(\n              instance=Name(\n                identifier='self',\n                original_node=...),\n              name='type_value_list_element',\n              original_node=...),\n            op='EQ',\n            right=Member(\n              instance=Name(\n                identifier='Submodel_element_elements',\n                original_node=...),\n              name='Range',\n              original_node=...),\n            original_node=...)],\n        original_node=...)],\n    original_node=...),\n  consequent=And(\n    values=[\n      IsNotNone(\n        value=Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='value_type_list_element',\n          original_node=...),\n        original_node=...),\n      FunctionCall(\n        name='properties_or_ranges_have_value_type',\n        args=[\n          Member(\n            instance=Name(\n              identifier='self',\n              original_node=...),\n            name='value',\n            original_node=...),\n          Member(\n            instance=Name(\n              identifier='self',\n              original_node=...),\n            name='value_type_list_element',\n            original_node=...)],\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=And(
+                values=[
+                  IsNotNone(
+                    value=Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='value',
+                      original_node=...),
+                    original_node=...),
+                  Or(
+                    values=[
+                      Comparison(
+                        left=Member(
+                          instance=Name(
+                            identifier='self',
+                            original_node=...),
+                          name='type_value_list_element',
+                          original_node=...),
+                        op='EQ',
+                        right=Member(
+                          instance=Name(
+                            identifier='Submodel_element_elements',
+                            original_node=...),
+                          name='Property',
+                          original_node=...),
+                        original_node=...),
+                      Comparison(
+                        left=Member(
+                          instance=Name(
+                            identifier='self',
+                            original_node=...),
+                          name='type_value_list_element',
+                          original_node=...),
+                        op='EQ',
+                        right=Member(
+                          instance=Name(
+                            identifier='Submodel_element_elements',
+                            original_node=...),
+                          name='Range',
+                          original_node=...),
+                        original_node=...)],
+                    original_node=...)],
+                original_node=...),
+              consequent=And(
+                values=[
+                  IsNotNone(
+                    value=Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='value_type_list_element',
+                      original_node=...),
+                    original_node=...),
+                  FunctionCall(
+                    name='properties_or_ranges_have_value_type',
+                    args=[
+                      Member(
+                        instance=Name(
+                          identifier='self',
+                          original_node=...),
+                        name='value',
+                        original_node=...),
+                      Member(
+                        instance=Name(
+                          identifier='self',
+                          original_node=...),
+                        name='value_type_list_element',
+                        original_node=...)],
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to ConcreteClass Submodel_element_list',
           parsed=...),
         Invariant(
           description='Short IDs need to be defined for all the elements.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='value',\n      original_node=...),\n    original_node=...),\n  consequent=All(\n    for_each=ForEach(\n      variable=Name(\n        identifier='element',\n        original_node=...),\n      iteration=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='value',\n        original_node=...),\n      original_node=...),\n    condition=IsNotNone(\n      value=Member(\n        instance=Name(\n          identifier='element',\n          original_node=...),\n        name='id_short',\n        original_node=...),\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='value',
+                  original_node=...),
+                original_node=...),
+              consequent=All(
+                for_each=ForEach(
+                  variable=Name(
+                    identifier='element',
+                    original_node=...),
+                  iteration=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='value',
+                    original_node=...),
+                  original_node=...),
+                condition=IsNotNone(
+                  value=Member(
+                    instance=Name(
+                      identifier='element',
+                      original_node=...),
+                    name='id_short',
+                    original_node=...),
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to ConcreteClass Submodel_element_list',
           parsed=...),
         Invariant(
           description=None,
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='value',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='id_shorts_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='value',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='value',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='id_shorts_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='value',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to ConcreteClass Submodel_element_list',
           parsed=...)],
       serialization=Serialization(
@@ -5117,19 +7024,35 @@ SymbolTable(
         constraints_by_identifier=[
           [
             'AASd-107',
-            '<field_body><paragraph>If a first level child element in a <SymbolReference refuri=".Submodel_element_list">.Submodel_element_list</SymbolReference> has\na <AttributeReference refuri="~Submodel_element.semantic_id">~Submodel_element.semantic_id</AttributeReference> it\nshall be identical to <AttributeReference refuri="~Submodel_element_list.semantic_id_list_element">~Submodel_element_list.semantic_id_list_element</AttributeReference>.</paragraph></field_body>'],
+            textwrap.dedent("""\
+              <field_body><paragraph>If a first level child element in a <SymbolReference refuri=".Submodel_element_list">.Submodel_element_list</SymbolReference> has
+              a <AttributeReference refuri="~Submodel_element.semantic_id">~Submodel_element.semantic_id</AttributeReference> it
+              shall be identical to <AttributeReference refuri="~Submodel_element_list.semantic_id_list_element">~Submodel_element_list.semantic_id_list_element</AttributeReference>.</paragraph></field_body>""")],
           [
             'AASd-114',
-            '<field_body><paragraph>If two first level child elements in a <SymbolReference refuri=".Submodel_element_list">.Submodel_element_list</SymbolReference> have\na <AttributeReference refuri="~Submodel_element.semantic_id">~Submodel_element.semantic_id</AttributeReference> then they shall be identical.</paragraph></field_body>'],
+            textwrap.dedent("""\
+              <field_body><paragraph>If two first level child elements in a <SymbolReference refuri=".Submodel_element_list">.Submodel_element_list</SymbolReference> have
+              a <AttributeReference refuri="~Submodel_element.semantic_id">~Submodel_element.semantic_id</AttributeReference> then they shall be identical.</paragraph></field_body>""")],
           [
             'AASd-115',
-            '<field_body><paragraph>If a first level child element in a <SymbolReference refuri=".Submodel_element_list">.Submodel_element_list</SymbolReference> does not\nspecify a <AttributeReference refuri="~Submodel_element.semantic_id">~Submodel_element.semantic_id</AttributeReference> then the value is assumed to be\nidentical to <AttributeReference refuri="~Submodel_element_list.semantic_id_list_element">~Submodel_element_list.semantic_id_list_element</AttributeReference>.</paragraph></field_body>'],
+            textwrap.dedent("""\
+              <field_body><paragraph>If a first level child element in a <SymbolReference refuri=".Submodel_element_list">.Submodel_element_list</SymbolReference> does not
+              specify a <AttributeReference refuri="~Submodel_element.semantic_id">~Submodel_element.semantic_id</AttributeReference> then the value is assumed to be
+              identical to <AttributeReference refuri="~Submodel_element_list.semantic_id_list_element">~Submodel_element_list.semantic_id_list_element</AttributeReference>.</paragraph></field_body>""")],
           [
             'AASd-108',
-            '<field_body><paragraph>All first level child elements in a <SymbolReference refuri=".Submodel_element_list">.Submodel_element_list</SymbolReference> shall have\nthe same submodel element type as specified in <AttributeReference refuri="~type_value_list_element">~type_value_list_element</AttributeReference>.</paragraph></field_body>'],
+            textwrap.dedent("""\
+              <field_body><paragraph>All first level child elements in a <SymbolReference refuri=".Submodel_element_list">.Submodel_element_list</SymbolReference> shall have
+              the same submodel element type as specified in <AttributeReference refuri="~type_value_list_element">~type_value_list_element</AttributeReference>.</paragraph></field_body>""")],
           [
             'AASd-109',
-            '<field_body><paragraph>If <AttributeReference refuri="~type_value_list_element">~type_value_list_element</AttributeReference> is equal to\n<AttributeReference refuri="Submodel_element_elements.Property">Submodel_element_elements.Property</AttributeReference> or\n<AttributeReference refuri="Submodel_element_elements.Range">Submodel_element_elements.Range</AttributeReference>\n<AttributeReference refuri="~value_type_list_element">~value_type_list_element</AttributeReference> shall be set and all first\nlevel child elements in the <SymbolReference refuri=".Submodel_element_list">.Submodel_element_list</SymbolReference> shall have\nthe value type as specified in <AttributeReference refuri="~value_type_list_element">~value_type_list_element</AttributeReference>.</paragraph></field_body>']],
+            textwrap.dedent("""\
+              <field_body><paragraph>If <AttributeReference refuri="~type_value_list_element">~type_value_list_element</AttributeReference> is equal to
+              <AttributeReference refuri="Submodel_element_elements.Property">Submodel_element_elements.Property</AttributeReference> or
+              <AttributeReference refuri="Submodel_element_elements.Range">Submodel_element_elements.Range</AttributeReference>
+              <AttributeReference refuri="~value_type_list_element">~value_type_list_element</AttributeReference> shall be set and all first
+              level child elements in the <SymbolReference refuri=".Submodel_element_list">.Submodel_element_list</SymbolReference> shall have
+              the value type as specified in <AttributeReference refuri="~value_type_list_element">~value_type_list_element</AttributeReference>.</paragraph></field_body>""")]],
         parsed=...),
       parsed=...,
       properties_by_name=...,
@@ -5170,13 +7093,21 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>In case of identifiables this attribute is a short name of the element.\nIn case of referable this ID is an identifying string of\nthe element within its name space.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>In case of identifiables this attribute is a short name of the element.
+              In case of referable this ID is an identifying string of
+              the element within its name space.</paragraph>"""),
             remarks=[
-              '<note><paragraph>In case the element is a property and the property has a semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>\nis typically identical to the short name in English.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>In case the element is a property and the property has a semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>
+                is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[
               [
                 'AASd-027',
-                '<field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>\'s shall have a maximum length\nof 128 characters.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>'s shall have a maximum length
+                  of 128 characters.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
@@ -5190,8 +7121,15 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>Display name. Can be provided in several languages.</paragraph>',
             remarks=[
-              '<paragraph>If no display name is defined in the language requested by the application,\nthen the display name is selected in the following order if available:</paragraph>',
-              '<bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,\nthen the corresponding preferred name in the language is chosen\naccording to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>'],
+              textwrap.dedent("""\
+                <paragraph>If no display name is defined in the language requested by the application,
+                then the display name is selected in the following order if available:</paragraph>"""),
+              textwrap.dedent("""\
+                <bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
+                then the corresponding preferred name in the language is chosen
+                according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -5204,9 +7142,18 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>The category is a value that gives further meta information\nw.r.t. to the class of the element.\nIt affects the expected existence of attributes and the applicability of\nconstraints.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>The category is a value that gives further meta information
+              w.r.t. to the class of the element.
+              It affects the expected existence of attributes and the applicability of
+              constraints.</paragraph>"""),
             remarks=[
-              '<note><paragraph>The category is not identical to the semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category\n<emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the\nsemantic definition of the element would\ndenote that it is the measured temperature.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>The category is not identical to the semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category
+                <emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the
+                semantic definition of the element would
+                denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -5222,8 +7169,14 @@ SymbolTable(
             summary='<paragraph>Description or comments on the element.</paragraph>',
             remarks=[
               '<paragraph>The description can be provided in several languages.</paragraph>',
-              '<paragraph>If no description is defined, then the definition of the concept\ndescription that defines the semantics of the element is used.</paragraph>',
-              '<paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is\nqualified and which qualifier types can be expected in which\ncontext or which additional data specification templates are\nprovided.</paragraph>'],
+              textwrap.dedent("""\
+                <paragraph>If no description is defined, then the definition of the concept
+                description that defines the semantics of the element is used.</paragraph>"""),
+              textwrap.dedent("""\
+                <paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is
+                qualified and which qualifier types can be expected in which
+                context or which additional data specification templates are
+                provided.</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -5236,9 +7189,15 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Checksum to be used to determine if an Referable (including its\naggregated child elements) has changed.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Checksum to be used to determine if an Referable (including its
+              aggregated child elements) has changed.</paragraph>"""),
             remarks=[
-              "<paragraph>The checksum is calculated by the user's tool environment.\nThe checksum has no semantic meaning for an asset administration\nshell model and there is no requirement for asset administration\nshell tools to manage the checksum</paragraph>"],
+              textwrap.dedent("""\
+                <paragraph>The checksum is calculated by the user's tool environment.
+                The checksum has no semantic meaning for an asset administration
+                shell model and there is no requirement for asset administration
+                shell tools to manage the checksum</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -5266,7 +7225,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Identifier of the semantic definition of the element. It is called semantic ID\nof the element.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Identifier of the semantic definition of the element. It is called semantic ID
+              of the element.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -5287,7 +7248,9 @@ SymbolTable(
             constraints_by_identifier=[
               [
                 'AASd-021',
-                '<field_body><paragraph>Every qualifiable can only have one qualifier with the same\n<AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph>Every qualifiable can only have one qualifier with the same
+                  <AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -5466,41 +7429,205 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='extensions',\n  argument='extensions',\n  default=None)",
-          "AssignArgument(\n  name='id_short',\n  argument='id_short',\n  default=None)",
-          "AssignArgument(\n  name='display_name',\n  argument='display_name',\n  default=None)",
-          "AssignArgument(\n  name='category',\n  argument='category',\n  default=None)",
-          "AssignArgument(\n  name='description',\n  argument='description',\n  default=None)",
-          "AssignArgument(\n  name='checksum',\n  argument='checksum',\n  default=None)",
-          "AssignArgument(\n  name='kind',\n  argument='kind',\n  default=DefaultEnumLiteral(\n    node=...,\n    enum='Reference to Enumeration Modeling_kind',\n    literal='Reference to EnumerationLiteral Instance'))",
-          "AssignArgument(\n  name='semantic_id',\n  argument='semantic_id',\n  default=None)",
-          "AssignArgument(\n  name='qualifiers',\n  argument='qualifiers',\n  default=None)",
-          "AssignArgument(\n  name='data_specifications',\n  argument='data_specifications',\n  default=None)",
-          "AssignArgument(\n  name='value',\n  argument='value',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='extensions',
+              argument='extensions',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='id_short',
+              argument='id_short',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='display_name',
+              argument='display_name',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='category',
+              argument='category',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='description',
+              argument='description',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='checksum',
+              argument='checksum',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='kind',
+              argument='kind',
+              default=DefaultEnumLiteral(
+                node=...,
+                enum='Reference to Enumeration Modeling_kind',
+                literal='Reference to EnumerationLiteral Instance'))"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='semantic_id',
+              argument='semantic_id',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='qualifiers',
+              argument='qualifiers',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='data_specifications',
+              argument='data_specifications',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='value',
+              argument='value',
+              default=None)""")]),
       invariants=[
         Invariant(
           description='Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='extensions',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='extension_names_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='extensions',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='extension_names_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='extensions',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
           description='Constraint AASd-027: ID-short shall have a maximum length of 128 characters.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='id_short',\n      original_node=...),\n    original_node=...),\n  consequent=Comparison(\n    left=FunctionCall(\n      name='len',\n      args=[\n        Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='id_short',\n          original_node=...)],\n      original_node=...),\n    op='LE',\n    right=Constant(\n      value=128,\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='id_short',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='id_short',
+                      original_node=...)],
+                  original_node=...),
+                op='LE',
+                right=Constant(
+                  value=128,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='qualifiers',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='qualifier_types_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='qualifiers',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='qualifier_types_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='qualifiers',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Invariant(
           description='Short IDs need to be defined for all the elements.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='value',\n      original_node=...),\n    original_node=...),\n  consequent=All(\n    for_each=ForEach(\n      variable=Name(\n        identifier='element',\n        original_node=...),\n      iteration=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='value',\n        original_node=...),\n      original_node=...),\n    condition=IsNotNone(\n      value=Member(\n        instance=Name(\n          identifier='element',\n          original_node=...),\n        name='id_short',\n        original_node=...),\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='value',
+                  original_node=...),
+                original_node=...),
+              consequent=All(
+                for_each=ForEach(
+                  variable=Name(
+                    identifier='element',
+                    original_node=...),
+                  iteration=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='value',
+                    original_node=...),
+                  original_node=...),
+                condition=IsNotNone(
+                  value=Member(
+                    instance=Name(
+                      identifier='element',
+                      original_node=...),
+                    name='id_short',
+                    original_node=...),
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to ConcreteClass Submodel_element_struct',
           parsed=...),
         Invariant(
           description=None,
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='value',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='id_shorts_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='value',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='value',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='id_shorts_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='value',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to ConcreteClass Submodel_element_struct',
           parsed=...)],
       serialization=Serialization(
@@ -5514,7 +7641,9 @@ SymbolTable(
         index=0,
         fragment=None),
       description=SymbolDescription(
-        summary='<paragraph>A submodel element struct is is a logical encapsulation of multiple values. It has\na number of of submodel elements.</paragraph>',
+        summary=textwrap.dedent("""\
+          <paragraph>A submodel element struct is is a logical encapsulation of multiple values. It has
+          a number of of submodel elements.</paragraph>"""),
         remarks=[],
         constraints_by_identifier=[],
         parsed=...),
@@ -5566,13 +7695,21 @@ SymbolTable(
                 parsed=...),
               parsed=...),
             description=PropertyDescription(
-              summary='<paragraph>In case of identifiables this attribute is a short name of the element.\nIn case of referable this ID is an identifying string of\nthe element within its name space.</paragraph>',
+              summary=textwrap.dedent("""\
+                <paragraph>In case of identifiables this attribute is a short name of the element.
+                In case of referable this ID is an identifying string of
+                the element within its name space.</paragraph>"""),
               remarks=[
-                '<note><paragraph>In case the element is a property and the property has a semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>\nis typically identical to the short name in English.</paragraph></note>'],
+                textwrap.dedent("""\
+                  <note><paragraph>In case the element is a property and the property has a semantic definition
+                  (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>
+                  is typically identical to the short name in English.</paragraph></note>""")],
               constraints_by_identifier=[
                 [
                   'AASd-027',
-                  '<field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>\'s shall have a maximum length\nof 128 characters.</paragraph></field_body>']],
+                  textwrap.dedent("""\
+                    <field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>'s shall have a maximum length
+                    of 128 characters.</paragraph></field_body>""")]],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
             parsed=...),
@@ -5586,8 +7723,15 @@ SymbolTable(
             description=PropertyDescription(
               summary='<paragraph>Display name. Can be provided in several languages.</paragraph>',
               remarks=[
-                '<paragraph>If no display name is defined in the language requested by the application,\nthen the display name is selected in the following order if available:</paragraph>',
-                '<bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,\nthen the corresponding preferred name in the language is chosen\naccording to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>'],
+                textwrap.dedent("""\
+                  <paragraph>If no display name is defined in the language requested by the application,
+                  then the display name is selected in the following order if available:</paragraph>"""),
+                textwrap.dedent("""\
+                  <bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining
+                  the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
+                  then the corresponding preferred name in the language is chosen
+                  according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
+                  the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -5600,9 +7744,18 @@ SymbolTable(
                 parsed=...),
               parsed=...),
             description=PropertyDescription(
-              summary='<paragraph>The category is a value that gives further meta information\nw.r.t. to the class of the element.\nIt affects the expected existence of attributes and the applicability of\nconstraints.</paragraph>',
+              summary=textwrap.dedent("""\
+                <paragraph>The category is a value that gives further meta information
+                w.r.t. to the class of the element.
+                It affects the expected existence of attributes and the applicability of
+                constraints.</paragraph>"""),
               remarks=[
-                '<note><paragraph>The category is not identical to the semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category\n<emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the\nsemantic definition of the element would\ndenote that it is the measured temperature.</paragraph></note>'],
+                textwrap.dedent("""\
+                  <note><paragraph>The category is not identical to the semantic definition
+                  (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category
+                  <emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the
+                  semantic definition of the element would
+                  denote that it is the measured temperature.</paragraph></note>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -5618,8 +7771,14 @@ SymbolTable(
               summary='<paragraph>Description or comments on the element.</paragraph>',
               remarks=[
                 '<paragraph>The description can be provided in several languages.</paragraph>',
-                '<paragraph>If no description is defined, then the definition of the concept\ndescription that defines the semantics of the element is used.</paragraph>',
-                '<paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is\nqualified and which qualifier types can be expected in which\ncontext or which additional data specification templates are\nprovided.</paragraph>'],
+                textwrap.dedent("""\
+                  <paragraph>If no description is defined, then the definition of the concept
+                  description that defines the semantics of the element is used.</paragraph>"""),
+                textwrap.dedent("""\
+                  <paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is
+                  qualified and which qualifier types can be expected in which
+                  context or which additional data specification templates are
+                  provided.</paragraph>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -5632,9 +7791,15 @@ SymbolTable(
                 parsed=...),
               parsed=...),
             description=PropertyDescription(
-              summary='<paragraph>Checksum to be used to determine if an Referable (including its\naggregated child elements) has changed.</paragraph>',
+              summary=textwrap.dedent("""\
+                <paragraph>Checksum to be used to determine if an Referable (including its
+                aggregated child elements) has changed.</paragraph>"""),
               remarks=[
-                "<paragraph>The checksum is calculated by the user's tool environment.\nThe checksum has no semantic meaning for an asset administration\nshell model and there is no requirement for asset administration\nshell tools to manage the checksum</paragraph>"],
+                textwrap.dedent("""\
+                  <paragraph>The checksum is calculated by the user's tool environment.
+                  The checksum has no semantic meaning for an asset administration
+                  shell model and there is no requirement for asset administration
+                  shell tools to manage the checksum</paragraph>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -5662,7 +7827,9 @@ SymbolTable(
                 parsed=...),
               parsed=...),
             description=PropertyDescription(
-              summary='<paragraph>Identifier of the semantic definition of the element. It is called semantic ID\nof the element.</paragraph>',
+              summary=textwrap.dedent("""\
+                <paragraph>Identifier of the semantic definition of the element. It is called semantic ID
+                of the element.</paragraph>"""),
               remarks=[],
               constraints_by_identifier=[],
               parsed=...),
@@ -5683,7 +7850,9 @@ SymbolTable(
               constraints_by_identifier=[
                 [
                   'AASd-021',
-                  '<field_body><paragraph>Every qualifiable can only have one qualifier with the same\n<AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>']],
+                  textwrap.dedent("""\
+                    <field_body><paragraph>Every qualifiable can only have one qualifier with the same
+                    <AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>""")]],
               parsed=...),
             specified_for='Reference to AbstractClass Qualifiable',
             parsed=...),
@@ -5705,14 +7874,22 @@ SymbolTable(
             parsed=...)],
         signatures=[],
         description=SymbolDescription(
-          summary='<paragraph>A data element is a submodel element that is not further composed out of\nother submodel elements.</paragraph>',
+          summary=textwrap.dedent("""\
+            <paragraph>A data element is a submodel element that is not further composed out of
+            other submodel elements.</paragraph>"""),
           remarks=[
-            '<paragraph>A data element is a submodel element that has a value. The type of value differs\nfor different subtypes of data elements.</paragraph>',
-            '<paragraph>A controlled value is a value whose meaning is given in an external source\n(see “ISO/TS 29002-10:2009(E)”).</paragraph>'],
+            textwrap.dedent("""\
+              <paragraph>A data element is a submodel element that has a value. The type of value differs
+              for different subtypes of data elements.</paragraph>"""),
+            textwrap.dedent("""\
+              <paragraph>A controlled value is a value whose meaning is given in an external source
+              (see “ISO/TS 29002-10:2009(E)”).</paragraph>""")],
           constraints_by_identifier=[
             [
               'AASd-090',
-              '<field_body><paragraph>For data elements <AttributeReference refuri="~category">~category</AttributeReference> shall be one of the following\nvalues: <literal>CONSTANT</literal>, <literal>PARAMETER</literal> or <literal>VARIABLE</literal>.</paragraph></field_body>']],
+              textwrap.dedent("""\
+                <field_body><paragraph>For data elements <AttributeReference refuri="~category">~category</AttributeReference> shall be one of the following
+                values: <literal>CONSTANT</literal>, <literal>PARAMETER</literal> or <literal>VARIABLE</literal>.</paragraph></field_body>""")]],
           parsed=...),
         parsed=...,
         properties_by_name=...,
@@ -5750,13 +7927,21 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>In case of identifiables this attribute is a short name of the element.\nIn case of referable this ID is an identifying string of\nthe element within its name space.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>In case of identifiables this attribute is a short name of the element.
+              In case of referable this ID is an identifying string of
+              the element within its name space.</paragraph>"""),
             remarks=[
-              '<note><paragraph>In case the element is a property and the property has a semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>\nis typically identical to the short name in English.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>In case the element is a property and the property has a semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>
+                is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[
               [
                 'AASd-027',
-                '<field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>\'s shall have a maximum length\nof 128 characters.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>'s shall have a maximum length
+                  of 128 characters.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
@@ -5770,8 +7955,15 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>Display name. Can be provided in several languages.</paragraph>',
             remarks=[
-              '<paragraph>If no display name is defined in the language requested by the application,\nthen the display name is selected in the following order if available:</paragraph>',
-              '<bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,\nthen the corresponding preferred name in the language is chosen\naccording to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>'],
+              textwrap.dedent("""\
+                <paragraph>If no display name is defined in the language requested by the application,
+                then the display name is selected in the following order if available:</paragraph>"""),
+              textwrap.dedent("""\
+                <bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
+                then the corresponding preferred name in the language is chosen
+                according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -5784,9 +7976,18 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>The category is a value that gives further meta information\nw.r.t. to the class of the element.\nIt affects the expected existence of attributes and the applicability of\nconstraints.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>The category is a value that gives further meta information
+              w.r.t. to the class of the element.
+              It affects the expected existence of attributes and the applicability of
+              constraints.</paragraph>"""),
             remarks=[
-              '<note><paragraph>The category is not identical to the semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category\n<emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the\nsemantic definition of the element would\ndenote that it is the measured temperature.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>The category is not identical to the semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category
+                <emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the
+                semantic definition of the element would
+                denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -5802,8 +8003,14 @@ SymbolTable(
             summary='<paragraph>Description or comments on the element.</paragraph>',
             remarks=[
               '<paragraph>The description can be provided in several languages.</paragraph>',
-              '<paragraph>If no description is defined, then the definition of the concept\ndescription that defines the semantics of the element is used.</paragraph>',
-              '<paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is\nqualified and which qualifier types can be expected in which\ncontext or which additional data specification templates are\nprovided.</paragraph>'],
+              textwrap.dedent("""\
+                <paragraph>If no description is defined, then the definition of the concept
+                description that defines the semantics of the element is used.</paragraph>"""),
+              textwrap.dedent("""\
+                <paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is
+                qualified and which qualifier types can be expected in which
+                context or which additional data specification templates are
+                provided.</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -5816,9 +8023,15 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Checksum to be used to determine if an Referable (including its\naggregated child elements) has changed.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Checksum to be used to determine if an Referable (including its
+              aggregated child elements) has changed.</paragraph>"""),
             remarks=[
-              "<paragraph>The checksum is calculated by the user's tool environment.\nThe checksum has no semantic meaning for an asset administration\nshell model and there is no requirement for asset administration\nshell tools to manage the checksum</paragraph>"],
+              textwrap.dedent("""\
+                <paragraph>The checksum is calculated by the user's tool environment.
+                The checksum has no semantic meaning for an asset administration
+                shell model and there is no requirement for asset administration
+                shell tools to manage the checksum</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -5846,7 +8059,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Identifier of the semantic definition of the element. It is called semantic ID\nof the element.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Identifier of the semantic definition of the element. It is called semantic ID
+              of the element.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -5867,7 +8082,9 @@ SymbolTable(
             constraints_by_identifier=[
               [
                 'AASd-021',
-                '<field_body><paragraph>Every qualifiable can only have one qualifier with the same\n<AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph>Every qualifiable can only have one qualifier with the same
+                  <AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -6017,35 +8234,183 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='extensions',\n  argument='extensions',\n  default=None)",
-          "AssignArgument(\n  name='id_short',\n  argument='id_short',\n  default=None)",
-          "AssignArgument(\n  name='display_name',\n  argument='display_name',\n  default=None)",
-          "AssignArgument(\n  name='category',\n  argument='category',\n  default=None)",
-          "AssignArgument(\n  name='description',\n  argument='description',\n  default=None)",
-          "AssignArgument(\n  name='checksum',\n  argument='checksum',\n  default=None)",
-          "AssignArgument(\n  name='kind',\n  argument='kind',\n  default=DefaultEnumLiteral(\n    node=...,\n    enum='Reference to Enumeration Modeling_kind',\n    literal='Reference to EnumerationLiteral Instance'))",
-          "AssignArgument(\n  name='semantic_id',\n  argument='semantic_id',\n  default=None)",
-          "AssignArgument(\n  name='qualifiers',\n  argument='qualifiers',\n  default=None)",
-          "AssignArgument(\n  name='data_specifications',\n  argument='data_specifications',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='extensions',
+              argument='extensions',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='id_short',
+              argument='id_short',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='display_name',
+              argument='display_name',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='category',
+              argument='category',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='description',
+              argument='description',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='checksum',
+              argument='checksum',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='kind',
+              argument='kind',
+              default=DefaultEnumLiteral(
+                node=...,
+                enum='Reference to Enumeration Modeling_kind',
+                literal='Reference to EnumerationLiteral Instance'))"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='semantic_id',
+              argument='semantic_id',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='qualifiers',
+              argument='qualifiers',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='data_specifications',
+              argument='data_specifications',
+              default=None)""")]),
       invariants=[
         Invariant(
           description='Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='extensions',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='extension_names_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='extensions',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='extension_names_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='extensions',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
           description='Constraint AASd-027: ID-short shall have a maximum length of 128 characters.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='id_short',\n      original_node=...),\n    original_node=...),\n  consequent=Comparison(\n    left=FunctionCall(\n      name='len',\n      args=[\n        Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='id_short',\n          original_node=...)],\n      original_node=...),\n    op='LE',\n    right=Constant(\n      value=128,\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='id_short',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='id_short',
+                      original_node=...)],
+                  original_node=...),
+                op='LE',
+                right=Constant(
+                  value=128,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='qualifiers',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='qualifier_types_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='qualifiers',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='qualifier_types_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='qualifiers',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Invariant(
           description='Constraint AASd-090: For data elements category shall be one of the following values: CONSTANT, PARAMETER or VARIABLE',
-          body="Or(\n  values=[\n    Comparison(\n      left=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='category',\n        original_node=...),\n      op='EQ',\n      right=Constant(\n        value='CONSTANT',\n        original_node=...),\n      original_node=...),\n    Comparison(\n      left=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='category',\n        original_node=...),\n      op='EQ',\n      right=Constant(\n        value='PARAMETER',\n        original_node=...),\n      original_node=...),\n    Comparison(\n      left=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='category',\n        original_node=...),\n      op='EQ',\n      right=Constant(\n        value='VARIABLE',\n        original_node=...),\n      original_node=...)],\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Or(
+              values=[
+                Comparison(
+                  left=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='category',
+                    original_node=...),
+                  op='EQ',
+                  right=Constant(
+                    value='CONSTANT',
+                    original_node=...),
+                  original_node=...),
+                Comparison(
+                  left=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='category',
+                    original_node=...),
+                  op='EQ',
+                  right=Constant(
+                    value='PARAMETER',
+                    original_node=...),
+                  original_node=...),
+                Comparison(
+                  left=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='category',
+                    original_node=...),
+                  op='EQ',
+                  right=Constant(
+                    value='VARIABLE',
+                    original_node=...),
+                  original_node=...)],
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Data_element',
           parsed=...)],
       serialization=Serialization(
@@ -6059,14 +8424,22 @@ SymbolTable(
         index=0,
         fragment=None),
       description=SymbolDescription(
-        summary='<paragraph>A data element is a submodel element that is not further composed out of\nother submodel elements.</paragraph>',
+        summary=textwrap.dedent("""\
+          <paragraph>A data element is a submodel element that is not further composed out of
+          other submodel elements.</paragraph>"""),
         remarks=[
-          '<paragraph>A data element is a submodel element that has a value. The type of value differs\nfor different subtypes of data elements.</paragraph>',
-          '<paragraph>A controlled value is a value whose meaning is given in an external source\n(see “ISO/TS 29002-10:2009(E)”).</paragraph>'],
+          textwrap.dedent("""\
+            <paragraph>A data element is a submodel element that has a value. The type of value differs
+            for different subtypes of data elements.</paragraph>"""),
+          textwrap.dedent("""\
+            <paragraph>A controlled value is a value whose meaning is given in an external source
+            (see “ISO/TS 29002-10:2009(E)”).</paragraph>""")],
         constraints_by_identifier=[
           [
             'AASd-090',
-            '<field_body><paragraph>For data elements <AttributeReference refuri="~category">~category</AttributeReference> shall be one of the following\nvalues: <literal>CONSTANT</literal>, <literal>PARAMETER</literal> or <literal>VARIABLE</literal>.</paragraph></field_body>']],
+            textwrap.dedent("""\
+              <field_body><paragraph>For data elements <AttributeReference refuri="~category">~category</AttributeReference> shall be one of the following
+              values: <literal>CONSTANT</literal>, <literal>PARAMETER</literal> or <literal>VARIABLE</literal>.</paragraph></field_body>""")]],
         parsed=...),
       parsed=...,
       properties_by_name=...,
@@ -6107,13 +8480,21 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>In case of identifiables this attribute is a short name of the element.\nIn case of referable this ID is an identifying string of\nthe element within its name space.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>In case of identifiables this attribute is a short name of the element.
+              In case of referable this ID is an identifying string of
+              the element within its name space.</paragraph>"""),
             remarks=[
-              '<note><paragraph>In case the element is a property and the property has a semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>\nis typically identical to the short name in English.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>In case the element is a property and the property has a semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>
+                is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[
               [
                 'AASd-027',
-                '<field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>\'s shall have a maximum length\nof 128 characters.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>'s shall have a maximum length
+                  of 128 characters.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
@@ -6127,8 +8508,15 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>Display name. Can be provided in several languages.</paragraph>',
             remarks=[
-              '<paragraph>If no display name is defined in the language requested by the application,\nthen the display name is selected in the following order if available:</paragraph>',
-              '<bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,\nthen the corresponding preferred name in the language is chosen\naccording to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>'],
+              textwrap.dedent("""\
+                <paragraph>If no display name is defined in the language requested by the application,
+                then the display name is selected in the following order if available:</paragraph>"""),
+              textwrap.dedent("""\
+                <bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
+                then the corresponding preferred name in the language is chosen
+                according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -6141,9 +8529,18 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>The category is a value that gives further meta information\nw.r.t. to the class of the element.\nIt affects the expected existence of attributes and the applicability of\nconstraints.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>The category is a value that gives further meta information
+              w.r.t. to the class of the element.
+              It affects the expected existence of attributes and the applicability of
+              constraints.</paragraph>"""),
             remarks=[
-              '<note><paragraph>The category is not identical to the semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category\n<emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the\nsemantic definition of the element would\ndenote that it is the measured temperature.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>The category is not identical to the semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category
+                <emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the
+                semantic definition of the element would
+                denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -6159,8 +8556,14 @@ SymbolTable(
             summary='<paragraph>Description or comments on the element.</paragraph>',
             remarks=[
               '<paragraph>The description can be provided in several languages.</paragraph>',
-              '<paragraph>If no description is defined, then the definition of the concept\ndescription that defines the semantics of the element is used.</paragraph>',
-              '<paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is\nqualified and which qualifier types can be expected in which\ncontext or which additional data specification templates are\nprovided.</paragraph>'],
+              textwrap.dedent("""\
+                <paragraph>If no description is defined, then the definition of the concept
+                description that defines the semantics of the element is used.</paragraph>"""),
+              textwrap.dedent("""\
+                <paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is
+                qualified and which qualifier types can be expected in which
+                context or which additional data specification templates are
+                provided.</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -6173,9 +8576,15 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Checksum to be used to determine if an Referable (including its\naggregated child elements) has changed.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Checksum to be used to determine if an Referable (including its
+              aggregated child elements) has changed.</paragraph>"""),
             remarks=[
-              "<paragraph>The checksum is calculated by the user's tool environment.\nThe checksum has no semantic meaning for an asset administration\nshell model and there is no requirement for asset administration\nshell tools to manage the checksum</paragraph>"],
+              textwrap.dedent("""\
+                <paragraph>The checksum is calculated by the user's tool environment.
+                The checksum has no semantic meaning for an asset administration
+                shell model and there is no requirement for asset administration
+                shell tools to manage the checksum</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -6203,7 +8612,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Identifier of the semantic definition of the element. It is called semantic ID\nof the element.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Identifier of the semantic definition of the element. It is called semantic ID
+              of the element.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -6224,7 +8635,9 @@ SymbolTable(
             constraints_by_identifier=[
               [
                 'AASd-021',
-                '<field_body><paragraph>Every qualifiable can only have one qualifier with the same\n<AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph>Every qualifiable can only have one qualifier with the same
+                  <AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -6443,43 +8856,229 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='extensions',\n  argument='extensions',\n  default=None)",
-          "AssignArgument(\n  name='id_short',\n  argument='id_short',\n  default=None)",
-          "AssignArgument(\n  name='display_name',\n  argument='display_name',\n  default=None)",
-          "AssignArgument(\n  name='category',\n  argument='category',\n  default=None)",
-          "AssignArgument(\n  name='description',\n  argument='description',\n  default=None)",
-          "AssignArgument(\n  name='checksum',\n  argument='checksum',\n  default=None)",
-          "AssignArgument(\n  name='kind',\n  argument='kind',\n  default=DefaultEnumLiteral(\n    node=...,\n    enum='Reference to Enumeration Modeling_kind',\n    literal='Reference to EnumerationLiteral Instance'))",
-          "AssignArgument(\n  name='semantic_id',\n  argument='semantic_id',\n  default=None)",
-          "AssignArgument(\n  name='qualifiers',\n  argument='qualifiers',\n  default=None)",
-          "AssignArgument(\n  name='data_specifications',\n  argument='data_specifications',\n  default=None)",
-          "AssignArgument(\n  name='value_type',\n  argument='value_type',\n  default=None)",
-          "AssignArgument(\n  name='value',\n  argument='value',\n  default=None)",
-          "AssignArgument(\n  name='value_id',\n  argument='value_id',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='extensions',
+              argument='extensions',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='id_short',
+              argument='id_short',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='display_name',
+              argument='display_name',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='category',
+              argument='category',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='description',
+              argument='description',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='checksum',
+              argument='checksum',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='kind',
+              argument='kind',
+              default=DefaultEnumLiteral(
+                node=...,
+                enum='Reference to Enumeration Modeling_kind',
+                literal='Reference to EnumerationLiteral Instance'))"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='semantic_id',
+              argument='semantic_id',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='qualifiers',
+              argument='qualifiers',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='data_specifications',
+              argument='data_specifications',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='value_type',
+              argument='value_type',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='value',
+              argument='value',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='value_id',
+              argument='value_id',
+              default=None)""")]),
       invariants=[
         Invariant(
           description='Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='extensions',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='extension_names_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='extensions',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='extension_names_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='extensions',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
           description='Constraint AASd-027: ID-short shall have a maximum length of 128 characters.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='id_short',\n      original_node=...),\n    original_node=...),\n  consequent=Comparison(\n    left=FunctionCall(\n      name='len',\n      args=[\n        Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='id_short',\n          original_node=...)],\n      original_node=...),\n    op='LE',\n    right=Constant(\n      value=128,\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='id_short',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='id_short',
+                      original_node=...)],
+                  original_node=...),
+                op='LE',
+                right=Constant(
+                  value=128,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='qualifiers',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='qualifier_types_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='qualifiers',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='qualifier_types_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='qualifiers',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Invariant(
           description='Constraint AASd-090: For data elements category shall be one of the following values: CONSTANT, PARAMETER or VARIABLE',
-          body="Or(\n  values=[\n    Comparison(\n      left=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='category',\n        original_node=...),\n      op='EQ',\n      right=Constant(\n        value='CONSTANT',\n        original_node=...),\n      original_node=...),\n    Comparison(\n      left=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='category',\n        original_node=...),\n      op='EQ',\n      right=Constant(\n        value='PARAMETER',\n        original_node=...),\n      original_node=...),\n    Comparison(\n      left=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='category',\n        original_node=...),\n      op='EQ',\n      right=Constant(\n        value='VARIABLE',\n        original_node=...),\n      original_node=...)],\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Or(
+              values=[
+                Comparison(
+                  left=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='category',
+                    original_node=...),
+                  op='EQ',
+                  right=Constant(
+                    value='CONSTANT',
+                    original_node=...),
+                  original_node=...),
+                Comparison(
+                  left=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='category',
+                    original_node=...),
+                  op='EQ',
+                  right=Constant(
+                    value='PARAMETER',
+                    original_node=...),
+                  original_node=...),
+                Comparison(
+                  left=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='category',
+                    original_node=...),
+                  op='EQ',
+                  right=Constant(
+                    value='VARIABLE',
+                    original_node=...),
+                  original_node=...)],
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Data_element',
           parsed=...),
         Invariant(
           description=None,
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='value',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='value_consistent_with_xsd_type',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='value',\n        original_node=...),\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='value_type',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='value',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='value_consistent_with_xsd_type',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='value',
+                    original_node=...),
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='value_type',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to ConcreteClass Property',
           parsed=...)],
       serialization=Serialization(
@@ -6498,7 +9097,10 @@ SymbolTable(
         constraints_by_identifier=[
           [
             'AASd-007',
-            '<field_body><paragraph>If both, the <AttributeReference refuri="~value">~value</AttributeReference> and the <AttributeReference refuri="~value_id">~value_id</AttributeReference> are\npresent then the value of <AttributeReference refuri="~value">~value</AttributeReference> needs to be identical to\nthe value of the referenced coded value in <AttributeReference refuri="~value_id">~value_id</AttributeReference>.</paragraph></field_body>']],
+            textwrap.dedent("""\
+              <field_body><paragraph>If both, the <AttributeReference refuri="~value">~value</AttributeReference> and the <AttributeReference refuri="~value_id">~value_id</AttributeReference> are
+              present then the value of <AttributeReference refuri="~value">~value</AttributeReference> needs to be identical to
+              the value of the referenced coded value in <AttributeReference refuri="~value_id">~value_id</AttributeReference>.</paragraph></field_body>""")]],
         parsed=...),
       parsed=...,
       properties_by_name=...,
@@ -6539,13 +9141,21 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>In case of identifiables this attribute is a short name of the element.\nIn case of referable this ID is an identifying string of\nthe element within its name space.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>In case of identifiables this attribute is a short name of the element.
+              In case of referable this ID is an identifying string of
+              the element within its name space.</paragraph>"""),
             remarks=[
-              '<note><paragraph>In case the element is a property and the property has a semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>\nis typically identical to the short name in English.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>In case the element is a property and the property has a semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>
+                is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[
               [
                 'AASd-027',
-                '<field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>\'s shall have a maximum length\nof 128 characters.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>'s shall have a maximum length
+                  of 128 characters.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
@@ -6559,8 +9169,15 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>Display name. Can be provided in several languages.</paragraph>',
             remarks=[
-              '<paragraph>If no display name is defined in the language requested by the application,\nthen the display name is selected in the following order if available:</paragraph>',
-              '<bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,\nthen the corresponding preferred name in the language is chosen\naccording to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>'],
+              textwrap.dedent("""\
+                <paragraph>If no display name is defined in the language requested by the application,
+                then the display name is selected in the following order if available:</paragraph>"""),
+              textwrap.dedent("""\
+                <bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
+                then the corresponding preferred name in the language is chosen
+                according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -6573,9 +9190,18 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>The category is a value that gives further meta information\nw.r.t. to the class of the element.\nIt affects the expected existence of attributes and the applicability of\nconstraints.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>The category is a value that gives further meta information
+              w.r.t. to the class of the element.
+              It affects the expected existence of attributes and the applicability of
+              constraints.</paragraph>"""),
             remarks=[
-              '<note><paragraph>The category is not identical to the semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category\n<emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the\nsemantic definition of the element would\ndenote that it is the measured temperature.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>The category is not identical to the semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category
+                <emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the
+                semantic definition of the element would
+                denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -6591,8 +9217,14 @@ SymbolTable(
             summary='<paragraph>Description or comments on the element.</paragraph>',
             remarks=[
               '<paragraph>The description can be provided in several languages.</paragraph>',
-              '<paragraph>If no description is defined, then the definition of the concept\ndescription that defines the semantics of the element is used.</paragraph>',
-              '<paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is\nqualified and which qualifier types can be expected in which\ncontext or which additional data specification templates are\nprovided.</paragraph>'],
+              textwrap.dedent("""\
+                <paragraph>If no description is defined, then the definition of the concept
+                description that defines the semantics of the element is used.</paragraph>"""),
+              textwrap.dedent("""\
+                <paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is
+                qualified and which qualifier types can be expected in which
+                context or which additional data specification templates are
+                provided.</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -6605,9 +9237,15 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Checksum to be used to determine if an Referable (including its\naggregated child elements) has changed.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Checksum to be used to determine if an Referable (including its
+              aggregated child elements) has changed.</paragraph>"""),
             remarks=[
-              "<paragraph>The checksum is calculated by the user's tool environment.\nThe checksum has no semantic meaning for an asset administration\nshell model and there is no requirement for asset administration\nshell tools to manage the checksum</paragraph>"],
+              textwrap.dedent("""\
+                <paragraph>The checksum is calculated by the user's tool environment.
+                The checksum has no semantic meaning for an asset administration
+                shell model and there is no requirement for asset administration
+                shell tools to manage the checksum</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -6635,7 +9273,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Identifier of the semantic definition of the element. It is called semantic ID\nof the element.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Identifier of the semantic definition of the element. It is called semantic ID
+              of the element.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -6656,7 +9296,9 @@ SymbolTable(
             constraints_by_identifier=[
               [
                 'AASd-021',
-                '<field_body><paragraph>Every qualifiable can only have one qualifier with the same\n<AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph>Every qualifiable can only have one qualifier with the same
+                  <AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -6856,37 +9498,193 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='extensions',\n  argument='extensions',\n  default=None)",
-          "AssignArgument(\n  name='id_short',\n  argument='id_short',\n  default=None)",
-          "AssignArgument(\n  name='display_name',\n  argument='display_name',\n  default=None)",
-          "AssignArgument(\n  name='category',\n  argument='category',\n  default=None)",
-          "AssignArgument(\n  name='description',\n  argument='description',\n  default=None)",
-          "AssignArgument(\n  name='checksum',\n  argument='checksum',\n  default=None)",
-          "AssignArgument(\n  name='kind',\n  argument='kind',\n  default=DefaultEnumLiteral(\n    node=...,\n    enum='Reference to Enumeration Modeling_kind',\n    literal='Reference to EnumerationLiteral Instance'))",
-          "AssignArgument(\n  name='semantic_id',\n  argument='semantic_id',\n  default=None)",
-          "AssignArgument(\n  name='qualifiers',\n  argument='qualifiers',\n  default=None)",
-          "AssignArgument(\n  name='data_specifications',\n  argument='data_specifications',\n  default=None)",
-          "AssignArgument(\n  name='value',\n  argument='value',\n  default=None)",
-          "AssignArgument(\n  name='value_id',\n  argument='value_id',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='extensions',
+              argument='extensions',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='id_short',
+              argument='id_short',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='display_name',
+              argument='display_name',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='category',
+              argument='category',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='description',
+              argument='description',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='checksum',
+              argument='checksum',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='kind',
+              argument='kind',
+              default=DefaultEnumLiteral(
+                node=...,
+                enum='Reference to Enumeration Modeling_kind',
+                literal='Reference to EnumerationLiteral Instance'))"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='semantic_id',
+              argument='semantic_id',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='qualifiers',
+              argument='qualifiers',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='data_specifications',
+              argument='data_specifications',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='value',
+              argument='value',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='value_id',
+              argument='value_id',
+              default=None)""")]),
       invariants=[
         Invariant(
           description='Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='extensions',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='extension_names_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='extensions',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='extension_names_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='extensions',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
           description='Constraint AASd-027: ID-short shall have a maximum length of 128 characters.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='id_short',\n      original_node=...),\n    original_node=...),\n  consequent=Comparison(\n    left=FunctionCall(\n      name='len',\n      args=[\n        Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='id_short',\n          original_node=...)],\n      original_node=...),\n    op='LE',\n    right=Constant(\n      value=128,\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='id_short',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='id_short',
+                      original_node=...)],
+                  original_node=...),
+                op='LE',
+                right=Constant(
+                  value=128,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='qualifiers',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='qualifier_types_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='qualifiers',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='qualifier_types_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='qualifiers',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Invariant(
           description='Constraint AASd-090: For data elements category shall be one of the following values: CONSTANT, PARAMETER or VARIABLE',
-          body="Or(\n  values=[\n    Comparison(\n      left=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='category',\n        original_node=...),\n      op='EQ',\n      right=Constant(\n        value='CONSTANT',\n        original_node=...),\n      original_node=...),\n    Comparison(\n      left=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='category',\n        original_node=...),\n      op='EQ',\n      right=Constant(\n        value='PARAMETER',\n        original_node=...),\n      original_node=...),\n    Comparison(\n      left=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='category',\n        original_node=...),\n      op='EQ',\n      right=Constant(\n        value='VARIABLE',\n        original_node=...),\n      original_node=...)],\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Or(
+              values=[
+                Comparison(
+                  left=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='category',
+                    original_node=...),
+                  op='EQ',
+                  right=Constant(
+                    value='CONSTANT',
+                    original_node=...),
+                  original_node=...),
+                Comparison(
+                  left=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='category',
+                    original_node=...),
+                  op='EQ',
+                  right=Constant(
+                    value='PARAMETER',
+                    original_node=...),
+                  original_node=...),
+                Comparison(
+                  left=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='category',
+                    original_node=...),
+                  op='EQ',
+                  right=Constant(
+                    value='VARIABLE',
+                    original_node=...),
+                  original_node=...)],
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Data_element',
           parsed=...)],
       serialization=Serialization(
@@ -6905,7 +9703,10 @@ SymbolTable(
         constraints_by_identifier=[
           [
             'AASd-012',
-            '<field_body><paragraph>If both the <AttributeReference refuri="~value">~value</AttributeReference> and the <AttributeReference refuri="~value_id">~value_id</AttributeReference> are present then for each\nstring in a specific language the meaning must be the same as specified in\n<AttributeReference refuri="~value_id">~value_id</AttributeReference>.</paragraph></field_body>']],
+            textwrap.dedent("""\
+              <field_body><paragraph>If both the <AttributeReference refuri="~value">~value</AttributeReference> and the <AttributeReference refuri="~value_id">~value_id</AttributeReference> are present then for each
+              string in a specific language the meaning must be the same as specified in
+              <AttributeReference refuri="~value_id">~value_id</AttributeReference>.</paragraph></field_body>""")]],
         parsed=...),
       parsed=...,
       properties_by_name=...,
@@ -6946,13 +9747,21 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>In case of identifiables this attribute is a short name of the element.\nIn case of referable this ID is an identifying string of\nthe element within its name space.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>In case of identifiables this attribute is a short name of the element.
+              In case of referable this ID is an identifying string of
+              the element within its name space.</paragraph>"""),
             remarks=[
-              '<note><paragraph>In case the element is a property and the property has a semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>\nis typically identical to the short name in English.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>In case the element is a property and the property has a semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>
+                is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[
               [
                 'AASd-027',
-                '<field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>\'s shall have a maximum length\nof 128 characters.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>'s shall have a maximum length
+                  of 128 characters.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
@@ -6966,8 +9775,15 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>Display name. Can be provided in several languages.</paragraph>',
             remarks=[
-              '<paragraph>If no display name is defined in the language requested by the application,\nthen the display name is selected in the following order if available:</paragraph>',
-              '<bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,\nthen the corresponding preferred name in the language is chosen\naccording to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>'],
+              textwrap.dedent("""\
+                <paragraph>If no display name is defined in the language requested by the application,
+                then the display name is selected in the following order if available:</paragraph>"""),
+              textwrap.dedent("""\
+                <bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
+                then the corresponding preferred name in the language is chosen
+                according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -6980,9 +9796,18 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>The category is a value that gives further meta information\nw.r.t. to the class of the element.\nIt affects the expected existence of attributes and the applicability of\nconstraints.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>The category is a value that gives further meta information
+              w.r.t. to the class of the element.
+              It affects the expected existence of attributes and the applicability of
+              constraints.</paragraph>"""),
             remarks=[
-              '<note><paragraph>The category is not identical to the semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category\n<emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the\nsemantic definition of the element would\ndenote that it is the measured temperature.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>The category is not identical to the semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category
+                <emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the
+                semantic definition of the element would
+                denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -6998,8 +9823,14 @@ SymbolTable(
             summary='<paragraph>Description or comments on the element.</paragraph>',
             remarks=[
               '<paragraph>The description can be provided in several languages.</paragraph>',
-              '<paragraph>If no description is defined, then the definition of the concept\ndescription that defines the semantics of the element is used.</paragraph>',
-              '<paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is\nqualified and which qualifier types can be expected in which\ncontext or which additional data specification templates are\nprovided.</paragraph>'],
+              textwrap.dedent("""\
+                <paragraph>If no description is defined, then the definition of the concept
+                description that defines the semantics of the element is used.</paragraph>"""),
+              textwrap.dedent("""\
+                <paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is
+                qualified and which qualifier types can be expected in which
+                context or which additional data specification templates are
+                provided.</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -7012,9 +9843,15 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Checksum to be used to determine if an Referable (including its\naggregated child elements) has changed.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Checksum to be used to determine if an Referable (including its
+              aggregated child elements) has changed.</paragraph>"""),
             remarks=[
-              "<paragraph>The checksum is calculated by the user's tool environment.\nThe checksum has no semantic meaning for an asset administration\nshell model and there is no requirement for asset administration\nshell tools to manage the checksum</paragraph>"],
+              textwrap.dedent("""\
+                <paragraph>The checksum is calculated by the user's tool environment.
+                The checksum has no semantic meaning for an asset administration
+                shell model and there is no requirement for asset administration
+                shell tools to manage the checksum</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -7042,7 +9879,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Identifier of the semantic definition of the element. It is called semantic ID\nof the element.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Identifier of the semantic definition of the element. It is called semantic ID
+              of the element.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -7063,7 +9902,9 @@ SymbolTable(
             constraints_by_identifier=[
               [
                 'AASd-021',
-                '<field_body><paragraph>Every qualifiable can only have one qualifier with the same\n<AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph>Every qualifiable can only have one qualifier with the same
+                  <AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -7103,7 +9944,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>The minimum value of the range.\nIf the min value is missing, then the value is assumed to be negative infinite.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>The minimum value of the range.
+              If the min value is missing, then the value is assumed to be negative infinite.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -7117,7 +9960,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>The maximum value of the range.\nIf the max value is missing,  then the value is assumed to be positive infinite.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>The maximum value of the range.
+              If the max value is missing,  then the value is assumed to be positive infinite.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -7282,48 +10127,260 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='extensions',\n  argument='extensions',\n  default=None)",
-          "AssignArgument(\n  name='id_short',\n  argument='id_short',\n  default=None)",
-          "AssignArgument(\n  name='display_name',\n  argument='display_name',\n  default=None)",
-          "AssignArgument(\n  name='category',\n  argument='category',\n  default=None)",
-          "AssignArgument(\n  name='description',\n  argument='description',\n  default=None)",
-          "AssignArgument(\n  name='checksum',\n  argument='checksum',\n  default=None)",
-          "AssignArgument(\n  name='kind',\n  argument='kind',\n  default=DefaultEnumLiteral(\n    node=...,\n    enum='Reference to Enumeration Modeling_kind',\n    literal='Reference to EnumerationLiteral Instance'))",
-          "AssignArgument(\n  name='semantic_id',\n  argument='semantic_id',\n  default=None)",
-          "AssignArgument(\n  name='qualifiers',\n  argument='qualifiers',\n  default=None)",
-          "AssignArgument(\n  name='data_specifications',\n  argument='data_specifications',\n  default=None)",
-          "AssignArgument(\n  name='value_type',\n  argument='value_type',\n  default=None)",
-          "AssignArgument(\n  name='min',\n  argument='min',\n  default=None)",
-          "AssignArgument(\n  name='max',\n  argument='max',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='extensions',
+              argument='extensions',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='id_short',
+              argument='id_short',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='display_name',
+              argument='display_name',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='category',
+              argument='category',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='description',
+              argument='description',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='checksum',
+              argument='checksum',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='kind',
+              argument='kind',
+              default=DefaultEnumLiteral(
+                node=...,
+                enum='Reference to Enumeration Modeling_kind',
+                literal='Reference to EnumerationLiteral Instance'))"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='semantic_id',
+              argument='semantic_id',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='qualifiers',
+              argument='qualifiers',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='data_specifications',
+              argument='data_specifications',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='value_type',
+              argument='value_type',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='min',
+              argument='min',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='max',
+              argument='max',
+              default=None)""")]),
       invariants=[
         Invariant(
           description='Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='extensions',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='extension_names_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='extensions',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='extension_names_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='extensions',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
           description='Constraint AASd-027: ID-short shall have a maximum length of 128 characters.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='id_short',\n      original_node=...),\n    original_node=...),\n  consequent=Comparison(\n    left=FunctionCall(\n      name='len',\n      args=[\n        Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='id_short',\n          original_node=...)],\n      original_node=...),\n    op='LE',\n    right=Constant(\n      value=128,\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='id_short',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='id_short',
+                      original_node=...)],
+                  original_node=...),
+                op='LE',
+                right=Constant(
+                  value=128,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='qualifiers',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='qualifier_types_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='qualifiers',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='qualifier_types_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='qualifiers',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Invariant(
           description='Constraint AASd-090: For data elements category shall be one of the following values: CONSTANT, PARAMETER or VARIABLE',
-          body="Or(\n  values=[\n    Comparison(\n      left=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='category',\n        original_node=...),\n      op='EQ',\n      right=Constant(\n        value='CONSTANT',\n        original_node=...),\n      original_node=...),\n    Comparison(\n      left=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='category',\n        original_node=...),\n      op='EQ',\n      right=Constant(\n        value='PARAMETER',\n        original_node=...),\n      original_node=...),\n    Comparison(\n      left=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='category',\n        original_node=...),\n      op='EQ',\n      right=Constant(\n        value='VARIABLE',\n        original_node=...),\n      original_node=...)],\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Or(
+              values=[
+                Comparison(
+                  left=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='category',
+                    original_node=...),
+                  op='EQ',
+                  right=Constant(
+                    value='CONSTANT',
+                    original_node=...),
+                  original_node=...),
+                Comparison(
+                  left=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='category',
+                    original_node=...),
+                  op='EQ',
+                  right=Constant(
+                    value='PARAMETER',
+                    original_node=...),
+                  original_node=...),
+                Comparison(
+                  left=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='category',
+                    original_node=...),
+                  op='EQ',
+                  right=Constant(
+                    value='VARIABLE',
+                    original_node=...),
+                  original_node=...)],
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Data_element',
           parsed=...),
         Invariant(
           description=None,
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='max',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='value_consistent_with_xsd_type',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='max',\n        original_node=...),\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='value_type',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='max',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='value_consistent_with_xsd_type',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='max',
+                    original_node=...),
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='value_type',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to ConcreteClass Range',
           parsed=...),
         Invariant(
           description=None,
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='min',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='value_consistent_with_xsd_type',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='min',\n        original_node=...),\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='value_type',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='min',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='value_consistent_with_xsd_type',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='min',
+                    original_node=...),
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='value_type',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to ConcreteClass Range',
           parsed=...)],
       serialization=Serialization(
@@ -7380,13 +10437,21 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>In case of identifiables this attribute is a short name of the element.\nIn case of referable this ID is an identifying string of\nthe element within its name space.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>In case of identifiables this attribute is a short name of the element.
+              In case of referable this ID is an identifying string of
+              the element within its name space.</paragraph>"""),
             remarks=[
-              '<note><paragraph>In case the element is a property and the property has a semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>\nis typically identical to the short name in English.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>In case the element is a property and the property has a semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>
+                is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[
               [
                 'AASd-027',
-                '<field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>\'s shall have a maximum length\nof 128 characters.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>'s shall have a maximum length
+                  of 128 characters.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
@@ -7400,8 +10465,15 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>Display name. Can be provided in several languages.</paragraph>',
             remarks=[
-              '<paragraph>If no display name is defined in the language requested by the application,\nthen the display name is selected in the following order if available:</paragraph>',
-              '<bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,\nthen the corresponding preferred name in the language is chosen\naccording to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>'],
+              textwrap.dedent("""\
+                <paragraph>If no display name is defined in the language requested by the application,
+                then the display name is selected in the following order if available:</paragraph>"""),
+              textwrap.dedent("""\
+                <bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
+                then the corresponding preferred name in the language is chosen
+                according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -7414,9 +10486,18 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>The category is a value that gives further meta information\nw.r.t. to the class of the element.\nIt affects the expected existence of attributes and the applicability of\nconstraints.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>The category is a value that gives further meta information
+              w.r.t. to the class of the element.
+              It affects the expected existence of attributes and the applicability of
+              constraints.</paragraph>"""),
             remarks=[
-              '<note><paragraph>The category is not identical to the semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category\n<emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the\nsemantic definition of the element would\ndenote that it is the measured temperature.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>The category is not identical to the semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category
+                <emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the
+                semantic definition of the element would
+                denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -7432,8 +10513,14 @@ SymbolTable(
             summary='<paragraph>Description or comments on the element.</paragraph>',
             remarks=[
               '<paragraph>The description can be provided in several languages.</paragraph>',
-              '<paragraph>If no description is defined, then the definition of the concept\ndescription that defines the semantics of the element is used.</paragraph>',
-              '<paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is\nqualified and which qualifier types can be expected in which\ncontext or which additional data specification templates are\nprovided.</paragraph>'],
+              textwrap.dedent("""\
+                <paragraph>If no description is defined, then the definition of the concept
+                description that defines the semantics of the element is used.</paragraph>"""),
+              textwrap.dedent("""\
+                <paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is
+                qualified and which qualifier types can be expected in which
+                context or which additional data specification templates are
+                provided.</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -7446,9 +10533,15 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Checksum to be used to determine if an Referable (including its\naggregated child elements) has changed.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Checksum to be used to determine if an Referable (including its
+              aggregated child elements) has changed.</paragraph>"""),
             remarks=[
-              "<paragraph>The checksum is calculated by the user's tool environment.\nThe checksum has no semantic meaning for an asset administration\nshell model and there is no requirement for asset administration\nshell tools to manage the checksum</paragraph>"],
+              textwrap.dedent("""\
+                <paragraph>The checksum is calculated by the user's tool environment.
+                The checksum has no semantic meaning for an asset administration
+                shell model and there is no requirement for asset administration
+                shell tools to manage the checksum</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -7476,7 +10569,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Identifier of the semantic definition of the element. It is called semantic ID\nof the element.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Identifier of the semantic definition of the element. It is called semantic ID
+              of the element.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -7497,7 +10592,9 @@ SymbolTable(
             constraints_by_identifier=[
               [
                 'AASd-021',
-                '<field_body><paragraph>Every qualifiable can only have one qualifier with the same\n<AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph>Every qualifiable can only have one qualifier with the same
+                  <AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -7525,7 +10622,10 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Global reference to an external object or entity or a logical reference to\nanother element within the same or another AAS (i.e. a model reference to\na Referable).</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Global reference to an external object or entity or a logical reference to
+              another element within the same or another AAS (i.e. a model reference to
+              a Referable).</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -7672,36 +10772,188 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='extensions',\n  argument='extensions',\n  default=None)",
-          "AssignArgument(\n  name='id_short',\n  argument='id_short',\n  default=None)",
-          "AssignArgument(\n  name='display_name',\n  argument='display_name',\n  default=None)",
-          "AssignArgument(\n  name='category',\n  argument='category',\n  default=None)",
-          "AssignArgument(\n  name='description',\n  argument='description',\n  default=None)",
-          "AssignArgument(\n  name='checksum',\n  argument='checksum',\n  default=None)",
-          "AssignArgument(\n  name='kind',\n  argument='kind',\n  default=DefaultEnumLiteral(\n    node=...,\n    enum='Reference to Enumeration Modeling_kind',\n    literal='Reference to EnumerationLiteral Instance'))",
-          "AssignArgument(\n  name='semantic_id',\n  argument='semantic_id',\n  default=None)",
-          "AssignArgument(\n  name='qualifiers',\n  argument='qualifiers',\n  default=None)",
-          "AssignArgument(\n  name='data_specifications',\n  argument='data_specifications',\n  default=None)",
-          "AssignArgument(\n  name='value',\n  argument='value',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='extensions',
+              argument='extensions',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='id_short',
+              argument='id_short',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='display_name',
+              argument='display_name',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='category',
+              argument='category',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='description',
+              argument='description',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='checksum',
+              argument='checksum',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='kind',
+              argument='kind',
+              default=DefaultEnumLiteral(
+                node=...,
+                enum='Reference to Enumeration Modeling_kind',
+                literal='Reference to EnumerationLiteral Instance'))"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='semantic_id',
+              argument='semantic_id',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='qualifiers',
+              argument='qualifiers',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='data_specifications',
+              argument='data_specifications',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='value',
+              argument='value',
+              default=None)""")]),
       invariants=[
         Invariant(
           description='Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='extensions',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='extension_names_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='extensions',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='extension_names_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='extensions',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
           description='Constraint AASd-027: ID-short shall have a maximum length of 128 characters.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='id_short',\n      original_node=...),\n    original_node=...),\n  consequent=Comparison(\n    left=FunctionCall(\n      name='len',\n      args=[\n        Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='id_short',\n          original_node=...)],\n      original_node=...),\n    op='LE',\n    right=Constant(\n      value=128,\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='id_short',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='id_short',
+                      original_node=...)],
+                  original_node=...),
+                op='LE',
+                right=Constant(
+                  value=128,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='qualifiers',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='qualifier_types_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='qualifiers',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='qualifier_types_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='qualifiers',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Invariant(
           description='Constraint AASd-090: For data elements category shall be one of the following values: CONSTANT, PARAMETER or VARIABLE',
-          body="Or(\n  values=[\n    Comparison(\n      left=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='category',\n        original_node=...),\n      op='EQ',\n      right=Constant(\n        value='CONSTANT',\n        original_node=...),\n      original_node=...),\n    Comparison(\n      left=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='category',\n        original_node=...),\n      op='EQ',\n      right=Constant(\n        value='PARAMETER',\n        original_node=...),\n      original_node=...),\n    Comparison(\n      left=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='category',\n        original_node=...),\n      op='EQ',\n      right=Constant(\n        value='VARIABLE',\n        original_node=...),\n      original_node=...)],\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Or(
+              values=[
+                Comparison(
+                  left=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='category',
+                    original_node=...),
+                  op='EQ',
+                  right=Constant(
+                    value='CONSTANT',
+                    original_node=...),
+                  original_node=...),
+                Comparison(
+                  left=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='category',
+                    original_node=...),
+                  op='EQ',
+                  right=Constant(
+                    value='PARAMETER',
+                    original_node=...),
+                  original_node=...),
+                Comparison(
+                  left=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='category',
+                    original_node=...),
+                  op='EQ',
+                  right=Constant(
+                    value='VARIABLE',
+                    original_node=...),
+                  original_node=...)],
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Data_element',
           parsed=...)],
       serialization=Serialization(
@@ -7715,7 +10967,10 @@ SymbolTable(
         index=0,
         fragment=None),
       description=SymbolDescription(
-        summary='<paragraph>A reference element is a data element that defines a logical reference to another\nelement within the same or another AAS or a reference to an external object or\nentity.</paragraph>',
+        summary=textwrap.dedent("""\
+          <paragraph>A reference element is a data element that defines a logical reference to another
+          element within the same or another AAS or a reference to an external object or
+          entity.</paragraph>"""),
         remarks=[],
         constraints_by_identifier=[],
         parsed=...),
@@ -7758,13 +11013,21 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>In case of identifiables this attribute is a short name of the element.\nIn case of referable this ID is an identifying string of\nthe element within its name space.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>In case of identifiables this attribute is a short name of the element.
+              In case of referable this ID is an identifying string of
+              the element within its name space.</paragraph>"""),
             remarks=[
-              '<note><paragraph>In case the element is a property and the property has a semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>\nis typically identical to the short name in English.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>In case the element is a property and the property has a semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>
+                is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[
               [
                 'AASd-027',
-                '<field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>\'s shall have a maximum length\nof 128 characters.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>'s shall have a maximum length
+                  of 128 characters.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
@@ -7778,8 +11041,15 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>Display name. Can be provided in several languages.</paragraph>',
             remarks=[
-              '<paragraph>If no display name is defined in the language requested by the application,\nthen the display name is selected in the following order if available:</paragraph>',
-              '<bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,\nthen the corresponding preferred name in the language is chosen\naccording to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>'],
+              textwrap.dedent("""\
+                <paragraph>If no display name is defined in the language requested by the application,
+                then the display name is selected in the following order if available:</paragraph>"""),
+              textwrap.dedent("""\
+                <bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
+                then the corresponding preferred name in the language is chosen
+                according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -7792,9 +11062,18 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>The category is a value that gives further meta information\nw.r.t. to the class of the element.\nIt affects the expected existence of attributes and the applicability of\nconstraints.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>The category is a value that gives further meta information
+              w.r.t. to the class of the element.
+              It affects the expected existence of attributes and the applicability of
+              constraints.</paragraph>"""),
             remarks=[
-              '<note><paragraph>The category is not identical to the semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category\n<emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the\nsemantic definition of the element would\ndenote that it is the measured temperature.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>The category is not identical to the semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category
+                <emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the
+                semantic definition of the element would
+                denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -7810,8 +11089,14 @@ SymbolTable(
             summary='<paragraph>Description or comments on the element.</paragraph>',
             remarks=[
               '<paragraph>The description can be provided in several languages.</paragraph>',
-              '<paragraph>If no description is defined, then the definition of the concept\ndescription that defines the semantics of the element is used.</paragraph>',
-              '<paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is\nqualified and which qualifier types can be expected in which\ncontext or which additional data specification templates are\nprovided.</paragraph>'],
+              textwrap.dedent("""\
+                <paragraph>If no description is defined, then the definition of the concept
+                description that defines the semantics of the element is used.</paragraph>"""),
+              textwrap.dedent("""\
+                <paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is
+                qualified and which qualifier types can be expected in which
+                context or which additional data specification templates are
+                provided.</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -7824,9 +11109,15 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Checksum to be used to determine if an Referable (including its\naggregated child elements) has changed.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Checksum to be used to determine if an Referable (including its
+              aggregated child elements) has changed.</paragraph>"""),
             remarks=[
-              "<paragraph>The checksum is calculated by the user's tool environment.\nThe checksum has no semantic meaning for an asset administration\nshell model and there is no requirement for asset administration\nshell tools to manage the checksum</paragraph>"],
+              textwrap.dedent("""\
+                <paragraph>The checksum is calculated by the user's tool environment.
+                The checksum has no semantic meaning for an asset administration
+                shell model and there is no requirement for asset administration
+                shell tools to manage the checksum</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -7854,7 +11145,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Identifier of the semantic definition of the element. It is called semantic ID\nof the element.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Identifier of the semantic definition of the element. It is called semantic ID
+              of the element.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -7875,7 +11168,9 @@ SymbolTable(
             constraints_by_identifier=[
               [
                 'AASd-021',
-                '<field_body><paragraph>Every qualifiable can only have one qualifier with the same\n<AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph>Every qualifiable can only have one qualifier with the same
+                  <AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -7903,7 +11198,10 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>MIME type of the content of the <SymbolReference refuri=".Blob">.Blob</SymbolReference>.</paragraph>',
             remarks=[
-              '<paragraph>The MIME type states which file extensions the file can have.\nValid values are e.g. <literal>application/json</literal>, <literal>application/xls</literal>, <literal>image/jpg</literal>.\nThe allowed values are defined as in RFC2046.</paragraph>'],
+              textwrap.dedent("""\
+                <paragraph>The MIME type states which file extensions the file can have.
+                Valid values are e.g. <literal>application/json</literal>, <literal>application/xls</literal>, <literal>image/jpg</literal>.
+                The allowed values are defined as in RFC2046.</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to ConcreteClass Blob',
@@ -7918,7 +11216,9 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>The value of the <SymbolReference refuri=".Blob">.Blob</SymbolReference> instance of a blob data element.</paragraph>',
             remarks=[
-              '<note><paragraph>In contrast to the file property the file content is stored directly as value\nin the <SymbolReference refuri=".Blob">.Blob</SymbolReference> data element.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>In contrast to the file property the file content is stored directly as value
+                in the <SymbolReference refuri=".Blob">.Blob</SymbolReference> data element.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to ConcreteClass Blob',
@@ -8071,37 +11371,193 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='extensions',\n  argument='extensions',\n  default=None)",
-          "AssignArgument(\n  name='id_short',\n  argument='id_short',\n  default=None)",
-          "AssignArgument(\n  name='display_name',\n  argument='display_name',\n  default=None)",
-          "AssignArgument(\n  name='category',\n  argument='category',\n  default=None)",
-          "AssignArgument(\n  name='description',\n  argument='description',\n  default=None)",
-          "AssignArgument(\n  name='checksum',\n  argument='checksum',\n  default=None)",
-          "AssignArgument(\n  name='kind',\n  argument='kind',\n  default=DefaultEnumLiteral(\n    node=...,\n    enum='Reference to Enumeration Modeling_kind',\n    literal='Reference to EnumerationLiteral Instance'))",
-          "AssignArgument(\n  name='semantic_id',\n  argument='semantic_id',\n  default=None)",
-          "AssignArgument(\n  name='qualifiers',\n  argument='qualifiers',\n  default=None)",
-          "AssignArgument(\n  name='data_specifications',\n  argument='data_specifications',\n  default=None)",
-          "AssignArgument(\n  name='MIME_type',\n  argument='MIME_type',\n  default=None)",
-          "AssignArgument(\n  name='value',\n  argument='value',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='extensions',
+              argument='extensions',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='id_short',
+              argument='id_short',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='display_name',
+              argument='display_name',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='category',
+              argument='category',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='description',
+              argument='description',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='checksum',
+              argument='checksum',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='kind',
+              argument='kind',
+              default=DefaultEnumLiteral(
+                node=...,
+                enum='Reference to Enumeration Modeling_kind',
+                literal='Reference to EnumerationLiteral Instance'))"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='semantic_id',
+              argument='semantic_id',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='qualifiers',
+              argument='qualifiers',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='data_specifications',
+              argument='data_specifications',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='MIME_type',
+              argument='MIME_type',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='value',
+              argument='value',
+              default=None)""")]),
       invariants=[
         Invariant(
           description='Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='extensions',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='extension_names_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='extensions',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='extension_names_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='extensions',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
           description='Constraint AASd-027: ID-short shall have a maximum length of 128 characters.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='id_short',\n      original_node=...),\n    original_node=...),\n  consequent=Comparison(\n    left=FunctionCall(\n      name='len',\n      args=[\n        Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='id_short',\n          original_node=...)],\n      original_node=...),\n    op='LE',\n    right=Constant(\n      value=128,\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='id_short',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='id_short',
+                      original_node=...)],
+                  original_node=...),
+                op='LE',
+                right=Constant(
+                  value=128,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='qualifiers',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='qualifier_types_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='qualifiers',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='qualifier_types_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='qualifiers',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Invariant(
           description='Constraint AASd-090: For data elements category shall be one of the following values: CONSTANT, PARAMETER or VARIABLE',
-          body="Or(\n  values=[\n    Comparison(\n      left=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='category',\n        original_node=...),\n      op='EQ',\n      right=Constant(\n        value='CONSTANT',\n        original_node=...),\n      original_node=...),\n    Comparison(\n      left=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='category',\n        original_node=...),\n      op='EQ',\n      right=Constant(\n        value='PARAMETER',\n        original_node=...),\n      original_node=...),\n    Comparison(\n      left=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='category',\n        original_node=...),\n      op='EQ',\n      right=Constant(\n        value='VARIABLE',\n        original_node=...),\n      original_node=...)],\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Or(
+              values=[
+                Comparison(
+                  left=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='category',
+                    original_node=...),
+                  op='EQ',
+                  right=Constant(
+                    value='CONSTANT',
+                    original_node=...),
+                  original_node=...),
+                Comparison(
+                  left=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='category',
+                    original_node=...),
+                  op='EQ',
+                  right=Constant(
+                    value='PARAMETER',
+                    original_node=...),
+                  original_node=...),
+                Comparison(
+                  left=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='category',
+                    original_node=...),
+                  op='EQ',
+                  right=Constant(
+                    value='VARIABLE',
+                    original_node=...),
+                  original_node=...)],
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Data_element',
           parsed=...)],
       serialization=Serialization(
@@ -8115,7 +11571,9 @@ SymbolTable(
         index=0,
         fragment=None),
       description=SymbolDescription(
-        summary='<paragraph>A <SymbolReference refuri=".Blob">.Blob</SymbolReference> is a data element that represents a file that is contained with its\nsource code in the value attribute.</paragraph>',
+        summary=textwrap.dedent("""\
+          <paragraph>A <SymbolReference refuri=".Blob">.Blob</SymbolReference> is a data element that represents a file that is contained with its
+          source code in the value attribute.</paragraph>"""),
         remarks=[],
         constraints_by_identifier=[],
         parsed=...),
@@ -8158,13 +11616,21 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>In case of identifiables this attribute is a short name of the element.\nIn case of referable this ID is an identifying string of\nthe element within its name space.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>In case of identifiables this attribute is a short name of the element.
+              In case of referable this ID is an identifying string of
+              the element within its name space.</paragraph>"""),
             remarks=[
-              '<note><paragraph>In case the element is a property and the property has a semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>\nis typically identical to the short name in English.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>In case the element is a property and the property has a semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>
+                is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[
               [
                 'AASd-027',
-                '<field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>\'s shall have a maximum length\nof 128 characters.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>'s shall have a maximum length
+                  of 128 characters.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
@@ -8178,8 +11644,15 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>Display name. Can be provided in several languages.</paragraph>',
             remarks=[
-              '<paragraph>If no display name is defined in the language requested by the application,\nthen the display name is selected in the following order if available:</paragraph>',
-              '<bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,\nthen the corresponding preferred name in the language is chosen\naccording to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>'],
+              textwrap.dedent("""\
+                <paragraph>If no display name is defined in the language requested by the application,
+                then the display name is selected in the following order if available:</paragraph>"""),
+              textwrap.dedent("""\
+                <bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
+                then the corresponding preferred name in the language is chosen
+                according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -8192,9 +11665,18 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>The category is a value that gives further meta information\nw.r.t. to the class of the element.\nIt affects the expected existence of attributes and the applicability of\nconstraints.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>The category is a value that gives further meta information
+              w.r.t. to the class of the element.
+              It affects the expected existence of attributes and the applicability of
+              constraints.</paragraph>"""),
             remarks=[
-              '<note><paragraph>The category is not identical to the semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category\n<emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the\nsemantic definition of the element would\ndenote that it is the measured temperature.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>The category is not identical to the semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category
+                <emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the
+                semantic definition of the element would
+                denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -8210,8 +11692,14 @@ SymbolTable(
             summary='<paragraph>Description or comments on the element.</paragraph>',
             remarks=[
               '<paragraph>The description can be provided in several languages.</paragraph>',
-              '<paragraph>If no description is defined, then the definition of the concept\ndescription that defines the semantics of the element is used.</paragraph>',
-              '<paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is\nqualified and which qualifier types can be expected in which\ncontext or which additional data specification templates are\nprovided.</paragraph>'],
+              textwrap.dedent("""\
+                <paragraph>If no description is defined, then the definition of the concept
+                description that defines the semantics of the element is used.</paragraph>"""),
+              textwrap.dedent("""\
+                <paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is
+                qualified and which qualifier types can be expected in which
+                context or which additional data specification templates are
+                provided.</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -8224,9 +11712,15 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Checksum to be used to determine if an Referable (including its\naggregated child elements) has changed.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Checksum to be used to determine if an Referable (including its
+              aggregated child elements) has changed.</paragraph>"""),
             remarks=[
-              "<paragraph>The checksum is calculated by the user's tool environment.\nThe checksum has no semantic meaning for an asset administration\nshell model and there is no requirement for asset administration\nshell tools to manage the checksum</paragraph>"],
+              textwrap.dedent("""\
+                <paragraph>The checksum is calculated by the user's tool environment.
+                The checksum has no semantic meaning for an asset administration
+                shell model and there is no requirement for asset administration
+                shell tools to manage the checksum</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -8254,7 +11748,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Identifier of the semantic definition of the element. It is called semantic ID\nof the element.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Identifier of the semantic definition of the element. It is called semantic ID
+              of the element.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -8275,7 +11771,9 @@ SymbolTable(
             constraints_by_identifier=[
               [
                 'AASd-021',
-                '<field_body><paragraph>Every qualifiable can only have one qualifier with the same\n<AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph>Every qualifiable can only have one qualifier with the same
+                  <AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -8316,7 +11814,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Path and name of the referenced file (with file extension).\nThe path can be absolute or relative.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Path and name of the referenced file (with file extension).
+              The path can be absolute or relative.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -8470,37 +11970,193 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='extensions',\n  argument='extensions',\n  default=None)",
-          "AssignArgument(\n  name='id_short',\n  argument='id_short',\n  default=None)",
-          "AssignArgument(\n  name='display_name',\n  argument='display_name',\n  default=None)",
-          "AssignArgument(\n  name='category',\n  argument='category',\n  default=None)",
-          "AssignArgument(\n  name='description',\n  argument='description',\n  default=None)",
-          "AssignArgument(\n  name='checksum',\n  argument='checksum',\n  default=None)",
-          "AssignArgument(\n  name='kind',\n  argument='kind',\n  default=DefaultEnumLiteral(\n    node=...,\n    enum='Reference to Enumeration Modeling_kind',\n    literal='Reference to EnumerationLiteral Instance'))",
-          "AssignArgument(\n  name='semantic_id',\n  argument='semantic_id',\n  default=None)",
-          "AssignArgument(\n  name='qualifiers',\n  argument='qualifiers',\n  default=None)",
-          "AssignArgument(\n  name='data_specifications',\n  argument='data_specifications',\n  default=None)",
-          "AssignArgument(\n  name='content_type',\n  argument='content_type',\n  default=None)",
-          "AssignArgument(\n  name='value',\n  argument='value',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='extensions',
+              argument='extensions',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='id_short',
+              argument='id_short',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='display_name',
+              argument='display_name',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='category',
+              argument='category',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='description',
+              argument='description',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='checksum',
+              argument='checksum',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='kind',
+              argument='kind',
+              default=DefaultEnumLiteral(
+                node=...,
+                enum='Reference to Enumeration Modeling_kind',
+                literal='Reference to EnumerationLiteral Instance'))"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='semantic_id',
+              argument='semantic_id',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='qualifiers',
+              argument='qualifiers',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='data_specifications',
+              argument='data_specifications',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='content_type',
+              argument='content_type',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='value',
+              argument='value',
+              default=None)""")]),
       invariants=[
         Invariant(
           description='Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='extensions',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='extension_names_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='extensions',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='extension_names_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='extensions',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
           description='Constraint AASd-027: ID-short shall have a maximum length of 128 characters.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='id_short',\n      original_node=...),\n    original_node=...),\n  consequent=Comparison(\n    left=FunctionCall(\n      name='len',\n      args=[\n        Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='id_short',\n          original_node=...)],\n      original_node=...),\n    op='LE',\n    right=Constant(\n      value=128,\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='id_short',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='id_short',
+                      original_node=...)],
+                  original_node=...),
+                op='LE',
+                right=Constant(
+                  value=128,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='qualifiers',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='qualifier_types_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='qualifiers',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='qualifier_types_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='qualifiers',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Invariant(
           description='Constraint AASd-090: For data elements category shall be one of the following values: CONSTANT, PARAMETER or VARIABLE',
-          body="Or(\n  values=[\n    Comparison(\n      left=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='category',\n        original_node=...),\n      op='EQ',\n      right=Constant(\n        value='CONSTANT',\n        original_node=...),\n      original_node=...),\n    Comparison(\n      left=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='category',\n        original_node=...),\n      op='EQ',\n      right=Constant(\n        value='PARAMETER',\n        original_node=...),\n      original_node=...),\n    Comparison(\n      left=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='category',\n        original_node=...),\n      op='EQ',\n      right=Constant(\n        value='VARIABLE',\n        original_node=...),\n      original_node=...)],\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Or(
+              values=[
+                Comparison(
+                  left=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='category',
+                    original_node=...),
+                  op='EQ',
+                  right=Constant(
+                    value='CONSTANT',
+                    original_node=...),
+                  original_node=...),
+                Comparison(
+                  left=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='category',
+                    original_node=...),
+                  op='EQ',
+                  right=Constant(
+                    value='PARAMETER',
+                    original_node=...),
+                  original_node=...),
+                Comparison(
+                  left=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='category',
+                    original_node=...),
+                  op='EQ',
+                  right=Constant(
+                    value='VARIABLE',
+                    original_node=...),
+                  original_node=...)],
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Data_element',
           parsed=...)],
       serialization=Serialization(
@@ -8558,13 +12214,21 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>In case of identifiables this attribute is a short name of the element.\nIn case of referable this ID is an identifying string of\nthe element within its name space.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>In case of identifiables this attribute is a short name of the element.
+              In case of referable this ID is an identifying string of
+              the element within its name space.</paragraph>"""),
             remarks=[
-              '<note><paragraph>In case the element is a property and the property has a semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>\nis typically identical to the short name in English.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>In case the element is a property and the property has a semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>
+                is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[
               [
                 'AASd-027',
-                '<field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>\'s shall have a maximum length\nof 128 characters.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>'s shall have a maximum length
+                  of 128 characters.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
@@ -8578,8 +12242,15 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>Display name. Can be provided in several languages.</paragraph>',
             remarks=[
-              '<paragraph>If no display name is defined in the language requested by the application,\nthen the display name is selected in the following order if available:</paragraph>',
-              '<bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,\nthen the corresponding preferred name in the language is chosen\naccording to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>'],
+              textwrap.dedent("""\
+                <paragraph>If no display name is defined in the language requested by the application,
+                then the display name is selected in the following order if available:</paragraph>"""),
+              textwrap.dedent("""\
+                <bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
+                then the corresponding preferred name in the language is chosen
+                according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -8592,9 +12263,18 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>The category is a value that gives further meta information\nw.r.t. to the class of the element.\nIt affects the expected existence of attributes and the applicability of\nconstraints.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>The category is a value that gives further meta information
+              w.r.t. to the class of the element.
+              It affects the expected existence of attributes and the applicability of
+              constraints.</paragraph>"""),
             remarks=[
-              '<note><paragraph>The category is not identical to the semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category\n<emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the\nsemantic definition of the element would\ndenote that it is the measured temperature.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>The category is not identical to the semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category
+                <emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the
+                semantic definition of the element would
+                denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -8610,8 +12290,14 @@ SymbolTable(
             summary='<paragraph>Description or comments on the element.</paragraph>',
             remarks=[
               '<paragraph>The description can be provided in several languages.</paragraph>',
-              '<paragraph>If no description is defined, then the definition of the concept\ndescription that defines the semantics of the element is used.</paragraph>',
-              '<paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is\nqualified and which qualifier types can be expected in which\ncontext or which additional data specification templates are\nprovided.</paragraph>'],
+              textwrap.dedent("""\
+                <paragraph>If no description is defined, then the definition of the concept
+                description that defines the semantics of the element is used.</paragraph>"""),
+              textwrap.dedent("""\
+                <paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is
+                qualified and which qualifier types can be expected in which
+                context or which additional data specification templates are
+                provided.</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -8624,9 +12310,15 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Checksum to be used to determine if an Referable (including its\naggregated child elements) has changed.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Checksum to be used to determine if an Referable (including its
+              aggregated child elements) has changed.</paragraph>"""),
             remarks=[
-              "<paragraph>The checksum is calculated by the user's tool environment.\nThe checksum has no semantic meaning for an asset administration\nshell model and there is no requirement for asset administration\nshell tools to manage the checksum</paragraph>"],
+              textwrap.dedent("""\
+                <paragraph>The checksum is calculated by the user's tool environment.
+                The checksum has no semantic meaning for an asset administration
+                shell model and there is no requirement for asset administration
+                shell tools to manage the checksum</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -8654,7 +12346,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Identifier of the semantic definition of the element. It is called semantic ID\nof the element.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Identifier of the semantic definition of the element. It is called semantic ID
+              of the element.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -8675,7 +12369,9 @@ SymbolTable(
             constraints_by_identifier=[
               [
                 'AASd-021',
-                '<field_body><paragraph>Every qualifiable can only have one qualifier with the same\n<AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph>Every qualifiable can only have one qualifier with the same
+                  <AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -8729,7 +12425,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>A data element that represents an annotation that holds for the relationship\nbetween the two elements</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>A data element that represents an annotation that holds for the relationship
+              between the two elements</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -8892,33 +12590,154 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='extensions',\n  argument='extensions',\n  default=None)",
-          "AssignArgument(\n  name='id_short',\n  argument='id_short',\n  default=None)",
-          "AssignArgument(\n  name='display_name',\n  argument='display_name',\n  default=None)",
-          "AssignArgument(\n  name='category',\n  argument='category',\n  default=None)",
-          "AssignArgument(\n  name='description',\n  argument='description',\n  default=None)",
-          "AssignArgument(\n  name='checksum',\n  argument='checksum',\n  default=None)",
-          "AssignArgument(\n  name='kind',\n  argument='kind',\n  default=DefaultEnumLiteral(\n    node=...,\n    enum='Reference to Enumeration Modeling_kind',\n    literal='Reference to EnumerationLiteral Instance'))",
-          "AssignArgument(\n  name='semantic_id',\n  argument='semantic_id',\n  default=None)",
-          "AssignArgument(\n  name='qualifiers',\n  argument='qualifiers',\n  default=None)",
-          "AssignArgument(\n  name='data_specifications',\n  argument='data_specifications',\n  default=None)",
-          "AssignArgument(\n  name='first',\n  argument='first',\n  default=None)",
-          "AssignArgument(\n  name='second',\n  argument='second',\n  default=None)",
-          "AssignArgument(\n  name='annotation',\n  argument='annotation',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='extensions',
+              argument='extensions',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='id_short',
+              argument='id_short',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='display_name',
+              argument='display_name',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='category',
+              argument='category',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='description',
+              argument='description',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='checksum',
+              argument='checksum',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='kind',
+              argument='kind',
+              default=DefaultEnumLiteral(
+                node=...,
+                enum='Reference to Enumeration Modeling_kind',
+                literal='Reference to EnumerationLiteral Instance'))"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='semantic_id',
+              argument='semantic_id',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='qualifiers',
+              argument='qualifiers',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='data_specifications',
+              argument='data_specifications',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='first',
+              argument='first',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='second',
+              argument='second',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='annotation',
+              argument='annotation',
+              default=None)""")]),
       invariants=[
         Invariant(
           description='Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='extensions',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='extension_names_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='extensions',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='extension_names_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='extensions',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
           description='Constraint AASd-027: ID-short shall have a maximum length of 128 characters.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='id_short',\n      original_node=...),\n    original_node=...),\n  consequent=Comparison(\n    left=FunctionCall(\n      name='len',\n      args=[\n        Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='id_short',\n          original_node=...)],\n      original_node=...),\n    op='LE',\n    right=Constant(\n      value=128,\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='id_short',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='id_short',
+                      original_node=...)],
+                  original_node=...),
+                op='LE',
+                right=Constant(
+                  value=128,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='qualifiers',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='qualifier_types_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='qualifiers',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='qualifier_types_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='qualifiers',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...)],
       serialization=Serialization(
@@ -8932,7 +12751,9 @@ SymbolTable(
         index=0,
         fragment=None),
       description=SymbolDescription(
-        summary='<paragraph>An annotated relationship element is a relationship element that can be annotated\nwith additional data elements.</paragraph>',
+        summary=textwrap.dedent("""\
+          <paragraph>An annotated relationship element is a relationship element that can be annotated
+          with additional data elements.</paragraph>"""),
         remarks=[],
         constraints_by_identifier=[],
         parsed=...),
@@ -8948,7 +12769,9 @@ SymbolTable(
           name='Co_managed_entity',
           value='COMANAGEDENTITY',
           description=EnumerationLiteralDescription(
-            summary='<paragraph>For co-managed entities there is no separate AAS. Co-managed entities need to be\npart of a self-managed entity.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>For co-managed entities there is no separate AAS. Co-managed entities need to be
+              part of a self-managed entity.</paragraph>"""),
             remarks=[],
             parsed=...),
           parsed=...),
@@ -8956,7 +12779,10 @@ SymbolTable(
           name='Self_managed_entity',
           value='SELFMANAGEDENTITY',
           description=EnumerationLiteralDescription(
-            summary='<paragraph>Self-Managed Entities have their own AAS but can be part of the bill of material of\na composite self-managed entity. The asset of an I4.0 Component is a self-managed\nentity per definition."</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Self-Managed Entities have their own AAS but can be part of the bill of material of
+              a composite self-managed entity. The asset of an I4.0 Component is a self-managed
+              entity per definition."</paragraph>"""),
             remarks=[],
             parsed=...),
           parsed=...)],
@@ -8970,7 +12796,9 @@ SymbolTable(
         index=1,
         fragment=None),
       description=SymbolDescription(
-        summary='<paragraph>Enumeration for denoting whether an entity is a self-managed entity or a co-managed\nentity.</paragraph>',
+        summary=textwrap.dedent("""\
+          <paragraph>Enumeration for denoting whether an entity is a self-managed entity or a co-managed
+          entity.</paragraph>"""),
         remarks=[],
         constraints_by_identifier=[],
         parsed=...),
@@ -9011,13 +12839,21 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>In case of identifiables this attribute is a short name of the element.\nIn case of referable this ID is an identifying string of\nthe element within its name space.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>In case of identifiables this attribute is a short name of the element.
+              In case of referable this ID is an identifying string of
+              the element within its name space.</paragraph>"""),
             remarks=[
-              '<note><paragraph>In case the element is a property and the property has a semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>\nis typically identical to the short name in English.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>In case the element is a property and the property has a semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>
+                is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[
               [
                 'AASd-027',
-                '<field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>\'s shall have a maximum length\nof 128 characters.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>'s shall have a maximum length
+                  of 128 characters.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
@@ -9031,8 +12867,15 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>Display name. Can be provided in several languages.</paragraph>',
             remarks=[
-              '<paragraph>If no display name is defined in the language requested by the application,\nthen the display name is selected in the following order if available:</paragraph>',
-              '<bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,\nthen the corresponding preferred name in the language is chosen\naccording to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>'],
+              textwrap.dedent("""\
+                <paragraph>If no display name is defined in the language requested by the application,
+                then the display name is selected in the following order if available:</paragraph>"""),
+              textwrap.dedent("""\
+                <bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
+                then the corresponding preferred name in the language is chosen
+                according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -9045,9 +12888,18 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>The category is a value that gives further meta information\nw.r.t. to the class of the element.\nIt affects the expected existence of attributes and the applicability of\nconstraints.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>The category is a value that gives further meta information
+              w.r.t. to the class of the element.
+              It affects the expected existence of attributes and the applicability of
+              constraints.</paragraph>"""),
             remarks=[
-              '<note><paragraph>The category is not identical to the semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category\n<emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the\nsemantic definition of the element would\ndenote that it is the measured temperature.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>The category is not identical to the semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category
+                <emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the
+                semantic definition of the element would
+                denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -9063,8 +12915,14 @@ SymbolTable(
             summary='<paragraph>Description or comments on the element.</paragraph>',
             remarks=[
               '<paragraph>The description can be provided in several languages.</paragraph>',
-              '<paragraph>If no description is defined, then the definition of the concept\ndescription that defines the semantics of the element is used.</paragraph>',
-              '<paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is\nqualified and which qualifier types can be expected in which\ncontext or which additional data specification templates are\nprovided.</paragraph>'],
+              textwrap.dedent("""\
+                <paragraph>If no description is defined, then the definition of the concept
+                description that defines the semantics of the element is used.</paragraph>"""),
+              textwrap.dedent("""\
+                <paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is
+                qualified and which qualifier types can be expected in which
+                context or which additional data specification templates are
+                provided.</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -9077,9 +12935,15 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Checksum to be used to determine if an Referable (including its\naggregated child elements) has changed.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Checksum to be used to determine if an Referable (including its
+              aggregated child elements) has changed.</paragraph>"""),
             remarks=[
-              "<paragraph>The checksum is calculated by the user's tool environment.\nThe checksum has no semantic meaning for an asset administration\nshell model and there is no requirement for asset administration\nshell tools to manage the checksum</paragraph>"],
+              textwrap.dedent("""\
+                <paragraph>The checksum is calculated by the user's tool environment.
+                The checksum has no semantic meaning for an asset administration
+                shell model and there is no requirement for asset administration
+                shell tools to manage the checksum</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -9107,7 +12971,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Identifier of the semantic definition of the element. It is called semantic ID\nof the element.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Identifier of the semantic definition of the element. It is called semantic ID
+              of the element.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -9128,7 +12994,9 @@ SymbolTable(
             constraints_by_identifier=[
               [
                 'AASd-021',
-                '<field_body><paragraph>Every qualifiable can only have one qualifier with the same\n<AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph>Every qualifiable can only have one qualifier with the same
+                  <AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -9170,7 +13038,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Describes statements applicable to the entity by a set of submodel elements,\ntypically with a qualified value.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Describes statements applicable to the entity by a set of submodel elements,
+              typically with a qualified value.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -9198,7 +13068,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Reference to an identifier key value pair representing a specific identifier\nof the asset represented by the asset administration shell.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Reference to an identifier key value pair representing a specific identifier
+              of the asset represented by the asset administration shell.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -9376,39 +13248,245 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='extensions',\n  argument='extensions',\n  default=None)",
-          "AssignArgument(\n  name='id_short',\n  argument='id_short',\n  default=None)",
-          "AssignArgument(\n  name='display_name',\n  argument='display_name',\n  default=None)",
-          "AssignArgument(\n  name='category',\n  argument='category',\n  default=None)",
-          "AssignArgument(\n  name='description',\n  argument='description',\n  default=None)",
-          "AssignArgument(\n  name='checksum',\n  argument='checksum',\n  default=None)",
-          "AssignArgument(\n  name='kind',\n  argument='kind',\n  default=DefaultEnumLiteral(\n    node=...,\n    enum='Reference to Enumeration Modeling_kind',\n    literal='Reference to EnumerationLiteral Instance'))",
-          "AssignArgument(\n  name='semantic_id',\n  argument='semantic_id',\n  default=None)",
-          "AssignArgument(\n  name='qualifiers',\n  argument='qualifiers',\n  default=None)",
-          "AssignArgument(\n  name='data_specifications',\n  argument='data_specifications',\n  default=None)",
-          "AssignArgument(\n  name='statements',\n  argument='statements',\n  default=None)",
-          "AssignArgument(\n  name='entity_type',\n  argument='entity_type',\n  default=None)",
-          "AssignArgument(\n  name='global_asset_id',\n  argument='global_asset_id',\n  default=None)",
-          "AssignArgument(\n  name='specific_asset_id',\n  argument='specific_asset_id',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='extensions',
+              argument='extensions',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='id_short',
+              argument='id_short',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='display_name',
+              argument='display_name',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='category',
+              argument='category',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='description',
+              argument='description',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='checksum',
+              argument='checksum',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='kind',
+              argument='kind',
+              default=DefaultEnumLiteral(
+                node=...,
+                enum='Reference to Enumeration Modeling_kind',
+                literal='Reference to EnumerationLiteral Instance'))"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='semantic_id',
+              argument='semantic_id',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='qualifiers',
+              argument='qualifiers',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='data_specifications',
+              argument='data_specifications',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='statements',
+              argument='statements',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='entity_type',
+              argument='entity_type',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='global_asset_id',
+              argument='global_asset_id',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='specific_asset_id',
+              argument='specific_asset_id',
+              default=None)""")]),
       invariants=[
         Invariant(
           description='Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='extensions',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='extension_names_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='extensions',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='extension_names_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='extensions',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
           description='Constraint AASd-027: ID-short shall have a maximum length of 128 characters.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='id_short',\n      original_node=...),\n    original_node=...),\n  consequent=Comparison(\n    left=FunctionCall(\n      name='len',\n      args=[\n        Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='id_short',\n          original_node=...)],\n      original_node=...),\n    op='LE',\n    right=Constant(\n      value=128,\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='id_short',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='id_short',
+                      original_node=...)],
+                  original_node=...),
+                op='LE',
+                right=Constant(
+                  value=128,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='qualifiers',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='qualifier_types_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='qualifiers',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='qualifier_types_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='qualifiers',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Invariant(
           description="Constraint AASd-014: Either the attribute global asset ID or specific asset ID must be set if entity type is set to 'SelfManagedEntity'. They are not existing otherwise.",
-          body="Or(\n  values=[\n    And(\n      values=[\n        Comparison(\n          left=Member(\n            instance=Name(\n              identifier='self',\n              original_node=...),\n            name='entity_type',\n            original_node=...),\n          op='EQ',\n          right=Member(\n            instance=Name(\n              identifier='Entity_type',\n              original_node=...),\n            name='Self_managed_entity',\n            original_node=...),\n          original_node=...),\n        Or(\n          values=[\n            And(\n              values=[\n                IsNotNone(\n                  value=Member(\n                    instance=Name(\n                      identifier='self',\n                      original_node=...),\n                    name='global_asset_id',\n                    original_node=...),\n                  original_node=...),\n                IsNone(\n                  value=Member(\n                    instance=Name(\n                      identifier='self',\n                      original_node=...),\n                    name='global_asset_id',\n                    original_node=...),\n                  original_node=...)],\n              original_node=...),\n            And(\n              values=[\n                IsNone(\n                  value=Member(\n                    instance=Name(\n                      identifier='self',\n                      original_node=...),\n                    name='global_asset_id',\n                    original_node=...),\n                  original_node=...),\n                IsNotNone(\n                  value=Member(\n                    instance=Name(\n                      identifier='self',\n                      original_node=...),\n                    name='global_asset_id',\n                    original_node=...),\n                  original_node=...)],\n              original_node=...)],\n          original_node=...)],\n      original_node=...),\n    And(\n      values=[\n        IsNone(\n          value=Member(\n            instance=Name(\n              identifier='self',\n              original_node=...),\n            name='global_asset_id',\n            original_node=...),\n          original_node=...),\n        IsNone(\n          value=Member(\n            instance=Name(\n              identifier='self',\n              original_node=...),\n            name='specific_asset_id',\n            original_node=...),\n          original_node=...)],\n      original_node=...)],\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Or(
+              values=[
+                And(
+                  values=[
+                    Comparison(
+                      left=Member(
+                        instance=Name(
+                          identifier='self',
+                          original_node=...),
+                        name='entity_type',
+                        original_node=...),
+                      op='EQ',
+                      right=Member(
+                        instance=Name(
+                          identifier='Entity_type',
+                          original_node=...),
+                        name='Self_managed_entity',
+                        original_node=...),
+                      original_node=...),
+                    Or(
+                      values=[
+                        And(
+                          values=[
+                            IsNotNone(
+                              value=Member(
+                                instance=Name(
+                                  identifier='self',
+                                  original_node=...),
+                                name='global_asset_id',
+                                original_node=...),
+                              original_node=...),
+                            IsNone(
+                              value=Member(
+                                instance=Name(
+                                  identifier='self',
+                                  original_node=...),
+                                name='global_asset_id',
+                                original_node=...),
+                              original_node=...)],
+                          original_node=...),
+                        And(
+                          values=[
+                            IsNone(
+                              value=Member(
+                                instance=Name(
+                                  identifier='self',
+                                  original_node=...),
+                                name='global_asset_id',
+                                original_node=...),
+                              original_node=...),
+                            IsNotNone(
+                              value=Member(
+                                instance=Name(
+                                  identifier='self',
+                                  original_node=...),
+                                name='global_asset_id',
+                                original_node=...),
+                              original_node=...)],
+                          original_node=...)],
+                      original_node=...)],
+                  original_node=...),
+                And(
+                  values=[
+                    IsNone(
+                      value=Member(
+                        instance=Name(
+                          identifier='self',
+                          original_node=...),
+                        name='global_asset_id',
+                        original_node=...),
+                      original_node=...),
+                    IsNone(
+                      value=Member(
+                        instance=Name(
+                          identifier='self',
+                          original_node=...),
+                        name='specific_asset_id',
+                        original_node=...),
+                      original_node=...)],
+                  original_node=...)],
+              original_node=...)"""),
           specified_for='Reference to ConcreteClass Entity',
           parsed=...)],
       serialization=Serialization(
@@ -9427,7 +13505,10 @@ SymbolTable(
         constraints_by_identifier=[
           [
             'AASd-014',
-            '<field_body><paragraph>Either the attribute <AttributeReference refuri="~global_asset_id">~global_asset_id</AttributeReference> or <AttributeReference refuri="~specific_asset_id">~specific_asset_id</AttributeReference>\nof an <SymbolReference refuri=".Entity">.Entity</SymbolReference> must be set if <AttributeReference refuri="~entity_type">~entity_type</AttributeReference> is set to\n<literal>SelfManagedEntity</literal>. They are not existing otherwise.</paragraph></field_body>']],
+            textwrap.dedent("""\
+              <field_body><paragraph>Either the attribute <AttributeReference refuri="~global_asset_id">~global_asset_id</AttributeReference> or <AttributeReference refuri="~specific_asset_id">~specific_asset_id</AttributeReference>
+              of an <SymbolReference refuri=".Entity">.Entity</SymbolReference> must be set if <AttributeReference refuri="~entity_type">~entity_type</AttributeReference> is set to
+              <literal>SelfManagedEntity</literal>. They are not existing otherwise.</paragraph></field_body>""")]],
         parsed=...),
       parsed=...,
       properties_by_name=...,
@@ -9521,7 +13602,10 @@ SymbolTable(
             symbol='Reference to symbol Model_reference',
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Reference to the source event element, including identification of\n<SymbolReference refuri=".Asset_administration_shell">.Asset_administration_shell</SymbolReference>, <SymbolReference refuri=".Submodel">.Submodel</SymbolReference>,\n<SymbolReference refuri=".Submodel_element">.Submodel_element</SymbolReference>\'s.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Reference to the source event element, including identification of
+              <SymbolReference refuri=".Asset_administration_shell">.Asset_administration_shell</SymbolReference>, <SymbolReference refuri=".Submodel">.Submodel</SymbolReference>,
+              <SymbolReference refuri=".Submodel_element">.Submodel_element</SymbolReference>'s.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -9549,7 +13633,9 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>Reference to the referable, which defines the scope of the event.</paragraph>',
             remarks=[
-              '<paragraph>Can be <SymbolReference refuri=".Asset_administration_shell">.Asset_administration_shell</SymbolReference>, <SymbolReference refuri=".Submodel">.Submodel</SymbolReference> or\n<SymbolReference refuri=".Submodel_element">.Submodel_element</SymbolReference>.</paragraph>'],
+              textwrap.dedent("""\
+                <paragraph>Can be <SymbolReference refuri=".Asset_administration_shell">.Asset_administration_shell</SymbolReference>, <SymbolReference refuri=".Submodel">.Submodel</SymbolReference> or
+                <SymbolReference refuri=".Submodel_element">.Submodel_element</SymbolReference>.</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to ConcreteClass Event_payload',
@@ -9562,7 +13648,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph><AttributeReference refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</AttributeReference> of the referable which defines the scope of\nthe event, if available.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph><AttributeReference refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</AttributeReference> of the referable which defines the scope of
+              the event, if available.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -9576,7 +13664,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Information for the outer message infrastructure for scheduling the event to\nthe respective communication channel.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Information for the outer message infrastructure for scheduling the event to
+              the respective communication channel.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -9712,14 +13802,46 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='source',\n  argument='source',\n  default=None)",
-          "AssignArgument(\n  name='observable_reference',\n  argument='observable_reference',\n  default=None)",
-          "AssignArgument(\n  name='time_stamp',\n  argument='time_stamp',\n  default=None)",
-          "AssignArgument(\n  name='source_semantic_id',\n  argument='source_semantic_id',\n  default=None)",
-          "AssignArgument(\n  name='observable_semantic_id',\n  argument='observable_semantic_id',\n  default=None)",
-          "AssignArgument(\n  name='topic',\n  argument='topic',\n  default=None)",
-          "AssignArgument(\n  name='subject_id',\n  argument='subject_id',\n  default=None)",
-          "AssignArgument(\n  name='payload',\n  argument='payload',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='source',
+              argument='source',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='observable_reference',
+              argument='observable_reference',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='time_stamp',
+              argument='time_stamp',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='source_semantic_id',
+              argument='source_semantic_id',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='observable_semantic_id',
+              argument='observable_semantic_id',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='topic',
+              argument='topic',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='subject_id',
+              argument='subject_id',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='payload',
+              argument='payload',
+              default=None)""")]),
       invariants=[],
       serialization=Serialization(
         with_model_type=False),
@@ -9734,7 +13856,9 @@ SymbolTable(
       description=SymbolDescription(
         summary='<paragraph>Defines the necessary information of an event instance sent out or received.</paragraph>',
         remarks=[
-          '<note><paragraph>The payload is not part of the information model as exchanged via\nthe AASX package format but used in re-active Asset Administration Shells.</paragraph></note>'],
+          textwrap.dedent("""\
+            <note><paragraph>The payload is not part of the information model as exchanged via
+            the AASX package format but used in re-active Asset Administration Shells.</paragraph></note>""")],
         constraints_by_identifier=[],
         parsed=...),
       parsed=...,
@@ -9780,13 +13904,21 @@ SymbolTable(
                 parsed=...),
               parsed=...),
             description=PropertyDescription(
-              summary='<paragraph>In case of identifiables this attribute is a short name of the element.\nIn case of referable this ID is an identifying string of\nthe element within its name space.</paragraph>',
+              summary=textwrap.dedent("""\
+                <paragraph>In case of identifiables this attribute is a short name of the element.
+                In case of referable this ID is an identifying string of
+                the element within its name space.</paragraph>"""),
               remarks=[
-                '<note><paragraph>In case the element is a property and the property has a semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>\nis typically identical to the short name in English.</paragraph></note>'],
+                textwrap.dedent("""\
+                  <note><paragraph>In case the element is a property and the property has a semantic definition
+                  (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>
+                  is typically identical to the short name in English.</paragraph></note>""")],
               constraints_by_identifier=[
                 [
                   'AASd-027',
-                  '<field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>\'s shall have a maximum length\nof 128 characters.</paragraph></field_body>']],
+                  textwrap.dedent("""\
+                    <field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>'s shall have a maximum length
+                    of 128 characters.</paragraph></field_body>""")]],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
             parsed=...),
@@ -9800,8 +13932,15 @@ SymbolTable(
             description=PropertyDescription(
               summary='<paragraph>Display name. Can be provided in several languages.</paragraph>',
               remarks=[
-                '<paragraph>If no display name is defined in the language requested by the application,\nthen the display name is selected in the following order if available:</paragraph>',
-                '<bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,\nthen the corresponding preferred name in the language is chosen\naccording to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>'],
+                textwrap.dedent("""\
+                  <paragraph>If no display name is defined in the language requested by the application,
+                  then the display name is selected in the following order if available:</paragraph>"""),
+                textwrap.dedent("""\
+                  <bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining
+                  the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
+                  then the corresponding preferred name in the language is chosen
+                  according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
+                  the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -9814,9 +13953,18 @@ SymbolTable(
                 parsed=...),
               parsed=...),
             description=PropertyDescription(
-              summary='<paragraph>The category is a value that gives further meta information\nw.r.t. to the class of the element.\nIt affects the expected existence of attributes and the applicability of\nconstraints.</paragraph>',
+              summary=textwrap.dedent("""\
+                <paragraph>The category is a value that gives further meta information
+                w.r.t. to the class of the element.
+                It affects the expected existence of attributes and the applicability of
+                constraints.</paragraph>"""),
               remarks=[
-                '<note><paragraph>The category is not identical to the semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category\n<emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the\nsemantic definition of the element would\ndenote that it is the measured temperature.</paragraph></note>'],
+                textwrap.dedent("""\
+                  <note><paragraph>The category is not identical to the semantic definition
+                  (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category
+                  <emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the
+                  semantic definition of the element would
+                  denote that it is the measured temperature.</paragraph></note>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -9832,8 +13980,14 @@ SymbolTable(
               summary='<paragraph>Description or comments on the element.</paragraph>',
               remarks=[
                 '<paragraph>The description can be provided in several languages.</paragraph>',
-                '<paragraph>If no description is defined, then the definition of the concept\ndescription that defines the semantics of the element is used.</paragraph>',
-                '<paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is\nqualified and which qualifier types can be expected in which\ncontext or which additional data specification templates are\nprovided.</paragraph>'],
+                textwrap.dedent("""\
+                  <paragraph>If no description is defined, then the definition of the concept
+                  description that defines the semantics of the element is used.</paragraph>"""),
+                textwrap.dedent("""\
+                  <paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is
+                  qualified and which qualifier types can be expected in which
+                  context or which additional data specification templates are
+                  provided.</paragraph>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -9846,9 +14000,15 @@ SymbolTable(
                 parsed=...),
               parsed=...),
             description=PropertyDescription(
-              summary='<paragraph>Checksum to be used to determine if an Referable (including its\naggregated child elements) has changed.</paragraph>',
+              summary=textwrap.dedent("""\
+                <paragraph>Checksum to be used to determine if an Referable (including its
+                aggregated child elements) has changed.</paragraph>"""),
               remarks=[
-                "<paragraph>The checksum is calculated by the user's tool environment.\nThe checksum has no semantic meaning for an asset administration\nshell model and there is no requirement for asset administration\nshell tools to manage the checksum</paragraph>"],
+                textwrap.dedent("""\
+                  <paragraph>The checksum is calculated by the user's tool environment.
+                  The checksum has no semantic meaning for an asset administration
+                  shell model and there is no requirement for asset administration
+                  shell tools to manage the checksum</paragraph>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -9876,7 +14036,9 @@ SymbolTable(
                 parsed=...),
               parsed=...),
             description=PropertyDescription(
-              summary='<paragraph>Identifier of the semantic definition of the element. It is called semantic ID\nof the element.</paragraph>',
+              summary=textwrap.dedent("""\
+                <paragraph>Identifier of the semantic definition of the element. It is called semantic ID
+                of the element.</paragraph>"""),
               remarks=[],
               constraints_by_identifier=[],
               parsed=...),
@@ -9897,7 +14059,9 @@ SymbolTable(
               constraints_by_identifier=[
                 [
                   'AASd-021',
-                  '<field_body><paragraph>Every qualifiable can only have one qualifier with the same\n<AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>']],
+                  textwrap.dedent("""\
+                    <field_body><paragraph>Every qualifiable can only have one qualifier with the same
+                    <AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>""")]],
               parsed=...),
             specified_for='Reference to AbstractClass Qualifiable',
             parsed=...),
@@ -9954,13 +14118,21 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>In case of identifiables this attribute is a short name of the element.\nIn case of referable this ID is an identifying string of\nthe element within its name space.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>In case of identifiables this attribute is a short name of the element.
+              In case of referable this ID is an identifying string of
+              the element within its name space.</paragraph>"""),
             remarks=[
-              '<note><paragraph>In case the element is a property and the property has a semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>\nis typically identical to the short name in English.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>In case the element is a property and the property has a semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>
+                is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[
               [
                 'AASd-027',
-                '<field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>\'s shall have a maximum length\nof 128 characters.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>'s shall have a maximum length
+                  of 128 characters.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
@@ -9974,8 +14146,15 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>Display name. Can be provided in several languages.</paragraph>',
             remarks=[
-              '<paragraph>If no display name is defined in the language requested by the application,\nthen the display name is selected in the following order if available:</paragraph>',
-              '<bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,\nthen the corresponding preferred name in the language is chosen\naccording to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>'],
+              textwrap.dedent("""\
+                <paragraph>If no display name is defined in the language requested by the application,
+                then the display name is selected in the following order if available:</paragraph>"""),
+              textwrap.dedent("""\
+                <bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
+                then the corresponding preferred name in the language is chosen
+                according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -9988,9 +14167,18 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>The category is a value that gives further meta information\nw.r.t. to the class of the element.\nIt affects the expected existence of attributes and the applicability of\nconstraints.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>The category is a value that gives further meta information
+              w.r.t. to the class of the element.
+              It affects the expected existence of attributes and the applicability of
+              constraints.</paragraph>"""),
             remarks=[
-              '<note><paragraph>The category is not identical to the semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category\n<emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the\nsemantic definition of the element would\ndenote that it is the measured temperature.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>The category is not identical to the semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category
+                <emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the
+                semantic definition of the element would
+                denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -10006,8 +14194,14 @@ SymbolTable(
             summary='<paragraph>Description or comments on the element.</paragraph>',
             remarks=[
               '<paragraph>The description can be provided in several languages.</paragraph>',
-              '<paragraph>If no description is defined, then the definition of the concept\ndescription that defines the semantics of the element is used.</paragraph>',
-              '<paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is\nqualified and which qualifier types can be expected in which\ncontext or which additional data specification templates are\nprovided.</paragraph>'],
+              textwrap.dedent("""\
+                <paragraph>If no description is defined, then the definition of the concept
+                description that defines the semantics of the element is used.</paragraph>"""),
+              textwrap.dedent("""\
+                <paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is
+                qualified and which qualifier types can be expected in which
+                context or which additional data specification templates are
+                provided.</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -10020,9 +14214,15 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Checksum to be used to determine if an Referable (including its\naggregated child elements) has changed.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Checksum to be used to determine if an Referable (including its
+              aggregated child elements) has changed.</paragraph>"""),
             remarks=[
-              "<paragraph>The checksum is calculated by the user's tool environment.\nThe checksum has no semantic meaning for an asset administration\nshell model and there is no requirement for asset administration\nshell tools to manage the checksum</paragraph>"],
+              textwrap.dedent("""\
+                <paragraph>The checksum is calculated by the user's tool environment.
+                The checksum has no semantic meaning for an asset administration
+                shell model and there is no requirement for asset administration
+                shell tools to manage the checksum</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -10050,7 +14250,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Identifier of the semantic definition of the element. It is called semantic ID\nof the element.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Identifier of the semantic definition of the element. It is called semantic ID
+              of the element.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -10071,7 +14273,9 @@ SymbolTable(
             constraints_by_identifier=[
               [
                 'AASd-021',
-                '<field_body><paragraph>Every qualifiable can only have one qualifier with the same\n<AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph>Every qualifiable can only have one qualifier with the same
+                  <AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -10221,30 +14425,139 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='extensions',\n  argument='extensions',\n  default=None)",
-          "AssignArgument(\n  name='id_short',\n  argument='id_short',\n  default=None)",
-          "AssignArgument(\n  name='display_name',\n  argument='display_name',\n  default=None)",
-          "AssignArgument(\n  name='category',\n  argument='category',\n  default=None)",
-          "AssignArgument(\n  name='description',\n  argument='description',\n  default=None)",
-          "AssignArgument(\n  name='checksum',\n  argument='checksum',\n  default=None)",
-          "AssignArgument(\n  name='kind',\n  argument='kind',\n  default=DefaultEnumLiteral(\n    node=...,\n    enum='Reference to Enumeration Modeling_kind',\n    literal='Reference to EnumerationLiteral Instance'))",
-          "AssignArgument(\n  name='semantic_id',\n  argument='semantic_id',\n  default=None)",
-          "AssignArgument(\n  name='qualifiers',\n  argument='qualifiers',\n  default=None)",
-          "AssignArgument(\n  name='data_specifications',\n  argument='data_specifications',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='extensions',
+              argument='extensions',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='id_short',
+              argument='id_short',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='display_name',
+              argument='display_name',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='category',
+              argument='category',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='description',
+              argument='description',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='checksum',
+              argument='checksum',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='kind',
+              argument='kind',
+              default=DefaultEnumLiteral(
+                node=...,
+                enum='Reference to Enumeration Modeling_kind',
+                literal='Reference to EnumerationLiteral Instance'))"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='semantic_id',
+              argument='semantic_id',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='qualifiers',
+              argument='qualifiers',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='data_specifications',
+              argument='data_specifications',
+              default=None)""")]),
       invariants=[
         Invariant(
           description='Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='extensions',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='extension_names_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='extensions',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='extension_names_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='extensions',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
           description='Constraint AASd-027: ID-short shall have a maximum length of 128 characters.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='id_short',\n      original_node=...),\n    original_node=...),\n  consequent=Comparison(\n    left=FunctionCall(\n      name='len',\n      args=[\n        Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='id_short',\n          original_node=...)],\n      original_node=...),\n    op='LE',\n    right=Constant(\n      value=128,\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='id_short',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='id_short',
+                      original_node=...)],
+                  original_node=...),
+                op='LE',
+                right=Constant(
+                  value=128,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='qualifiers',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='qualifier_types_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='qualifiers',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='qualifier_types_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='qualifiers',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...)],
       serialization=Serialization(
@@ -10301,13 +14614,21 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>In case of identifiables this attribute is a short name of the element.\nIn case of referable this ID is an identifying string of\nthe element within its name space.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>In case of identifiables this attribute is a short name of the element.
+              In case of referable this ID is an identifying string of
+              the element within its name space.</paragraph>"""),
             remarks=[
-              '<note><paragraph>In case the element is a property and the property has a semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>\nis typically identical to the short name in English.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>In case the element is a property and the property has a semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>
+                is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[
               [
                 'AASd-027',
-                '<field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>\'s shall have a maximum length\nof 128 characters.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>'s shall have a maximum length
+                  of 128 characters.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
@@ -10321,8 +14642,15 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>Display name. Can be provided in several languages.</paragraph>',
             remarks=[
-              '<paragraph>If no display name is defined in the language requested by the application,\nthen the display name is selected in the following order if available:</paragraph>',
-              '<bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,\nthen the corresponding preferred name in the language is chosen\naccording to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>'],
+              textwrap.dedent("""\
+                <paragraph>If no display name is defined in the language requested by the application,
+                then the display name is selected in the following order if available:</paragraph>"""),
+              textwrap.dedent("""\
+                <bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
+                then the corresponding preferred name in the language is chosen
+                according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -10335,9 +14663,18 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>The category is a value that gives further meta information\nw.r.t. to the class of the element.\nIt affects the expected existence of attributes and the applicability of\nconstraints.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>The category is a value that gives further meta information
+              w.r.t. to the class of the element.
+              It affects the expected existence of attributes and the applicability of
+              constraints.</paragraph>"""),
             remarks=[
-              '<note><paragraph>The category is not identical to the semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category\n<emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the\nsemantic definition of the element would\ndenote that it is the measured temperature.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>The category is not identical to the semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category
+                <emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the
+                semantic definition of the element would
+                denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -10353,8 +14690,14 @@ SymbolTable(
             summary='<paragraph>Description or comments on the element.</paragraph>',
             remarks=[
               '<paragraph>The description can be provided in several languages.</paragraph>',
-              '<paragraph>If no description is defined, then the definition of the concept\ndescription that defines the semantics of the element is used.</paragraph>',
-              '<paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is\nqualified and which qualifier types can be expected in which\ncontext or which additional data specification templates are\nprovided.</paragraph>'],
+              textwrap.dedent("""\
+                <paragraph>If no description is defined, then the definition of the concept
+                description that defines the semantics of the element is used.</paragraph>"""),
+              textwrap.dedent("""\
+                <paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is
+                qualified and which qualifier types can be expected in which
+                context or which additional data specification templates are
+                provided.</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -10367,9 +14710,15 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Checksum to be used to determine if an Referable (including its\naggregated child elements) has changed.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Checksum to be used to determine if an Referable (including its
+              aggregated child elements) has changed.</paragraph>"""),
             remarks=[
-              "<paragraph>The checksum is calculated by the user's tool environment.\nThe checksum has no semantic meaning for an asset administration\nshell model and there is no requirement for asset administration\nshell tools to manage the checksum</paragraph>"],
+              textwrap.dedent("""\
+                <paragraph>The checksum is calculated by the user's tool environment.
+                The checksum has no semantic meaning for an asset administration
+                shell model and there is no requirement for asset administration
+                shell tools to manage the checksum</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -10397,7 +14746,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Identifier of the semantic definition of the element. It is called semantic ID\nof the element.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Identifier of the semantic definition of the element. It is called semantic ID
+              of the element.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -10418,7 +14769,9 @@ SymbolTable(
             constraints_by_identifier=[
               [
                 'AASd-021',
-                '<field_body><paragraph>Every qualifiable can only have one qualifier with the same\n<AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph>Every qualifiable can only have one qualifier with the same
+                  <AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -10444,7 +14797,11 @@ SymbolTable(
             symbol='Reference to symbol Model_reference',
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Reference to the <SymbolReference refuri=".Referable">.Referable</SymbolReference>, which defines the scope of the event.\nCan be <SymbolReference refuri=".Asset_administration_shell">.Asset_administration_shell</SymbolReference>, <SymbolReference refuri=".Submodel">.Submodel</SymbolReference>, or\n<SymbolReference refuri=".Submodel_element">.Submodel_element</SymbolReference>. Reference to a referable, e.g. a data element or\na submodel, that is being observed.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Reference to the <SymbolReference refuri=".Referable">.Referable</SymbolReference>, which defines the scope of the event.
+              Can be <SymbolReference refuri=".Asset_administration_shell">.Asset_administration_shell</SymbolReference>, <SymbolReference refuri=".Submodel">.Submodel</SymbolReference>, or
+              <SymbolReference refuri=".Submodel_element">.Submodel_element</SymbolReference>. Reference to a referable, e.g. a data element or
+              a submodel, that is being observed.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -10456,7 +14813,9 @@ SymbolTable(
             symbol='Reference to symbol Direction',
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Direction of event.\nCan be <literal>{ Input, Output }</literal>.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Direction of event.
+              Can be <literal>{ Input, Output }</literal>.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -10468,7 +14827,9 @@ SymbolTable(
             symbol='Reference to symbol State_of_event',
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>State of event.\nCan be <literal>{ On, Off }</literal>.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>State of event.
+              Can be <literal>{ On, Off }</literal>.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -10482,7 +14843,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Information for the outer message infrastructure for scheduling the event to the\nrespective communication channel.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Information for the outer message infrastructure for scheduling the event to the
+              respective communication channel.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -10496,10 +14859,18 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Information, which outer message infrastructure shall handle messages for\nthe <SymbolReference refuri=".Event_element">.Event_element</SymbolReference>.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Information, which outer message infrastructure shall handle messages for
+              the <SymbolReference refuri=".Event_element">.Event_element</SymbolReference>.</paragraph>"""),
             remarks=[
-              '<paragraph>Refers to a <SymbolReference refuri=".Submodel">.Submodel</SymbolReference>, <SymbolReference refuri=".Submodel_element_list">.Submodel_element_list</SymbolReference>,\n<SymbolReference refuri=".Submodel_element_struct">.Submodel_element_struct</SymbolReference> or <SymbolReference refuri=".Entity">.Entity</SymbolReference>, which contains\n<SymbolReference refuri=".Data_element">.Data_element</SymbolReference>\'s describing the proprietary specification for\nthe message broker.</paragraph>',
-              '<note><paragraph>For different message infrastructure, e.g. OPC UA or MQTT or AMQP, these\nproprietary specification could be standardized by having respective Submodels.</paragraph></note>'],
+              textwrap.dedent("""\
+                <paragraph>Refers to a <SymbolReference refuri=".Submodel">.Submodel</SymbolReference>, <SymbolReference refuri=".Submodel_element_list">.Submodel_element_list</SymbolReference>,
+                <SymbolReference refuri=".Submodel_element_struct">.Submodel_element_struct</SymbolReference> or <SymbolReference refuri=".Entity">.Entity</SymbolReference>, which contains
+                <SymbolReference refuri=".Data_element">.Data_element</SymbolReference>'s describing the proprietary specification for
+                the message broker.</paragraph>"""),
+              textwrap.dedent("""\
+                <note><paragraph>For different message infrastructure, e.g. OPC UA or MQTT or AMQP, these
+                proprietary specification could be standardized by having respective Submodels.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to ConcreteClass Basic_event_element',
@@ -10512,7 +14883,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Timestamp in UTC, when the last event was received (input direction) or sent\n(output direction).</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Timestamp in UTC, when the last event was received (input direction) or sent
+              (output direction).</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -10526,7 +14899,11 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>For input direction, reports on the maximum frequency, the software entity behind\nthe respective Referable can handle input events. For output events, specifies\nthe maximum frequency of outputting this event to an outer infrastructure.\nMight be not specified, that is, there is no minimum interval.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>For input direction, reports on the maximum frequency, the software entity behind
+              the respective Referable can handle input events. For output events, specifies
+              the maximum frequency of outputting this event to an outer infrastructure.
+              Might be not specified, that is, there is no minimum interval.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -10540,7 +14917,11 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>For input direction: not applicable.\nFor output direction: maximum interval in time, the respective Referable shall send\nan update of the status of the event, even if no other trigger condition for\nthe event was not met. Might be not specified, that is, there is no maximum interval.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>For input direction: not applicable.
+              For output direction: maximum interval in time, the respective Referable shall send
+              an update of the status of the event, even if no other trigger condition for
+              the event was not met. Might be not specified, that is, there is no maximum interval.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -10752,38 +15133,179 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='extensions',\n  argument='extensions',\n  default=None)",
-          "AssignArgument(\n  name='id_short',\n  argument='id_short',\n  default=None)",
-          "AssignArgument(\n  name='display_name',\n  argument='display_name',\n  default=None)",
-          "AssignArgument(\n  name='category',\n  argument='category',\n  default=None)",
-          "AssignArgument(\n  name='description',\n  argument='description',\n  default=None)",
-          "AssignArgument(\n  name='checksum',\n  argument='checksum',\n  default=None)",
-          "AssignArgument(\n  name='kind',\n  argument='kind',\n  default=DefaultEnumLiteral(\n    node=...,\n    enum='Reference to Enumeration Modeling_kind',\n    literal='Reference to EnumerationLiteral Instance'))",
-          "AssignArgument(\n  name='semantic_id',\n  argument='semantic_id',\n  default=None)",
-          "AssignArgument(\n  name='qualifiers',\n  argument='qualifiers',\n  default=None)",
-          "AssignArgument(\n  name='data_specifications',\n  argument='data_specifications',\n  default=None)",
-          "AssignArgument(\n  name='observed',\n  argument='observed',\n  default=None)",
-          "AssignArgument(\n  name='direction',\n  argument='direction',\n  default=None)",
-          "AssignArgument(\n  name='state',\n  argument='state',\n  default=None)",
-          "AssignArgument(\n  name='message_topic',\n  argument='message_topic',\n  default=None)",
-          "AssignArgument(\n  name='message_broker',\n  argument='message_broker',\n  default=None)",
-          "AssignArgument(\n  name='last_update',\n  argument='last_update',\n  default=None)",
-          "AssignArgument(\n  name='min_interval',\n  argument='min_interval',\n  default=None)",
-          "AssignArgument(\n  name='max_interval',\n  argument='max_interval',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='extensions',
+              argument='extensions',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='id_short',
+              argument='id_short',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='display_name',
+              argument='display_name',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='category',
+              argument='category',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='description',
+              argument='description',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='checksum',
+              argument='checksum',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='kind',
+              argument='kind',
+              default=DefaultEnumLiteral(
+                node=...,
+                enum='Reference to Enumeration Modeling_kind',
+                literal='Reference to EnumerationLiteral Instance'))"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='semantic_id',
+              argument='semantic_id',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='qualifiers',
+              argument='qualifiers',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='data_specifications',
+              argument='data_specifications',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='observed',
+              argument='observed',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='direction',
+              argument='direction',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='state',
+              argument='state',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='message_topic',
+              argument='message_topic',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='message_broker',
+              argument='message_broker',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='last_update',
+              argument='last_update',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='min_interval',
+              argument='min_interval',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='max_interval',
+              argument='max_interval',
+              default=None)""")]),
       invariants=[
         Invariant(
           description='Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='extensions',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='extension_names_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='extensions',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='extension_names_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='extensions',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
           description='Constraint AASd-027: ID-short shall have a maximum length of 128 characters.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='id_short',\n      original_node=...),\n    original_node=...),\n  consequent=Comparison(\n    left=FunctionCall(\n      name='len',\n      args=[\n        Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='id_short',\n          original_node=...)],\n      original_node=...),\n    op='LE',\n    right=Constant(\n      value=128,\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='id_short',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='id_short',
+                      original_node=...)],
+                  original_node=...),
+                op='LE',
+                right=Constant(
+                  value=128,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='qualifiers',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='qualifier_types_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='qualifiers',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='qualifier_types_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='qualifiers',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...)],
       serialization=Serialization(
@@ -10840,13 +15362,21 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>In case of identifiables this attribute is a short name of the element.\nIn case of referable this ID is an identifying string of\nthe element within its name space.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>In case of identifiables this attribute is a short name of the element.
+              In case of referable this ID is an identifying string of
+              the element within its name space.</paragraph>"""),
             remarks=[
-              '<note><paragraph>In case the element is a property and the property has a semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>\nis typically identical to the short name in English.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>In case the element is a property and the property has a semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>
+                is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[
               [
                 'AASd-027',
-                '<field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>\'s shall have a maximum length\nof 128 characters.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>'s shall have a maximum length
+                  of 128 characters.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
@@ -10860,8 +15390,15 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>Display name. Can be provided in several languages.</paragraph>',
             remarks=[
-              '<paragraph>If no display name is defined in the language requested by the application,\nthen the display name is selected in the following order if available:</paragraph>',
-              '<bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,\nthen the corresponding preferred name in the language is chosen\naccording to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>'],
+              textwrap.dedent("""\
+                <paragraph>If no display name is defined in the language requested by the application,
+                then the display name is selected in the following order if available:</paragraph>"""),
+              textwrap.dedent("""\
+                <bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
+                then the corresponding preferred name in the language is chosen
+                according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -10874,9 +15411,18 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>The category is a value that gives further meta information\nw.r.t. to the class of the element.\nIt affects the expected existence of attributes and the applicability of\nconstraints.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>The category is a value that gives further meta information
+              w.r.t. to the class of the element.
+              It affects the expected existence of attributes and the applicability of
+              constraints.</paragraph>"""),
             remarks=[
-              '<note><paragraph>The category is not identical to the semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category\n<emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the\nsemantic definition of the element would\ndenote that it is the measured temperature.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>The category is not identical to the semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category
+                <emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the
+                semantic definition of the element would
+                denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -10892,8 +15438,14 @@ SymbolTable(
             summary='<paragraph>Description or comments on the element.</paragraph>',
             remarks=[
               '<paragraph>The description can be provided in several languages.</paragraph>',
-              '<paragraph>If no description is defined, then the definition of the concept\ndescription that defines the semantics of the element is used.</paragraph>',
-              '<paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is\nqualified and which qualifier types can be expected in which\ncontext or which additional data specification templates are\nprovided.</paragraph>'],
+              textwrap.dedent("""\
+                <paragraph>If no description is defined, then the definition of the concept
+                description that defines the semantics of the element is used.</paragraph>"""),
+              textwrap.dedent("""\
+                <paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is
+                qualified and which qualifier types can be expected in which
+                context or which additional data specification templates are
+                provided.</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -10906,9 +15458,15 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Checksum to be used to determine if an Referable (including its\naggregated child elements) has changed.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Checksum to be used to determine if an Referable (including its
+              aggregated child elements) has changed.</paragraph>"""),
             remarks=[
-              "<paragraph>The checksum is calculated by the user's tool environment.\nThe checksum has no semantic meaning for an asset administration\nshell model and there is no requirement for asset administration\nshell tools to manage the checksum</paragraph>"],
+              textwrap.dedent("""\
+                <paragraph>The checksum is calculated by the user's tool environment.
+                The checksum has no semantic meaning for an asset administration
+                shell model and there is no requirement for asset administration
+                shell tools to manage the checksum</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -10936,7 +15494,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Identifier of the semantic definition of the element. It is called semantic ID\nof the element.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Identifier of the semantic definition of the element. It is called semantic ID
+              of the element.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -10957,7 +15517,9 @@ SymbolTable(
             constraints_by_identifier=[
               [
                 'AASd-021',
-                '<field_body><paragraph>Every qualifiable can only have one qualifier with the same\n<AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph>Every qualifiable can only have one qualifier with the same
+                  <AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -11194,33 +15756,154 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='extensions',\n  argument='extensions',\n  default=None)",
-          "AssignArgument(\n  name='id_short',\n  argument='id_short',\n  default=None)",
-          "AssignArgument(\n  name='display_name',\n  argument='display_name',\n  default=None)",
-          "AssignArgument(\n  name='category',\n  argument='category',\n  default=None)",
-          "AssignArgument(\n  name='description',\n  argument='description',\n  default=None)",
-          "AssignArgument(\n  name='checksum',\n  argument='checksum',\n  default=None)",
-          "AssignArgument(\n  name='kind',\n  argument='kind',\n  default=DefaultEnumLiteral(\n    node=...,\n    enum='Reference to Enumeration Modeling_kind',\n    literal='Reference to EnumerationLiteral Instance'))",
-          "AssignArgument(\n  name='semantic_id',\n  argument='semantic_id',\n  default=None)",
-          "AssignArgument(\n  name='qualifiers',\n  argument='qualifiers',\n  default=None)",
-          "AssignArgument(\n  name='data_specifications',\n  argument='data_specifications',\n  default=None)",
-          "AssignArgument(\n  name='input_variables',\n  argument='input_variables',\n  default=None)",
-          "AssignArgument(\n  name='output_variables',\n  argument='output_variables',\n  default=None)",
-          "AssignArgument(\n  name='inoutput_variables',\n  argument='inoutput_variables',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='extensions',
+              argument='extensions',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='id_short',
+              argument='id_short',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='display_name',
+              argument='display_name',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='category',
+              argument='category',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='description',
+              argument='description',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='checksum',
+              argument='checksum',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='kind',
+              argument='kind',
+              default=DefaultEnumLiteral(
+                node=...,
+                enum='Reference to Enumeration Modeling_kind',
+                literal='Reference to EnumerationLiteral Instance'))"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='semantic_id',
+              argument='semantic_id',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='qualifiers',
+              argument='qualifiers',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='data_specifications',
+              argument='data_specifications',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='input_variables',
+              argument='input_variables',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='output_variables',
+              argument='output_variables',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='inoutput_variables',
+              argument='inoutput_variables',
+              default=None)""")]),
       invariants=[
         Invariant(
           description='Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='extensions',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='extension_names_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='extensions',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='extension_names_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='extensions',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
           description='Constraint AASd-027: ID-short shall have a maximum length of 128 characters.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='id_short',\n      original_node=...),\n    original_node=...),\n  consequent=Comparison(\n    left=FunctionCall(\n      name='len',\n      args=[\n        Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='id_short',\n          original_node=...)],\n      original_node=...),\n    op='LE',\n    right=Constant(\n      value=128,\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='id_short',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='id_short',
+                      original_node=...)],
+                  original_node=...),
+                op='LE',
+                right=Constant(
+                  value=128,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='qualifiers',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='qualifier_types_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='qualifiers',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='qualifier_types_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='qualifiers',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...)],
       serialization=Serialization(
@@ -11285,7 +15968,11 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='value',\n  argument='value',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='value',
+              argument='value',
+              default=None)""")]),
       invariants=[],
       serialization=Serialization(
         with_model_type=False),
@@ -11298,9 +15985,13 @@ SymbolTable(
         index=1,
         fragment=None),
       description=SymbolDescription(
-        summary='<paragraph>An operation variable is a submodel element that is used as input or output variable\nof an operation.</paragraph>',
+        summary=textwrap.dedent("""\
+          <paragraph>An operation variable is a submodel element that is used as input or output variable
+          of an operation.</paragraph>"""),
         remarks=[
-          '<note><paragraph><SymbolReference refuri=".Operation_variable">.Operation_variable</SymbolReference> is introduced as separate class to enable future\nextensions, e.g. for adding a default value, cardinality (option/mandatory).</paragraph></note>'],
+          textwrap.dedent("""\
+            <note><paragraph><SymbolReference refuri=".Operation_variable">.Operation_variable</SymbolReference> is introduced as separate class to enable future
+            extensions, e.g. for adding a default value, cardinality (option/mandatory).</paragraph></note>""")],
         constraints_by_identifier=[],
         parsed=...),
       parsed=...,
@@ -11342,13 +16033,21 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>In case of identifiables this attribute is a short name of the element.\nIn case of referable this ID is an identifying string of\nthe element within its name space.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>In case of identifiables this attribute is a short name of the element.
+              In case of referable this ID is an identifying string of
+              the element within its name space.</paragraph>"""),
             remarks=[
-              '<note><paragraph>In case the element is a property and the property has a semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>\nis typically identical to the short name in English.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>In case the element is a property and the property has a semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>
+                is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[
               [
                 'AASd-027',
-                '<field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>\'s shall have a maximum length\nof 128 characters.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>'s shall have a maximum length
+                  of 128 characters.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
@@ -11362,8 +16061,15 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>Display name. Can be provided in several languages.</paragraph>',
             remarks=[
-              '<paragraph>If no display name is defined in the language requested by the application,\nthen the display name is selected in the following order if available:</paragraph>',
-              '<bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,\nthen the corresponding preferred name in the language is chosen\naccording to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>'],
+              textwrap.dedent("""\
+                <paragraph>If no display name is defined in the language requested by the application,
+                then the display name is selected in the following order if available:</paragraph>"""),
+              textwrap.dedent("""\
+                <bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
+                then the corresponding preferred name in the language is chosen
+                according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -11376,9 +16082,18 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>The category is a value that gives further meta information\nw.r.t. to the class of the element.\nIt affects the expected existence of attributes and the applicability of\nconstraints.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>The category is a value that gives further meta information
+              w.r.t. to the class of the element.
+              It affects the expected existence of attributes and the applicability of
+              constraints.</paragraph>"""),
             remarks=[
-              '<note><paragraph>The category is not identical to the semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category\n<emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the\nsemantic definition of the element would\ndenote that it is the measured temperature.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>The category is not identical to the semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category
+                <emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the
+                semantic definition of the element would
+                denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -11394,8 +16109,14 @@ SymbolTable(
             summary='<paragraph>Description or comments on the element.</paragraph>',
             remarks=[
               '<paragraph>The description can be provided in several languages.</paragraph>',
-              '<paragraph>If no description is defined, then the definition of the concept\ndescription that defines the semantics of the element is used.</paragraph>',
-              '<paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is\nqualified and which qualifier types can be expected in which\ncontext or which additional data specification templates are\nprovided.</paragraph>'],
+              textwrap.dedent("""\
+                <paragraph>If no description is defined, then the definition of the concept
+                description that defines the semantics of the element is used.</paragraph>"""),
+              textwrap.dedent("""\
+                <paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is
+                qualified and which qualifier types can be expected in which
+                context or which additional data specification templates are
+                provided.</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -11408,9 +16129,15 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Checksum to be used to determine if an Referable (including its\naggregated child elements) has changed.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Checksum to be used to determine if an Referable (including its
+              aggregated child elements) has changed.</paragraph>"""),
             remarks=[
-              "<paragraph>The checksum is calculated by the user's tool environment.\nThe checksum has no semantic meaning for an asset administration\nshell model and there is no requirement for asset administration\nshell tools to manage the checksum</paragraph>"],
+              textwrap.dedent("""\
+                <paragraph>The checksum is calculated by the user's tool environment.
+                The checksum has no semantic meaning for an asset administration
+                shell model and there is no requirement for asset administration
+                shell tools to manage the checksum</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -11438,7 +16165,9 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Identifier of the semantic definition of the element. It is called semantic ID\nof the element.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Identifier of the semantic definition of the element. It is called semantic ID
+              of the element.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -11459,7 +16188,9 @@ SymbolTable(
             constraints_by_identifier=[
               [
                 'AASd-021',
-                '<field_body><paragraph>Every qualifiable can only have one qualifier with the same\n<AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph>Every qualifiable can only have one qualifier with the same
+                  <AttributeReference refuri="~Qualifier.type">~Qualifier.type</AttributeReference>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -11609,30 +16340,139 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='extensions',\n  argument='extensions',\n  default=None)",
-          "AssignArgument(\n  name='id_short',\n  argument='id_short',\n  default=None)",
-          "AssignArgument(\n  name='display_name',\n  argument='display_name',\n  default=None)",
-          "AssignArgument(\n  name='category',\n  argument='category',\n  default=None)",
-          "AssignArgument(\n  name='description',\n  argument='description',\n  default=None)",
-          "AssignArgument(\n  name='checksum',\n  argument='checksum',\n  default=None)",
-          "AssignArgument(\n  name='kind',\n  argument='kind',\n  default=DefaultEnumLiteral(\n    node=...,\n    enum='Reference to Enumeration Modeling_kind',\n    literal='Reference to EnumerationLiteral Instance'))",
-          "AssignArgument(\n  name='semantic_id',\n  argument='semantic_id',\n  default=None)",
-          "AssignArgument(\n  name='qualifiers',\n  argument='qualifiers',\n  default=None)",
-          "AssignArgument(\n  name='data_specifications',\n  argument='data_specifications',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='extensions',
+              argument='extensions',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='id_short',
+              argument='id_short',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='display_name',
+              argument='display_name',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='category',
+              argument='category',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='description',
+              argument='description',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='checksum',
+              argument='checksum',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='kind',
+              argument='kind',
+              default=DefaultEnumLiteral(
+                node=...,
+                enum='Reference to Enumeration Modeling_kind',
+                literal='Reference to EnumerationLiteral Instance'))"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='semantic_id',
+              argument='semantic_id',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='qualifiers',
+              argument='qualifiers',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='data_specifications',
+              argument='data_specifications',
+              default=None)""")]),
       invariants=[
         Invariant(
           description='Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='extensions',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='extension_names_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='extensions',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='extension_names_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='extensions',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
           description='Constraint AASd-027: ID-short shall have a maximum length of 128 characters.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='id_short',\n      original_node=...),\n    original_node=...),\n  consequent=Comparison(\n    left=FunctionCall(\n      name='len',\n      args=[\n        Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='id_short',\n          original_node=...)],\n      original_node=...),\n    op='LE',\n    right=Constant(\n      value=128,\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='id_short',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='id_short',
+                      original_node=...)],
+                  original_node=...),
+                op='LE',
+                right=Constant(
+                  value=128,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='qualifiers',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='qualifier_types_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='qualifiers',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='qualifier_types_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='qualifiers',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...)],
       serialization=Serialization(
@@ -11646,9 +16486,13 @@ SymbolTable(
         index=0,
         fragment=None),
       description=SymbolDescription(
-        summary='<paragraph>A capability is the implementation-independent description of the potential of an\nasset to achieve a certain effect in the physical or virtual world.</paragraph>',
+        summary=textwrap.dedent("""\
+          <paragraph>A capability is the implementation-independent description of the potential of an
+          asset to achieve a certain effect in the physical or virtual world.</paragraph>"""),
         remarks=[
-          '<note><paragraph>The <AttributeReference refuri="~semantic_id">~semantic_id</AttributeReference> of a capability is typically an ontology.\nThus, reasoning on capabilities is enabled.</paragraph></note>'],
+          textwrap.dedent("""\
+            <note><paragraph>The <AttributeReference refuri="~semantic_id">~semantic_id</AttributeReference> of a capability is typically an ontology.
+            Thus, reasoning on capabilities is enabled.</paragraph></note>""")],
         constraints_by_identifier=[],
         parsed=...),
       parsed=...,
@@ -11691,13 +16535,21 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>In case of identifiables this attribute is a short name of the element.\nIn case of referable this ID is an identifying string of\nthe element within its name space.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>In case of identifiables this attribute is a short name of the element.
+              In case of referable this ID is an identifying string of
+              the element within its name space.</paragraph>"""),
             remarks=[
-              '<note><paragraph>In case the element is a property and the property has a semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>\nis typically identical to the short name in English.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>In case the element is a property and the property has a semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) conformant to IEC61360 the <AttributeReference refuri="~id_short">~id_short</AttributeReference>
+                is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[
               [
                 'AASd-027',
-                '<field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>\'s shall have a maximum length\nof 128 characters.</paragraph></field_body>']],
+                textwrap.dedent("""\
+                  <field_body><paragraph><AttributeReference refuri="~id_short">~id_short</AttributeReference> of <SymbolReference refuri=".Referable">.Referable</SymbolReference>'s shall have a maximum length
+                  of 128 characters.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
@@ -11711,8 +16563,15 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>Display name. Can be provided in several languages.</paragraph>',
             remarks=[
-              '<paragraph>If no display name is defined in the language requested by the application,\nthen the display name is selected in the following order if available:</paragraph>',
-              '<bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,\nthen the corresponding preferred name in the language is chosen\naccording to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining\nthe semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>'],
+              textwrap.dedent("""\
+                <paragraph>If no display name is defined in the language requested by the application,
+                then the display name is selected in the following order if available:</paragraph>"""),
+              textwrap.dedent("""\
+                <bullet_list bullet="*"><list_item><paragraph>the preferred name in the requested language of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
+                then the corresponding preferred name in the language is chosen
+                according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <AttributeReference refuri="~id_short">~id_short</AttributeReference> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -11725,9 +16584,18 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>The category is a value that gives further meta information\nw.r.t. to the class of the element.\nIt affects the expected existence of attributes and the applicability of\nconstraints.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>The category is a value that gives further meta information
+              w.r.t. to the class of the element.
+              It affects the expected existence of attributes and the applicability of
+              constraints.</paragraph>"""),
             remarks=[
-              '<note><paragraph>The category is not identical to the semantic definition\n(<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category\n<emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the\nsemantic definition of the element would\ndenote that it is the measured temperature.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>The category is not identical to the semantic definition
+                (<SymbolReference refuri=".Has_semantics">.Has_semantics</SymbolReference>) of an element. The category
+                <emphasis>e.g.</emphasis> could denote that the element is a measurement value whereas the
+                semantic definition of the element would
+                denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -11743,8 +16611,14 @@ SymbolTable(
             summary='<paragraph>Description or comments on the element.</paragraph>',
             remarks=[
               '<paragraph>The description can be provided in several languages.</paragraph>',
-              '<paragraph>If no description is defined, then the definition of the concept\ndescription that defines the semantics of the element is used.</paragraph>',
-              '<paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is\nqualified and which qualifier types can be expected in which\ncontext or which additional data specification templates are\nprovided.</paragraph>'],
+              textwrap.dedent("""\
+                <paragraph>If no description is defined, then the definition of the concept
+                description that defines the semantics of the element is used.</paragraph>"""),
+              textwrap.dedent("""\
+                <paragraph>Additional information can be provided, <emphasis>e.g.</emphasis>, if the element is
+                qualified and which qualifier types can be expected in which
+                context or which additional data specification templates are
+                provided.</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -11757,9 +16631,15 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=PropertyDescription(
-            summary='<paragraph>Checksum to be used to determine if an Referable (including its\naggregated child elements) has changed.</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Checksum to be used to determine if an Referable (including its
+              aggregated child elements) has changed.</paragraph>"""),
             remarks=[
-              "<paragraph>The checksum is calculated by the user's tool environment.\nThe checksum has no semantic meaning for an asset administration\nshell model and there is no requirement for asset administration\nshell tools to manage the checksum</paragraph>"],
+              textwrap.dedent("""\
+                <paragraph>The checksum is calculated by the user's tool environment.
+                The checksum has no semantic meaning for an asset administration
+                shell model and there is no requirement for asset administration
+                shell tools to manage the checksum</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -11786,7 +16666,9 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>Administrative information of an identifiable element.</paragraph>',
             remarks=[
-              '<note><paragraph>Some of the administrative information like the version number might need to\nbe part of the identification.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>Some of the administrative information like the version number might need to
+                be part of the identification.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Identifiable',
@@ -11950,30 +16832,136 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='extensions',\n  argument='extensions',\n  default=None)",
-          "AssignArgument(\n  name='id_short',\n  argument='id_short',\n  default=None)",
-          "AssignArgument(\n  name='display_name',\n  argument='display_name',\n  default=None)",
-          "AssignArgument(\n  name='category',\n  argument='category',\n  default=None)",
-          "AssignArgument(\n  name='description',\n  argument='description',\n  default=None)",
-          "AssignArgument(\n  name='checksum',\n  argument='checksum',\n  default=None)",
-          "AssignArgument(\n  name='ID',\n  argument='ID',\n  default=None)",
-          "AssignArgument(\n  name='administration',\n  argument='administration',\n  default=None)",
-          "AssignArgument(\n  name='data_specifications',\n  argument='data_specifications',\n  default=None)",
-          "AssignArgument(\n  name='is_case_of',\n  argument='is_case_of',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='extensions',
+              argument='extensions',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='id_short',
+              argument='id_short',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='display_name',
+              argument='display_name',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='category',
+              argument='category',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='description',
+              argument='description',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='checksum',
+              argument='checksum',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='ID',
+              argument='ID',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='administration',
+              argument='administration',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='data_specifications',
+              argument='data_specifications',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='is_case_of',
+              argument='is_case_of',
+              default=None)""")]),
       invariants=[
         Invariant(
           description='Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='extensions',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='extension_names_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='extensions',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='extension_names_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='extensions',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
           description='Constraint AASd-027: ID-short shall have a maximum length of 128 characters.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='id_short',\n      original_node=...),\n    original_node=...),\n  consequent=Comparison(\n    left=FunctionCall(\n      name='len',\n      args=[\n        Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='id_short',\n          original_node=...)],\n      original_node=...),\n    op='LE',\n    right=Constant(\n      value=128,\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='id_short',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='id_short',
+                      original_node=...)],
+                  original_node=...),
+                op='LE',
+                right=Constant(
+                  value=128,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to AbstractClass Referable',
           parsed=...),
         Invariant(
           description="Constraint AASd-051: A concept description shall have one of the following categories: 'VALUE', 'PROPERTY', 'REFERENCE', 'DOCUMENT', 'CAPABILITY',; 'RELATIONSHIP', 'COLLECTION', 'FUNCTION', 'EVENT', 'ENTITY', 'APPLICATION_CLASS', 'QUALIFIER', 'VIEW'.",
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='category',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='concept_description_category_is_valid',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='category',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='category',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='concept_description_category_is_valid',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='category',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to ConcreteClass Concept_description',
           parsed=...)],
       serialization=Serialization(
@@ -11986,12 +16974,19 @@ SymbolTable(
         index=0,
         fragment=None),
       description=SymbolDescription(
-        summary='<paragraph>The semantics of a property or other elements that may have a semantic description\nis defined by a concept description. The description of the concept should follow a\nstandardized schema (realized as data specification template).</paragraph>',
+        summary=textwrap.dedent("""\
+          <paragraph>The semantics of a property or other elements that may have a semantic description
+          is defined by a concept description. The description of the concept should follow a
+          standardized schema (realized as data specification template).</paragraph>"""),
         remarks=[],
         constraints_by_identifier=[
           [
             'AASd-051',
-            '<field_body><paragraph>A <SymbolReference refuri=".Concept_description">.Concept_description</SymbolReference> shall have one of the following categories\n<literal>VALUE</literal>, <literal>PROPERTY</literal>, <literal>REFERENCE</literal>, <literal>DOCUMENT</literal>, <literal>CAPABILITY</literal>,\n<literal>RELATIONSHIP</literal>, <literal>COLLECTION</literal>, <literal>FUNCTION</literal>, <literal>EVENT</literal>, <literal>ENTITY</literal>,\n<literal>APPLICATION_CLASS</literal>, <literal>QUALIFIER</literal>, <literal>VIEW</literal>.</paragraph><paragraph>Default: <literal>PROPERTY</literal>.</paragraph></field_body>']],
+            textwrap.dedent("""\
+              <field_body><paragraph>A <SymbolReference refuri=".Concept_description">.Concept_description</SymbolReference> shall have one of the following categories
+              <literal>VALUE</literal>, <literal>PROPERTY</literal>, <literal>REFERENCE</literal>, <literal>DOCUMENT</literal>, <literal>CAPABILITY</literal>,
+              <literal>RELATIONSHIP</literal>, <literal>COLLECTION</literal>, <literal>FUNCTION</literal>, <literal>EVENT</literal>, <literal>ENTITY</literal>,
+              <literal>APPLICATION_CLASS</literal>, <literal>QUALIFIER</literal>, <literal>VIEW</literal>.</paragraph><paragraph>Default: <literal>PROPERTY</literal>.</paragraph></field_body>""")]],
         parsed=...),
       parsed=...,
       properties_by_name=...,
@@ -12013,7 +17008,9 @@ SymbolTable(
         properties=[],
         signatures=[],
         description=SymbolDescription(
-          summary='<paragraph>Reference to either a model element of the same or another AAs or to an external\nentity.</paragraph>',
+          summary=textwrap.dedent("""\
+            <paragraph>Reference to either a model element of the same or another AAs or to an external
+            entity.</paragraph>"""),
           remarks=[],
           constraints_by_identifier=[],
           parsed=...),
@@ -12051,7 +17048,9 @@ SymbolTable(
         index=0,
         fragment=None),
       description=SymbolDescription(
-        summary='<paragraph>Reference to either a model element of the same or another AAs or to an external\nentity.</paragraph>',
+        summary=textwrap.dedent("""\
+          <paragraph>Reference to either a model element of the same or another AAs or to an external
+          entity.</paragraph>"""),
         remarks=[],
         constraints_by_identifier=[],
         parsed=...),
@@ -12078,7 +17077,9 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>Unique identifier</paragraph>',
             remarks=[
-              '<paragraph>The identifier can be a concatenation of different identifiers, for example\nrepresenting an IRDI path etc.</paragraph>'],
+              textwrap.dedent("""\
+                <paragraph>The identifier can be a concatenation of different identifiers, for example
+                representing an IRDI path etc.</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to ConcreteClass Global_reference',
@@ -12104,7 +17105,11 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='value',\n  argument='value',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='value',
+              argument='value',
+              default=None)""")]),
       invariants=[],
       serialization=Serialization(
         with_model_type=True),
@@ -12198,12 +17203,36 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='keys',\n  argument='keys',\n  default=None)",
-          "AssignArgument(\n  name='referred_semantic_id',\n  argument='referred_semantic_id',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='keys',
+              argument='keys',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='referred_semantic_id',
+              argument='referred_semantic_id',
+              default=None)""")]),
       invariants=[
         Invariant(
           description=None,
-          body="Comparison(\n  left=FunctionCall(\n    name='len',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='keys',\n        original_node=...)],\n    original_node=...),\n  op='GE',\n  right=Constant(\n    value=1,\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Comparison(
+              left=FunctionCall(
+                name='len',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='keys',
+                    original_node=...)],
+                original_node=...),
+              op='GE',
+              right=Constant(
+                value=1,
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to ConcreteClass Model_reference',
           parsed=...)],
       serialization=Serialization(
@@ -12219,7 +17248,10 @@ SymbolTable(
       description=SymbolDescription(
         summary='<paragraph>Reference to a model element of the same or another AAS.</paragraph>',
         remarks=[
-          '<paragraph>A model reference is an ordered list of keys, each key referencing an element.\nThe complete list of keys may for example be concatenated to a path that then gives\nunique access to an element.</paragraph>'],
+          textwrap.dedent("""\
+            <paragraph>A model reference is an ordered list of keys, each key referencing an element.
+            The complete list of keys may for example be concatenated to a path that then gives
+            unique access to an element.</paragraph>""")],
         constraints_by_identifier=[],
         parsed=...),
       parsed=...,
@@ -12244,8 +17276,12 @@ SymbolTable(
           description=PropertyDescription(
             summary='<paragraph>Denote which kind of entity is referenced.</paragraph>',
             remarks=[
-              '<paragraph>In case type = FragmentReference the key represents a bookmark or a similar local\nidentifier within its parent element as specified by the key that precedes this key.</paragraph>',
-              '<paragraph>In all other cases the key references a model element of the same or of another AAS.\nThe name of the model element is explicitly listed.</paragraph>'],
+              textwrap.dedent("""\
+                <paragraph>In case type = FragmentReference the key represents a bookmark or a similar local
+                identifier within its parent element as specified by the key that precedes this key.</paragraph>"""),
+              textwrap.dedent("""\
+                <paragraph>In all other cases the key references a model element of the same or of another AAS.
+                The name of the model element is explicitly listed.</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to ConcreteClass Key',
@@ -12290,8 +17326,16 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='type',\n  argument='type',\n  default=None)",
-          "AssignArgument(\n  name='value',\n  argument='value',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='type',
+              argument='type',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='value',
+              argument='value',
+              default=None)""")]),
       invariants=[],
       serialization=Serialization(
         with_model_type=False),
@@ -12377,7 +17421,9 @@ SymbolTable(
           description=EnumerationLiteralDescription(
             summary='<paragraph>Data Element.</paragraph>',
             remarks=[
-              '<note><paragraph>Data Element is abstract, <emphasis>i.e.</emphasis> if a key uses <AttributeReference refuri="~Data_element">~Data_element</AttributeReference>\nthe reference may be a <SymbolReference refuri=".Property">.Property</SymbolReference>, a <SymbolReference refuri=".File">.File</SymbolReference> etc.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>Data Element is abstract, <emphasis>i.e.</emphasis> if a key uses <AttributeReference refuri="~Data_element">~Data_element</AttributeReference>
+                the reference may be a <SymbolReference refuri=".Property">.Property</SymbolReference>, a <SymbolReference refuri=".File">.File</SymbolReference> etc.</paragraph></note>""")],
             parsed=...),
           parsed=...),
         EnumerationLiteral(
@@ -12447,7 +17493,10 @@ SymbolTable(
           description=EnumerationLiteralDescription(
             summary='<paragraph>Submodel Element</paragraph>',
             remarks=[
-              '<note><paragraph>Submodel Element is abstract, i.e. if a key uses\n<AttributeReference refuri="Submodel_element">Submodel_element</AttributeReference> the reference may be a <SymbolReference refuri=".Property">.Property</SymbolReference>,\na <SymbolReference refuri=".Submodel_element_list">.Submodel_element_list</SymbolReference>, an <SymbolReference refuri=".Operation">.Operation</SymbolReference> etc.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>Submodel Element is abstract, i.e. if a key uses
+                <AttributeReference refuri="Submodel_element">Submodel_element</AttributeReference> the reference may be a <SymbolReference refuri=".Property">.Property</SymbolReference>,
+                a <SymbolReference refuri=".Submodel_element_list">.Submodel_element_list</SymbolReference>, an <SymbolReference refuri=".Operation">.Operation</SymbolReference> etc.</paragraph></note>""")],
             parsed=...),
           parsed=...),
         EnumerationLiteral(
@@ -12522,7 +17571,9 @@ SymbolTable(
           description=EnumerationLiteralDescription(
             summary='<paragraph>Data element.</paragraph>',
             remarks=[
-              '<note><paragraph>Data Element is abstract, <emphasis>i.e.</emphasis> if a key uses <AttributeReference refuri="~Data_element">~Data_element</AttributeReference>\nthe reference may be a <SymbolReference refuri=".Property">.Property</SymbolReference>, a <SymbolReference refuri=".File">.File</SymbolReference> <emphasis>etc.</emphasis></paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>Data Element is abstract, <emphasis>i.e.</emphasis> if a key uses <AttributeReference refuri="~Data_element">~Data_element</AttributeReference>
+                the reference may be a <SymbolReference refuri=".Property">.Property</SymbolReference>, a <SymbolReference refuri=".File">.File</SymbolReference> <emphasis>etc.</emphasis></paragraph></note>""")],
             parsed=...),
           parsed=...),
         EnumerationLiteral(
@@ -12597,7 +17648,9 @@ SymbolTable(
           description=EnumerationLiteralDescription(
             summary='<paragraph>Submodel Element</paragraph>',
             remarks=[
-              '<note><paragraph>Submodel Element is abstract, <emphasis>i.e.</emphasis> if a key uses <AttributeReference refuri="~Submodel_element">~Submodel_element</AttributeReference>\nthe reference may be a <SymbolReference refuri=".Property">.Property</SymbolReference>, an <SymbolReference refuri=".Operation">.Operation</SymbolReference> <emphasis>etc.</emphasis></paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>Submodel Element is abstract, <emphasis>i.e.</emphasis> if a key uses <AttributeReference refuri="~Submodel_element">~Submodel_element</AttributeReference>
+                the reference may be a <SymbolReference refuri=".Property">.Property</SymbolReference>, an <SymbolReference refuri=".Operation">.Operation</SymbolReference> <emphasis>etc.</emphasis></paragraph></note>""")],
             parsed=...),
           parsed=...),
         EnumerationLiteral(
@@ -12642,7 +17695,9 @@ SymbolTable(
           name='Fragment_reference',
           value='FragmentReference',
           description=EnumerationLiteralDescription(
-            summary='<paragraph>Bookmark or a similar local identifier of a subordinate part of\na primary resource</paragraph>',
+            summary=textwrap.dedent("""\
+              <paragraph>Bookmark or a similar local identifier of a subordinate part of
+              a primary resource</paragraph>"""),
             remarks=[],
             parsed=...),
           parsed=...),
@@ -12687,7 +17742,9 @@ SymbolTable(
           description=EnumerationLiteralDescription(
             summary='<paragraph>Data element.</paragraph>',
             remarks=[
-              '<note><paragraph>Data Element is abstract, <emphasis>i.e.</emphasis> if a key uses <AttributeReference refuri="~Data_element">~Data_element</AttributeReference>\nthe reference may be a Property, a File <emphasis>etc.</emphasis></paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>Data Element is abstract, <emphasis>i.e.</emphasis> if a key uses <AttributeReference refuri="~Data_element">~Data_element</AttributeReference>
+                the reference may be a Property, a File <emphasis>etc.</emphasis></paragraph></note>""")],
             parsed=...),
           parsed=...),
         EnumerationLiteral(
@@ -12762,7 +17819,9 @@ SymbolTable(
           description=EnumerationLiteralDescription(
             summary='<paragraph>Submodel Element</paragraph>',
             remarks=[
-              '<note><paragraph>Submodel Element is abstract, <emphasis>i.e.</emphasis> if a key uses <AttributeReference refuri="~Submodel_element">~Submodel_element</AttributeReference>\nthe reference may be a <SymbolReference refuri=".Property">.Property</SymbolReference>, an <SymbolReference refuri=".Operation">.Operation</SymbolReference> <emphasis>etc.</emphasis></paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>Submodel Element is abstract, <emphasis>i.e.</emphasis> if a key uses <AttributeReference refuri="~Submodel_element">~Submodel_element</AttributeReference>
+                the reference may be a <SymbolReference refuri=".Property">.Property</SymbolReference>, an <SymbolReference refuri=".Operation">.Operation</SymbolReference> <emphasis>etc.</emphasis></paragraph></note>""")],
             parsed=...),
           parsed=...),
         EnumerationLiteral(
@@ -12993,7 +18052,12 @@ SymbolTable(
           description=EnumerationLiteralDescription(
             summary='<paragraph>String with a language tag</paragraph>',
             remarks=[
-              '<note><paragraph>RDF requires IETF BCP 47  language tags, i.e. simple two-letter language tags\nfor Locales like “de” conformant to ISO 639-1 are allowed as well as language\ntags plus extension like “de-DE” for country code, dialect etc. like in “en-US”\nor “en-GB” for English (United Kingdom) and English (United States).\nIETF language tags are referencing ISO 639, ISO 3166 and ISO 15924.</paragraph></note>'],
+              textwrap.dedent("""\
+                <note><paragraph>RDF requires IETF BCP 47  language tags, i.e. simple two-letter language tags
+                for Locales like “de” conformant to ISO 639-1 are allowed as well as language
+                tags plus extension like “de-DE” for country code, dialect etc. like in “en-US”
+                or “en-GB” for English (United Kingdom) and English (United States).
+                IETF language tags are referencing ISO 639, ISO 3166 and ISO 15924.</paragraph></note>""")],
             parsed=...),
           parsed=...)],
       is_superset_of=[],
@@ -13198,7 +18262,9 @@ SymbolTable(
         index=0,
         fragment=None),
       description=SymbolDescription(
-        summary='<paragraph>string with values of enumerations <SymbolReference refuri=".Data_type_def_XSD">.Data_type_def_XSD</SymbolReference>,\n<SymbolReference refuri=".Data_type_def_RDF">.Data_type_def_RDF</SymbolReference></paragraph>',
+        summary=textwrap.dedent("""\
+          <paragraph>string with values of enumerations <SymbolReference refuri=".Data_type_def_XSD">.Data_type_def_XSD</SymbolReference>,
+          <SymbolReference refuri=".Data_type_def_RDF">.Data_type_def_RDF</SymbolReference></paragraph>"""),
         remarks=[],
         constraints_by_identifier=[],
         parsed=...),
@@ -13266,8 +18332,16 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='language',\n  argument='language',\n  default=None)",
-          "AssignArgument(\n  name='text',\n  argument='text',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='language',
+              argument='language',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='text',
+              argument='text',
+              default=None)""")]),
       invariants=[],
       serialization=Serialization(
         with_model_type=False),
@@ -13335,16 +18409,46 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='lang_strings',\n  argument='lang_strings',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='lang_strings',
+              argument='lang_strings',
+              default=None)""")]),
       invariants=[
         Invariant(
           description=None,
-          body="Comparison(\n  left=FunctionCall(\n    name='len',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='lang_strings',\n        original_node=...)],\n    original_node=...),\n  op='GE',\n  right=Constant(\n    value=1,\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Comparison(
+              left=FunctionCall(
+                name='len',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='lang_strings',
+                    original_node=...)],
+                original_node=...),
+              op='GE',
+              right=Constant(
+                value=1,
+                original_node=...),
+              original_node=...)"""),
           specified_for='Reference to ConcreteClass Lang_string_set',
           parsed=...),
         Invariant(
           description=None,
-          body="FunctionCall(\n  name='lang_strings_have_unique_languages',\n  args=[\n    Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='lang_strings',\n      original_node=...)],\n  original_node=...)",
+          body=textwrap.dedent("""\
+            FunctionCall(
+              name='lang_strings_have_unique_languages',
+              args=[
+                Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='lang_strings',
+                  original_node=...)],
+              original_node=...)"""),
           specified_for='Reference to ConcreteClass Lang_string_set',
           parsed=...)],
       serialization=Serialization(
@@ -13361,7 +18465,10 @@ SymbolTable(
         summary='<paragraph>Array of elements of type langString</paragraph>',
         remarks=[
           '<note><paragraph>langString is a RDF data type.</paragraph></note>',
-          '<paragraph>A langString is a string value tagged with a language code.\nIt depends on the serialization rules for a technology how\nthis is realized.</paragraph>'],
+          textwrap.dedent("""\
+            <paragraph>A langString is a string value tagged with a language code.
+            It depends on the serialization rules for a technology how
+            this is realized.</paragraph>""")],
         constraints_by_identifier=[],
         parsed=...),
       parsed=...,
@@ -13479,9 +18586,21 @@ SymbolTable(
         arguments_by_name=...,
         is_implementation_specific=False,
         statements=[
-          "AssignArgument(\n  name='asset_administration_shells',\n  argument='asset_administration_shells',\n  default=None)",
-          "AssignArgument(\n  name='submodels',\n  argument='submodels',\n  default=None)",
-          "AssignArgument(\n  name='concept_descriptions',\n  argument='concept_descriptions',\n  default=None)"]),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='asset_administration_shells',
+              argument='asset_administration_shells',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='submodels',
+              argument='submodels',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='concept_descriptions',
+              argument='concept_descriptions',
+              default=None)""")]),
       invariants=[],
       serialization=Serialization(
         with_model_type=False),
@@ -13495,7 +18614,10 @@ SymbolTable(
       description=SymbolDescription(
         summary='<paragraph>Container for the sets of different identifiables.</paragraph>',
         remarks=[
-          '<note><paragraph>w.r.t. file exchange: There is exactly one environment independent on how many\nfiles the contained elements are split. If the file is split then there\nshall be no element with the same identifier in two different files.</paragraph></note>'],
+          textwrap.dedent("""\
+            <note><paragraph>w.r.t. file exchange: There is exactly one environment independent on how many
+            files the contained elements are split. If the file is split then there
+            shall be no element with the same identifier in two different files.</paragraph></note>""")],
         constraints_by_identifier=[],
         parsed=...),
       parsed=...,
@@ -13572,7 +18694,10 @@ SymbolTable(
       description=SignatureDescription(
         summary='<paragraph>Check that <ArgumentReference refuri="text">text</ArgumentReference> conforms to the pattern of an <literal>xs:dateTimeStamp</literal>.</paragraph>',
         remarks=[
-          '<paragraph>The time zone must be fixed to UTC. We verify only that the <literal>text</literal> matches\na pre-defined pattern. We <emphasis>do not</emphasis> verify that the day of month is\ncorrect nor do we check for leap seconds.</paragraph>',
+          textwrap.dedent("""\
+            <paragraph>The time zone must be fixed to UTC. We verify only that the <literal>text</literal> matches
+            a pre-defined pattern. We <emphasis>do not</emphasis> verify that the day of month is
+            correct nor do we check for leap seconds.</paragraph>"""),
           '<paragraph>See: <reference refuri="https://www.w3.org/TR/xmlschema11-2/#dateTimeStamp">https://www.w3.org/TR/xmlschema11-2/#dateTimeStamp</reference></paragraph>'],
         arguments_by_name=[
           [
@@ -13603,7 +18728,10 @@ SymbolTable(
       description=SignatureDescription(
         summary='<paragraph>Check that <ArgumentReference refuri="text">text</ArgumentReference> is a <literal>xs:dateTimeStamp</literal> with time zone set to UTC.</paragraph>',
         remarks=[
-          '<paragraph>The <literal>text</literal> is assumed to match a pre-defined pattern for <literal>xs:dateTimeStamp</literal> with\nthe time zone set to UTC. In this function, we check for days of month (<emphasis>e.g.</emphasis>,\nFebruary 29th).</paragraph>',
+          textwrap.dedent("""\
+            <paragraph>The <literal>text</literal> is assumed to match a pre-defined pattern for <literal>xs:dateTimeStamp</literal> with
+            the time zone set to UTC. In this function, we check for days of month (<emphasis>e.g.</emphasis>,
+            February 29th).</paragraph>"""),
           '<paragraph>See: <reference refuri="https://www.w3.org/TR/xmlschema11-2/#dateTimeStamp">https://www.w3.org/TR/xmlschema11-2/#dateTimeStamp</reference></paragraph>'],
         arguments_by_name=[
           [
@@ -13633,7 +18761,11 @@ SymbolTable(
       description=SignatureDescription(
         summary='<paragraph>Check that <ArgumentReference refuri="text">text</ArgumentReference> conforms to the pattern of MIME type.</paragraph>',
         remarks=[
-          '<paragraph>The definition has been taken from:\n<reference refuri="https://www.rfc-editor.org/rfc/rfc7231#section-3.1.1.1">https://www.rfc-editor.org/rfc/rfc7231#section-3.1.1.1</reference>,\n<reference refuri="https://www.rfc-editor.org/rfc/rfc7230#section-3.2.3">https://www.rfc-editor.org/rfc/rfc7230#section-3.2.3</reference> and\n<reference refuri="https://www.rfc-editor.org/rfc/rfc7230#section-3.2.6">https://www.rfc-editor.org/rfc/rfc7230#section-3.2.6</reference>.</paragraph>'],
+          textwrap.dedent("""\
+            <paragraph>The definition has been taken from:
+            <reference refuri="https://www.rfc-editor.org/rfc/rfc7231#section-3.1.1.1">https://www.rfc-editor.org/rfc/rfc7231#section-3.1.1.1</reference>,
+            <reference refuri="https://www.rfc-editor.org/rfc/rfc7230#section-3.2.3">https://www.rfc-editor.org/rfc/rfc7230#section-3.2.3</reference> and
+            <reference refuri="https://www.rfc-editor.org/rfc/rfc7230#section-3.2.6">https://www.rfc-editor.org/rfc/rfc7230#section-3.2.6</reference>.</paragraph>""")],
         arguments_by_name=[
           [
             'text',
@@ -13663,7 +18795,9 @@ SymbolTable(
       description=SignatureDescription(
         summary='<paragraph>Check that <ArgumentReference refuri="text">text</ArgumentReference> is a path conforming to the pattern of RFC 8089.</paragraph>',
         remarks=[
-          '<paragraph>The definition has been taken from:\n<reference refuri="https://datatracker.ietf.org/doc/html/rfc8089">https://datatracker.ietf.org/doc/html/rfc8089</reference></paragraph>'],
+          textwrap.dedent("""\
+            <paragraph>The definition has been taken from:
+            <reference refuri="https://datatracker.ietf.org/doc/html/rfc8089">https://datatracker.ietf.org/doc/html/rfc8089</reference></paragraph>""")],
         arguments_by_name=[
           [
             'text',
@@ -13720,7 +18854,9 @@ SymbolTable(
         a_type='BOOL',
         parsed=...),
       description=SignatureDescription(
-        summary='<paragraph>Check that the <ArgumentReference refuri="lang_strings">lang_strings</ArgumentReference> do not have overlapping\n<AttributeReference refuri="~Lang_string.language">~Lang_string.language</AttributeReference>\'s</paragraph>',
+        summary=textwrap.dedent("""\
+          <paragraph>Check that the <ArgumentReference refuri="lang_strings">lang_strings</ArgumentReference> do not have overlapping
+          <AttributeReference refuri="~Lang_string.language">~Lang_string.language</AttributeReference>'s</paragraph>"""),
         remarks=[],
         arguments_by_name=[],
         returns=None,
@@ -13777,7 +18913,9 @@ SymbolTable(
       description=SignatureDescription(
         summary='<paragraph>Check that <ArgumentReference refuri="text">text</ArgumentReference> conforms to the pattern of an <literal>xs:anyURI</literal>.</paragraph>',
         remarks=[
-          '<paragraph>See: <reference refuri="https://www.w3.org/TR/xmlschema11-2/#anyURI">https://www.w3.org/TR/xmlschema11-2/#anyURI</reference> and\n<reference refuri="https://datatracker.ietf.org/doc/html/rfc3987">https://datatracker.ietf.org/doc/html/rfc3987</reference></paragraph>'],
+          textwrap.dedent("""\
+            <paragraph>See: <reference refuri="https://www.w3.org/TR/xmlschema11-2/#anyURI">https://www.w3.org/TR/xmlschema11-2/#anyURI</reference> and
+            <reference refuri="https://datatracker.ietf.org/doc/html/rfc3987">https://datatracker.ietf.org/doc/html/rfc3987</reference></paragraph>""")],
         arguments_by_name=[
           [
             'text',
@@ -14807,7 +19945,9 @@ SymbolTable(
         a_type='BOOL',
         parsed=...),
       description=SignatureDescription(
-        summary='<paragraph>Check that the <AttributeReference refuri="~Referable.id_short">~Referable.id_short</AttributeReference>\'s in the <ArgumentReference refuri="namespace">namespace</ArgumentReference> are\nunique.</paragraph>',
+        summary=textwrap.dedent("""\
+          <paragraph>Check that the <AttributeReference refuri="~Referable.id_short">~Referable.id_short</AttributeReference>'s in the <ArgumentReference refuri="namespace">namespace</ArgumentReference> are
+          unique.</paragraph>"""),
         remarks=[],
         arguments_by_name=[],
         returns=None,
@@ -14893,7 +20033,9 @@ SymbolTable(
         a_type='BOOL',
         parsed=...),
       description=SignatureDescription(
-        summary='<paragraph>Check that the run-time type of the <ArgumentReference refuri="element">element</ArgumentReference> coincides with\n<ArgumentReference refuri="element_type">element_type</ArgumentReference>.</paragraph>',
+        summary=textwrap.dedent("""\
+          <paragraph>Check that the run-time type of the <ArgumentReference refuri="element">element</ArgumentReference> coincides with
+          <ArgumentReference refuri="element_type">element_type</ArgumentReference>.</paragraph>"""),
         remarks=[],
         arguments_by_name=[],
         returns=None,
@@ -14952,7 +20094,9 @@ SymbolTable(
         a_type='BOOL',
         parsed=...),
       description=SignatureDescription(
-        summary='<paragraph>Check that the <ArgumentReference refuri="category">category</ArgumentReference> is a valid category for\na <SymbolReference refuri=".Concept_description">.Concept_description</SymbolReference>.</paragraph>',
+        summary=textwrap.dedent("""\
+          <paragraph>Check that the <ArgumentReference refuri="category">category</ArgumentReference> is a valid category for
+          a <SymbolReference refuri=".Concept_description">.Concept_description</SymbolReference>.</paragraph>"""),
         remarks=[],
         arguments_by_name=[],
         returns=None,
@@ -14968,11 +20112,18 @@ SymbolTable(
     description=MetaModelDescription(
       summary='<paragraph>Provide the meta model for Asset Administration Shell V3.0 Release Candidate 2.</paragraph>',
       remarks=[
-        '<paragraph>We could not implement the following constraints since they depend on registry\nand can not be verified without it:</paragraph>',
+        textwrap.dedent("""\
+          <paragraph>We could not implement the following constraints since they depend on registry
+          and can not be verified without it:</paragraph>"""),
         '<bullet_list bullet="*"><list_item><paragraph><ConstraintReference refuri="AASd-006">AASd-006</ConstraintReference></paragraph></list_item><list_item><paragraph><ConstraintReference refuri="AASd-007">AASd-007</ConstraintReference></paragraph></list_item></bullet_list>',
-        '<paragraph>Some of the constraints are not enforceable as they depend on the wider context\nsuch as language understanding, so we could not formalize them:</paragraph>',
+        textwrap.dedent("""\
+          <paragraph>Some of the constraints are not enforceable as they depend on the wider context
+          such as language understanding, so we could not formalize them:</paragraph>"""),
         '<bullet_list bullet="*"><list_item><paragraph><ConstraintReference refuri="AASd-012">AASd-012</ConstraintReference></paragraph></list_item></bullet_list>',
-        '<paragraph>We could not formalize the constraints which prescribed how to deal with\nthe default values as the semantic of the default values has not been defined\nin the meta-model:</paragraph>',
+        textwrap.dedent("""\
+          <paragraph>We could not formalize the constraints which prescribed how to deal with
+          the default values as the semantic of the default values has not been defined
+          in the meta-model:</paragraph>"""),
         '<bullet_list bullet="*"><list_item><paragraph><ConstraintReference refuri="AASd-115">AASd-115</ConstraintReference></paragraph></list_item></bullet_list>'],
       constraints_by_identifier=[],
       parsed=...),

--- a/test_data/parse/expected/method/contracts/multiple_contracts_in_order/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/contracts/multiple_contracts_in_order/expected_symbol_table.txt
@@ -52,7 +52,10 @@ UnverifiedSymbolTable(
                 args=[
                   'x'],
                 name='double_x',
-                body="Name(\n  identifier='x',\n  original_node=...)",
+                body=textwrap.dedent("""\
+                  Name(
+                    identifier='x',
+                    original_node=...)"""),
                 node=...)],
             postconditions=[
               Contract(

--- a/test_data/parse/expected/method/contracts/postcondition/snapshot/with_keyword_arguments/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/contracts/postcondition/snapshot/with_keyword_arguments/expected_symbol_table.txt
@@ -35,7 +35,16 @@ UnverifiedSymbolTable(
                 args=[
                   'lst'],
                 name='lst',
-                body="MethodCall(\n  member=Member(\n    instance=Name(\n      identifier='lst',\n      original_node=...),\n    name='copy',\n    original_node=...),\n  args=[],\n  original_node=...)",
+                body=textwrap.dedent("""\
+                  MethodCall(
+                    member=Member(
+                      instance=Name(
+                        identifier='lst',
+                        original_node=...),
+                      name='copy',
+                      original_node=...),
+                    args=[],
+                    original_node=...)"""),
                 node=...)],
             postconditions=[
               Contract(

--- a/test_data/parse/expected/method/contracts/postcondition/snapshot/with_positional_arguments/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/contracts/postcondition/snapshot/with_positional_arguments/expected_symbol_table.txt
@@ -35,7 +35,16 @@ UnverifiedSymbolTable(
                 args=[
                   'lst'],
                 name='lst',
-                body="MethodCall(\n  member=Member(\n    instance=Name(\n      identifier='lst',\n      original_node=...),\n    name='copy',\n    original_node=...),\n  args=[],\n  original_node=...)",
+                body=textwrap.dedent("""\
+                  MethodCall(
+                    member=Member(
+                      instance=Name(
+                        identifier='lst',
+                        original_node=...),
+                      name='copy',
+                      original_node=...),
+                    args=[],
+                    original_node=...)"""),
                 node=...)],
             postconditions=[
               Contract(

--- a/test_data/parse/real_meta_models/aas_core_meta.v3rc2/expected_symbol_table.txt
+++ b/test_data/parse/real_meta_models/aas_core_meta.v3rc2/expected_symbol_table.txt
@@ -10,7 +10,20 @@ UnverifiedSymbolTable(
       invariants=[
         Invariant(
           description=None,
-          body="Comparison(\n  left=FunctionCall(\n    name='len',\n    args=[\n      Name(\n        identifier='self',\n        original_node=...)],\n    original_node=...),\n  op='GE',\n  right=Constant(\n    value=1,\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Comparison(
+              left=FunctionCall(
+                name='len',
+                args=[
+                  Name(
+                    identifier='self',
+                    original_node=...)],
+                original_node=...),
+              op='GE',
+              right=Constant(
+                value=1,
+                original_node=...),
+              original_node=...)"""),
           node=...)],
       serialization=None,
       reference_in_the_book=None,
@@ -30,11 +43,25 @@ UnverifiedSymbolTable(
       invariants=[
         Invariant(
           description=None,
-          body="FunctionCall(\n  name='matches_xs_date_time_stamp_utc',\n  args=[\n    Name(\n      identifier='self',\n      original_node=...)],\n  original_node=...)",
+          body=textwrap.dedent("""\
+            FunctionCall(
+              name='matches_xs_date_time_stamp_utc',
+              args=[
+                Name(
+                  identifier='self',
+                  original_node=...)],
+              original_node=...)"""),
           node=...),
         Invariant(
           description=None,
-          body="FunctionCall(\n  name='is_xs_date_time_stamp_utc',\n  args=[\n    Name(\n      identifier='self',\n      original_node=...)],\n  original_node=...)",
+          body=textwrap.dedent("""\
+            FunctionCall(
+              name='is_xs_date_time_stamp_utc',
+              args=[
+                Name(
+                  identifier='self',
+                  original_node=...)],
+              original_node=...)"""),
           node=...)],
       serialization=None,
       reference_in_the_book=None,
@@ -100,7 +127,14 @@ UnverifiedSymbolTable(
       invariants=[
         Invariant(
           description=None,
-          body="FunctionCall(\n  name='matches_BCP_47',\n  args=[\n    Name(\n      identifier='self',\n      original_node=...)],\n  original_node=...)",
+          body=textwrap.dedent("""\
+            FunctionCall(
+              name='matches_BCP_47',
+              args=[
+                Name(
+                  identifier='self',
+                  original_node=...)],
+              original_node=...)"""),
           node=...)],
       serialization=None,
       reference_in_the_book=None,
@@ -120,7 +154,14 @@ UnverifiedSymbolTable(
       invariants=[
         Invariant(
           description=None,
-          body="FunctionCall(\n  name='matches_MIME_type',\n  args=[\n    Name(\n      identifier='self',\n      original_node=...)],\n  original_node=...)",
+          body=textwrap.dedent("""\
+            FunctionCall(
+              name='matches_MIME_type',
+              args=[
+                Name(
+                  identifier='self',
+                  original_node=...)],
+              original_node=...)"""),
           node=...)],
       serialization=None,
       reference_in_the_book=ReferenceInTheBook(
@@ -147,7 +188,14 @@ UnverifiedSymbolTable(
       invariants=[
         Invariant(
           description=None,
-          body="FunctionCall(\n  name='matches_RFC_8089_path',\n  args=[\n    Name(\n      identifier='self',\n      original_node=...)],\n  original_node=...)",
+          body=textwrap.dedent("""\
+            FunctionCall(
+              name='matches_RFC_8089_path',
+              args=[
+                Name(
+                  identifier='self',
+                  original_node=...)],
+              original_node=...)"""),
           node=...)],
       serialization=None,
       reference_in_the_book=ReferenceInTheBook(
@@ -546,7 +594,27 @@ UnverifiedSymbolTable(
       invariants=[
         Invariant(
           description='Constraint AASd-077: The name of an extension within Has_extensions needs to be unique.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='extensions',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='extension_names_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='extensions',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='extension_names_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='extensions',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           node=...)],
       serialization=None,
       reference_in_the_book=ReferenceInTheBook(
@@ -732,7 +800,33 @@ UnverifiedSymbolTable(
       invariants=[
         Invariant(
           description='Constraint AASd-027: ID-short shall have a maximum length of 128 characters.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='id_short',\n      original_node=...),\n    original_node=...),\n  consequent=Comparison(\n    left=FunctionCall(\n      name='len',\n      args=[\n        Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='id_short',\n          original_node=...)],\n      original_node=...),\n    op='LE',\n    right=Constant(\n      value=128,\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='id_short',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='id_short',
+                      original_node=...)],
+                  original_node=...),
+                op='LE',
+                right=Constant(
+                  value=128,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           node=...)],
       serialization=Serialization(
         with_model_type=True),
@@ -1171,7 +1265,25 @@ UnverifiedSymbolTable(
       invariants=[
         Invariant(
           description='Constraint AASd-005: If version is not specified than also revision shall be unspecified. This means, a revision requires a version. If there is no version there is no revision neither. Revision is optional.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='revision',\n      original_node=...),\n    original_node=...),\n  consequent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='version',\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='revision',
+                  original_node=...),
+                original_node=...),
+              consequent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='version',
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           node=...)],
       serialization=None,
       reference_in_the_book=ReferenceInTheBook(
@@ -1248,7 +1360,27 @@ UnverifiedSymbolTable(
       invariants=[
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='qualifiers',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='qualifier_types_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='qualifiers',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='qualifier_types_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='qualifiers',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           node=...)],
       serialization=Serialization(
         with_model_type=True),
@@ -1388,7 +1520,33 @@ UnverifiedSymbolTable(
       invariants=[
         Invariant(
           description='Constraint AASd-020: The value shall be consistent to the data type as defined in value_type.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='value',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='value_consistent_with_xsd_type',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='value',\n        original_node=...),\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='value_type',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='value',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='value_consistent_with_xsd_type',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='value',
+                    original_node=...),
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='value_type',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           node=...)],
       serialization=Serialization(
         with_model_type=True),
@@ -1620,11 +1778,73 @@ UnverifiedSymbolTable(
       invariants=[
         Invariant(
           description=None,
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='derived_from',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='is_model_reference_to',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='derived_from',\n        original_node=...),\n      Member(\n        instance=Name(\n          identifier='Key_elements',\n          original_node=...),\n        name='Asset_administration_shell',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='derived_from',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='is_model_reference_to',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='derived_from',
+                    original_node=...),
+                  Member(
+                    instance=Name(
+                      identifier='Key_elements',
+                      original_node=...),
+                    name='Asset_administration_shell',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           node=...),
         Invariant(
           description=None,
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='submodels',\n      original_node=...),\n    original_node=...),\n  consequent=All(\n    for_each=ForEach(\n      variable=Name(\n        identifier='reference',\n        original_node=...),\n      iteration=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='submodels',\n        original_node=...),\n      original_node=...),\n    condition=FunctionCall(\n      name='is_model_reference_to',\n      args=[\n        Name(\n          identifier='reference',\n          original_node=...),\n        Member(\n          instance=Name(\n            identifier='Key_elements',\n            original_node=...),\n          name='Submodel',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='submodels',
+                  original_node=...),
+                original_node=...),
+              consequent=All(
+                for_each=ForEach(
+                  variable=Name(
+                    identifier='reference',
+                    original_node=...),
+                  iteration=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='submodels',
+                    original_node=...),
+                  original_node=...),
+                condition=FunctionCall(
+                  name='is_model_reference_to',
+                  args=[
+                    Name(
+                      identifier='reference',
+                      original_node=...),
+                    Member(
+                      instance=Name(
+                        identifier='Key_elements',
+                        original_node=...),
+                      name='Submodel',
+                      original_node=...)],
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           node=...)],
       serialization=Serialization(
         with_model_type=True),
@@ -2126,11 +2346,62 @@ UnverifiedSymbolTable(
       invariants=[
         Invariant(
           description='Short IDs need to be defined for all the submodel elements.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='submodel_elements',\n      original_node=...),\n    original_node=...),\n  consequent=All(\n    for_each=ForEach(\n      variable=Name(\n        identifier='element',\n        original_node=...),\n      iteration=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='submodel_elements',\n        original_node=...),\n      original_node=...),\n    condition=IsNotNone(\n      value=Member(\n        instance=Name(\n          identifier='element',\n          original_node=...),\n        name='id_short',\n        original_node=...),\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='submodel_elements',
+                  original_node=...),
+                original_node=...),
+              consequent=All(
+                for_each=ForEach(
+                  variable=Name(
+                    identifier='element',
+                    original_node=...),
+                  iteration=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='submodel_elements',
+                    original_node=...),
+                  original_node=...),
+                condition=IsNotNone(
+                  value=Member(
+                    instance=Name(
+                      identifier='element',
+                      original_node=...),
+                    name='id_short',
+                    original_node=...),
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           node=...),
         Invariant(
           description=None,
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='submodel_elements',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='id_shorts_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='submodel_elements',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='submodel_elements',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='id_shorts_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='submodel_elements',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           node=...)],
       serialization=None,
       reference_in_the_book=ReferenceInTheBook(
@@ -2811,27 +3082,266 @@ UnverifiedSymbolTable(
       invariants=[
         Invariant(
           description='Constraint AASd-107: If a first level child element has a semantic ID it shall be identical to semantic ID list element.',
-          body="Implication(\n  antecedent=And(\n    values=[\n      IsNotNone(\n        value=Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='value',\n          original_node=...),\n        original_node=...),\n      IsNotNone(\n        value=Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='semantic_id_list_element',\n          original_node=...),\n        original_node=...)],\n    original_node=...),\n  consequent=All(\n    for_each=ForEach(\n      variable=Name(\n        identifier='child',\n        original_node=...),\n      iteration=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='value',\n        original_node=...),\n      original_node=...),\n    condition=Implication(\n      antecedent=IsNotNone(\n        value=Member(\n          instance=Name(\n            identifier='child',\n            original_node=...),\n          name='semantic_id',\n          original_node=...),\n        original_node=...),\n      consequent=Comparison(\n        left=Member(\n          instance=Name(\n            identifier='child',\n            original_node=...),\n          name='semantic_id',\n          original_node=...),\n        op='EQ',\n        right=Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='semantic_id_list_element',\n          original_node=...),\n        original_node=...),\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=And(
+                values=[
+                  IsNotNone(
+                    value=Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='value',
+                      original_node=...),
+                    original_node=...),
+                  IsNotNone(
+                    value=Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='semantic_id_list_element',
+                      original_node=...),
+                    original_node=...)],
+                original_node=...),
+              consequent=All(
+                for_each=ForEach(
+                  variable=Name(
+                    identifier='child',
+                    original_node=...),
+                  iteration=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='value',
+                    original_node=...),
+                  original_node=...),
+                condition=Implication(
+                  antecedent=IsNotNone(
+                    value=Member(
+                      instance=Name(
+                        identifier='child',
+                        original_node=...),
+                      name='semantic_id',
+                      original_node=...),
+                    original_node=...),
+                  consequent=Comparison(
+                    left=Member(
+                      instance=Name(
+                        identifier='child',
+                        original_node=...),
+                      name='semantic_id',
+                      original_node=...),
+                    op='EQ',
+                    right=Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='semantic_id_list_element',
+                      original_node=...),
+                    original_node=...),
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           node=...),
         Invariant(
           description='Constraint AASd-114: If two first level child elements have a semantic ID then they shall be identical.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='value',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='submodel_elements_have_identical_semantic_ids',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='value',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='value',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='submodel_elements_have_identical_semantic_ids',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='value',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           node=...),
         Invariant(
           description='Constraint AASd-108: All first level child elements shall have the same submodel element type as specified in type value list element.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='value',\n      original_node=...),\n    original_node=...),\n  consequent=All(\n    for_each=ForEach(\n      variable=Name(\n        identifier='element',\n        original_node=...),\n      iteration=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='value',\n        original_node=...),\n      original_node=...),\n    condition=FunctionCall(\n      name='submodel_element_is_of_type',\n      args=[\n        Name(\n          identifier='element',\n          original_node=...),\n        Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='type_value_list_element',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='value',
+                  original_node=...),
+                original_node=...),
+              consequent=All(
+                for_each=ForEach(
+                  variable=Name(
+                    identifier='element',
+                    original_node=...),
+                  iteration=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='value',
+                    original_node=...),
+                  original_node=...),
+                condition=FunctionCall(
+                  name='submodel_element_is_of_type',
+                  args=[
+                    Name(
+                      identifier='element',
+                      original_node=...),
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='type_value_list_element',
+                      original_node=...)],
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           node=...),
         Invariant(
           description='Constraint AASd-109: If type value list element is equal to Property or Range value type list element shall be set and all first level child elements shall have the value type as specified in value type list element.',
-          body="Implication(\n  antecedent=And(\n    values=[\n      IsNotNone(\n        value=Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='value',\n          original_node=...),\n        original_node=...),\n      Or(\n        values=[\n          Comparison(\n            left=Member(\n              instance=Name(\n                identifier='self',\n                original_node=...),\n              name='type_value_list_element',\n              original_node=...),\n            op='EQ',\n            right=Member(\n              instance=Name(\n                identifier='Submodel_element_elements',\n                original_node=...),\n              name='Property',\n              original_node=...),\n            original_node=...),\n          Comparison(\n            left=Member(\n              instance=Name(\n                identifier='self',\n                original_node=...),\n              name='type_value_list_element',\n              original_node=...),\n            op='EQ',\n            right=Member(\n              instance=Name(\n                identifier='Submodel_element_elements',\n                original_node=...),\n              name='Range',\n              original_node=...),\n            original_node=...)],\n        original_node=...)],\n    original_node=...),\n  consequent=And(\n    values=[\n      IsNotNone(\n        value=Member(\n          instance=Name(\n            identifier='self',\n            original_node=...),\n          name='value_type_list_element',\n          original_node=...),\n        original_node=...),\n      FunctionCall(\n        name='properties_or_ranges_have_value_type',\n        args=[\n          Member(\n            instance=Name(\n              identifier='self',\n              original_node=...),\n            name='value',\n            original_node=...),\n          Member(\n            instance=Name(\n              identifier='self',\n              original_node=...),\n            name='value_type_list_element',\n            original_node=...)],\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=And(
+                values=[
+                  IsNotNone(
+                    value=Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='value',
+                      original_node=...),
+                    original_node=...),
+                  Or(
+                    values=[
+                      Comparison(
+                        left=Member(
+                          instance=Name(
+                            identifier='self',
+                            original_node=...),
+                          name='type_value_list_element',
+                          original_node=...),
+                        op='EQ',
+                        right=Member(
+                          instance=Name(
+                            identifier='Submodel_element_elements',
+                            original_node=...),
+                          name='Property',
+                          original_node=...),
+                        original_node=...),
+                      Comparison(
+                        left=Member(
+                          instance=Name(
+                            identifier='self',
+                            original_node=...),
+                          name='type_value_list_element',
+                          original_node=...),
+                        op='EQ',
+                        right=Member(
+                          instance=Name(
+                            identifier='Submodel_element_elements',
+                            original_node=...),
+                          name='Range',
+                          original_node=...),
+                        original_node=...)],
+                    original_node=...)],
+                original_node=...),
+              consequent=And(
+                values=[
+                  IsNotNone(
+                    value=Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='value_type_list_element',
+                      original_node=...),
+                    original_node=...),
+                  FunctionCall(
+                    name='properties_or_ranges_have_value_type',
+                    args=[
+                      Member(
+                        instance=Name(
+                          identifier='self',
+                          original_node=...),
+                        name='value',
+                        original_node=...),
+                      Member(
+                        instance=Name(
+                          identifier='self',
+                          original_node=...),
+                        name='value_type_list_element',
+                        original_node=...)],
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           node=...),
         Invariant(
           description='Short IDs need to be defined for all the elements.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='value',\n      original_node=...),\n    original_node=...),\n  consequent=All(\n    for_each=ForEach(\n      variable=Name(\n        identifier='element',\n        original_node=...),\n      iteration=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='value',\n        original_node=...),\n      original_node=...),\n    condition=IsNotNone(\n      value=Member(\n        instance=Name(\n          identifier='element',\n          original_node=...),\n        name='id_short',\n        original_node=...),\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='value',
+                  original_node=...),
+                original_node=...),
+              consequent=All(
+                for_each=ForEach(
+                  variable=Name(
+                    identifier='element',
+                    original_node=...),
+                  iteration=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='value',
+                    original_node=...),
+                  original_node=...),
+                condition=IsNotNone(
+                  value=Member(
+                    instance=Name(
+                      identifier='element',
+                      original_node=...),
+                    name='id_short',
+                    original_node=...),
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           node=...),
         Invariant(
           description=None,
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='value',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='id_shorts_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='value',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='value',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='id_shorts_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='value',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           node=...)],
       serialization=None,
       reference_in_the_book=ReferenceInTheBook(
@@ -3041,11 +3551,62 @@ UnverifiedSymbolTable(
       invariants=[
         Invariant(
           description='Short IDs need to be defined for all the elements.',
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='value',\n      original_node=...),\n    original_node=...),\n  consequent=All(\n    for_each=ForEach(\n      variable=Name(\n        identifier='element',\n        original_node=...),\n      iteration=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='value',\n        original_node=...),\n      original_node=...),\n    condition=IsNotNone(\n      value=Member(\n        instance=Name(\n          identifier='element',\n          original_node=...),\n        name='id_short',\n        original_node=...),\n      original_node=...),\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='value',
+                  original_node=...),
+                original_node=...),
+              consequent=All(
+                for_each=ForEach(
+                  variable=Name(
+                    identifier='element',
+                    original_node=...),
+                  iteration=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='value',
+                    original_node=...),
+                  original_node=...),
+                condition=IsNotNone(
+                  value=Member(
+                    instance=Name(
+                      identifier='element',
+                      original_node=...),
+                    name='id_short',
+                    original_node=...),
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
           node=...),
         Invariant(
           description=None,
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='value',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='id_shorts_are_unique',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='value',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='value',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='id_shorts_are_unique',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='value',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           node=...)],
       serialization=None,
       reference_in_the_book=ReferenceInTheBook(
@@ -3222,7 +3783,46 @@ UnverifiedSymbolTable(
       invariants=[
         Invariant(
           description='Constraint AASd-090: For data elements category shall be one of the following values: CONSTANT, PARAMETER or VARIABLE',
-          body="Or(\n  values=[\n    Comparison(\n      left=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='category',\n        original_node=...),\n      op='EQ',\n      right=Constant(\n        value='CONSTANT',\n        original_node=...),\n      original_node=...),\n    Comparison(\n      left=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='category',\n        original_node=...),\n      op='EQ',\n      right=Constant(\n        value='PARAMETER',\n        original_node=...),\n      original_node=...),\n    Comparison(\n      left=Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='category',\n        original_node=...),\n      op='EQ',\n      right=Constant(\n        value='VARIABLE',\n        original_node=...),\n      original_node=...)],\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Or(
+              values=[
+                Comparison(
+                  left=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='category',
+                    original_node=...),
+                  op='EQ',
+                  right=Constant(
+                    value='CONSTANT',
+                    original_node=...),
+                  original_node=...),
+                Comparison(
+                  left=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='category',
+                    original_node=...),
+                  op='EQ',
+                  right=Constant(
+                    value='PARAMETER',
+                    original_node=...),
+                  original_node=...),
+                Comparison(
+                  left=Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='category',
+                    original_node=...),
+                  op='EQ',
+                  right=Constant(
+                    value='VARIABLE',
+                    original_node=...),
+                  original_node=...)],
+              original_node=...)"""),
           node=...)],
       serialization=None,
       reference_in_the_book=ReferenceInTheBook(
@@ -3465,7 +4065,33 @@ UnverifiedSymbolTable(
       invariants=[
         Invariant(
           description=None,
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='value',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='value_consistent_with_xsd_type',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='value',\n        original_node=...),\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='value_type',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='value',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='value_consistent_with_xsd_type',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='value',
+                    original_node=...),
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='value_type',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           node=...)],
       serialization=None,
       reference_in_the_book=ReferenceInTheBook(
@@ -3931,11 +4557,63 @@ UnverifiedSymbolTable(
       invariants=[
         Invariant(
           description=None,
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='max',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='value_consistent_with_xsd_type',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='max',\n        original_node=...),\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='value_type',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='max',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='value_consistent_with_xsd_type',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='max',
+                    original_node=...),
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='value_type',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           node=...),
         Invariant(
           description=None,
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='min',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='value_consistent_with_xsd_type',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='min',\n        original_node=...),\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='value_type',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='min',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='value_consistent_with_xsd_type',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='min',
+                    original_node=...),
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='value_type',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           node=...)],
       serialization=None,
       reference_in_the_book=ReferenceInTheBook(
@@ -5088,7 +5766,88 @@ UnverifiedSymbolTable(
       invariants=[
         Invariant(
           description="Constraint AASd-014: Either the attribute global asset ID or specific asset ID must be set if entity type is set to 'SelfManagedEntity'. They are not existing otherwise.",
-          body="Or(\n  values=[\n    And(\n      values=[\n        Comparison(\n          left=Member(\n            instance=Name(\n              identifier='self',\n              original_node=...),\n            name='entity_type',\n            original_node=...),\n          op='EQ',\n          right=Member(\n            instance=Name(\n              identifier='Entity_type',\n              original_node=...),\n            name='Self_managed_entity',\n            original_node=...),\n          original_node=...),\n        Or(\n          values=[\n            And(\n              values=[\n                IsNotNone(\n                  value=Member(\n                    instance=Name(\n                      identifier='self',\n                      original_node=...),\n                    name='global_asset_id',\n                    original_node=...),\n                  original_node=...),\n                IsNone(\n                  value=Member(\n                    instance=Name(\n                      identifier='self',\n                      original_node=...),\n                    name='global_asset_id',\n                    original_node=...),\n                  original_node=...)],\n              original_node=...),\n            And(\n              values=[\n                IsNone(\n                  value=Member(\n                    instance=Name(\n                      identifier='self',\n                      original_node=...),\n                    name='global_asset_id',\n                    original_node=...),\n                  original_node=...),\n                IsNotNone(\n                  value=Member(\n                    instance=Name(\n                      identifier='self',\n                      original_node=...),\n                    name='global_asset_id',\n                    original_node=...),\n                  original_node=...)],\n              original_node=...)],\n          original_node=...)],\n      original_node=...),\n    And(\n      values=[\n        IsNone(\n          value=Member(\n            instance=Name(\n              identifier='self',\n              original_node=...),\n            name='global_asset_id',\n            original_node=...),\n          original_node=...),\n        IsNone(\n          value=Member(\n            instance=Name(\n              identifier='self',\n              original_node=...),\n            name='specific_asset_id',\n            original_node=...),\n          original_node=...)],\n      original_node=...)],\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Or(
+              values=[
+                And(
+                  values=[
+                    Comparison(
+                      left=Member(
+                        instance=Name(
+                          identifier='self',
+                          original_node=...),
+                        name='entity_type',
+                        original_node=...),
+                      op='EQ',
+                      right=Member(
+                        instance=Name(
+                          identifier='Entity_type',
+                          original_node=...),
+                        name='Self_managed_entity',
+                        original_node=...),
+                      original_node=...),
+                    Or(
+                      values=[
+                        And(
+                          values=[
+                            IsNotNone(
+                              value=Member(
+                                instance=Name(
+                                  identifier='self',
+                                  original_node=...),
+                                name='global_asset_id',
+                                original_node=...),
+                              original_node=...),
+                            IsNone(
+                              value=Member(
+                                instance=Name(
+                                  identifier='self',
+                                  original_node=...),
+                                name='global_asset_id',
+                                original_node=...),
+                              original_node=...)],
+                          original_node=...),
+                        And(
+                          values=[
+                            IsNone(
+                              value=Member(
+                                instance=Name(
+                                  identifier='self',
+                                  original_node=...),
+                                name='global_asset_id',
+                                original_node=...),
+                              original_node=...),
+                            IsNotNone(
+                              value=Member(
+                                instance=Name(
+                                  identifier='self',
+                                  original_node=...),
+                                name='global_asset_id',
+                                original_node=...),
+                              original_node=...)],
+                          original_node=...)],
+                      original_node=...)],
+                  original_node=...),
+                And(
+                  values=[
+                    IsNone(
+                      value=Member(
+                        instance=Name(
+                          identifier='self',
+                          original_node=...),
+                        name='global_asset_id',
+                        original_node=...),
+                      original_node=...),
+                    IsNone(
+                      value=Member(
+                        instance=Name(
+                          identifier='self',
+                          original_node=...),
+                        name='specific_asset_id',
+                        original_node=...),
+                      original_node=...)],
+                  original_node=...)],
+              original_node=...)"""),
           node=...)],
       serialization=None,
       reference_in_the_book=ReferenceInTheBook(
@@ -6573,7 +7332,27 @@ UnverifiedSymbolTable(
       invariants=[
         Invariant(
           description="Constraint AASd-051: A concept description shall have one of the following categories: 'VALUE', 'PROPERTY', 'REFERENCE', 'DOCUMENT', 'CAPABILITY',; 'RELATIONSHIP', 'COLLECTION', 'FUNCTION', 'EVENT', 'ENTITY', 'APPLICATION_CLASS', 'QUALIFIER', 'VIEW'.",
-          body="Implication(\n  antecedent=IsNotNone(\n    value=Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='category',\n      original_node=...),\n    original_node=...),\n  consequent=FunctionCall(\n    name='concept_description_category_is_valid',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='category',\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='category',
+                  original_node=...),
+                original_node=...),
+              consequent=FunctionCall(
+                name='concept_description_category_is_valid',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='category',
+                    original_node=...)],
+                original_node=...),
+              original_node=...)"""),
           node=...)],
       serialization=Serialization(
         with_model_type=True),
@@ -6748,7 +7527,23 @@ UnverifiedSymbolTable(
       invariants=[
         Invariant(
           description=None,
-          body="Comparison(\n  left=FunctionCall(\n    name='len',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='keys',\n        original_node=...)],\n    original_node=...),\n  op='GE',\n  right=Constant(\n    value=1,\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Comparison(
+              left=FunctionCall(
+                name='len',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='keys',
+                    original_node=...)],
+                original_node=...),
+              op='GE',
+              right=Constant(
+                value=1,
+                original_node=...),
+              original_node=...)"""),
           node=...)],
       serialization=Serialization(
         with_model_type=True),
@@ -7793,11 +8588,37 @@ UnverifiedSymbolTable(
       invariants=[
         Invariant(
           description=None,
-          body="Comparison(\n  left=FunctionCall(\n    name='len',\n    args=[\n      Member(\n        instance=Name(\n          identifier='self',\n          original_node=...),\n        name='lang_strings',\n        original_node=...)],\n    original_node=...),\n  op='GE',\n  right=Constant(\n    value=1,\n    original_node=...),\n  original_node=...)",
+          body=textwrap.dedent("""\
+            Comparison(
+              left=FunctionCall(
+                name='len',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='lang_strings',
+                    original_node=...)],
+                original_node=...),
+              op='GE',
+              right=Constant(
+                value=1,
+                original_node=...),
+              original_node=...)"""),
           node=...),
         Invariant(
           description=None,
-          body="FunctionCall(\n  name='lang_strings_have_unique_languages',\n  args=[\n    Member(\n      instance=Name(\n        identifier='self',\n        original_node=...),\n      name='lang_strings',\n      original_node=...)],\n  original_node=...)",
+          body=textwrap.dedent("""\
+            FunctionCall(
+              name='lang_strings_have_unique_languages',
+              args=[
+                Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='lang_strings',
+                  original_node=...)],
+              original_node=...)"""),
           node=...)],
       serialization=None,
       reference_in_the_book=ReferenceInTheBook(
@@ -7975,18 +8796,241 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='digit',\n    original_node=...),\n  value=Constant(\n    value='[0-9]',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='year_frag',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '-?(([1-9]',\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      '+)|(0',\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      '))'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='month_frag',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '((0[1-9])|(1[0-2]))'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='day_frag',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '((0[1-9])|([12]',\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      ')|(3[01]))'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='hour_frag',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(([01]',\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      ')|(2[0-3]))'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='minute_frag',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '[0-5]',\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='second_frag',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '([0-5]',\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      ')(\\\\.',\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      '+)?'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='end_of_day_frag',\n    original_node=...),\n  value=Constant(\n    value='24:00:00(\\\\.0+)?',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='timezone_frag',\n    original_node=...),\n  value=Constant(\n    value='Z',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='date_time_stamp_lexical_rep',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      FormattedValue(\n        value=Name(\n          identifier='year_frag',\n          original_node=...),\n        original_node=...),\n      '-',\n      FormattedValue(\n        value=Name(\n          identifier='month_frag',\n          original_node=...),\n        original_node=...),\n      '-',\n      FormattedValue(\n        value=Name(\n          identifier='day_frag',\n          original_node=...),\n        original_node=...),\n      'T((',\n      FormattedValue(\n        value=Name(\n          identifier='hour_frag',\n          original_node=...),\n        original_node=...),\n      ':',\n      FormattedValue(\n        value=Name(\n          identifier='minute_frag',\n          original_node=...),\n        original_node=...),\n      ':',\n      FormattedValue(\n        value=Name(\n          identifier='second_frag',\n          original_node=...),\n        original_node=...),\n      ')|',\n      FormattedValue(\n        value=Name(\n          identifier='end_of_day_frag',\n          original_node=...),\n        original_node=...),\n      ')',\n      FormattedValue(\n        value=Name(\n          identifier='timezone_frag',\n          original_node=...),\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='date_time_stamp_lexical_rep',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='digit',
+              original_node=...),
+            value=Constant(
+              value='[0-9]',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='year_frag',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '-?(([1-9]',
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                '+)|(0',
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                '))'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='month_frag',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '((0[1-9])|(1[0-2]))'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='day_frag',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '((0[1-9])|([12]',
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                ')|(3[01]))'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='hour_frag',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(([01]',
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                ')|(2[0-3]))'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='minute_frag',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '[0-5]',
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...)],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='second_frag',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '([0-5]',
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                ')(\\\\.',
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                '+)?'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='end_of_day_frag',
+              original_node=...),
+            value=Constant(
+              value='24:00:00(\\\\.0+)?',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='timezone_frag',
+              original_node=...),
+            value=Constant(
+              value='Z',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='date_time_stamp_lexical_rep',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                FormattedValue(
+                  value=Name(
+                    identifier='year_frag',
+                    original_node=...),
+                  original_node=...),
+                '-',
+                FormattedValue(
+                  value=Name(
+                    identifier='month_frag',
+                    original_node=...),
+                  original_node=...),
+                '-',
+                FormattedValue(
+                  value=Name(
+                    identifier='day_frag',
+                    original_node=...),
+                  original_node=...),
+                'T((',
+                FormattedValue(
+                  value=Name(
+                    identifier='hour_frag',
+                    original_node=...),
+                  original_node=...),
+                ':',
+                FormattedValue(
+                  value=Name(
+                    identifier='minute_frag',
+                    original_node=...),
+                  original_node=...),
+                ':',
+                FormattedValue(
+                  value=Name(
+                    identifier='second_frag',
+                    original_node=...),
+                  original_node=...),
+                ')|',
+                FormattedValue(
+                  value=Name(
+                    identifier='end_of_day_frag',
+                    original_node=...),
+                  original_node=...),
+                ')',
+                FormattedValue(
+                  value=Name(
+                    identifier='timezone_frag',
+                    original_node=...),
+                  original_node=...)],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='date_time_stamp_lexical_rep',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     ImplementationSpecificMethod(
@@ -8034,18 +9078,212 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        'Assignment(\n  target=Name(\n    identifier=\'tchar\',\n    original_node=...),\n  value=Constant(\n    value="[!#$%&\'*+\\\\-.^_`|~0-9a-zA-Z]",\n    original_node=...),\n  original_node=...)',
-        "Assignment(\n  target=Name(\n    identifier='token',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='tchar',\n          original_node=...),\n        original_node=...),\n      ')+'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='type',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      FormattedValue(\n        value=Name(\n          identifier='token',\n          original_node=...),\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='subtype',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      FormattedValue(\n        value=Name(\n          identifier='token',\n          original_node=...),\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='ows',\n    original_node=...),\n  value=Constant(\n    value='[ \\t]*',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='obs_text',\n    original_node=...),\n  value=Constant(\n    value='[\\\\x80-\\\\xff]',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='qd_text',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '([\\t !#-\\\\[\\\\]-~]|',\n      FormattedValue(\n        value=Name(\n          identifier='obs_text',\n          original_node=...),\n        original_node=...),\n      ')'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='quoted_pair',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '\\\\\\\\([\\t !-~]|',\n      FormattedValue(\n        value=Name(\n          identifier='obs_text',\n          original_node=...),\n        original_node=...),\n      ')'],\n    original_node=...),\n  original_node=...)",
-        'Assignment(\n  target=Name(\n    identifier=\'quoted_string\',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      \'"(\',\n      FormattedValue(\n        value=Name(\n          identifier=\'qd_text\',\n          original_node=...),\n        original_node=...),\n      \'|\',\n      FormattedValue(\n        value=Name(\n          identifier=\'quoted_pair\',\n          original_node=...),\n        original_node=...),\n      \')*"\'],\n    original_node=...),\n  original_node=...)',
-        "Assignment(\n  target=Name(\n    identifier='parameter',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      FormattedValue(\n        value=Name(\n          identifier='token',\n          original_node=...),\n        original_node=...),\n      '=(',\n      FormattedValue(\n        value=Name(\n          identifier='token',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='quoted_string',\n          original_node=...),\n        original_node=...),\n      ')'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='media_type',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='type',\n          original_node=...),\n        original_node=...),\n      '/',\n      FormattedValue(\n        value=Name(\n          identifier='subtype',\n          original_node=...),\n        original_node=...),\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='ows',\n          original_node=...),\n        original_node=...),\n      ';',\n      FormattedValue(\n        value=Name(\n          identifier='ows',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='parameter',\n          original_node=...),\n        original_node=...),\n      ')*$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='media_type',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='tchar',
+              original_node=...),
+            value=Constant(
+              value="[!#$%&'*+\\\\-.^_`|~0-9a-zA-Z]",
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='token',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='tchar',
+                    original_node=...),
+                  original_node=...),
+                ')+'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='type',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                FormattedValue(
+                  value=Name(
+                    identifier='token',
+                    original_node=...),
+                  original_node=...)],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='subtype',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                FormattedValue(
+                  value=Name(
+                    identifier='token',
+                    original_node=...),
+                  original_node=...)],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='ows',
+              original_node=...),
+            value=Constant(
+              value='[ \\t]*',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='obs_text',
+              original_node=...),
+            value=Constant(
+              value='[\\\\x80-\\\\xff]',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='qd_text',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '([\\t !#-\\\\[\\\\]-~]|',
+                FormattedValue(
+                  value=Name(
+                    identifier='obs_text',
+                    original_node=...),
+                  original_node=...),
+                ')'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='quoted_pair',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '\\\\\\\\([\\t !-~]|',
+                FormattedValue(
+                  value=Name(
+                    identifier='obs_text',
+                    original_node=...),
+                  original_node=...),
+                ')'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='quoted_string',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '"(',
+                FormattedValue(
+                  value=Name(
+                    identifier='qd_text',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='quoted_pair',
+                    original_node=...),
+                  original_node=...),
+                ')*"'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='parameter',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                FormattedValue(
+                  value=Name(
+                    identifier='token',
+                    original_node=...),
+                  original_node=...),
+                '=(',
+                FormattedValue(
+                  value=Name(
+                    identifier='token',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='quoted_string',
+                    original_node=...),
+                  original_node=...),
+                ')'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='media_type',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='type',
+                    original_node=...),
+                  original_node=...),
+                '/',
+                FormattedValue(
+                  value=Name(
+                    identifier='subtype',
+                    original_node=...),
+                  original_node=...),
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='ows',
+                    original_node=...),
+                  original_node=...),
+                ';',
+                FormattedValue(
+                  value=Name(
+                    identifier='ows',
+                    original_node=...),
+                  original_node=...),
+                FormattedValue(
+                  value=Name(
+                    identifier='parameter',
+                    original_node=...),
+                  original_node=...),
+                ')*$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='media_type',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -8070,30 +9308,598 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='h16',\n    original_node=...),\n  value=Constant(\n    value='[0-9A-Fa-f]{1,4}',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='dec_octet',\n    original_node=...),\n  value=Constant(\n    value='([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='ipv4address',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      FormattedValue(\n        value=Name(\n          identifier='dec_octet',\n          original_node=...),\n        original_node=...),\n      '\\\\.',\n      FormattedValue(\n        value=Name(\n          identifier='dec_octet',\n          original_node=...),\n        original_node=...),\n      '\\\\.',\n      FormattedValue(\n        value=Name(\n          identifier='dec_octet',\n          original_node=...),\n        original_node=...),\n      '\\\\.',\n      FormattedValue(\n        value=Name(\n          identifier='dec_octet',\n          original_node=...),\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='ls32',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ':',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='ipv4address',\n          original_node=...),\n        original_node=...),\n      ')'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='ipv6address',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '((',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ':){6}',\n      FormattedValue(\n        value=Name(\n          identifier='ls32',\n          original_node=...),\n        original_node=...),\n      '|::(',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ':){5}',\n      FormattedValue(\n        value=Name(\n          identifier='ls32',\n          original_node=...),\n        original_node=...),\n      '|(',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ')?::(',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ':){4}',\n      FormattedValue(\n        value=Name(\n          identifier='ls32',\n          original_node=...),\n        original_node=...),\n      '|((',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ':)?',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ')?::(',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ':){3}',\n      FormattedValue(\n        value=Name(\n          identifier='ls32',\n          original_node=...),\n        original_node=...),\n      '|((',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ':){2}',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ')?::(',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ':){2}',\n      FormattedValue(\n        value=Name(\n          identifier='ls32',\n          original_node=...),\n        original_node=...),\n      '|((',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ':){3}',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ')?::',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ':',\n      FormattedValue(\n        value=Name(\n          identifier='ls32',\n          original_node=...),\n        original_node=...),\n      '|((',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ':){4}',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ')?::',\n      FormattedValue(\n        value=Name(\n          identifier='ls32',\n          original_node=...),\n        original_node=...),\n      '|((',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ':){5}',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ')?::',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      '|((',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ':){6}',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ')?::)'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='unreserved',\n    original_node=...),\n  value=Constant(\n    value='[a-zA-Z0-9\\\\-._~]',\n    original_node=...),\n  original_node=...)",
-        'Assignment(\n  target=Name(\n    identifier=\'sub_delims\',\n    original_node=...),\n  value=Constant(\n    value="[!$&\'()*+,;=]",\n    original_node=...),\n  original_node=...)',
-        "Assignment(\n  target=Name(\n    identifier='ipvfuture',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '[vV][0-9A-Fa-f]+\\\\.(',\n      FormattedValue(\n        value=Name(\n          identifier='unreserved',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='sub_delims',\n          original_node=...),\n        original_node=...),\n      '|:)+'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='ip_literal',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '\\\\[(',\n      FormattedValue(\n        value=Name(\n          identifier='ipv6address',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='ipvfuture',\n          original_node=...),\n        original_node=...),\n      ')\\\\]'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pct_encoded',\n    original_node=...),\n  value=Constant(\n    value='%[0-9A-Fa-f][0-9A-Fa-f]',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='reg_name',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='unreserved',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='pct_encoded',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='sub_delims',\n          original_node=...),\n        original_node=...),\n      ')*'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='host',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='ip_literal',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='ipv4address',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='reg_name',\n          original_node=...),\n        original_node=...),\n      ')'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='file_auth',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(localhost|',\n      FormattedValue(\n        value=Name(\n          identifier='host',\n          original_node=...),\n        original_node=...),\n      ')'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pchar',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='unreserved',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='pct_encoded',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='sub_delims',\n          original_node=...),\n        original_node=...),\n      '|[:@])'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='segment_nz',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='pchar',\n          original_node=...),\n        original_node=...),\n      ')+'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='segment',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='pchar',\n          original_node=...),\n        original_node=...),\n      ')*'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='path_absolute',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '/(',\n      FormattedValue(\n        value=Name(\n          identifier='segment_nz',\n          original_node=...),\n        original_node=...),\n      '(/',\n      FormattedValue(\n        value=Name(\n          identifier='segment',\n          original_node=...),\n        original_node=...),\n      ')*)?'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='auth_path',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='file_auth',\n          original_node=...),\n        original_node=...),\n      ')?',\n      FormattedValue(\n        value=Name(\n          identifier='path_absolute',\n          original_node=...),\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='local_path',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      FormattedValue(\n        value=Name(\n          identifier='path_absolute',\n          original_node=...),\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='file_hier_part',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(//',\n      FormattedValue(\n        value=Name(\n          identifier='auth_path',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='local_path',\n          original_node=...),\n        original_node=...),\n      ')'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='file_scheme',\n    original_node=...),\n  value=Constant(\n    value='file',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='file_uri',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      FormattedValue(\n        value=Name(\n          identifier='file_scheme',\n          original_node=...),\n        original_node=...),\n      ':',\n      FormattedValue(\n        value=Name(\n          identifier='file_hier_part',\n          original_node=...),\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='file_uri',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='h16',
+              original_node=...),
+            value=Constant(
+              value='[0-9A-Fa-f]{1,4}',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='dec_octet',
+              original_node=...),
+            value=Constant(
+              value='([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='ipv4address',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                FormattedValue(
+                  value=Name(
+                    identifier='dec_octet',
+                    original_node=...),
+                  original_node=...),
+                '\\\\.',
+                FormattedValue(
+                  value=Name(
+                    identifier='dec_octet',
+                    original_node=...),
+                  original_node=...),
+                '\\\\.',
+                FormattedValue(
+                  value=Name(
+                    identifier='dec_octet',
+                    original_node=...),
+                  original_node=...),
+                '\\\\.',
+                FormattedValue(
+                  value=Name(
+                    identifier='dec_octet',
+                    original_node=...),
+                  original_node=...)],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='ls32',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ':',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='ipv4address',
+                    original_node=...),
+                  original_node=...),
+                ')'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='ipv6address',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '((',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ':){6}',
+                FormattedValue(
+                  value=Name(
+                    identifier='ls32',
+                    original_node=...),
+                  original_node=...),
+                '|::(',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ':){5}',
+                FormattedValue(
+                  value=Name(
+                    identifier='ls32',
+                    original_node=...),
+                  original_node=...),
+                '|(',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ')?::(',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ':){4}',
+                FormattedValue(
+                  value=Name(
+                    identifier='ls32',
+                    original_node=...),
+                  original_node=...),
+                '|((',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ':)?',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ')?::(',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ':){3}',
+                FormattedValue(
+                  value=Name(
+                    identifier='ls32',
+                    original_node=...),
+                  original_node=...),
+                '|((',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ':){2}',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ')?::(',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ':){2}',
+                FormattedValue(
+                  value=Name(
+                    identifier='ls32',
+                    original_node=...),
+                  original_node=...),
+                '|((',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ':){3}',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ')?::',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ':',
+                FormattedValue(
+                  value=Name(
+                    identifier='ls32',
+                    original_node=...),
+                  original_node=...),
+                '|((',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ':){4}',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ')?::',
+                FormattedValue(
+                  value=Name(
+                    identifier='ls32',
+                    original_node=...),
+                  original_node=...),
+                '|((',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ':){5}',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ')?::',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                '|((',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ':){6}',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ')?::)'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='unreserved',
+              original_node=...),
+            value=Constant(
+              value='[a-zA-Z0-9\\\\-._~]',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='sub_delims',
+              original_node=...),
+            value=Constant(
+              value="[!$&'()*+,;=]",
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='ipvfuture',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '[vV][0-9A-Fa-f]+\\\\.(',
+                FormattedValue(
+                  value=Name(
+                    identifier='unreserved',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='sub_delims',
+                    original_node=...),
+                  original_node=...),
+                '|:)+'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='ip_literal',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '\\\\[(',
+                FormattedValue(
+                  value=Name(
+                    identifier='ipv6address',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='ipvfuture',
+                    original_node=...),
+                  original_node=...),
+                ')\\\\]'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pct_encoded',
+              original_node=...),
+            value=Constant(
+              value='%[0-9A-Fa-f][0-9A-Fa-f]',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='reg_name',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='unreserved',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='pct_encoded',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='sub_delims',
+                    original_node=...),
+                  original_node=...),
+                ')*'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='host',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='ip_literal',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='ipv4address',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='reg_name',
+                    original_node=...),
+                  original_node=...),
+                ')'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='file_auth',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(localhost|',
+                FormattedValue(
+                  value=Name(
+                    identifier='host',
+                    original_node=...),
+                  original_node=...),
+                ')'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pchar',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='unreserved',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='pct_encoded',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='sub_delims',
+                    original_node=...),
+                  original_node=...),
+                '|[:@])'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='segment_nz',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='pchar',
+                    original_node=...),
+                  original_node=...),
+                ')+'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='segment',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='pchar',
+                    original_node=...),
+                  original_node=...),
+                ')*'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='path_absolute',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '/(',
+                FormattedValue(
+                  value=Name(
+                    identifier='segment_nz',
+                    original_node=...),
+                  original_node=...),
+                '(/',
+                FormattedValue(
+                  value=Name(
+                    identifier='segment',
+                    original_node=...),
+                  original_node=...),
+                ')*)?'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='auth_path',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='file_auth',
+                    original_node=...),
+                  original_node=...),
+                ')?',
+                FormattedValue(
+                  value=Name(
+                    identifier='path_absolute',
+                    original_node=...),
+                  original_node=...)],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='local_path',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                FormattedValue(
+                  value=Name(
+                    identifier='path_absolute',
+                    original_node=...),
+                  original_node=...)],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='file_hier_part',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(//',
+                FormattedValue(
+                  value=Name(
+                    identifier='auth_path',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='local_path',
+                    original_node=...),
+                  original_node=...),
+                ')'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='file_scheme',
+              original_node=...),
+            value=Constant(
+              value='file',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='file_uri',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                FormattedValue(
+                  value=Name(
+                    identifier='file_scheme',
+                    original_node=...),
+                  original_node=...),
+                ':',
+                FormattedValue(
+                  value=Name(
+                    identifier='file_hier_part',
+                    original_node=...),
+                  original_node=...)],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='file_uri',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -8118,22 +9924,270 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='alphanum',\n    original_node=...),\n  value=Constant(\n    value='[a-zA-Z0-9]',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='singleton',\n    original_node=...),\n  value=Constant(\n    value='[0-9A-WY-Za-wy-z]',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='extension',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      FormattedValue(\n        value=Name(\n          identifier='singleton',\n          original_node=...),\n        original_node=...),\n      '(-(',\n      FormattedValue(\n        value=Name(\n          identifier='alphanum',\n          original_node=...),\n        original_node=...),\n      '){2,8})+'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='extlang',\n    original_node=...),\n  value=Constant(\n    value='[a-zA-Z]{3}(-[a-zA-Z]{3}){2}',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='irregular',\n    original_node=...),\n  value=Constant(\n    value='(en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='regular',\n    original_node=...),\n  value=Constant(\n    value='(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='grandfathered',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='irregular',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='regular',\n          original_node=...),\n        original_node=...),\n      ')'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='language',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '([a-zA-Z]{2,3}(-',\n      FormattedValue(\n        value=Name(\n          identifier='extlang',\n          original_node=...),\n        original_node=...),\n      ')?|[a-zA-Z]{4}|[a-zA-Z]{5,8})'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='script',\n    original_node=...),\n  value=Constant(\n    value='[a-zA-Z]{4}',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='region',\n    original_node=...),\n  value=Constant(\n    value='([a-zA-Z]{2}|[0-9]{3})',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='variant',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '((',\n      FormattedValue(\n        value=Name(\n          identifier='alphanum',\n          original_node=...),\n        original_node=...),\n      '){5,8}|[0-9](',\n      FormattedValue(\n        value=Name(\n          identifier='alphanum',\n          original_node=...),\n        original_node=...),\n      '){3})'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='privateuse',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '[xX](-(',\n      FormattedValue(\n        value=Name(\n          identifier='alphanum',\n          original_node=...),\n        original_node=...),\n      '){1,8})+'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='langtag',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      FormattedValue(\n        value=Name(\n          identifier='language',\n          original_node=...),\n        original_node=...),\n      '(-',\n      FormattedValue(\n        value=Name(\n          identifier='script',\n          original_node=...),\n        original_node=...),\n      ')?(-',\n      FormattedValue(\n        value=Name(\n          identifier='region',\n          original_node=...),\n        original_node=...),\n      ')?(-',\n      FormattedValue(\n        value=Name(\n          identifier='variant',\n          original_node=...),\n        original_node=...),\n      ')*(-',\n      FormattedValue(\n        value=Name(\n          identifier='extension',\n          original_node=...),\n        original_node=...),\n      ')*(-',\n      FormattedValue(\n        value=Name(\n          identifier='privateuse',\n          original_node=...),\n        original_node=...),\n      ')?'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='language_tag',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='langtag',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='privateuse',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='grandfathered',\n          original_node=...),\n        original_node=...),\n      ')'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='language_tag',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='alphanum',
+              original_node=...),
+            value=Constant(
+              value='[a-zA-Z0-9]',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='singleton',
+              original_node=...),
+            value=Constant(
+              value='[0-9A-WY-Za-wy-z]',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='extension',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                FormattedValue(
+                  value=Name(
+                    identifier='singleton',
+                    original_node=...),
+                  original_node=...),
+                '(-(',
+                FormattedValue(
+                  value=Name(
+                    identifier='alphanum',
+                    original_node=...),
+                  original_node=...),
+                '){2,8})+'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='extlang',
+              original_node=...),
+            value=Constant(
+              value='[a-zA-Z]{3}(-[a-zA-Z]{3}){2}',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='irregular',
+              original_node=...),
+            value=Constant(
+              value='(en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='regular',
+              original_node=...),
+            value=Constant(
+              value='(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='grandfathered',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='irregular',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='regular',
+                    original_node=...),
+                  original_node=...),
+                ')'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='language',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '([a-zA-Z]{2,3}(-',
+                FormattedValue(
+                  value=Name(
+                    identifier='extlang',
+                    original_node=...),
+                  original_node=...),
+                ')?|[a-zA-Z]{4}|[a-zA-Z]{5,8})'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='script',
+              original_node=...),
+            value=Constant(
+              value='[a-zA-Z]{4}',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='region',
+              original_node=...),
+            value=Constant(
+              value='([a-zA-Z]{2}|[0-9]{3})',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='variant',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '((',
+                FormattedValue(
+                  value=Name(
+                    identifier='alphanum',
+                    original_node=...),
+                  original_node=...),
+                '){5,8}|[0-9](',
+                FormattedValue(
+                  value=Name(
+                    identifier='alphanum',
+                    original_node=...),
+                  original_node=...),
+                '){3})'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='privateuse',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '[xX](-(',
+                FormattedValue(
+                  value=Name(
+                    identifier='alphanum',
+                    original_node=...),
+                  original_node=...),
+                '){1,8})+'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='langtag',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                FormattedValue(
+                  value=Name(
+                    identifier='language',
+                    original_node=...),
+                  original_node=...),
+                '(-',
+                FormattedValue(
+                  value=Name(
+                    identifier='script',
+                    original_node=...),
+                  original_node=...),
+                ')?(-',
+                FormattedValue(
+                  value=Name(
+                    identifier='region',
+                    original_node=...),
+                  original_node=...),
+                ')?(-',
+                FormattedValue(
+                  value=Name(
+                    identifier='variant',
+                    original_node=...),
+                  original_node=...),
+                ')*(-',
+                FormattedValue(
+                  value=Name(
+                    identifier='extension',
+                    original_node=...),
+                  original_node=...),
+                ')*(-',
+                FormattedValue(
+                  value=Name(
+                    identifier='privateuse',
+                    original_node=...),
+                  original_node=...),
+                ')?'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='language_tag',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='langtag',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='privateuse',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='grandfathered',
+                    original_node=...),
+                  original_node=...),
+                ')'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='language_tag',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     ImplementationSpecificMethod(
@@ -8212,43 +10266,904 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='scheme',\n    original_node=...),\n  value=Constant(\n    value='[a-zA-Z][a-zA-Z0-9+\\\\-.]*',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='ucschar',\n    original_node=...),\n  value=Constant(\n    value='[\\\\xa0-\\\\ud7ff\\\\uf900-\\\\ufdcf\\\\ufdf0-\\\\uffef\\\\u10000-\\\\u1fffd\\\\u20000-\\\\u2fffd\\\\u30000-\\\\u3fffd\\\\u40000-\\\\u4fffd\\\\u50000-\\\\u5fffd\\\\u60000-\\\\u6fffd\\\\u70000-\\\\u7fffd\\\\u80000-\\\\u8fffd\\\\u90000-\\\\u9fffd\\\\ua0000-\\\\uafffd\\\\ub0000-\\\\ubfffd\\\\uc0000-\\\\ucfffd\\\\ud0000-\\\\udfffd\\\\ue1000-\\\\uefffd]',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='iunreserved',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '([a-zA-Z0-9\\\\-._~]|',\n      FormattedValue(\n        value=Name(\n          identifier='ucschar',\n          original_node=...),\n        original_node=...),\n      ')'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pct_encoded',\n    original_node=...),\n  value=Constant(\n    value='%[0-9A-Fa-f][0-9A-Fa-f]',\n    original_node=...),\n  original_node=...)",
-        'Assignment(\n  target=Name(\n    identifier=\'sub_delims\',\n    original_node=...),\n  value=Constant(\n    value="[!$&\'()*+,;=]",\n    original_node=...),\n  original_node=...)',
-        "Assignment(\n  target=Name(\n    identifier='iuserinfo',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='iunreserved',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='pct_encoded',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='sub_delims',\n          original_node=...),\n        original_node=...),\n      '|:)*'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='h16',\n    original_node=...),\n  value=Constant(\n    value='[0-9A-Fa-f]{1,4}',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='dec_octet',\n    original_node=...),\n  value=Constant(\n    value='([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='ipv4address',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      FormattedValue(\n        value=Name(\n          identifier='dec_octet',\n          original_node=...),\n        original_node=...),\n      '\\\\.',\n      FormattedValue(\n        value=Name(\n          identifier='dec_octet',\n          original_node=...),\n        original_node=...),\n      '\\\\.',\n      FormattedValue(\n        value=Name(\n          identifier='dec_octet',\n          original_node=...),\n        original_node=...),\n      '\\\\.',\n      FormattedValue(\n        value=Name(\n          identifier='dec_octet',\n          original_node=...),\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='ls32',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ':',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='ipv4address',\n          original_node=...),\n        original_node=...),\n      ')'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='ipv6address',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '((',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ':){6}',\n      FormattedValue(\n        value=Name(\n          identifier='ls32',\n          original_node=...),\n        original_node=...),\n      '|::(',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ':){5}',\n      FormattedValue(\n        value=Name(\n          identifier='ls32',\n          original_node=...),\n        original_node=...),\n      '|(',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ')?::(',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ':){4}',\n      FormattedValue(\n        value=Name(\n          identifier='ls32',\n          original_node=...),\n        original_node=...),\n      '|((',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ':)?',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ')?::(',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ':){3}',\n      FormattedValue(\n        value=Name(\n          identifier='ls32',\n          original_node=...),\n        original_node=...),\n      '|((',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ':){2}',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ')?::(',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ':){2}',\n      FormattedValue(\n        value=Name(\n          identifier='ls32',\n          original_node=...),\n        original_node=...),\n      '|((',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ':){3}',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ')?::',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ':',\n      FormattedValue(\n        value=Name(\n          identifier='ls32',\n          original_node=...),\n        original_node=...),\n      '|((',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ':){4}',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ')?::',\n      FormattedValue(\n        value=Name(\n          identifier='ls32',\n          original_node=...),\n        original_node=...),\n      '|((',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ':){5}',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ')?::',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      '|((',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ':){6}',\n      FormattedValue(\n        value=Name(\n          identifier='h16',\n          original_node=...),\n        original_node=...),\n      ')?::)'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='unreserved',\n    original_node=...),\n  value=Constant(\n    value='[a-zA-Z0-9\\\\-._~]',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='ipvfuture',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '[vV][0-9A-Fa-f]+\\\\.(',\n      FormattedValue(\n        value=Name(\n          identifier='unreserved',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='sub_delims',\n          original_node=...),\n        original_node=...),\n      '|:)+'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='ip_literal',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '\\\\[(',\n      FormattedValue(\n        value=Name(\n          identifier='ipv6address',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='ipvfuture',\n          original_node=...),\n        original_node=...),\n      ')\\\\]'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='ireg_name',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='iunreserved',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='pct_encoded',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='sub_delims',\n          original_node=...),\n        original_node=...),\n      ')*'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='ihost',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='ip_literal',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='ipv4address',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='ireg_name',\n          original_node=...),\n        original_node=...),\n      ')'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='port',\n    original_node=...),\n  value=Constant(\n    value='[0-9]*',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='iauthority',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='iuserinfo',\n          original_node=...),\n        original_node=...),\n      '@)?',\n      FormattedValue(\n        value=Name(\n          identifier='ihost',\n          original_node=...),\n        original_node=...),\n      '(:',\n      FormattedValue(\n        value=Name(\n          identifier='port',\n          original_node=...),\n        original_node=...),\n      ')?'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='ipchar',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='iunreserved',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='pct_encoded',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='sub_delims',\n          original_node=...),\n        original_node=...),\n      '|[:@])'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='isegment',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='ipchar',\n          original_node=...),\n        original_node=...),\n      ')*'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='ipath_abempty',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(/',\n      FormattedValue(\n        value=Name(\n          identifier='isegment',\n          original_node=...),\n        original_node=...),\n      ')*'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='isegment_nz',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='ipchar',\n          original_node=...),\n        original_node=...),\n      ')+'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='ipath_absolute',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '/(',\n      FormattedValue(\n        value=Name(\n          identifier='isegment_nz',\n          original_node=...),\n        original_node=...),\n      '(/',\n      FormattedValue(\n        value=Name(\n          identifier='isegment',\n          original_node=...),\n        original_node=...),\n      ')*)?'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='ipath_rootless',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      FormattedValue(\n        value=Name(\n          identifier='isegment_nz',\n          original_node=...),\n        original_node=...),\n      '(/',\n      FormattedValue(\n        value=Name(\n          identifier='isegment',\n          original_node=...),\n        original_node=...),\n      ')*'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='ipath_empty',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='ipchar',\n          original_node=...),\n        original_node=...),\n      '){0}'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='ihier_part',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(//',\n      FormattedValue(\n        value=Name(\n          identifier='iauthority',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='ipath_abempty',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='ipath_absolute',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='ipath_rootless',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='ipath_empty',\n          original_node=...),\n        original_node=...),\n      ')'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='iprivate',\n    original_node=...),\n  value=Constant(\n    value='[\\\\ue000-\\\\uf8ff\\\\uf0000-\\\\uffffd\\\\u100000-\\\\u10fffd]',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='iquery',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='ipchar',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='iprivate',\n          original_node=...),\n        original_node=...),\n      '|[/?])*'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='ifragment',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='ipchar',\n          original_node=...),\n        original_node=...),\n      '|[/?])*'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='isegment_nz_nc',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='iunreserved',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='pct_encoded',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='sub_delims',\n          original_node=...),\n        original_node=...),\n      '|@)+'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='ipath_noscheme',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      FormattedValue(\n        value=Name(\n          identifier='isegment_nz_nc',\n          original_node=...),\n        original_node=...),\n      '(/',\n      FormattedValue(\n        value=Name(\n          identifier='isegment',\n          original_node=...),\n        original_node=...),\n      ')*'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='irelative_part',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(//',\n      FormattedValue(\n        value=Name(\n          identifier='iauthority',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='ipath_abempty',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='ipath_absolute',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='ipath_noscheme',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='ipath_empty',\n          original_node=...),\n        original_node=...),\n      ')'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='irelative_ref',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      FormattedValue(\n        value=Name(\n          identifier='irelative_part',\n          original_node=...),\n        original_node=...),\n      '(\\\\?',\n      FormattedValue(\n        value=Name(\n          identifier='iquery',\n          original_node=...),\n        original_node=...),\n      ')?(\\\\#',\n      FormattedValue(\n        value=Name(\n          identifier='ifragment',\n          original_node=...),\n        original_node=...),\n      ')?'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='iri',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      FormattedValue(\n        value=Name(\n          identifier='scheme',\n          original_node=...),\n        original_node=...),\n      ':',\n      FormattedValue(\n        value=Name(\n          identifier='ihier_part',\n          original_node=...),\n        original_node=...),\n      '(\\\\?',\n      FormattedValue(\n        value=Name(\n          identifier='iquery',\n          original_node=...),\n        original_node=...),\n      ')?(\\\\#',\n      FormattedValue(\n        value=Name(\n          identifier='ifragment',\n          original_node=...),\n        original_node=...),\n      ')?'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='iri_reference',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='iri',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='irelative_ref',\n          original_node=...),\n        original_node=...),\n      ')'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='iri_reference',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='scheme',
+              original_node=...),
+            value=Constant(
+              value='[a-zA-Z][a-zA-Z0-9+\\\\-.]*',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='ucschar',
+              original_node=...),
+            value=Constant(
+              value='[\\\\xa0-\\\\ud7ff\\\\uf900-\\\\ufdcf\\\\ufdf0-\\\\uffef\\\\u10000-\\\\u1fffd\\\\u20000-\\\\u2fffd\\\\u30000-\\\\u3fffd\\\\u40000-\\\\u4fffd\\\\u50000-\\\\u5fffd\\\\u60000-\\\\u6fffd\\\\u70000-\\\\u7fffd\\\\u80000-\\\\u8fffd\\\\u90000-\\\\u9fffd\\\\ua0000-\\\\uafffd\\\\ub0000-\\\\ubfffd\\\\uc0000-\\\\ucfffd\\\\ud0000-\\\\udfffd\\\\ue1000-\\\\uefffd]',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='iunreserved',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '([a-zA-Z0-9\\\\-._~]|',
+                FormattedValue(
+                  value=Name(
+                    identifier='ucschar',
+                    original_node=...),
+                  original_node=...),
+                ')'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pct_encoded',
+              original_node=...),
+            value=Constant(
+              value='%[0-9A-Fa-f][0-9A-Fa-f]',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='sub_delims',
+              original_node=...),
+            value=Constant(
+              value="[!$&'()*+,;=]",
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='iuserinfo',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='iunreserved',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='pct_encoded',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='sub_delims',
+                    original_node=...),
+                  original_node=...),
+                '|:)*'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='h16',
+              original_node=...),
+            value=Constant(
+              value='[0-9A-Fa-f]{1,4}',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='dec_octet',
+              original_node=...),
+            value=Constant(
+              value='([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='ipv4address',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                FormattedValue(
+                  value=Name(
+                    identifier='dec_octet',
+                    original_node=...),
+                  original_node=...),
+                '\\\\.',
+                FormattedValue(
+                  value=Name(
+                    identifier='dec_octet',
+                    original_node=...),
+                  original_node=...),
+                '\\\\.',
+                FormattedValue(
+                  value=Name(
+                    identifier='dec_octet',
+                    original_node=...),
+                  original_node=...),
+                '\\\\.',
+                FormattedValue(
+                  value=Name(
+                    identifier='dec_octet',
+                    original_node=...),
+                  original_node=...)],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='ls32',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ':',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='ipv4address',
+                    original_node=...),
+                  original_node=...),
+                ')'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='ipv6address',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '((',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ':){6}',
+                FormattedValue(
+                  value=Name(
+                    identifier='ls32',
+                    original_node=...),
+                  original_node=...),
+                '|::(',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ':){5}',
+                FormattedValue(
+                  value=Name(
+                    identifier='ls32',
+                    original_node=...),
+                  original_node=...),
+                '|(',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ')?::(',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ':){4}',
+                FormattedValue(
+                  value=Name(
+                    identifier='ls32',
+                    original_node=...),
+                  original_node=...),
+                '|((',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ':)?',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ')?::(',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ':){3}',
+                FormattedValue(
+                  value=Name(
+                    identifier='ls32',
+                    original_node=...),
+                  original_node=...),
+                '|((',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ':){2}',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ')?::(',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ':){2}',
+                FormattedValue(
+                  value=Name(
+                    identifier='ls32',
+                    original_node=...),
+                  original_node=...),
+                '|((',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ':){3}',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ')?::',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ':',
+                FormattedValue(
+                  value=Name(
+                    identifier='ls32',
+                    original_node=...),
+                  original_node=...),
+                '|((',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ':){4}',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ')?::',
+                FormattedValue(
+                  value=Name(
+                    identifier='ls32',
+                    original_node=...),
+                  original_node=...),
+                '|((',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ':){5}',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ')?::',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                '|((',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ':){6}',
+                FormattedValue(
+                  value=Name(
+                    identifier='h16',
+                    original_node=...),
+                  original_node=...),
+                ')?::)'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='unreserved',
+              original_node=...),
+            value=Constant(
+              value='[a-zA-Z0-9\\\\-._~]',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='ipvfuture',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '[vV][0-9A-Fa-f]+\\\\.(',
+                FormattedValue(
+                  value=Name(
+                    identifier='unreserved',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='sub_delims',
+                    original_node=...),
+                  original_node=...),
+                '|:)+'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='ip_literal',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '\\\\[(',
+                FormattedValue(
+                  value=Name(
+                    identifier='ipv6address',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='ipvfuture',
+                    original_node=...),
+                  original_node=...),
+                ')\\\\]'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='ireg_name',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='iunreserved',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='pct_encoded',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='sub_delims',
+                    original_node=...),
+                  original_node=...),
+                ')*'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='ihost',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='ip_literal',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='ipv4address',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='ireg_name',
+                    original_node=...),
+                  original_node=...),
+                ')'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='port',
+              original_node=...),
+            value=Constant(
+              value='[0-9]*',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='iauthority',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='iuserinfo',
+                    original_node=...),
+                  original_node=...),
+                '@)?',
+                FormattedValue(
+                  value=Name(
+                    identifier='ihost',
+                    original_node=...),
+                  original_node=...),
+                '(:',
+                FormattedValue(
+                  value=Name(
+                    identifier='port',
+                    original_node=...),
+                  original_node=...),
+                ')?'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='ipchar',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='iunreserved',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='pct_encoded',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='sub_delims',
+                    original_node=...),
+                  original_node=...),
+                '|[:@])'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='isegment',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='ipchar',
+                    original_node=...),
+                  original_node=...),
+                ')*'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='ipath_abempty',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(/',
+                FormattedValue(
+                  value=Name(
+                    identifier='isegment',
+                    original_node=...),
+                  original_node=...),
+                ')*'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='isegment_nz',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='ipchar',
+                    original_node=...),
+                  original_node=...),
+                ')+'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='ipath_absolute',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '/(',
+                FormattedValue(
+                  value=Name(
+                    identifier='isegment_nz',
+                    original_node=...),
+                  original_node=...),
+                '(/',
+                FormattedValue(
+                  value=Name(
+                    identifier='isegment',
+                    original_node=...),
+                  original_node=...),
+                ')*)?'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='ipath_rootless',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                FormattedValue(
+                  value=Name(
+                    identifier='isegment_nz',
+                    original_node=...),
+                  original_node=...),
+                '(/',
+                FormattedValue(
+                  value=Name(
+                    identifier='isegment',
+                    original_node=...),
+                  original_node=...),
+                ')*'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='ipath_empty',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='ipchar',
+                    original_node=...),
+                  original_node=...),
+                '){0}'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='ihier_part',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(//',
+                FormattedValue(
+                  value=Name(
+                    identifier='iauthority',
+                    original_node=...),
+                  original_node=...),
+                FormattedValue(
+                  value=Name(
+                    identifier='ipath_abempty',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='ipath_absolute',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='ipath_rootless',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='ipath_empty',
+                    original_node=...),
+                  original_node=...),
+                ')'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='iprivate',
+              original_node=...),
+            value=Constant(
+              value='[\\\\ue000-\\\\uf8ff\\\\uf0000-\\\\uffffd\\\\u100000-\\\\u10fffd]',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='iquery',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='ipchar',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='iprivate',
+                    original_node=...),
+                  original_node=...),
+                '|[/?])*'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='ifragment',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='ipchar',
+                    original_node=...),
+                  original_node=...),
+                '|[/?])*'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='isegment_nz_nc',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='iunreserved',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='pct_encoded',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='sub_delims',
+                    original_node=...),
+                  original_node=...),
+                '|@)+'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='ipath_noscheme',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                FormattedValue(
+                  value=Name(
+                    identifier='isegment_nz_nc',
+                    original_node=...),
+                  original_node=...),
+                '(/',
+                FormattedValue(
+                  value=Name(
+                    identifier='isegment',
+                    original_node=...),
+                  original_node=...),
+                ')*'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='irelative_part',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(//',
+                FormattedValue(
+                  value=Name(
+                    identifier='iauthority',
+                    original_node=...),
+                  original_node=...),
+                FormattedValue(
+                  value=Name(
+                    identifier='ipath_abempty',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='ipath_absolute',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='ipath_noscheme',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='ipath_empty',
+                    original_node=...),
+                  original_node=...),
+                ')'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='irelative_ref',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                FormattedValue(
+                  value=Name(
+                    identifier='irelative_part',
+                    original_node=...),
+                  original_node=...),
+                '(\\\\?',
+                FormattedValue(
+                  value=Name(
+                    identifier='iquery',
+                    original_node=...),
+                  original_node=...),
+                ')?(\\\\#',
+                FormattedValue(
+                  value=Name(
+                    identifier='ifragment',
+                    original_node=...),
+                  original_node=...),
+                ')?'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='iri',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                FormattedValue(
+                  value=Name(
+                    identifier='scheme',
+                    original_node=...),
+                  original_node=...),
+                ':',
+                FormattedValue(
+                  value=Name(
+                    identifier='ihier_part',
+                    original_node=...),
+                  original_node=...),
+                '(\\\\?',
+                FormattedValue(
+                  value=Name(
+                    identifier='iquery',
+                    original_node=...),
+                  original_node=...),
+                ')?(\\\\#',
+                FormattedValue(
+                  value=Name(
+                    identifier='ifragment',
+                    original_node=...),
+                  original_node=...),
+                ')?'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='iri_reference',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='iri',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='irelative_ref',
+                    original_node=...),
+                  original_node=...),
+                ')'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='iri_reference',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -8273,20 +11188,266 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='b04_char',\n    original_node=...),\n  value=Constant(\n    value='[AQgw]',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='b04',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      FormattedValue(\n        value=Name(\n          identifier='b04_char',\n          original_node=...),\n        original_node=...),\n      '\\\\x20?'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='b16_char',\n    original_node=...),\n  value=Constant(\n    value='[AEIMQUYcgkosw048]',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='b16',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      FormattedValue(\n        value=Name(\n          identifier='b16_char',\n          original_node=...),\n        original_node=...),\n      '\\\\x20?'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='b64_char',\n    original_node=...),\n  value=Constant(\n    value='[A-Za-z0-9+/]',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='b64',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      FormattedValue(\n        value=Name(\n          identifier='b64_char',\n          original_node=...),\n        original_node=...),\n      '\\\\x20?'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='b64quad',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='b64',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='b64',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='b64',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='b64',\n          original_node=...),\n        original_node=...),\n      ')'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='b64_final_quad',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='b64',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='b64',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='b64',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='b64_char',\n          original_node=...),\n        original_node=...),\n      ')'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='padded_8',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      FormattedValue(\n        value=Name(\n          identifier='b64',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='b04',\n          original_node=...),\n        original_node=...),\n      '= ?='],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='padded_16',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      FormattedValue(\n        value=Name(\n          identifier='b64',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='b64',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='b16',\n          original_node=...),\n        original_node=...),\n      '='],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='b64final',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='b64_final_quad',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='padded_16',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='padded_8',\n          original_node=...),\n        original_node=...),\n      ')'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='base64_binary',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='b64quad',\n          original_node=...),\n        original_node=...),\n      '*',\n      FormattedValue(\n        value=Name(\n          identifier='b64final',\n          original_node=...),\n        original_node=...),\n      ')?'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='base64_binary',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='b04_char',
+              original_node=...),
+            value=Constant(
+              value='[AQgw]',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='b04',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                FormattedValue(
+                  value=Name(
+                    identifier='b04_char',
+                    original_node=...),
+                  original_node=...),
+                '\\\\x20?'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='b16_char',
+              original_node=...),
+            value=Constant(
+              value='[AEIMQUYcgkosw048]',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='b16',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                FormattedValue(
+                  value=Name(
+                    identifier='b16_char',
+                    original_node=...),
+                  original_node=...),
+                '\\\\x20?'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='b64_char',
+              original_node=...),
+            value=Constant(
+              value='[A-Za-z0-9+/]',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='b64',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                FormattedValue(
+                  value=Name(
+                    identifier='b64_char',
+                    original_node=...),
+                  original_node=...),
+                '\\\\x20?'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='b64quad',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='b64',
+                    original_node=...),
+                  original_node=...),
+                FormattedValue(
+                  value=Name(
+                    identifier='b64',
+                    original_node=...),
+                  original_node=...),
+                FormattedValue(
+                  value=Name(
+                    identifier='b64',
+                    original_node=...),
+                  original_node=...),
+                FormattedValue(
+                  value=Name(
+                    identifier='b64',
+                    original_node=...),
+                  original_node=...),
+                ')'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='b64_final_quad',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='b64',
+                    original_node=...),
+                  original_node=...),
+                FormattedValue(
+                  value=Name(
+                    identifier='b64',
+                    original_node=...),
+                  original_node=...),
+                FormattedValue(
+                  value=Name(
+                    identifier='b64',
+                    original_node=...),
+                  original_node=...),
+                FormattedValue(
+                  value=Name(
+                    identifier='b64_char',
+                    original_node=...),
+                  original_node=...),
+                ')'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='padded_8',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                FormattedValue(
+                  value=Name(
+                    identifier='b64',
+                    original_node=...),
+                  original_node=...),
+                FormattedValue(
+                  value=Name(
+                    identifier='b04',
+                    original_node=...),
+                  original_node=...),
+                '= ?='],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='padded_16',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                FormattedValue(
+                  value=Name(
+                    identifier='b64',
+                    original_node=...),
+                  original_node=...),
+                FormattedValue(
+                  value=Name(
+                    identifier='b64',
+                    original_node=...),
+                  original_node=...),
+                FormattedValue(
+                  value=Name(
+                    identifier='b16',
+                    original_node=...),
+                  original_node=...),
+                '='],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='b64final',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='b64_final_quad',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='padded_16',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='padded_8',
+                    original_node=...),
+                  original_node=...),
+                ')'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='base64_binary',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='b64quad',
+                    original_node=...),
+                  original_node=...),
+                '*',
+                FormattedValue(
+                  value=Name(
+                    identifier='b64final',
+                    original_node=...),
+                  original_node=...),
+                ')?'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='base64_binary',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -8311,8 +11472,30 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=Constant(\n    value='^(true|false|1|0)$',\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=Constant(
+              value='^(true|false|1|0)$',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -8337,15 +11520,183 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='digit',\n    original_node=...),\n  value=Constant(\n    value='[0-9]',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='year_frag',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '-?(([1-9]',\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      '+)|(0',\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      '))'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='month_frag',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '((0[1-9])|(1[0-2]))'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='day_frag',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '((0[1-9])|([12]',\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      ')|(3[01]))'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='minute_frag',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '[0-5]',\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='timezone_frag',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(Z|(\\\\+|-)(0',\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      '|1[0-3]):',\n      FormattedValue(\n        value=Name(\n          identifier='minute_frag',\n          original_node=...),\n        original_node=...),\n      '|14:00)'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='date_lexical_rep',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      FormattedValue(\n        value=Name(\n          identifier='year_frag',\n          original_node=...),\n        original_node=...),\n      '-',\n      FormattedValue(\n        value=Name(\n          identifier='month_frag',\n          original_node=...),\n        original_node=...),\n      '-',\n      FormattedValue(\n        value=Name(\n          identifier='day_frag',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='timezone_frag',\n          original_node=...),\n        original_node=...),\n      '?'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='date_lexical_rep',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='digit',
+              original_node=...),
+            value=Constant(
+              value='[0-9]',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='year_frag',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '-?(([1-9]',
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                '+)|(0',
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                '))'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='month_frag',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '((0[1-9])|(1[0-2]))'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='day_frag',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '((0[1-9])|([12]',
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                ')|(3[01]))'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='minute_frag',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '[0-5]',
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...)],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='timezone_frag',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(Z|(\\\\+|-)(0',
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                '|1[0-3]):',
+                FormattedValue(
+                  value=Name(
+                    identifier='minute_frag',
+                    original_node=...),
+                  original_node=...),
+                '|14:00)'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='date_lexical_rep',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                FormattedValue(
+                  value=Name(
+                    identifier='year_frag',
+                    original_node=...),
+                  original_node=...),
+                '-',
+                FormattedValue(
+                  value=Name(
+                    identifier='month_frag',
+                    original_node=...),
+                  original_node=...),
+                '-',
+                FormattedValue(
+                  value=Name(
+                    identifier='day_frag',
+                    original_node=...),
+                  original_node=...),
+                FormattedValue(
+                  value=Name(
+                    identifier='timezone_frag',
+                    original_node=...),
+                  original_node=...),
+                '?'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='date_lexical_rep',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -8370,18 +11721,255 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='digit',\n    original_node=...),\n  value=Constant(\n    value='[0-9]',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='year_frag',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '-?(([1-9]',\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      '+)|(0',\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      '))'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='month_frag',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '((0[1-9])|(1[0-2]))'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='day_frag',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '((0[1-9])|([12]',\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      ')|(3[01]))'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='hour_frag',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(([01]',\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      ')|(2[0-3]))'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='minute_frag',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '[0-5]',\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='second_frag',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '([0-5]',\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      ')(\\\\.',\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      '+)?'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='end_of_day_frag',\n    original_node=...),\n  value=Constant(\n    value='24:00:00(\\\\.0+)?',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='timezone_frag',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(Z|(\\\\+|-)(0',\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      '|1[0-3]):',\n      FormattedValue(\n        value=Name(\n          identifier='minute_frag',\n          original_node=...),\n        original_node=...),\n      '|14:00)'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='date_time_lexical_rep',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      FormattedValue(\n        value=Name(\n          identifier='year_frag',\n          original_node=...),\n        original_node=...),\n      '-',\n      FormattedValue(\n        value=Name(\n          identifier='month_frag',\n          original_node=...),\n        original_node=...),\n      '-',\n      FormattedValue(\n        value=Name(\n          identifier='day_frag',\n          original_node=...),\n        original_node=...),\n      'T((',\n      FormattedValue(\n        value=Name(\n          identifier='hour_frag',\n          original_node=...),\n        original_node=...),\n      ':',\n      FormattedValue(\n        value=Name(\n          identifier='minute_frag',\n          original_node=...),\n        original_node=...),\n      ':',\n      FormattedValue(\n        value=Name(\n          identifier='second_frag',\n          original_node=...),\n        original_node=...),\n      ')|',\n      FormattedValue(\n        value=Name(\n          identifier='end_of_day_frag',\n          original_node=...),\n        original_node=...),\n      ')',\n      FormattedValue(\n        value=Name(\n          identifier='timezone_frag',\n          original_node=...),\n        original_node=...),\n      '?'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='date_time_lexical_rep',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='digit',
+              original_node=...),
+            value=Constant(
+              value='[0-9]',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='year_frag',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '-?(([1-9]',
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                '+)|(0',
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                '))'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='month_frag',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '((0[1-9])|(1[0-2]))'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='day_frag',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '((0[1-9])|([12]',
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                ')|(3[01]))'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='hour_frag',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(([01]',
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                ')|(2[0-3]))'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='minute_frag',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '[0-5]',
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...)],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='second_frag',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '([0-5]',
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                ')(\\\\.',
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                '+)?'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='end_of_day_frag',
+              original_node=...),
+            value=Constant(
+              value='24:00:00(\\\\.0+)?',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='timezone_frag',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(Z|(\\\\+|-)(0',
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                '|1[0-3]):',
+                FormattedValue(
+                  value=Name(
+                    identifier='minute_frag',
+                    original_node=...),
+                  original_node=...),
+                '|14:00)'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='date_time_lexical_rep',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                FormattedValue(
+                  value=Name(
+                    identifier='year_frag',
+                    original_node=...),
+                  original_node=...),
+                '-',
+                FormattedValue(
+                  value=Name(
+                    identifier='month_frag',
+                    original_node=...),
+                  original_node=...),
+                '-',
+                FormattedValue(
+                  value=Name(
+                    identifier='day_frag',
+                    original_node=...),
+                  original_node=...),
+                'T((',
+                FormattedValue(
+                  value=Name(
+                    identifier='hour_frag',
+                    original_node=...),
+                  original_node=...),
+                ':',
+                FormattedValue(
+                  value=Name(
+                    identifier='minute_frag',
+                    original_node=...),
+                  original_node=...),
+                ':',
+                FormattedValue(
+                  value=Name(
+                    identifier='second_frag',
+                    original_node=...),
+                  original_node=...),
+                ')|',
+                FormattedValue(
+                  value=Name(
+                    identifier='end_of_day_frag',
+                    original_node=...),
+                  original_node=...),
+                ')',
+                FormattedValue(
+                  value=Name(
+                    identifier='timezone_frag',
+                    original_node=...),
+                  original_node=...),
+                '?'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='date_time_lexical_rep',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -8406,18 +11994,254 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='digit',\n    original_node=...),\n  value=Constant(\n    value='[0-9]',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='year_frag',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '-?(([1-9]',\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      '+)|(0',\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      '))'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='month_frag',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '((0[1-9])|(1[0-2]))'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='day_frag',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '((0[1-9])|([12]',\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      ')|(3[01]))'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='hour_frag',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(([01]',\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      ')|(2[0-3]))'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='minute_frag',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '[0-5]',\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='second_frag',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '([0-5]',\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      ')(\\\\.',\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      '+)?'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='end_of_day_frag',\n    original_node=...),\n  value=Constant(\n    value='24:00:00(\\\\.0+)?',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='timezone_frag',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(Z|(\\\\+|-)(0',\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      '|1[0-3]):',\n      FormattedValue(\n        value=Name(\n          identifier='minute_frag',\n          original_node=...),\n        original_node=...),\n      '|14:00)'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='date_time_stamp_lexical_rep',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      FormattedValue(\n        value=Name(\n          identifier='year_frag',\n          original_node=...),\n        original_node=...),\n      '-',\n      FormattedValue(\n        value=Name(\n          identifier='month_frag',\n          original_node=...),\n        original_node=...),\n      '-',\n      FormattedValue(\n        value=Name(\n          identifier='day_frag',\n          original_node=...),\n        original_node=...),\n      'T((',\n      FormattedValue(\n        value=Name(\n          identifier='hour_frag',\n          original_node=...),\n        original_node=...),\n      ':',\n      FormattedValue(\n        value=Name(\n          identifier='minute_frag',\n          original_node=...),\n        original_node=...),\n      ':',\n      FormattedValue(\n        value=Name(\n          identifier='second_frag',\n          original_node=...),\n        original_node=...),\n      ')|',\n      FormattedValue(\n        value=Name(\n          identifier='end_of_day_frag',\n          original_node=...),\n        original_node=...),\n      ')',\n      FormattedValue(\n        value=Name(\n          identifier='timezone_frag',\n          original_node=...),\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='date_time_stamp_lexical_rep',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='digit',
+              original_node=...),
+            value=Constant(
+              value='[0-9]',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='year_frag',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '-?(([1-9]',
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                '+)|(0',
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                '))'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='month_frag',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '((0[1-9])|(1[0-2]))'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='day_frag',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '((0[1-9])|([12]',
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                ')|(3[01]))'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='hour_frag',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(([01]',
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                ')|(2[0-3]))'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='minute_frag',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '[0-5]',
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...)],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='second_frag',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '([0-5]',
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                ')(\\\\.',
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                '+)?'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='end_of_day_frag',
+              original_node=...),
+            value=Constant(
+              value='24:00:00(\\\\.0+)?',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='timezone_frag',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(Z|(\\\\+|-)(0',
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                '|1[0-3]):',
+                FormattedValue(
+                  value=Name(
+                    identifier='minute_frag',
+                    original_node=...),
+                  original_node=...),
+                '|14:00)'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='date_time_stamp_lexical_rep',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                FormattedValue(
+                  value=Name(
+                    identifier='year_frag',
+                    original_node=...),
+                  original_node=...),
+                '-',
+                FormattedValue(
+                  value=Name(
+                    identifier='month_frag',
+                    original_node=...),
+                  original_node=...),
+                '-',
+                FormattedValue(
+                  value=Name(
+                    identifier='day_frag',
+                    original_node=...),
+                  original_node=...),
+                'T((',
+                FormattedValue(
+                  value=Name(
+                    identifier='hour_frag',
+                    original_node=...),
+                  original_node=...),
+                ':',
+                FormattedValue(
+                  value=Name(
+                    identifier='minute_frag',
+                    original_node=...),
+                  original_node=...),
+                ':',
+                FormattedValue(
+                  value=Name(
+                    identifier='second_frag',
+                    original_node=...),
+                  original_node=...),
+                ')|',
+                FormattedValue(
+                  value=Name(
+                    identifier='end_of_day_frag',
+                    original_node=...),
+                  original_node=...),
+                ')',
+                FormattedValue(
+                  value=Name(
+                    identifier='timezone_frag',
+                    original_node=...),
+                  original_node=...)],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='date_time_stamp_lexical_rep',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -8442,15 +12266,156 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='digit',\n    original_node=...),\n  value=Constant(\n    value='[0-9]',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='unsigned_no_decimal_pt_numeral',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      '+'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='no_decimal_pt_numeral',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(\\\\+|-)?',\n      FormattedValue(\n        value=Name(\n          identifier='unsigned_no_decimal_pt_numeral',\n          original_node=...),\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='frac_frag',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      FormattedValue(\n        value=Name(\n          identifier='digit',\n          original_node=...),\n        original_node=...),\n      '+'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='unsigned_decimal_pt_numeral',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='unsigned_no_decimal_pt_numeral',\n          original_node=...),\n        original_node=...),\n      '\\\\.',\n      FormattedValue(\n        value=Name(\n          identifier='frac_frag',\n          original_node=...),\n        original_node=...),\n      '|\\\\.',\n      FormattedValue(\n        value=Name(\n          identifier='frac_frag',\n          original_node=...),\n        original_node=...),\n      ')'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='decimal_pt_numeral',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(\\\\+|-)?',\n      FormattedValue(\n        value=Name(\n          identifier='unsigned_decimal_pt_numeral',\n          original_node=...),\n        original_node=...)],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='decimal_lexical_rep',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '(',\n      FormattedValue(\n        value=Name(\n          identifier='decimal_pt_numeral',\n          original_node=...),\n        original_node=...),\n      '|',\n      FormattedValue(\n        value=Name(\n          identifier='no_decimal_pt_numeral',\n          original_node=...),\n        original_node=...),\n      ')'],\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='decimal_lexical_rep',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='digit',
+              original_node=...),
+            value=Constant(
+              value='[0-9]',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='unsigned_no_decimal_pt_numeral',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                '+'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='no_decimal_pt_numeral',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(\\\\+|-)?',
+                FormattedValue(
+                  value=Name(
+                    identifier='unsigned_no_decimal_pt_numeral',
+                    original_node=...),
+                  original_node=...)],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='frac_frag',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                FormattedValue(
+                  value=Name(
+                    identifier='digit',
+                    original_node=...),
+                  original_node=...),
+                '+'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='unsigned_decimal_pt_numeral',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='unsigned_no_decimal_pt_numeral',
+                    original_node=...),
+                  original_node=...),
+                '\\\\.',
+                FormattedValue(
+                  value=Name(
+                    identifier='frac_frag',
+                    original_node=...),
+                  original_node=...),
+                '|\\\\.',
+                FormattedValue(
+                  value=Name(
+                    identifier='frac_frag',
+                    original_node=...),
+                  original_node=...),
+                ')'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='decimal_pt_numeral',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(\\\\+|-)?',
+                FormattedValue(
+                  value=Name(
+                    identifier='unsigned_decimal_pt_numeral',
+                    original_node=...),
+                  original_node=...)],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='decimal_lexical_rep',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '(',
+                FormattedValue(
+                  value=Name(
+                    identifier='decimal_pt_numeral',
+                    original_node=...),
+                  original_node=...),
+                '|',
+                FormattedValue(
+                  value=Name(
+                    identifier='no_decimal_pt_numeral',
+                    original_node=...),
+                  original_node=...),
+                ')'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='decimal_lexical_rep',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -8475,9 +12440,46 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='double_rep',\n    original_node=...),\n  value=Constant(\n    value='(\\\\+|-)?([0-9]+(\\\\.[0-9]*)?|\\\\.[0-9]+)([Ee](\\\\+|-)?[0-9]+)?|(\\\\+|-)?INF|NaN',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='double_rep',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='double_rep',
+              original_node=...),
+            value=Constant(
+              value='(\\\\+|-)?([0-9]+(\\\\.[0-9]*)?|\\\\.[0-9]+)([Ee](\\\\+|-)?[0-9]+)?|(\\\\+|-)?INF|NaN',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='double_rep',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -8502,9 +12504,46 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='duration_rep',\n    original_node=...),\n  value=Constant(\n    value='-?P((([0-9]+Y([0-9]+M)?([0-9]+D)?|([0-9]+M)([0-9]+D)?|([0-9]+D))(T(([0-9]+H)([0-9]+M)?([0-9]+(\\\\.[0-9]+)?S)?|([0-9]+M)([0-9]+(\\\\.[0-9]+)?S)?|([0-9]+(\\\\.[0-9]+)?S)))?)|(T(([0-9]+H)([0-9]+M)?([0-9]+(\\\\.[0-9]+)?S)?|([0-9]+M)([0-9]+(\\\\.[0-9]+)?S)?|([0-9]+(\\\\.[0-9]+)?S))))',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='duration_rep',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='duration_rep',
+              original_node=...),
+            value=Constant(
+              value='-?P((([0-9]+Y([0-9]+M)?([0-9]+D)?|([0-9]+M)([0-9]+D)?|([0-9]+D))(T(([0-9]+H)([0-9]+M)?([0-9]+(\\\\.[0-9]+)?S)?|([0-9]+M)([0-9]+(\\\\.[0-9]+)?S)?|([0-9]+(\\\\.[0-9]+)?S)))?)|(T(([0-9]+H)([0-9]+M)?([0-9]+(\\\\.[0-9]+)?S)?|([0-9]+M)([0-9]+(\\\\.[0-9]+)?S)?|([0-9]+(\\\\.[0-9]+)?S))))',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='duration_rep',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -8529,9 +12568,46 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='float_rep',\n    original_node=...),\n  value=Constant(\n    value='(\\\\+|-)?([0-9]+(\\\\.[0-9]*)?|\\\\.[0-9]+)([Ee](\\\\+|-)?[0-9]+)?|(\\\\+|-)?INF|NaN',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='float_rep',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='float_rep',
+              original_node=...),
+            value=Constant(
+              value='(\\\\+|-)?([0-9]+(\\\\.[0-9]*)?|\\\\.[0-9]+)([Ee](\\\\+|-)?[0-9]+)?|(\\\\+|-)?INF|NaN',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='float_rep',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -8556,9 +12632,46 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='g_day_lexical_rep',\n    original_node=...),\n  value=Constant(\n    value='---(0[1-9]|[12][0-9]|3[01])(Z|(\\\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='g_day_lexical_rep',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='g_day_lexical_rep',
+              original_node=...),
+            value=Constant(
+              value='---(0[1-9]|[12][0-9]|3[01])(Z|(\\\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='g_day_lexical_rep',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -8583,9 +12696,46 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='g_month_lexical_rep',\n    original_node=...),\n  value=Constant(\n    value='--(0[1-9]|1[0-2])(Z|(\\\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='g_month_lexical_rep',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='g_month_lexical_rep',
+              original_node=...),
+            value=Constant(
+              value='--(0[1-9]|1[0-2])(Z|(\\\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='g_month_lexical_rep',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -8610,9 +12760,46 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='g_month_day_rep',\n    original_node=...),\n  value=Constant(\n    value='--(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])(Z|(\\\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='g_month_day_rep',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='g_month_day_rep',
+              original_node=...),
+            value=Constant(
+              value='--(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])(Z|(\\\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='g_month_day_rep',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -8637,9 +12824,46 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='g_year_rep',\n    original_node=...),\n  value=Constant(\n    value='-?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\\\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='g_year_rep',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='g_year_rep',
+              original_node=...),
+            value=Constant(
+              value='-?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\\\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='g_year_rep',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -8664,9 +12888,46 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='g_year_month_rep',\n    original_node=...),\n  value=Constant(\n    value='-?([1-9][0-9]{3,}|0[0-9]{3})-(0[1-9]|1[0-2])(Z|(\\\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='g_year_month_rep',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='g_year_month_rep',
+              original_node=...),
+            value=Constant(
+              value='-?([1-9][0-9]{3,}|0[0-9]{3})-(0[1-9]|1[0-2])(Z|(\\\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='g_year_month_rep',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -8691,9 +12952,46 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='hex_binary',\n    original_node=...),\n  value=Constant(\n    value='([0-9a-fA-F]{2})*',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='hex_binary',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='hex_binary',
+              original_node=...),
+            value=Constant(
+              value='([0-9a-fA-F]{2})*',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='hex_binary',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -8718,9 +13016,46 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='time_rep',\n    original_node=...),\n  value=Constant(\n    value='(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\\\\.[0-9]+)?|(24:00:00(\\\\.0+)?))(Z|(\\\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='time_rep',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='time_rep',
+              original_node=...),
+            value=Constant(
+              value='(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\\\\.[0-9]+)?|(24:00:00(\\\\.0+)?))(Z|(\\\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='time_rep',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -8745,9 +13080,46 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='day_time_duration_rep',\n    original_node=...),\n  value=Constant(\n    value='-?P((([0-9]+D)(T(([0-9]+H)([0-9]+M)?([0-9]+(\\\\.[0-9]+)?S)?|([0-9]+M)([0-9]+(\\\\.[0-9]+)?S)?|([0-9]+(\\\\.[0-9]+)?S)))?)|(T(([0-9]+H)([0-9]+M)?([0-9]+(\\\\.[0-9]+)?S)?|([0-9]+M)([0-9]+(\\\\.[0-9]+)?S)?|([0-9]+(\\\\.[0-9]+)?S))))',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='day_time_duration_rep',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='day_time_duration_rep',
+              original_node=...),
+            value=Constant(
+              value='-?P((([0-9]+D)(T(([0-9]+H)([0-9]+M)?([0-9]+(\\\\.[0-9]+)?S)?|([0-9]+M)([0-9]+(\\\\.[0-9]+)?S)?|([0-9]+(\\\\.[0-9]+)?S)))?)|(T(([0-9]+H)([0-9]+M)?([0-9]+(\\\\.[0-9]+)?S)?|([0-9]+M)([0-9]+(\\\\.[0-9]+)?S)?|([0-9]+(\\\\.[0-9]+)?S))))',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='day_time_duration_rep',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -8772,9 +13144,46 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='year_month_duration_rep',\n    original_node=...),\n  value=Constant(\n    value='-?P((([0-9]+Y)([0-9]+M)?)|([0-9]+M))',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='year_month_duration_rep',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='year_month_duration_rep',
+              original_node=...),
+            value=Constant(
+              value='-?P((([0-9]+Y)([0-9]+M)?)|([0-9]+M))',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='year_month_duration_rep',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -8799,9 +13208,46 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='integer_rep',\n    original_node=...),\n  value=Constant(\n    value='[\\\\-+]?[0-9]+',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='integer_rep',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='integer_rep',
+              original_node=...),
+            value=Constant(
+              value='[\\\\-+]?[0-9]+',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='integer_rep',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -8826,9 +13272,46 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='long_rep',\n    original_node=...),\n  value=Constant(\n    value='[\\\\-+]?[0-9]+',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='long_rep',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='long_rep',
+              original_node=...),
+            value=Constant(
+              value='[\\\\-+]?[0-9]+',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='long_rep',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -8853,9 +13336,46 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='int_rep',\n    original_node=...),\n  value=Constant(\n    value='[\\\\-+]?[0-9]+',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='int_rep',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='int_rep',
+              original_node=...),
+            value=Constant(
+              value='[\\\\-+]?[0-9]+',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='int_rep',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -8880,9 +13400,46 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='short_rep',\n    original_node=...),\n  value=Constant(\n    value='[\\\\-+]?[0-9]+',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='short_rep',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='short_rep',
+              original_node=...),
+            value=Constant(
+              value='[\\\\-+]?[0-9]+',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='short_rep',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -8907,9 +13464,46 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='byte_rep',\n    original_node=...),\n  value=Constant(\n    value='[\\\\-+]?[0-9]+',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='byte_rep',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='byte_rep',
+              original_node=...),
+            value=Constant(
+              value='[\\\\-+]?[0-9]+',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='byte_rep',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -8934,9 +13528,46 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='non_negative_integer_rep',\n    original_node=...),\n  value=Constant(\n    value='(-0|\\\\+?[0-9]+)',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='non_negative_integer_rep',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='non_negative_integer_rep',
+              original_node=...),
+            value=Constant(
+              value='(-0|\\\\+?[0-9]+)',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='non_negative_integer_rep',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -8961,9 +13592,46 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='positive_integer_rep',\n    original_node=...),\n  value=Constant(\n    value='\\\\+?0*[1-9][0-9]*',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='positive_integer_rep',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='positive_integer_rep',
+              original_node=...),
+            value=Constant(
+              value='\\\\+?0*[1-9][0-9]*',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='positive_integer_rep',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -8988,9 +13656,46 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='unsigned_long_rep',\n    original_node=...),\n  value=Constant(\n    value='(-0|\\\\+?[0-9]+)',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='unsigned_long_rep',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='unsigned_long_rep',
+              original_node=...),
+            value=Constant(
+              value='(-0|\\\\+?[0-9]+)',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='unsigned_long_rep',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -9015,9 +13720,46 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='unsigned_int_rep',\n    original_node=...),\n  value=Constant(\n    value='(-0|\\\\+?[0-9]+)',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='unsigned_int_rep',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='unsigned_int_rep',
+              original_node=...),
+            value=Constant(
+              value='(-0|\\\\+?[0-9]+)',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='unsigned_int_rep',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -9042,9 +13784,46 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='unsigned_short_rep',\n    original_node=...),\n  value=Constant(\n    value='(-0|\\\\+?[0-9]+)',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='unsigned_short_rep',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='unsigned_short_rep',
+              original_node=...),
+            value=Constant(
+              value='(-0|\\\\+?[0-9]+)',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='unsigned_short_rep',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -9069,9 +13848,46 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='unsigned_byte_rep',\n    original_node=...),\n  value=Constant(\n    value='(-0|\\\\+?[0-9]+)',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='unsigned_byte_rep',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='unsigned_byte_rep',
+              original_node=...),
+            value=Constant(
+              value='(-0|\\\\+?[0-9]+)',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='unsigned_byte_rep',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -9096,9 +13912,46 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='non_positive_integer_rep',\n    original_node=...),\n  value=Constant(\n    value='(\\\\+0|0|-[0-9]+)',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='non_positive_integer_rep',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='non_positive_integer_rep',
+              original_node=...),
+            value=Constant(
+              value='(\\\\+0|0|-[0-9]+)',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='non_positive_integer_rep',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     UnderstoodMethod(
@@ -9123,9 +13976,46 @@ UnverifiedSymbolTable(
         snapshots=[],
         postconditions=[]),
       body=[
-        "Assignment(\n  target=Name(\n    identifier='negative_integer_rep',\n    original_node=...),\n  value=Constant(\n    value='(-0*[1-9][0-9]*)',\n    original_node=...),\n  original_node=...)",
-        "Assignment(\n  target=Name(\n    identifier='pattern',\n    original_node=...),\n  value=JoinedStr(\n    values=[\n      '^',\n      FormattedValue(\n        value=Name(\n          identifier='negative_integer_rep',\n          original_node=...),\n        original_node=...),\n      '$'],\n    original_node=...),\n  original_node=...)",
-        "Return(\n  value=IsNotNone(\n    value=FunctionCall(\n      name='match',\n      args=[\n        Name(\n          identifier='pattern',\n          original_node=...),\n        Name(\n          identifier='text',\n          original_node=...)],\n      original_node=...),\n    original_node=...),\n  original_node=...)"],
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='negative_integer_rep',
+              original_node=...),
+            value=Constant(
+              value='(-0*[1-9][0-9]*)',
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Assignment(
+            target=Name(
+              identifier='pattern',
+              original_node=...),
+            value=JoinedStr(
+              values=[
+                '^',
+                FormattedValue(
+                  value=Name(
+                    identifier='negative_integer_rep',
+                    original_node=...),
+                  original_node=...),
+                '$'],
+              original_node=...),
+            original_node=...)"""),
+        textwrap.dedent("""\
+          Return(
+            value=IsNotNone(
+              value=FunctionCall(
+                name='match',
+                args=[
+                  Name(
+                    identifier='pattern',
+                    original_node=...),
+                  Name(
+                    identifier='text',
+                    original_node=...)],
+                original_node=...),
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     ImplementationSpecificMethod(


### PR DESCRIPTION
Currently, stringify outputs a single-line string representation of
text. This makes it very hard to diff test data against changes when we
manually need to inspect it.

Hence we render the multi-line text in the stringified test data as
multi-line string literals to make the diffing easier for the developer.