### PR TITLE
Introduce `specified_for` for methods

### DIFF
--- a/aas_core_codegen/csharp/structure/_generate.py
+++ b/aas_core_codegen/csharp/structure/_generate.py
@@ -882,6 +882,9 @@ def _generate_class(
     errors = []  # type: List[Error]
 
     for method in cls.methods:
+        if method.specified_for is not cls:
+            continue
+
         if isinstance(method, intermediate.ImplementationSpecificMethod):
             implementation_key = specific_implementations.ImplementationKey(
                 f"Types/{cls.name}/{method.name}.cs"

--- a/aas_core_codegen/intermediate/_stringify.py
+++ b/aas_core_codegen/intermediate/_stringify.py
@@ -24,7 +24,6 @@ from aas_core_codegen.intermediate._types import (
     Invariant,
     ListTypeAnnotation,
     MetaModel,
-    Method,
     OptionalTypeAnnotation,
     OurTypeAnnotation,
     PatternVerification,
@@ -394,10 +393,6 @@ def _stringify_a_signature_like(that: SignatureLike) -> stringify.Entity:
     return result
 
 
-def _stringify_method(that: Method) -> stringify.Entity:
-    return _stringify_a_signature_like(that)
-
-
 def _stringify_implementation_specific_method(
     that: ImplementationSpecificMethod,
 ) -> stringify.Entity:
@@ -408,6 +403,11 @@ def _stringify_implementation_specific_method(
             stringify.Property("arguments", list(map(_stringify, that.arguments))),
             stringify.Property("returns", _stringify(that.returns)),
             stringify.Property("description", _stringify(that.description)),
+            stringify.Property(
+                "specified_for",
+                f"Reference to {that.specified_for.__class__.__name__} "
+                f"{that.specified_for.name}",
+            ),
             stringify.Property("contracts", _stringify(that.contracts)),
             stringify.PropertyEllipsis("parsed", that.parsed),
             stringify.PropertyEllipsis("arguments_by_name", that.arguments_by_name),
@@ -427,6 +427,11 @@ def _stringify_understood_method(
             stringify.Property("arguments", list(map(_stringify, that.arguments))),
             stringify.Property("returns", _stringify(that.returns)),
             stringify.Property("description", _stringify(that.description)),
+            stringify.Property(
+                "specified_for",
+                f"Reference to {that.specified_for.__class__.__name__} "
+                f"{that.specified_for.name}",
+            ),
             stringify.Property("contracts", _stringify(that.contracts)),
             stringify.PropertyEllipsis("parsed", that.parsed),
             stringify.Property("body", [parse_tree.dump(stmt) for stmt in that.body]),

--- a/aas_core_codegen/intermediate/_types.py
+++ b/aas_core_codegen/intermediate/_types.py
@@ -760,6 +760,12 @@ class Method(SignatureLike):
 
     parsed: parse.Method
 
+    #: The original class where this method is specified.
+    #: We stack all the methods over the ancestors, so using ``specified_for``
+    #: you can distinguish between inherited methods and genuine methods of
+    #: a class.
+    specified_for: Final["Class"]
+
     # fmt: off
     @require(
         lambda name:
@@ -798,6 +804,7 @@ class Method(SignatureLike):
         arguments: Sequence[Argument],
         returns: Optional[TypeAnnotationUnion],
         description: Optional[SignatureDescription],
+        specified_for: "Class",
         contracts: Contracts,
         parsed: parse.Method,
     ) -> None:
@@ -811,6 +818,8 @@ class Method(SignatureLike):
             contracts=contracts,
             parsed=parsed,
         )
+
+        self.specified_for = specified_for
 
     @abc.abstractmethod
     def __repr__(self) -> str:
@@ -866,6 +875,7 @@ class UnderstoodMethod(Method):
         arguments: Sequence[Argument],
         returns: Optional[TypeAnnotationUnion],
         description: Optional[SignatureDescription],
+        specified_for: "Class",
         contracts: Contracts,
         body: Sequence[parse_tree.Node],
         parsed: parse.Method,
@@ -877,6 +887,7 @@ class UnderstoodMethod(Method):
             arguments=arguments,
             returns=returns,
             description=description,
+            specified_for=specified_for,
             contracts=contracts,
             parsed=parsed,
         )

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/input/snippets/Types/Concept_description/category_or_default.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/input/snippets/Types/Concept_description/category_or_default.cs
@@ -1,0 +1,20 @@
+/// <summary>
+/// Return the <see cref="Aas.ConceptDescription.Category" /> or the default value
+/// if it has not been set.
+/// </summary>
+public string CategoryOrDefault()
+{
+    string result = (this.category != null)
+        ? this.category
+        : "PROPERTY";
+
+#if DEBUG
+    if (!Verification.ConceptDescriptionCategoryIsValid(
+            result))
+    {
+        throw new System.InvalidOperationException(
+            $"Unexpected default category: {result}"
+        );
+    }
+#endif
+}

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/input/snippets/Types/Extension/value_type_or_default.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/input/snippets/Types/Extension/value_type_or_default.cs
@@ -1,0 +1,10 @@
+/// <summary>
+/// Return the <see cref="Aas.Extension.ValueType" /> or the default value
+/// if it has not been set.
+/// </summary>
+public Aas.DataTypeDefXsd ValueTypeOrDefault()
+{
+    return (this.valueType != null)
+        ? this.valueType
+        : Aas.DataTypeDefXsd.String;
+}

--- a/test_data/intermediate/expected/class/implementation_specific_method/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/class/implementation_specific_method/expected_symbol_table.txt
@@ -24,6 +24,7 @@ SymbolTable(
             a_type='INT',
             parsed=...),
           description=None,
+          specified_for='Reference to ConcreteClass Concrete',
           contracts=Contracts(
             preconditions=[],
             snapshots=[],

--- a/test_data/intermediate/expected/class/inheritance/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/class/inheritance/expected_symbol_table.txt
@@ -64,6 +64,7 @@ SymbolTable(
             arguments_by_name=[],
             returns=None,
             parsed=...),
+          specified_for='Reference to AbstractClass VeryAbstract',
           contracts=Contracts(
             preconditions=[],
             snapshots=[],
@@ -219,6 +220,7 @@ SymbolTable(
             arguments_by_name=[],
             returns=None,
             parsed=...),
+          specified_for='Reference to AbstractClass VeryAbstract',
           contracts=Contracts(
             preconditions=[],
             snapshots=[],
@@ -236,6 +238,7 @@ SymbolTable(
             arguments_by_name=[],
             returns=None,
             parsed=...),
+          specified_for='Reference to AbstractClass Abstract',
           contracts=Contracts(
             preconditions=[],
             snapshots=[],
@@ -350,6 +353,7 @@ SymbolTable(
             arguments_by_name=[],
             returns=None,
             parsed=...),
+          specified_for='Reference to AbstractClass VeryAbstract',
           contracts=Contracts(
             preconditions=[],
             snapshots=[],
@@ -367,6 +371,7 @@ SymbolTable(
             arguments_by_name=[],
             returns=None,
             parsed=...),
+          specified_for='Reference to AbstractClass Abstract',
           contracts=Contracts(
             preconditions=[],
             snapshots=[],
@@ -384,6 +389,7 @@ SymbolTable(
             arguments_by_name=[],
             returns=None,
             parsed=...),
+          specified_for='Reference to ConcreteClass Concrete',
           contracts=Contracts(
             preconditions=[],
             snapshots=[],

--- a/test_data/intermediate/expected/class/methods_with_contracts/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/class/methods_with_contracts/expected_symbol_table.txt
@@ -37,6 +37,7 @@ SymbolTable(
             arguments_by_name=[],
             returns=None,
             parsed=...),
+          specified_for='Reference to ConcreteClass Concrete',
           contracts=Contracts(
             preconditions=[
               Contract(

--- a/test_data/intermediate/expected/class/only_method_no_property/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/class/only_method_no_property/expected_symbol_table.txt
@@ -24,6 +24,7 @@ SymbolTable(
             a_type='INT',
             parsed=...),
           description=None,
+          specified_for='Reference to ConcreteClass Concrete',
           contracts=Contracts(
             preconditions=[],
             snapshots=[],

--- a/test_data/intermediate/expected/interface/basic/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/interface/basic/expected_symbol_table.txt
@@ -52,6 +52,7 @@ SymbolTable(
           arguments=[],
           returns=None,
           description=None,
+          specified_for='Reference to AbstractClass Abstract',
           contracts=Contracts(
             preconditions=[],
             snapshots=[],

--- a/test_data/intermediate/expected/interface/inheritance/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/interface/inheritance/expected_symbol_table.txt
@@ -52,6 +52,7 @@ SymbolTable(
           arguments=[],
           returns=None,
           description=None,
+          specified_for='Reference to AbstractClass VeryAbstract',
           contracts=Contracts(
             preconditions=[],
             snapshots=[],
@@ -190,6 +191,7 @@ SymbolTable(
           arguments=[],
           returns=None,
           description=None,
+          specified_for='Reference to AbstractClass VeryAbstract',
           contracts=Contracts(
             preconditions=[],
             snapshots=[],
@@ -202,6 +204,7 @@ SymbolTable(
           arguments=[],
           returns=None,
           description=None,
+          specified_for='Reference to AbstractClass Abstract',
           contracts=Contracts(
             preconditions=[],
             snapshots=[],

--- a/test_data/intermediate/expected/interface/method_signature/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/interface/method_signature/expected_symbol_table.txt
@@ -69,6 +69,7 @@ SymbolTable(
             a_type='BOOL',
             parsed=...),
           description=None,
+          specified_for='Reference to AbstractClass Abstract',
           contracts=Contracts(
             preconditions=[
               Contract(


### PR DESCRIPTION
Since the methods are inherited, we need to introduce `specified_for`
in the intermediate representation so that we do not re-generate the
same method in the descendant classes.