### PR TITLE
Re-visit inheritance of methods and signatures

### DIFF
--- a/aas_core_codegen/csharp/structure/_generate.py
+++ b/aas_core_codegen/csharp/structure/_generate.py
@@ -360,7 +360,7 @@ def _generate_interface(
 
     # endregion
 
-    # region Methods
+    # region Signatures
 
     for signature in interface.signatures:
         signature_blocks = []  # type: List[Stripped]
@@ -882,12 +882,16 @@ def _generate_class(
     errors = []  # type: List[Error]
 
     for method in cls.methods:
-        if method.specified_for is not cls:
-            continue
-
         if isinstance(method, intermediate.ImplementationSpecificMethod):
+            # NOTE (mristin, 2022-05-18):
+            # We have to repeat the implementation of the method in all the descendants
+            # since we share only interfaces between the classes, but not
+            # the implementations.
+            #
+            # This makes the code a bit larger, but the class hierarchy is much simpler
+            # and the individual classes are much easier to grasp.
             implementation_key = specific_implementations.ImplementationKey(
-                f"Types/{cls.name}/{method.name}.cs"
+                f"Types/{method.specified_for.name}/{method.name}.cs"
             )
 
             implementation = spec_impls.get(implementation_key, None)

--- a/aas_core_codegen/intermediate/_types.py
+++ b/aas_core_codegen/intermediate/_types.py
@@ -1803,6 +1803,7 @@ class Interface:
                 parsed=method.parsed,
             )
             for method in base.methods
+            if method.specified_for is base
         ]
 
         self.description = base.description

--- a/test_data/intermediate/expected/class/inheritance/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/class/inheritance/expected_symbol_table.txt
@@ -154,22 +154,6 @@ SymbolTable(
             parsed=...)],
         signatures=[
           Signature(
-            name='some_func',
-            arguments=[],
-            returns=None,
-            description=SignatureDescription(
-              summary='<paragraph>Do something.</paragraph>',
-              remarks=[],
-              arguments_by_name=[],
-              returns=None,
-              parsed=...),
-            contracts=Contracts(
-              preconditions=[],
-              snapshots=[],
-              postconditions=[]),
-            parsed=...,
-            arguments_by_name=...),
-          Signature(
             name='another_func',
             arguments=[],
             returns=None,

--- a/test_data/intermediate/expected/interface/inheritance/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/interface/inheritance/expected_symbol_table.txt
@@ -141,17 +141,6 @@ SymbolTable(
             parsed=...)],
         signatures=[
           Signature(
-            name='some_func',
-            arguments=[],
-            returns=None,
-            description=None,
-            contracts=Contracts(
-              preconditions=[],
-              snapshots=[],
-              postconditions=[]),
-            parsed=...,
-            arguments_by_name=...),
-          Signature(
             name='another_func',
             arguments=[],
             returns=None,


### PR DESCRIPTION
We re-visited how the methods are inherited and interfaces are
generated, and discovered a couple of subtle bugs related to
how we ignored `specified_for` of a method during the translation stage
to intermediate.

This patch fixes the issue.