### PR TITLE
Fix XSD for abstract classes without implementers

### DIFF
--- a/aas_core_codegen/xsd/main.py
+++ b/aas_core_codegen/xsd/main.py
@@ -259,11 +259,12 @@ def _generate_xs_element_for_a_list_property(
         elif isinstance(
             symbol, (intermediate.AbstractClass, intermediate.ConcreteClass)
         ):
-            if isinstance(symbol, intermediate.AbstractClass) or (
-                isinstance(symbol, intermediate.ConcreteClass)
-                and len(symbol.concrete_descendants) > 0
-            ):
-
+            # NOTE (mristin, 2022-05-26):
+            # We need to check for the concrete descendants. If there are no concrete
+            # descendants, there is no choice group either. Notably, this not only
+            # applies to concrete classes, but there is no choice group for the abstract
+            # classes without descendants either.
+            if len(symbol.concrete_descendants) > 0:
                 choice_group_name = xsd_naming.choice_group_name(symbol.name)
                 xs_group = ET.Element(
                     "xs:group",
@@ -285,9 +286,6 @@ def _generate_xs_element_for_a_list_property(
                 )
                 xs_element.append(xs_complex_type)
             else:
-                assert isinstance(symbol, intermediate.ConcreteClass)
-                assert len(symbol.concrete_descendants) == 0
-
                 xs_element_inner = ET.Element(
                     "xs:element",
                     {
@@ -369,10 +367,15 @@ def _generate_xs_element_for_a_property(
         elif isinstance(
             symbol, (intermediate.AbstractClass, intermediate.ConcreteClass)
         ):
-            if isinstance(symbol, intermediate.AbstractClass) or (
-                isinstance(symbol, intermediate.ConcreteClass)
-                and len(symbol.concrete_descendants) > 0
-            ):
+            # NOTE (mristin, 2022-05-26):
+            # We generate choices only if there are at least one concrete descendant.
+            # Otherwise, the choice is not generated. Hence we need to reference
+            # a choice only if there is actually one.
+            #
+            # This is especially necessary for abstract classes with no descendants
+            # which we still want to include in the schema. We simply generate an empty
+            # element in the schema for such abstract classes without descendants.
+            if len(symbol.concrete_descendants) > 0:
                 xs_sequence = ET.Element("xs:sequence")
                 xs_sequence.append(
                     ET.Element(
@@ -388,11 +391,6 @@ def _generate_xs_element_for_a_property(
                 )
                 xs_element.append(xs_complex_type)
             else:
-                assert (
-                    isinstance(symbol, intermediate.ConcreteClass)
-                    and len(symbol.concrete_descendants) == 0
-                )
-
                 xs_element = ET.Element(
                     "xs:element",
                     {

--- a/test_data/xsd/test_main/aas_core_meta.v3rc2/examples/expected/submodels/property/property_with_id_short.xml
+++ b/test_data/xsd/test_main/aas_core_meta.v3rc2/examples/expected/submodels/property/property_with_id_short.xml
@@ -5,7 +5,7 @@
             <id>an-identifier-1</id>
             <submodelElements>
                 <property>
-                    <idShort>an-id-short-1</idShort>
+                    <idShort>an_id_short_1</idShort>
                     <valueType>xs:boolean</valueType>
                 </property>
             </submodelElements>


### PR DESCRIPTION
In cases where an abstract class is defined in the meta-model, but no
implementers are provided, we generated an invalid XSD. Namely, we
expected a choice group to exist, but since there were no implementers,
no choice group has been generated.

In this patch, we generate an empty element for the abstract class and
simply refer to it instead of the choice.

We manually tested against aas-core-meta 2022.5.26. Therefore we also
update the example to comply with this newer meta-model despite the fact
that the repository still uses aas-core-meta 2022.5.30a6 for testing.

We will update to the latest aas-core-meta 2022.5.26 very soon in one of
the upcoming commits.