### PR TITLE
Relax constraints on C# namespace identifiers

### DIFF
--- a/aas_core_codegen/csharp/common.py
+++ b/aas_core_codegen/csharp/common.py
@@ -156,7 +156,7 @@ INDENT5 = INDENT * 5
 INDENT6 = INDENT * 6
 
 NAMESPACE_IDENTIFIER_RE = re.compile(
-    r"[a-zA-Z_][a-zA-Z_0-9]*(\.[a-zA-Z_][a-zA-Z_0-9]*)"
+    r"[a-zA-Z_][a-zA-Z_0-9]*(\.[a-zA-Z_][a-zA-Z_0-9]*)*"
 )
 
 


### PR DESCRIPTION
We originally always tought in multi-segment namespaces. Eventually,
when we started writing unit tests, such a constraint turned out that it
was too restrictive.