### PR TITLE
Add experimental support for ``any`` in invariants

### DIFF
--- a/.idea/aas-core-csharp-codegen.iml
+++ b/.idea/aas-core-csharp-codegen.iml
@@ -4,6 +4,7 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.mypy_cache" />
       <excludeFolder url="file://$MODULE_DIR$/aas_core_csharp_codegen.egg-info" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
       <excludeFolder url="file://$MODULE_DIR$/deleteme" />
       <excludeFolder url="file://$MODULE_DIR$/obsolete" />
       <excludeFolder url="file://$MODULE_DIR$/test_data" />

--- a/aas_core_codegen/intermediate/type_inference.py
+++ b/aas_core_codegen/intermediate/type_inference.py
@@ -908,7 +908,9 @@ class Inferrer(parse_tree.RestrictedTransformer[Optional["TypeAnnotationUnion"]]
         self.type_map[node] = result
         return result
 
-    def transform_all(self, node: parse_tree.All) -> Optional["TypeAnnotationUnion"]:
+    def _transform_any_or_all(
+        self, node: Union[parse_tree.Any, parse_tree.All]
+    ) -> Optional["TypeAnnotationUnion"]:
         a_type = self.transform(node.for_each)
         if a_type is None:
             return None
@@ -920,6 +922,12 @@ class Inferrer(parse_tree.RestrictedTransformer[Optional["TypeAnnotationUnion"]]
         result = PrimitiveTypeAnnotation(PrimitiveType.BOOL)
         self.type_map[node] = result
         return result
+
+    def transform_any(self, node: parse_tree.Any) -> Optional["TypeAnnotationUnion"]:
+        return self._transform_any_or_all(node)
+
+    def transform_all(self, node: parse_tree.All) -> Optional["TypeAnnotationUnion"]:
+        return self._transform_any_or_all(node)
 
     def transform_assignment(
         self, node: parse_tree.Assignment


### PR DESCRIPTION
We did not thouroughly test the transpilation of ``any`` in invariants,
but add it to our parsing. This is necessary since we need to create a
new version of aas-core-meta which uses ``any`` in some of the
invariants and the smoke tests fail at the moment.

Non-experimental support and testing is coming in one of the upcoming
commits.