### PR TITLE
Fix stacking of inferred schema constraints

### DIFF
--- a/aas_core_codegen/infer_for_schema/__init__.py
+++ b/aas_core_codegen/infer_for_schema/__init__.py
@@ -1,15 +1,18 @@
 """Infer constraints representable in common schemas such as JSON Schema or XSD."""
 
-from aas_core_codegen.infer_for_schema import _len, _pattern, _inline, _stringify
+from aas_core_codegen.infer_for_schema import (
+    _len,
+    _pattern,
+    _inline,
+    _stringify,
+    _types,
+)
 
-LenConstraint = _len.LenConstraint
+LenConstraint = _types.LenConstraint
+PatternConstraint = _types.PatternConstraint
+ConstraintsByProperty = _types.ConstraintsByProperty
 
-PatternConstraint = _pattern.PatternConstraint
-
-ConstraintsByProperty = _inline.ConstraintsByProperty
 infer_constraints_by_class = _inline.infer_constraints_by_class
+merge_constraints_with_ancestors = _inline.merge_constraints_with_ancestors
 
 dump = _stringify.dump
-dump_len_constraints_by_properties = _stringify.dump_len_constraints_by_properties
-dump_patterns = _stringify.dump_patterns
-dump_patterns_by_properties = _stringify.dump_patterns_by_properties

--- a/aas_core_codegen/infer_for_schema/_inline.py
+++ b/aas_core_codegen/infer_for_schema/_inline.py
@@ -10,17 +10,18 @@ from aas_core_codegen.infer_for_schema import (
     _len as infer_for_schema_len,
     _pattern as infer_for_schema_pattern,
 )
+from aas_core_codegen.infer_for_schema._types import (
+    ConstraintsByProperty,
+    LenConstraint,
+    PatternConstraint,
+)
 
 
 @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
 def _infer_len_constraints_by_constrained_primitive(
     symbol_table: intermediate.SymbolTable,
 ) -> Tuple[
-    Optional[
-        MutableMapping[
-            intermediate.ConstrainedPrimitive, infer_for_schema_len.LenConstraint
-        ]
-    ],
+    Optional[MutableMapping[intermediate.ConstrainedPrimitive, LenConstraint]],
     Optional[List[Error]],
 ]:
     """Infer the constraints on ``len(.)`` of the constrained primitives."""
@@ -33,8 +34,8 @@ def _infer_len_constraints_by_constrained_primitive(
     errors = []  # type: List[Error]
 
     first_pass: MutableMapping[
-        intermediate.ConstrainedPrimitive, infer_for_schema_len.LenConstraint
-    ] = dict()
+        intermediate.ConstrainedPrimitive, LenConstraint
+    ] = collections.OrderedDict()
 
     for symbol in symbol_table.symbols:
         if isinstance(symbol, intermediate.ConstrainedPrimitive):
@@ -56,8 +57,8 @@ def _infer_len_constraints_by_constrained_primitive(
         return None, errors
 
     second_pass: MutableMapping[
-        intermediate.ConstrainedPrimitive, infer_for_schema_len.LenConstraint
-    ] = dict()
+        intermediate.ConstrainedPrimitive, LenConstraint
+    ] = collections.OrderedDict()
 
     for symbol in symbol_table.symbols_topologically_sorted:
         if isinstance(symbol, intermediate.ConstrainedPrimitive):
@@ -99,9 +100,7 @@ def _infer_len_constraints_by_constrained_primitive(
 def _infer_pattern_constraints_by_constrained_primitive(
     symbol_table: intermediate.SymbolTable,
     pattern_verifications_by_name: infer_for_schema_pattern.PatternVerificationsByName,
-) -> MutableMapping[
-    intermediate.ConstrainedPrimitive, List[infer_for_schema_pattern.PatternConstraint]
-]:
+) -> MutableMapping[intermediate.ConstrainedPrimitive, List[PatternConstraint]]:
     """Infer the pattern constraints of the constrained strings."""
 
     # NOTE (mristin, 2022-02-11):
@@ -111,7 +110,7 @@ def _infer_pattern_constraints_by_constrained_primitive(
 
     first_pass: MutableMapping[
         intermediate.ConstrainedPrimitive,
-        List[infer_for_schema_pattern.PatternConstraint],
+        List[PatternConstraint],
     ] = collections.OrderedDict()
 
     for symbol in symbol_table.symbols:
@@ -128,8 +127,8 @@ def _infer_pattern_constraints_by_constrained_primitive(
 
     second_pass: MutableMapping[
         intermediate.ConstrainedPrimitive,
-        List[infer_for_schema_pattern.PatternConstraint],
-    ] = dict()
+        List[PatternConstraint],
+    ] = collections.OrderedDict()
 
     for symbol in first_pass:
         # NOTE (mristin, 2022-02-11):
@@ -155,28 +154,6 @@ def _infer_pattern_constraints_by_constrained_primitive(
         second_pass[symbol] = pattern_constraints
 
     return second_pass
-
-
-class ConstraintsByProperty:
-    """
-    Represent all the inferred property constraints of a symbol.
-
-    The constraints coming from the constrained primitives are in-lined and hence also
-    included in this representation.
-    """
-
-    def __init__(
-        self,
-        len_constraints_by_property: Mapping[
-            intermediate.Property, infer_for_schema_len.LenConstraint
-        ],
-        patterns_by_property: Mapping[
-            intermediate.Property, Sequence[infer_for_schema_pattern.PatternConstraint]
-        ],
-    ) -> None:
-        """Initialize with the given values."""
-        self.len_constraints_by_property = len_constraints_by_property
-        self.patterns_by_property = patterns_by_property
 
 
 @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
@@ -214,7 +191,9 @@ def infer_constraints_by_class(
         )
     )
 
-    result: MutableMapping[intermediate.ClassUnion, ConstraintsByProperty] = dict()
+    result: MutableMapping[
+        intermediate.ClassUnion, ConstraintsByProperty
+    ] = collections.OrderedDict()
 
     for symbol in symbol_table.symbols:
         if not isinstance(
@@ -225,8 +204,8 @@ def infer_constraints_by_class(
         # region Infer constraints on ``len(.)``
 
         len_constraints_by_property: MutableMapping[
-            intermediate.Property, infer_for_schema_len.LenConstraint
-        ] = dict()
+            intermediate.Property, LenConstraint
+        ] = collections.OrderedDict()
 
         (
             len_constraints_from_invariants,
@@ -240,14 +219,16 @@ def infer_constraints_by_class(
         assert len_constraints_from_invariants is not None
 
         patterns_by_property: MutableMapping[
-            intermediate.Property, List[infer_for_schema_pattern.PatternConstraint]
-        ] = dict()
+            intermediate.Property, List[PatternConstraint]
+        ] = collections.OrderedDict()
 
         patterns_from_invariants_by_property = (
             infer_for_schema_pattern.patterns_from_invariants(
                 cls=symbol, pattern_verifications_by_name=pattern_verifications_by_name
             )
         )
+
+        # region Merge the length constraints
 
         for prop in symbol.properties:
             # NOTE (mristin, 2022-03-03):
@@ -256,9 +237,7 @@ def infer_constraints_by_class(
             # ``Optional``, the client code needs to cover them separately.
             type_anno = intermediate.beneath_optional(prop.type_annotation)
 
-            len_constraint_from_type: Optional[
-                infer_for_schema_len.LenConstraint
-            ] = None
+            len_constraint_from_type: Optional[LenConstraint] = None
 
             len_constraint_from_invariants = len_constraints_from_invariants.get(
                 prop, None
@@ -277,19 +256,27 @@ def infer_constraints_by_class(
                 len_constraint_from_type is None
                 and len_constraint_from_invariants is None
             ):
-                continue
+                pass
 
             elif (
                 len_constraint_from_type is not None
                 and len_constraint_from_invariants is None
             ):
-                len_constraints_by_property[prop] = len_constraint_from_type
+                if (
+                    len_constraint_from_type.min_value is not None
+                    or len_constraint_from_type.max_value is not None
+                ):
+                    len_constraints_by_property[prop] = len_constraint_from_type
 
             elif (
                 len_constraint_from_type is None
                 and len_constraint_from_invariants is not None
             ):
-                len_constraints_by_property[prop] = len_constraint_from_invariants
+                if (
+                    len_constraint_from_invariants.min_value is not None
+                    or len_constraint_from_invariants.max_value is not None
+                ):
+                    len_constraints_by_property[prop] = len_constraint_from_invariants
 
             elif (
                 len_constraint_from_type is not None
@@ -326,9 +313,10 @@ def infer_constraints_by_class(
                     )
                     continue
 
-                len_constraints_by_property[prop] = infer_for_schema_len.LenConstraint(
-                    min_value=min_value, max_value=max_value
-                )
+                if min_value is not None or max_value is not None:
+                    len_constraints_by_property[prop] = LenConstraint(
+                        min_value=min_value, max_value=max_value
+                    )
 
             else:
                 raise AssertionError(
@@ -336,11 +324,18 @@ def infer_constraints_by_class(
                     f"{len_constraint_from_type=}, {len_constraint_from_invariants}"
                 )
 
-            # endregion
+        # endregion
 
-            # region Infer constraints on string patterns
+        # region Infer constraints on string patterns
 
-            patterns_from_type: List[infer_for_schema_pattern.PatternConstraint] = []
+        for prop in symbol.properties:
+            # NOTE (mristin, 2022-03-03):
+            # We need to go beneath ``Optional`` as the constraints are applied even
+            # if a property is optional. In cases where cardinality is affected by
+            # ``Optional``, the client code needs to cover them separately.
+            type_anno = intermediate.beneath_optional(prop.type_annotation)
+
+            patterns_from_type: List[PatternConstraint] = []
             patterns_from_invariants = patterns_from_invariants_by_property.get(
                 prop, []
             )
@@ -368,3 +363,148 @@ def infer_constraints_by_class(
         return None, errors
 
     return result, None
+
+
+@ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
+def merge_constraints_with_ancestors(
+    symbol_table: intermediate.SymbolTable,
+    constraints_by_class: Mapping[intermediate.ClassUnion, ConstraintsByProperty],
+) -> Tuple[
+    Optional[MutableMapping[intermediate.ClassUnion, ConstraintsByProperty]],
+    Optional[Error],
+]:
+    """
+    Merge the constraints over all the classes with their ancestors.
+
+    Usually, when you generate a schema, you do *not* want to inherit the constraints
+    over the properties. Most schema engines will do that for you and you want to be
+    as explicit as possible in the schema for readability (whereas merged constraints
+    might not be as readable, since you do not explicitly see their origin).
+
+    However, for some applications we indeed want to stack the constraints and merge
+    them. For example, this is the case when we (semi-)automatically generate test
+    data. In those cases, you should use this function.
+
+    The length constraints are merged by picking the smaller interval that fits.
+    Patterns are simply stacked together.
+    """
+    new_constraints_by_class: MutableMapping[
+        intermediate.ClassUnion, ConstraintsByProperty
+    ] = collections.OrderedDict()
+
+    for symbol in symbol_table.symbols_topologically_sorted:
+        if not isinstance(
+            symbol, (intermediate.AbstractClass, intermediate.ConcreteClass)
+        ):
+            continue
+
+        this_constraints_by_props = constraints_by_class[symbol]
+
+        new_len_constraints_by_property: MutableMapping[
+            intermediate.Property, LenConstraint
+        ] = collections.OrderedDict()
+
+        new_patterns_by_property: MutableMapping[
+            intermediate.Property, Sequence[PatternConstraint]
+        ] = collections.OrderedDict()
+
+        for prop in symbol.properties:
+            # region Merge len constraints
+
+            len_constraints = []
+
+            this_len_constraint = (
+                this_constraints_by_props.len_constraints_by_property.get(prop, None)
+            )
+            if this_len_constraint is not None:
+                len_constraints.append(this_len_constraint)
+
+            for parent in symbol.inheritances:
+                # NOTE (mristin, 2022-05-15):
+                # Assume here that all the ancestors already inherited their constraints due to
+                # the topological order in the iteration.
+                that_constraints_by_props = new_constraints_by_class[parent]
+
+                that_len_constraint = (
+                    that_constraints_by_props.len_constraints_by_property.get(
+                        prop, None
+                    )
+                )
+                if that_len_constraint is not None:
+                    len_constraints.append(that_len_constraint)
+
+            min_value = None
+            max_value = None
+
+            for len_constraint in len_constraints:
+                if min_value is None:
+                    min_value = len_constraint.min_value
+                else:
+                    if len_constraint.min_value is not None:
+                        min_value = max(len_constraint.min_value, min_value)
+
+                if max_value is None:
+                    max_value = len_constraint.max_value
+                else:
+                    if len_constraint.max_value is not None:
+                        max_value = min(len_constraint.max_value, max_value)
+
+            if (
+                min_value is not None
+                and max_value is not None
+                and min_value > max_value
+            ):
+                return None, Error(
+                    symbol.parsed.node,
+                    f"We could not stack the length constraints "
+                    f"on the property {prop.name} as they are contradicting: "
+                    f"min_value == {min_value} and max_value == {max_value}. "
+                    f"Please check the invariants and the invariants of all "
+                    f"the ancestors.",
+                )
+
+            if min_value is not None or max_value is not None:
+                new_len_constraints_by_property[prop] = LenConstraint(
+                    min_value=min_value, max_value=max_value
+                )
+
+            # endregion
+
+            # region Merge patterns
+
+            # NOTE (mristin, 2022-05-15):
+            # The following logic has quadratic time complexity, but it seems that
+            # the runtime is currently no problem in practice.
+
+            patterns = []  # type: List[PatternConstraint]
+
+            this_patterns = this_constraints_by_props.patterns_by_property.get(
+                prop, None
+            )
+            if this_patterns is not None:
+                patterns.extend(this_patterns)
+
+            for parent in symbol.inheritances:
+                # NOTE (mristin, 2022-05-15):
+                # Assume here that all the ancestors already inherited their constraints due to
+                # the topological order in the iteration.
+                that_constraints_by_props = new_constraints_by_class[parent]
+
+                that_patterns = that_constraints_by_props.patterns_by_property.get(
+                    prop, None
+                )
+
+                if that_patterns is not None:
+                    patterns.extend(that_patterns)
+
+            if len(patterns) > 0:
+                new_patterns_by_property[prop] = patterns
+
+            # endregion
+
+        new_constraints_by_class[symbol] = ConstraintsByProperty(
+            len_constraints_by_property=new_len_constraints_by_property,
+            patterns_by_property=new_patterns_by_property,
+        )
+
+    return new_constraints_by_class, None

--- a/aas_core_codegen/infer_for_schema/_len.py
+++ b/aas_core_codegen/infer_for_schema/_len.py
@@ -11,6 +11,7 @@ from aas_core_codegen.common import (
     assert_union_of_descendants_exhaustive,
 )
 from aas_core_codegen.infer_for_schema import _common as infer_for_schema_common
+from aas_core_codegen.infer_for_schema._types import LenConstraint
 from aas_core_codegen.parse import tree as parse_tree
 
 
@@ -240,35 +241,6 @@ def max_with_none(*args: Optional[int]) -> Optional[int]:
                 maximum = max(arg, maximum)
 
     return maximum
-
-
-class LenConstraint:
-    """
-    Represent the inferred constraint on the ``len`` of something.
-
-    Both bounds are inclusive: ``min_value ≤ len ≤ max_value``.
-    """
-
-    # fmt: off
-    @require(
-        lambda min_value, max_value:
-        not (min_value is not None and max_value is not None)
-        or 0 < min_value <= max_value
-    )
-    # fmt: on
-    def __init__(self, min_value: Optional[int], max_value: Optional[int]) -> None:
-        """Initialize with the given values."""
-        self.min_value = min_value
-        self.max_value = max_value
-
-    def copy(self) -> "LenConstraint":
-        """Create a copy of the self."""
-        return LenConstraint(min_value=self.min_value, max_value=self.max_value)
-
-    def __str__(self) -> str:
-        return (
-            f"LenConstraint(min_value={self.min_value!r}, max_value={self.max_value!r})"
-        )
 
 
 class _LenConstraintOnProperty:

--- a/aas_core_codegen/infer_for_schema/_pattern.py
+++ b/aas_core_codegen/infer_for_schema/_pattern.py
@@ -14,6 +14,7 @@ from icontract import require
 from aas_core_codegen import intermediate
 from aas_core_codegen.common import Identifier
 from aas_core_codegen.infer_for_schema import _common as infer_for_schema_common
+from aas_core_codegen.infer_for_schema._types import PatternConstraint
 from aas_core_codegen.parse import tree as parse_tree
 
 
@@ -65,14 +66,6 @@ def map_pattern_verifications_by_name(
             result[verification.name] = verification
 
     return PatternVerificationsByName(result)
-
-
-class PatternConstraint:
-    """Constrain a string to comply to a regular expression."""
-
-    def __init__(self, pattern: str) -> None:
-        """Initialize with the given values."""
-        self.pattern = pattern
 
 
 class _ConstraintOnProperty:

--- a/aas_core_codegen/infer_for_schema/_types.py
+++ b/aas_core_codegen/infer_for_schema/_types.py
@@ -1,0 +1,63 @@
+"""Provide data structures for the constraint inferences."""
+from typing import Mapping, Sequence, Optional
+
+from icontract import require
+
+from aas_core_codegen import intermediate
+
+
+class LenConstraint:
+    """
+    Represent the inferred constraint on the ``len`` of something.
+
+    Both bounds are inclusive: ``min_value ≤ len ≤ max_value``.
+    """
+
+    # fmt: off
+    @require(
+        lambda min_value, max_value:
+        not (min_value is not None and max_value is not None)
+        or 0 < min_value <= max_value
+    )
+    # fmt: on
+    def __init__(self, min_value: Optional[int], max_value: Optional[int]) -> None:
+        """Initialize with the given values."""
+        self.min_value = min_value
+        self.max_value = max_value
+
+    def copy(self) -> "LenConstraint":
+        """Create a copy of the self."""
+        return LenConstraint(min_value=self.min_value, max_value=self.max_value)
+
+    def __str__(self) -> str:
+        return (
+            f"LenConstraint(min_value={self.min_value!r}, max_value={self.max_value!r})"
+        )
+
+
+class PatternConstraint:
+    """Constrain a string to comply to a regular expression."""
+
+    def __init__(self, pattern: str) -> None:
+        """Initialize with the given values."""
+        self.pattern = pattern
+
+
+class ConstraintsByProperty:
+    """
+    Represent all the inferred property constraints of a symbol.
+
+    The constraints coming from the constrained primitives are in-lined and hence also
+    included in this representation.
+    """
+
+    def __init__(
+        self,
+        len_constraints_by_property: Mapping[intermediate.Property, LenConstraint],
+        patterns_by_property: Mapping[
+            intermediate.Property, Sequence[PatternConstraint]
+        ],
+    ) -> None:
+        """Initialize with the given values."""
+        self.len_constraints_by_property = len_constraints_by_property
+        self.patterns_by_property = patterns_by_property

--- a/aas_core_codegen/stringify.py
+++ b/aas_core_codegen/stringify.py
@@ -22,6 +22,8 @@ Stringifiable = Union[
     PrimitiveStringifiable,
     Sequence[PrimitiveStringifiable],
     Sequence[Sequence[PrimitiveStringifiable]],
+    Mapping[str, PrimitiveStringifiable],
+    Mapping[str, Sequence[PrimitiveStringifiable]],
 ]
 
 
@@ -126,6 +128,25 @@ def dump(stringifiable: Stringifiable) -> str:
 
                 if i == len(stringifiable) - 1:
                     writer.write("]")
+                else:
+                    writer.write(",\n")
+
+            return writer.getvalue()
+
+    elif isinstance(stringifiable, collections.abc.Mapping):
+        if len(stringifiable) == 0:
+            return "{}"
+        else:
+            writer = io.StringIO()
+            writer.write("{\n")
+            for i, (key, value) in enumerate(stringifiable.items()):
+                key_str = dump(key)
+
+                value_str = dump(value)
+                writer.write(textwrap.indent(f"{key_str}: {value_str}", "  "))
+
+                if i == len(stringifiable) - 1:
+                    writer.write("}")
                 else:
                     writer.write(",\n")
 

--- a/test_data/xsd/test_main/aas_core_meta.v3rc2/expected_output/schema.xsd
+++ b/test_data/xsd/test_main/aas_core_meta.v3rc2/expected_output/schema.xsd
@@ -102,11 +102,7 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="value" minOccurs="0">
-        <xs:simpleType>
-          <xs:restriction base="xs:base64Binary"/>
-        </xs:simpleType>
-      </xs:element>
+      <xs:element name="value" type="xs:base64Binary" minOccurs="0"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="capability">
@@ -239,11 +235,7 @@
         </xs:simpleType>
       </xs:element>
       <xs:element name="valueType" type="dataTypeDefXsd_t" minOccurs="0"/>
-      <xs:element name="value" minOccurs="0">
-        <xs:simpleType>
-          <xs:restriction base="xs:string"/>
-        </xs:simpleType>
-      </xs:element>
+      <xs:element name="value" type="xs:string" minOccurs="0"/>
       <xs:element name="refersTo" type="modelReference_t" minOccurs="0"/>
     </xs:sequence>
   </xs:group>
@@ -528,11 +520,7 @@
     <xs:sequence>
       <xs:group ref="dataElement"/>
       <xs:element name="valueType" type="dataTypeDefXsd_t"/>
-      <xs:element name="value" minOccurs="0">
-        <xs:simpleType>
-          <xs:restriction base="xs:string"/>
-        </xs:simpleType>
-      </xs:element>
+      <xs:element name="value" type="xs:string" minOccurs="0"/>
       <xs:element name="valueId" type="globalReference_t" minOccurs="0"/>
     </xs:sequence>
   </xs:group>
@@ -576,11 +564,7 @@
         </xs:simpleType>
       </xs:element>
       <xs:element name="valueType" type="dataTypeDefXsd_t"/>
-      <xs:element name="value" minOccurs="0">
-        <xs:simpleType>
-          <xs:restriction base="xs:string"/>
-        </xs:simpleType>
-      </xs:element>
+      <xs:element name="value" type="xs:string" minOccurs="0"/>
       <xs:element name="valueId" type="globalReference_t" minOccurs="0"/>
     </xs:sequence>
   </xs:group>
@@ -588,16 +572,8 @@
     <xs:sequence>
       <xs:group ref="dataElement"/>
       <xs:element name="valueType" type="dataTypeDefXsd_t"/>
-      <xs:element name="min" minOccurs="0">
-        <xs:simpleType>
-          <xs:restriction base="xs:string"/>
-        </xs:simpleType>
-      </xs:element>
-      <xs:element name="max" minOccurs="0">
-        <xs:simpleType>
-          <xs:restriction base="xs:string"/>
-        </xs:simpleType>
-      </xs:element>
+      <xs:element name="min" type="xs:string" minOccurs="0"/>
+      <xs:element name="max" type="xs:string" minOccurs="0"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="referable">

--- a/tests/infer_for_schema/common.py
+++ b/tests/infer_for_schema/common.py
@@ -1,0 +1,50 @@
+"""Provide functions shared among the tests."""
+from typing import Tuple, MutableMapping
+
+import tests.common
+from aas_core_codegen import intermediate, infer_for_schema
+from aas_core_codegen.common import Identifier
+
+
+def parse_to_symbol_table_and_something_cls(
+    source: str,
+) -> Tuple[intermediate.SymbolTable, intermediate.ClassUnion]:
+    """
+    Parse the ``source``.
+
+    Return the symbol table and the symbol corresponding to the class ``Something``
+    in the ``source``.
+    """
+    symbol_table, error = tests.common.translate_source_to_intermediate(source=source)
+    assert error is None, tests.common.most_underlying_messages(error)
+    assert symbol_table is not None
+    something_cls = symbol_table.must_find(Identifier("Something"))
+    assert isinstance(
+        something_cls, (intermediate.AbstractClass, intermediate.ConcreteClass)
+    )
+
+    return symbol_table, something_cls
+
+
+def parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+    source: str,
+) -> Tuple[
+    intermediate.SymbolTable,
+    intermediate.ClassUnion,
+    MutableMapping[intermediate.ClassUnion, infer_for_schema.ConstraintsByProperty],
+]:
+    """
+    Parse the ``source``.
+
+    Return the symbol table and the symbol corresponding to the class ``Something``
+    in the ``source`` as well as the the inferred constraints mapped by classes.
+    """
+    symbol_table, something_cls = parse_to_symbol_table_and_something_cls(source=source)
+
+    constraints_by_class, error = infer_for_schema.infer_constraints_by_class(
+        symbol_table=symbol_table
+    )
+    assert error is None, tests.common.most_underlying_messages(error)
+    assert constraints_by_class is not None
+
+    return symbol_table, something_cls, constraints_by_class

--- a/tests/infer_for_schema/test_len_on_properties.py
+++ b/tests/infer_for_schema/test_len_on_properties.py
@@ -2,33 +2,11 @@
 
 import textwrap
 import unittest
-from typing import Tuple, Optional, MutableMapping, List
-
-from icontract import ensure
+from typing import Optional, MutableMapping
 
 import tests.common
-from aas_core_codegen import intermediate, infer_for_schema
-from aas_core_codegen.infer_for_schema import _len as infer_for_schema_len
-from aas_core_codegen.common import Identifier, Error
-
-
-@ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
-def infer_constraints_by_properties_of_class_something(
-    source: str,
-) -> Tuple[
-    Optional[MutableMapping[intermediate.Property, infer_for_schema_len.LenConstraint]],
-    Optional[List[Error]],
-]:
-    """Translate the ``source`` into inferred constraints of the class ``Something``."""
-    symbol_table, error = tests.common.translate_source_to_intermediate(source=source)
-    assert error is None, tests.common.most_underlying_messages(error)
-    assert symbol_table is not None
-    symbol = symbol_table.must_find(Identifier("Something"))
-    assert isinstance(symbol, intermediate.Class)
-
-    result = infer_for_schema_len.len_constraints_from_invariants(cls=symbol)
-
-    return result
+import tests.infer_for_schema.common
+from aas_core_codegen import infer_for_schema, intermediate
 
 
 class Test_expected(unittest.TestCase):
@@ -46,15 +24,26 @@ class Test_expected(unittest.TestCase):
             """
         )
 
-        by_props, errors = infer_constraints_by_properties_of_class_something(
+        (
+            _,
+            something_cls,
+            constraints_by_class,
+        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
             source=source
         )
 
-        assert errors is None, tests.common.most_underlying_messages(errors)
-        assert by_props is not None
+        constraints_by_props = constraints_by_class[something_cls]
 
-        text = infer_for_schema.dump_len_constraints_by_properties(by_props)
-        self.assertEqual("{}", text)
+        text = infer_for_schema.dump(constraints_by_props)
+        self.assertEqual(
+            textwrap.dedent(
+                """\
+                ConstraintsByProperty(
+                  len_constraints_by_property={},
+                  patterns_by_property={})"""
+            ),
+            text,
+        )
 
     def test_min_value_constant_left(self) -> None:
         source = textwrap.dedent(
@@ -72,23 +61,26 @@ class Test_expected(unittest.TestCase):
             """
         )
 
-        by_props, errors = infer_constraints_by_properties_of_class_something(
+        (
+            _,
+            something_cls,
+            constraints_by_class,
+        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
             source=source
         )
 
-        assert errors is None, tests.common.most_underlying_messages(errors)
-        assert by_props is not None
+        constraints_by_props = constraints_by_class[something_cls]
 
-        text = infer_for_schema.dump_len_constraints_by_properties(by_props)
+        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
             textwrap.dedent(
                 """\
-            {
-              'some_property':
-              LenConstraint(
-                min_value=11,
-                max_value=None)
-            }"""
+                ConstraintsByProperty(
+                  len_constraints_by_property={
+                    'some_property': LenConstraint(
+                      min_value=11,
+                      max_value=None)},
+                  patterns_by_property={})"""
             ),
             text,
         )
@@ -109,23 +101,26 @@ class Test_expected(unittest.TestCase):
             """
         )
 
-        by_props, errors = infer_constraints_by_properties_of_class_something(
+        (
+            _,
+            something_cls,
+            constraints_by_class,
+        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
             source=source
         )
 
-        assert errors is None, tests.common.most_underlying_messages(errors)
-        assert by_props is not None
+        constraints_by_props = constraints_by_class[something_cls]
 
-        text = infer_for_schema.dump_len_constraints_by_properties(by_props)
+        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
             textwrap.dedent(
                 """\
-            {
-              'some_property':
-              LenConstraint(
-                min_value=11,
-                max_value=None)
-            }"""
+                ConstraintsByProperty(
+                  len_constraints_by_property={
+                    'some_property': LenConstraint(
+                      min_value=11,
+                      max_value=None)},
+                  patterns_by_property={})"""
             ),
             text,
         )
@@ -146,23 +141,26 @@ class Test_expected(unittest.TestCase):
             """
         )
 
-        by_props, errors = infer_constraints_by_properties_of_class_something(
+        (
+            _,
+            something_cls,
+            constraints_by_class,
+        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
             source=source
         )
 
-        assert errors is None, tests.common.most_underlying_messages(errors)
-        assert by_props is not None
+        constraints_by_props = constraints_by_class[something_cls]
 
-        text = infer_for_schema.dump_len_constraints_by_properties(by_props)
+        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
             textwrap.dedent(
                 """\
-            {
-              'some_property':
-              LenConstraint(
-                min_value=None,
-                max_value=9)
-            }"""
+                ConstraintsByProperty(
+                  len_constraints_by_property={
+                    'some_property': LenConstraint(
+                      min_value=None,
+                      max_value=9)},
+                  patterns_by_property={})"""
             ),
             text,
         )
@@ -183,23 +181,70 @@ class Test_expected(unittest.TestCase):
             """
         )
 
-        by_props, errors = infer_constraints_by_properties_of_class_something(
+        (
+            _,
+            something_cls,
+            constraints_by_class,
+        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
             source=source
         )
 
-        assert errors is None, tests.common.most_underlying_messages(errors)
-        assert by_props is not None
+        constraints_by_props = constraints_by_class[something_cls]
 
-        text = infer_for_schema.dump_len_constraints_by_properties(by_props)
+        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
             textwrap.dedent(
                 """\
-            {
-              'some_property':
-              LenConstraint(
-                min_value=None,
-                max_value=9)
-            }"""
+                ConstraintsByProperty(
+                  len_constraints_by_property={
+                    'some_property': LenConstraint(
+                      min_value=None,
+                      max_value=9)},
+                  patterns_by_property={})"""
+            ),
+            text,
+        )
+
+    def test_max_value_constant_right_and_not_required(self) -> None:
+        source = textwrap.dedent(
+            """\
+            @invariant(
+                lambda self:
+                not (self.some_property is not None)
+                or len(self.some_property) <= 128
+            )
+            class Something:
+                some_property: str
+
+                def __init__(self, some_property: str) -> None:
+                    self.some_property = some_property
+
+
+            __book_url__ = "dummy"
+            __book_version__ = "dummy"
+            """
+        )
+
+        (
+            _,
+            something_cls,
+            constraints_by_class,
+        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+            source=source
+        )
+
+        constraints_by_props = constraints_by_class[something_cls]
+
+        text = infer_for_schema.dump(constraints_by_props)
+        self.assertEqual(
+            textwrap.dedent(
+                """\
+                ConstraintsByProperty(
+                  len_constraints_by_property={
+                    'some_property': LenConstraint(
+                      min_value=None,
+                      max_value=128)},
+                  patterns_by_property={})"""
             ),
             text,
         )
@@ -220,23 +265,26 @@ class Test_expected(unittest.TestCase):
             """
         )
 
-        by_props, errors = infer_constraints_by_properties_of_class_something(
+        (
+            _,
+            something_cls,
+            constraints_by_class,
+        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
             source=source
         )
 
-        assert errors is None, tests.common.most_underlying_messages(errors)
-        assert by_props is not None
+        constraints_by_props = constraints_by_class[something_cls]
 
-        text = infer_for_schema.dump_len_constraints_by_properties(by_props)
+        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
             textwrap.dedent(
                 """\
-            {
-              'some_property':
-              LenConstraint(
-                min_value=10,
-                max_value=10)
-            }"""
+                ConstraintsByProperty(
+                  len_constraints_by_property={
+                    'some_property': LenConstraint(
+                      min_value=10,
+                      max_value=10)},
+                  patterns_by_property={})"""
             ),
             text,
         )
@@ -257,23 +305,26 @@ class Test_expected(unittest.TestCase):
             """
         )
 
-        by_props, errors = infer_constraints_by_properties_of_class_something(
+        (
+            _,
+            something_cls,
+            constraints_by_class,
+        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
             source=source
         )
 
-        assert errors is None, tests.common.most_underlying_messages(errors)
-        assert by_props is not None
+        constraints_by_props = constraints_by_class[something_cls]
 
-        text = infer_for_schema.dump_len_constraints_by_properties(by_props)
+        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
             textwrap.dedent(
                 """\
-            {
-              'some_property':
-              LenConstraint(
-                min_value=10,
-                max_value=10)
-            }"""
+                ConstraintsByProperty(
+                  len_constraints_by_property={
+                    'some_property': LenConstraint(
+                      min_value=10,
+                      max_value=10)},
+                  patterns_by_property={})"""
             ),
             text,
         )
@@ -298,28 +349,31 @@ class Test_expected(unittest.TestCase):
             """
         )
 
-        by_props, errors = infer_constraints_by_properties_of_class_something(
+        (
+            _,
+            something_cls,
+            constraints_by_class,
+        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
             source=source
         )
 
-        assert errors is None, tests.common.most_underlying_messages(errors)
-        assert by_props is not None
+        constraints_by_props = constraints_by_class[something_cls]
 
-        text = infer_for_schema.dump_len_constraints_by_properties(by_props)
+        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
             textwrap.dedent(
                 """\
-            {
-              'some_property':
-              LenConstraint(
-                min_value=10,
-                max_value=10)
-            }"""
+                ConstraintsByProperty(
+                  len_constraints_by_property={
+                    'some_property': LenConstraint(
+                      min_value=10,
+                      max_value=10)},
+                  patterns_by_property={})"""
             ),
             text,
         )
 
-    def test_inheritance(self) -> None:
+    def test_no_inheritance_by_default(self) -> None:
         source = textwrap.dedent(
             """\
             @invariant(lambda self: len(self.some_property) > 3)
@@ -344,28 +398,34 @@ class Test_expected(unittest.TestCase):
             """
         )
 
-        by_props, errors = infer_constraints_by_properties_of_class_something(
-            source=source
-        )
-
-        assert errors is None, tests.common.most_underlying_messages(errors)
-        assert by_props is not None
-
         # NOTE (mristin, 2022-01-02):
         # We infer only the constraints as specified in the class itself, and
         # ignore the constraints of the ancestors in *this particular kind of
         # inference*.
+        #
+        # This is necessary as we want to use these constraints to generate schemas
+        # whereas it is the job of the schema engine to stack the constraints together.
 
-        text = infer_for_schema.dump_len_constraints_by_properties(by_props)
+        (
+            _,
+            something_cls,
+            constraints_by_class,
+        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+            source=source
+        )
+
+        constraints_by_props = constraints_by_class[something_cls]
+
+        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
             textwrap.dedent(
                 """\
-                {
-                  'some_property':
-                  LenConstraint(
-                    min_value=6,
-                    max_value=None)
-                }"""
+                ConstraintsByProperty(
+                  len_constraints_by_property={
+                    'some_property': LenConstraint(
+                      min_value=6,
+                      max_value=None)},
+                  patterns_by_property={})"""
             ),
             text,
         )
@@ -389,13 +449,22 @@ class Test_unexpected(unittest.TestCase):
             """
         )
 
-        _, errors = infer_constraints_by_properties_of_class_something(source=source)
+        (
+            symbol_table,
+            _,
+        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls(
+            source=source
+        )
 
-        assert errors is not None
+        _, error = infer_for_schema.infer_constraints_by_class(
+            symbol_table=symbol_table
+        )
+
+        assert error is not None
         self.assertEqual(
             "The property some_property has conflicting invariants on the length: "
             "the minimum length, 11, contradicts the maximum length 2.",
-            tests.common.most_underlying_messages(errors),
+            tests.common.most_underlying_messages(error),
         )
 
     def test_conflicting_min_and_exact(self) -> None:
@@ -415,13 +484,22 @@ class Test_unexpected(unittest.TestCase):
             """
         )
 
-        _, errors = infer_constraints_by_properties_of_class_something(source=source)
+        (
+            symbol_table,
+            _,
+        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls(
+            source=source
+        )
 
-        assert errors is not None
+        _, error = infer_for_schema.infer_constraints_by_class(
+            symbol_table=symbol_table
+        )
+
+        assert error is not None
         self.assertEqual(
             "The property some_property has conflicting invariants on the length: "
             "the minimum length, 11, contradicts the exactly expected length 3.",
-            tests.common.most_underlying_messages(errors),
+            tests.common.most_underlying_messages(error),
         )
 
     def test_conflicting_max_and_exact(self) -> None:
@@ -441,13 +519,203 @@ class Test_unexpected(unittest.TestCase):
             """
         )
 
-        _, errors = infer_constraints_by_properties_of_class_something(source=source)
+        (
+            symbol_table,
+            _,
+        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls(
+            source=source
+        )
 
-        assert errors is not None
+        _, error = infer_for_schema.infer_constraints_by_class(
+            symbol_table=symbol_table
+        )
+
+        assert error is not None
         self.assertEqual(
             "The property some_property has conflicting invariants on the length: "
             "the maximum length, 9, contradicts the exactly expected length 30.",
-            tests.common.most_underlying_messages(errors),
+            tests.common.most_underlying_messages(error),
+        )
+
+
+class Test_stacking(unittest.TestCase):
+    def test_no_inheritance_involved(self) -> None:
+        source = textwrap.dedent(
+            """\
+            @invariant(lambda self: len(self.some_property) < 10)
+            class Something:
+                some_property: str
+
+                def __init__(self, some_property: str) -> None:
+                    self.some_property = some_property
+
+
+            __book_url__ = "dummy"
+            __book_version__ = "dummy"
+            """
+        )
+
+        # NOTE (mristin, 2022-05-18):
+        # This definition here is necessary for mypy.
+        constraints_by_class: Optional[
+            MutableMapping[
+                intermediate.ClassUnion, infer_for_schema.ConstraintsByProperty
+            ]
+        ] = None
+
+        (
+            symbol_table,
+            something_cls,
+            constraints_by_class,
+        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+            source=source
+        )
+
+        constraints_by_class, error = infer_for_schema.merge_constraints_with_ancestors(
+            symbol_table=symbol_table, constraints_by_class=constraints_by_class
+        )
+        assert error is None, tests.common.most_underlying_messages(error)
+        assert constraints_by_class is not None
+
+        constraints_by_props = constraints_by_class[something_cls]
+
+        text = infer_for_schema.dump(constraints_by_props)
+        self.assertEqual(
+            textwrap.dedent(
+                """\
+                ConstraintsByProperty(
+                  len_constraints_by_property={
+                    'some_property': LenConstraint(
+                      min_value=None,
+                      max_value=9)},
+                  patterns_by_property={})"""
+            ),
+            text,
+        )
+
+    def test_inheritance_from_parent_with_no_patterns_of_own(self) -> None:
+        source = textwrap.dedent(
+            """\
+            @invariant(lambda self: len(self.some_property) > 3)
+            class Parent:
+                some_property: str
+
+                def __init__(self, some_property: str) -> None:
+                    self.some_property = some_property
+
+
+            class Something(Parent):
+                def __init__(self, some_property: str) -> None:
+                    Parent.__init__(
+                        self,
+                        some_property=some_property
+                    )
+
+
+            __book_url__ = "dummy"
+            __book_version__ = "dummy"
+            """
+        )
+
+        # NOTE (mristin, 2022-05-18):
+        # This definition here is necessary for mypy.
+        constraints_by_class: Optional[
+            MutableMapping[
+                intermediate.ClassUnion, infer_for_schema.ConstraintsByProperty
+            ]
+        ] = None
+
+        (
+            symbol_table,
+            something_cls,
+            constraints_by_class,
+        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+            source=source
+        )
+
+        constraints_by_class, error = infer_for_schema.merge_constraints_with_ancestors(
+            symbol_table=symbol_table, constraints_by_class=constraints_by_class
+        )
+        assert error is None, tests.common.most_underlying_messages(error)
+        assert constraints_by_class is not None
+
+        constraints_by_props = constraints_by_class[something_cls]
+
+        text = infer_for_schema.dump(constraints_by_props)
+        self.assertEqual(
+            textwrap.dedent(
+                """\
+                ConstraintsByProperty(
+                  len_constraints_by_property={
+                    'some_property': LenConstraint(
+                      min_value=4,
+                      max_value=None)},
+                  patterns_by_property={})"""
+            ),
+            text,
+        )
+
+    def test_merge_with_parent(self) -> None:
+        source = textwrap.dedent(
+            """\
+            @invariant(lambda self: len(self.some_property) > 3)
+            class Parent:
+                some_property: str
+
+                def __init__(self, some_property: str) -> None:
+                    self.some_property = some_property
+
+
+            @invariant(lambda self: len(self.some_property) < 10)
+            class Something(Parent):
+                def __init__(self, some_property: str) -> None:
+                    Parent.__init__(
+                        self,
+                        some_property=some_property
+                    )
+
+
+            __book_url__ = "dummy"
+            __book_version__ = "dummy"
+            """
+        )
+
+        # NOTE (mristin, 2022-05-18):
+        # This definition here is necessary for mypy.
+        constraints_by_class: Optional[
+            MutableMapping[
+                intermediate.ClassUnion, infer_for_schema.ConstraintsByProperty
+            ]
+        ] = None
+
+        (
+            symbol_table,
+            something_cls,
+            constraints_by_class,
+        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+            source=source
+        )
+
+        constraints_by_class, error = infer_for_schema.merge_constraints_with_ancestors(
+            symbol_table=symbol_table, constraints_by_class=constraints_by_class
+        )
+        assert error is None, tests.common.most_underlying_messages(error)
+        assert constraints_by_class is not None
+
+        constraints_by_props = constraints_by_class[something_cls]
+
+        text = infer_for_schema.dump(constraints_by_props)
+        self.assertEqual(
+            textwrap.dedent(
+                """\
+                ConstraintsByProperty(
+                  len_constraints_by_property={
+                    'some_property': LenConstraint(
+                      min_value=4,
+                      max_value=9)},
+                  patterns_by_property={})"""
+            ),
+            text,
         )
 
 

--- a/tests/infer_for_schema/test_len_on_self.py
+++ b/tests/infer_for_schema/test_len_on_self.py
@@ -2,58 +2,48 @@
 
 import textwrap
 import unittest
-from typing import Tuple, Optional, MutableMapping, List
-
-from icontract import ensure
 
 import tests.common
-from aas_core_codegen import intermediate, infer_for_schema
-from aas_core_codegen.infer_for_schema import _len as infer_for_schema_len
-from aas_core_codegen.common import Identifier, Error
-
-
-@ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
-def infer_constraints_on_self_of_class_something(
-    source: str,
-) -> Tuple[Optional[infer_for_schema_len.LenConstraint], Optional[List[Error]]]:
-    """Translate the ``source`` into inferred constraints on the class ``Something``."""
-    symbol_table, error = tests.common.translate_source_to_intermediate(source=source)
-    assert error is None, tests.common.most_underlying_messages(error)
-    assert symbol_table is not None
-    symbol = symbol_table.must_find(Identifier("Something"))
-    assert isinstance(symbol, intermediate.ConstrainedPrimitive)
-
-    result = infer_for_schema_len.infer_len_constraint_of_self(
-        constrained_primitive=symbol
-    )
-
-    return result
+import tests.infer_for_schema.common
+from aas_core_codegen import infer_for_schema
 
 
 class Test_expected(unittest.TestCase):
     def test_no_constraints(self) -> None:
         source = textwrap.dedent(
             """\
-            class Something(str):
+            class Some_constrained_primitive(str):
                 pass
+
+
+            class Something:
+                some_property: Some_constrained_primitive
+
+                def __init__(self, some_property: Some_constrained_primitive) -> None:
+                    self.some_property = some_property
+
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             """
         )
 
-        constraint, errors = infer_constraints_on_self_of_class_something(source=source)
+        (
+            _,
+            something_cls,
+            constraints_by_class,
+        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+            source=source
+        )
 
-        assert errors is None, tests.common.most_underlying_messages(errors)
-        assert constraint is not None
-
-        text = infer_for_schema.dump(constraint)
+        constraints_by_props = constraints_by_class[something_cls]
+        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
             textwrap.dedent(
                 """\
-                LenConstraint(
-                  min_value=None,
-                  max_value=None)"""
+                ConstraintsByProperty(
+                  len_constraints_by_property={},
+                  patterns_by_property={})"""
             ),
             text,
         )
@@ -62,26 +52,41 @@ class Test_expected(unittest.TestCase):
         source = textwrap.dedent(
             """\
             @invariant(lambda self: 10 < len(self))
-            class Something(str):
+            class Some_constrained_primitive(str):
                 pass
+
+
+            class Something:
+                some_property: Some_constrained_primitive
+
+                def __init__(self, some_property: Some_constrained_primitive) -> None:
+                    self.some_property = some_property
+
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             """
         )
 
-        constraint, errors = infer_constraints_on_self_of_class_something(source=source)
+        (
+            _,
+            something_cls,
+            constraints_by_class,
+        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+            source=source
+        )
 
-        assert errors is None, tests.common.most_underlying_messages(errors)
-        assert constraint is not None
-
-        text = infer_for_schema.dump(constraint)
+        constraints_by_props = constraints_by_class[something_cls]
+        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
             textwrap.dedent(
                 """\
-                LenConstraint(
-                  min_value=11,
-                  max_value=None)"""
+                ConstraintsByProperty(
+                  len_constraints_by_property={
+                    'some_property': LenConstraint(
+                      min_value=11,
+                      max_value=None)},
+                  patterns_by_property={})"""
             ),
             text,
         )
@@ -90,26 +95,41 @@ class Test_expected(unittest.TestCase):
         source = textwrap.dedent(
             """\
             @invariant(lambda self: len(self) > 10)
-            class Something(str):
+            class Some_constrained_primitive(str):
                 pass
+
+
+            class Something:
+                some_property: Some_constrained_primitive
+
+                def __init__(self, some_property: Some_constrained_primitive) -> None:
+                    self.some_property = some_property
+
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             """
         )
 
-        constraint, errors = infer_constraints_on_self_of_class_something(source=source)
+        (
+            _,
+            something_cls,
+            constraints_by_class,
+        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+            source=source
+        )
 
-        assert errors is None, tests.common.most_underlying_messages(errors)
-        assert constraint is not None
-
-        text = infer_for_schema.dump(constraint)
+        constraints_by_props = constraints_by_class[something_cls]
+        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
             textwrap.dedent(
                 """\
-                LenConstraint(
-                  min_value=11,
-                  max_value=None)"""
+                ConstraintsByProperty(
+                  len_constraints_by_property={
+                    'some_property': LenConstraint(
+                      min_value=11,
+                      max_value=None)},
+                  patterns_by_property={})"""
             ),
             text,
         )
@@ -118,26 +138,41 @@ class Test_expected(unittest.TestCase):
         source = textwrap.dedent(
             """\
             @invariant(lambda self: len(self) < 10)
-            class Something(str):
+            class Some_constrained_primitive(str):
                 pass
+
+
+            class Something:
+                some_property: Some_constrained_primitive
+
+                def __init__(self, some_property: Some_constrained_primitive) -> None:
+                    self.some_property = some_property
+
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             """
         )
 
-        constraint, errors = infer_constraints_on_self_of_class_something(source=source)
+        (
+            _,
+            something_cls,
+            constraints_by_class,
+        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+            source=source
+        )
 
-        assert errors is None, tests.common.most_underlying_messages(errors)
-        assert constraint is not None
-
-        text = infer_for_schema.dump(constraint)
+        constraints_by_props = constraints_by_class[something_cls]
+        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
             textwrap.dedent(
                 """\
-                LenConstraint(
-                  min_value=None,
-                  max_value=9)"""
+                ConstraintsByProperty(
+                  len_constraints_by_property={
+                    'some_property': LenConstraint(
+                      min_value=None,
+                      max_value=9)},
+                  patterns_by_property={})"""
             ),
             text,
         )
@@ -146,26 +181,41 @@ class Test_expected(unittest.TestCase):
         source = textwrap.dedent(
             """\
             @invariant(lambda self: 10 > len(self))
-            class Something(str):
+            class Some_constrained_primitive(str):
                 pass
+
+
+            class Something:
+                some_property: Some_constrained_primitive
+
+                def __init__(self, some_property: Some_constrained_primitive) -> None:
+                    self.some_property = some_property
+
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             """
         )
 
-        constraint, errors = infer_constraints_on_self_of_class_something(source=source)
+        (
+            _,
+            something_cls,
+            constraints_by_class,
+        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+            source=source
+        )
 
-        assert errors is None, tests.common.most_underlying_messages(errors)
-        assert constraint is not None
-
-        text = infer_for_schema.dump(constraint)
+        constraints_by_props = constraints_by_class[something_cls]
+        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
             textwrap.dedent(
                 """\
-                LenConstraint(
-                  min_value=None,
-                  max_value=9)"""
+                ConstraintsByProperty(
+                  len_constraints_by_property={
+                    'some_property': LenConstraint(
+                      min_value=None,
+                      max_value=9)},
+                  patterns_by_property={})"""
             ),
             text,
         )
@@ -174,26 +224,41 @@ class Test_expected(unittest.TestCase):
         source = textwrap.dedent(
             """\
             @invariant(lambda self: 10 == len(self))
-            class Something(str):
+            class Some_constrained_primitive(str):
                 pass
+
+
+            class Something:
+                some_property: Some_constrained_primitive
+
+                def __init__(self, some_property: Some_constrained_primitive) -> None:
+                    self.some_property = some_property
+
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             """
         )
 
-        constraint, errors = infer_constraints_on_self_of_class_something(source=source)
+        (
+            _,
+            something_cls,
+            constraints_by_class,
+        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+            source=source
+        )
 
-        assert errors is None, tests.common.most_underlying_messages(errors)
-        assert constraint is not None
-
-        text = infer_for_schema.dump(constraint)
+        constraints_by_props = constraints_by_class[something_cls]
+        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
             textwrap.dedent(
                 """\
-                        LenConstraint(
-                          min_value=10,
-                          max_value=10)"""
+                ConstraintsByProperty(
+                  len_constraints_by_property={
+                    'some_property': LenConstraint(
+                      min_value=10,
+                      max_value=10)},
+                  patterns_by_property={})"""
             ),
             text,
         )
@@ -202,41 +267,63 @@ class Test_expected(unittest.TestCase):
         source = textwrap.dedent(
             """\
             @invariant(lambda self: len(self) == 10)
-            class Something(str):
+            class Some_constrained_primitive(str):
                 pass
+
+
+            class Something:
+                some_property: Some_constrained_primitive
+
+                def __init__(self, some_property: Some_constrained_primitive) -> None:
+                    self.some_property = some_property
+
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             """
         )
 
-        constraint, errors = infer_constraints_on_self_of_class_something(source=source)
+        (
+            _,
+            something_cls,
+            constraints_by_class,
+        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+            source=source
+        )
 
-        assert errors is None, tests.common.most_underlying_messages(errors)
-        assert constraint is not None
-
-        text = infer_for_schema.dump(constraint)
+        constraints_by_props = constraints_by_class[something_cls]
+        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
             textwrap.dedent(
                 """\
-                LenConstraint(
-                  min_value=10,
-                  max_value=10)"""
+                ConstraintsByProperty(
+                  len_constraints_by_property={
+                    'some_property': LenConstraint(
+                      min_value=10,
+                      max_value=10)},
+                  patterns_by_property={})"""
             ),
             text,
         )
 
-    def test_inheritance(self) -> None:
+    def test_inheritance_between_constrained_primitives_by_default(self) -> None:
         source = textwrap.dedent(
             """\
             @invariant(lambda self: len(self) > 3)
-            class Parent(str):
+            class Parent_constrained_primitive(str):
                 pass
 
 
-            @invariant(lambda self: len(self) > 5)
-            class Something(Parent):
+            @invariant(lambda self: len(self) < 6)
+            class Some_constrained_primitive(Parent_constrained_primitive):
                 pass
+
+
+            class Something:
+                some_property: Some_constrained_primitive
+
+                def __init__(self, some_property: Some_constrained_primitive) -> None:
+                    self.some_property = some_property
 
 
             __book_url__ = "dummy"
@@ -244,23 +331,29 @@ class Test_expected(unittest.TestCase):
             """
         )
 
-        constraint, errors = infer_constraints_on_self_of_class_something(source=source)
+        # NOTE (mristin, 2022-05-15):
+        # In contrast to classes, we do inherit the constraints among the constrained
+        # primitives as we in-line them later in the schema classes.
 
-        assert errors is None, tests.common.most_underlying_messages(errors)
-        assert constraint is not None
+        (
+            _,
+            something_cls,
+            constraints_by_class,
+        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+            source=source
+        )
 
-        # NOTE (mristin, 2022-01-02):
-        # We infer only the constraints as specified in the class itself, and
-        # ignore the constraints of the ancestors in *this particular kind of
-        # inference*.
-
-        text = infer_for_schema.dump(constraint)
+        constraints_by_props = constraints_by_class[something_cls]
+        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
             textwrap.dedent(
                 """\
-                LenConstraint(
-                  min_value=6,
-                  max_value=None)"""
+                ConstraintsByProperty(
+                  len_constraints_by_property={
+                    'some_property': LenConstraint(
+                      min_value=4,
+                      max_value=5)},
+                  patterns_by_property={})"""
             ),
             text,
         )
@@ -272,8 +365,15 @@ class Test_unexpected(unittest.TestCase):
             """\
             @invariant(lambda self: len(self) > 10)
             @invariant(lambda self: len(self) < 3)
-            class Something(str):
+            class Some_constrained_primitive(str):
                 pass
+
+
+            class Something:
+                some_property: Some_constrained_primitive
+
+                def __init__(self, some_property: Some_constrained_primitive) -> None:
+                    self.some_property = some_property
 
 
             __book_url__ = "dummy"
@@ -281,13 +381,22 @@ class Test_unexpected(unittest.TestCase):
             """
         )
 
-        _, errors = infer_constraints_on_self_of_class_something(source=source)
+        (
+            symbol_table,
+            _,
+        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls(
+            source=source
+        )
 
-        assert errors is not None
+        _, error = infer_for_schema.infer_constraints_by_class(
+            symbol_table=symbol_table
+        )
+
+        assert error is not None
         self.assertEqual(
             "There are conflicting invariants on the length: "
             "the minimum length, 11, contradicts the maximum length 2.",
-            tests.common.most_underlying_messages(errors),
+            tests.common.most_underlying_messages(error),
         )
 
     def test_conflicting_min_and_exact(self) -> None:
@@ -295,8 +404,15 @@ class Test_unexpected(unittest.TestCase):
             """\
             @invariant(lambda self: len(self) > 10)
             @invariant(lambda self: len(self) == 3)
-            class Something(str):
+            class Some_constrained_primitive(str):
                 pass
+
+
+            class Something:
+                some_property: Some_constrained_primitive
+
+                def __init__(self, some_property: Some_constrained_primitive) -> None:
+                    self.some_property = some_property
 
 
             __book_url__ = "dummy"
@@ -304,13 +420,22 @@ class Test_unexpected(unittest.TestCase):
             """
         )
 
-        _, errors = infer_constraints_on_self_of_class_something(source=source)
+        (
+            symbol_table,
+            _,
+        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls(
+            source=source
+        )
 
-        assert errors is not None
+        _, error = infer_for_schema.infer_constraints_by_class(
+            symbol_table=symbol_table
+        )
+
+        assert error is not None
         self.assertEqual(
             "There are conflicting invariants on the length: "
             "the minimum length, 11, contradicts the exactly expected length 3.",
-            tests.common.most_underlying_messages(errors),
+            tests.common.most_underlying_messages(error),
         )
 
     def test_conflicting_max_and_exact(self) -> None:
@@ -318,21 +443,38 @@ class Test_unexpected(unittest.TestCase):
             """\
             @invariant(lambda self: len(self) < 10)
             @invariant(lambda self: len(self) == 30)
-            class Something(str):
+            class Some_constrained_primitive(str):
                 pass
+
+
+            class Something:
+                some_property: Some_constrained_primitive
+
+                def __init__(self, some_property: Some_constrained_primitive) -> None:
+                    self.some_property = some_property
+
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
             """
         )
 
-        _, errors = infer_constraints_on_self_of_class_something(source=source)
+        (
+            symbol_table,
+            _,
+        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls(
+            source=source
+        )
 
-        assert errors is not None
+        _, error = infer_for_schema.infer_constraints_by_class(
+            symbol_table=symbol_table
+        )
+
+        assert error is not None
         self.assertEqual(
             "There are conflicting invariants on the length: "
             "the maximum length, 9, contradicts the exactly expected length 30.",
-            tests.common.most_underlying_messages(errors),
+            tests.common.most_underlying_messages(error),
         )
 
 


### PR DESCRIPTION
We infer the schema constraints (currently only length and patterns)
based on the meta-model. We do not inherit them by default since we
usually generate the invariants for each class in the schema
*separately* and let the schema engine deal with the inheritance.

However, in the case of test data generation, it would be helpful if the
schema constraints are properly inherited among the classes.

In this patch, we re-structure the code and the tests to cater for that
use case and extend the logic with an additional function to stack the
schema constraints by the class ontology.

Unsurprisingly, a couple of bugs were discovered and fixed along
the re-structuring.