### PR TITLE
Refactor ``RERECORD`` into ``tests.common``

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1,4 +1,5 @@
 """Provide common functionality across different tests."""
+import os
 from typing import List, Tuple, Optional, Union, Sequence
 
 import asttokens
@@ -88,3 +89,12 @@ def translate_source_to_intermediate(
     assert parsed_symbol_table is not None
 
     return intermediate.translate(parsed_symbol_table=parsed_symbol_table, atok=atok)
+
+
+#: If set, this environment variable indicates that the golden files should be
+#: re-recorded instead of checked against.
+RERECORD = os.environ.get("AAS_CORE_CODEGEN_RERECORD", "").lower() in (
+    "1",
+    "true",
+    "on",
+)

--- a/tests/csharp/test_main.py
+++ b/tests/csharp/test_main.py
@@ -11,14 +11,10 @@ import aas_core_meta.v3rc2
 
 import aas_core_codegen.main
 
+import tests.common
+
 
 class Test_against_recorded(unittest.TestCase):
-    RERECORD = os.environ.get("AAS_CORE_CODEGEN_RERECORD", "").lower() in (
-        "1",
-        "true",
-        "on",
-    )
-
     def test_cases(self) -> None:
         repo_dir = pathlib.Path(os.path.realpath(__file__)).parent.parent.parent
 
@@ -41,7 +37,7 @@ class Test_against_recorded(unittest.TestCase):
             expected_output_dir = case_dir / "expected_output"
 
             with contextlib.ExitStack() as exit_stack:
-                if Test_against_recorded.RERECORD:
+                if tests.common.RERECORD:
                     output_dir = expected_output_dir
                     expected_output_dir.mkdir(exist_ok=True, parents=True)
                 else:
@@ -84,7 +80,7 @@ class Test_against_recorded(unittest.TestCase):
                     str(output_dir), "<output dir>"
                 )
 
-                if Test_against_recorded.RERECORD:
+                if tests.common.RERECORD:
                     stdout_pth.write_text(normalized_stdout, encoding="utf-8")
                 else:
                     self.assertEqual(
@@ -119,7 +115,7 @@ class Test_against_recorded(unittest.TestCase):
                             f"Failed to read the output from {output_pth}"
                         ) from exception
 
-                    if Test_against_recorded.RERECORD:
+                    if tests.common.RERECORD:
                         expected_pth.write_text(output, encoding="utf-8")
                     else:
                         try:

--- a/tests/csharp/test_verification.py
+++ b/tests/csharp/test_verification.py
@@ -11,6 +11,8 @@ from aas_core_codegen.csharp import (
 )
 from aas_core_codegen import parse
 
+import tests.common
+
 
 class Test_wrap_invariant_description(unittest.TestCase):
     def test_empty(self) -> None:
@@ -100,12 +102,6 @@ class Test_wrap_invariant_description(unittest.TestCase):
 
 
 class Test_pattern_translation_against_recorded(unittest.TestCase):
-    RERECORD = os.environ.get("AAS_CORE_CODEGEN_RERECORD", "").lower() in (
-        "1",
-        "true",
-        "on",
-    )
-
     def test_cases(self) -> None:
         repo_dir = pathlib.Path(os.path.realpath(__file__)).parent.parent.parent
 
@@ -158,7 +154,7 @@ class Test_pattern_translation_against_recorded(unittest.TestCase):
             assert code is not None
 
             expected_pth = model_pth.parent / "expected_verification.cs"
-            if Test_pattern_translation_against_recorded.RERECORD:
+            if tests.common.RERECORD:
                 expected_pth.write_text(code, encoding="utf-8")
             else:
                 try:

--- a/tests/intermediate/test_translate.py
+++ b/tests/intermediate/test_translate.py
@@ -8,10 +8,11 @@ from typing import List, Tuple
 
 import aas_core_meta.v3rc2
 
-import tests.common
 from aas_core_codegen import intermediate
 from aas_core_codegen.intermediate import doc as intermediate_doc
 from aas_core_codegen.common import Identifier
+
+import tests.common
 
 
 class Test_in_lining_of_constructor_statements(unittest.TestCase):
@@ -154,12 +155,6 @@ class Test_parsing_docstrings(unittest.TestCase):
 
 
 class Test_against_recorded(unittest.TestCase):
-    RERECORD = os.environ.get("AAS_CORE_CODEGEN_RERECORD", "").lower() in (
-        "1",
-        "true",
-        "on",
-    )
-
     def test_cases(self) -> None:
         this_dir = pathlib.Path(os.path.realpath(__file__)).parent
         repo_root = this_dir.parent.parent
@@ -231,7 +226,7 @@ class Test_against_recorded(unittest.TestCase):
 
                 error_str = tests.common.most_underlying_messages(error)
 
-                if Test_against_recorded.RERECORD:
+                if tests.common.RERECORD:
                     expected_error_pth.write_text(error_str, encoding="utf-8")
                 else:
                     expected_error_str = expected_error_pth.read_text(encoding="utf-8")
@@ -248,7 +243,7 @@ class Test_against_recorded(unittest.TestCase):
 
                 symbol_table_str = intermediate.dump(symbol_table)
 
-                if Test_against_recorded.RERECORD:
+                if tests.common.RERECORD:
                     expected_symbol_table_pth.write_text(
                         symbol_table_str, encoding="utf-8"
                     )
@@ -312,7 +307,7 @@ class Test_against_recorded(unittest.TestCase):
 
             symbol_table_str = intermediate.dump(symbol_table)
 
-            if Test_against_recorded.RERECORD:
+            if tests.common.RERECORD:
                 expected_symbol_table_pth.write_text(symbol_table_str, encoding="utf-8")
             else:
                 try:

--- a/tests/our_jsonschema/test_main.py
+++ b/tests/our_jsonschema/test_main.py
@@ -12,6 +12,8 @@ import warnings
 import aas_core_meta.v3rc1
 import aas_core_meta.v3rc2
 
+import tests.common
+
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     # NOTE (mristin, 2022-04-08):
@@ -27,12 +29,6 @@ import aas_core_codegen.main
 
 
 class Test_against_recorded(unittest.TestCase):
-    RERECORD = os.environ.get("AAS_CORE_CODEGEN_RERECORD", "").lower() in (
-        "1",
-        "true",
-        "on",
-    )
-
     _REPO_DIR = pathlib.Path(os.path.realpath(__file__)).parent.parent.parent
     PARENT_CASE_DIR = _REPO_DIR / "test_data" / "jsonschema" / "test_main"
 
@@ -59,7 +55,7 @@ class Test_against_recorded(unittest.TestCase):
             expected_output_dir = case_dir / "expected_output"
 
             with contextlib.ExitStack() as exit_stack:
-                if Test_against_recorded.RERECORD:
+                if tests.common.RERECORD:
                     output_dir = expected_output_dir
                     expected_output_dir.mkdir(exist_ok=True, parents=True)
                 else:
@@ -102,7 +98,7 @@ class Test_against_recorded(unittest.TestCase):
                     str(output_dir), "<output dir>"
                 )
 
-                if Test_against_recorded.RERECORD:
+                if tests.common.RERECORD:
                     stdout_pth.write_text(normalized_stdout, encoding="utf-8")
                 else:
                     self.assertEqual(
@@ -124,7 +120,7 @@ class Test_against_recorded(unittest.TestCase):
                             f"The output file is missing: {output_pth}"
                         )
 
-                    if Test_against_recorded.RERECORD:
+                    if tests.common.RERECORD:
                         expected_pth.write_text(
                             output_pth.read_text(encoding="utf-8"), encoding="utf-8"
                         )

--- a/tests/parse/test_parse.py
+++ b/tests/parse/test_parse.py
@@ -16,9 +16,10 @@ import docutils.nodes
 
 import aas_core_meta.v3rc2
 
-import tests.common
 from aas_core_codegen import parse
 from aas_core_codegen.common import Error, Identifier
+
+import tests.common
 
 
 class Test_parsing_AST(unittest.TestCase):
@@ -360,12 +361,6 @@ class Test_parse_type_annotation_fail(unittest.TestCase):
 
 
 class Test_against_recorded(unittest.TestCase):
-    RERECORD = os.environ.get("AAS_CORE_CODEGEN_RERECORD", "").lower() in (
-        "1",
-        "true",
-        "on",
-    )
-
     def test_cases(self) -> None:
         this_dir = pathlib.Path(os.path.realpath(__file__)).parent
         test_cases_dir = this_dir.parent.parent / "test_data/parse"
@@ -429,7 +424,7 @@ class Test_against_recorded(unittest.TestCase):
 
                 error_str = tests.common.most_underlying_messages(error)
 
-                if Test_against_recorded.RERECORD:
+                if tests.common.RERECORD:
                     expected_error_pth.write_text(error_str, encoding="utf-8")
                 else:
                     expected_error_str = expected_error_pth.read_text(encoding="utf-8")
@@ -446,7 +441,7 @@ class Test_against_recorded(unittest.TestCase):
 
                 symbol_table_str = parse.dump(symbol_table)
 
-                if Test_against_recorded.RERECORD:
+                if tests.common.RERECORD:
                     expected_symbol_table_pth.write_text(
                         symbol_table_str, encoding="utf-8"
                     )
@@ -499,7 +494,7 @@ class Test_against_recorded(unittest.TestCase):
 
             symbol_table_str = parse.dump(symbol_table)
 
-            if Test_against_recorded.RERECORD:
+            if tests.common.RERECORD:
                 expected_symbol_table_pth.write_text(symbol_table_str, encoding="utf-8")
             else:
                 expected_symbol_table_str = expected_symbol_table_pth.read_text(

--- a/tests/parse/test_retree.py
+++ b/tests/parse/test_retree.py
@@ -11,13 +11,14 @@ from typing import Tuple, List, Union, Sequence
 
 import asttokens
 
-import tests.common
 from aas_core_codegen.common import assert_never
 from aas_core_codegen.parse import (
     tree as parse_tree,
     _rules as parse_rules,
     retree as parse_retree,
 )
+
+import tests.common
 
 
 def parse_values_from_source(
@@ -136,12 +137,6 @@ class Test_cursor(unittest.TestCase):
 
 
 class Test_against_recorded(unittest.TestCase):
-    RERECORD = os.environ.get("AAS_CORE_CODEGEN_RERECORD", "").lower() in (
-        "1",
-        "true",
-        "on",
-    )
-
     def test_cases(self) -> None:
         this_dir = pathlib.Path(os.path.realpath(__file__)).parent
         test_cases_dir = this_dir.parent.parent / "test_data/parse_retree"
@@ -215,7 +210,7 @@ class Test_against_recorded(unittest.TestCase):
                 regex_line, pointer_line = parse_retree.render_pointer(error.cursor)
                 error_str = f"{error.message}\n" f"{regex_line}\n" f"{pointer_line}\n"
 
-                if Test_against_recorded.RERECORD:
+                if tests.common.RERECORD:
                     expected_error_pth.write_text(error_str, encoding="utf-8")
                 else:
                     expected_error_str = expected_error_pth.read_text(encoding="utf-8")
@@ -242,7 +237,7 @@ class Test_against_recorded(unittest.TestCase):
                         assert_never(value)
                 rendered_regex_str = "".join(rendered_parts)
 
-                if Test_against_recorded.RERECORD:
+                if tests.common.RERECORD:
                     expected_parsed_regex_pth.write_text(
                         parsed_regex_str, encoding="utf-8"
                     )

--- a/tests/rdf_shacl/test_main.py
+++ b/tests/rdf_shacl/test_main.py
@@ -12,14 +12,10 @@ import aas_core_meta.v3rc2
 
 import aas_core_codegen.main
 
+import tests.common
+
 
 class Test_against_recorded(unittest.TestCase):
-    RERECORD = os.environ.get("AAS_CORE_CODEGEN_RERECORD", "").lower() in (
-        "1",
-        "true",
-        "on",
-    )
-
     def test_against_aas_core_meta(self) -> None:
         repo_dir = pathlib.Path(os.path.realpath(__file__)).parent.parent.parent
 
@@ -42,7 +38,7 @@ class Test_against_recorded(unittest.TestCase):
             expected_output_dir = case_dir / "expected_output"
 
             with contextlib.ExitStack() as exit_stack:
-                if Test_against_recorded.RERECORD:
+                if tests.common.RERECORD:
                     output_dir = expected_output_dir
                     expected_output_dir.mkdir(exist_ok=True, parents=True)
                 else:
@@ -85,7 +81,7 @@ class Test_against_recorded(unittest.TestCase):
                     str(output_dir), "<output dir>"
                 )
 
-                if Test_against_recorded.RERECORD:
+                if tests.common.RERECORD:
                     stdout_pth.write_text(normalized_stdout, encoding="utf-8")
                 else:
                     self.assertEqual(
@@ -106,7 +102,7 @@ class Test_against_recorded(unittest.TestCase):
                             f"The output file is missing: {output_pth}"
                         )
 
-                    if Test_against_recorded.RERECORD:
+                    if tests.common.RERECORD:
                         expected_pth.write_text(
                             data=output_pth.read_text(encoding="utf-8"),
                             encoding="utf-8",

--- a/tests/smoke/test_main.py
+++ b/tests/smoke/test_main.py
@@ -12,14 +12,10 @@ import aas_core_meta.v3rc2
 
 from aas_core_codegen.smoke import main as smoke_main
 
+import tests.common
+
 
 class Test_against_recorded(unittest.TestCase):
-    RERECORD = os.environ.get("AAS_CORE_CODEGEN_RERECORD", "").lower() in (
-        "1",
-        "true",
-        "on",
-    )
-
     def test_cases(self) -> None:
         repo_dir = pathlib.Path(os.path.realpath(__file__)).parent.parent.parent
 
@@ -79,7 +75,7 @@ class Test_against_recorded(unittest.TestCase):
                 str(model_pth), f"<{model_pth.name}>"
             )
 
-            if Test_against_recorded.RERECORD:
+            if tests.common.RERECORD:
                 stderr_pth.write_text(normalized_stderr, encoding="utf-8")
             else:
                 self.assertEqual(

--- a/tests/xsd/test_main.py
+++ b/tests/xsd/test_main.py
@@ -13,6 +13,8 @@ import aas_core_meta.v3rc2
 import aas_core_codegen.main
 from aas_core_codegen.xsd import main as xsd_main
 
+import tests.common
+
 
 class Test_undo_escaping_x(unittest.TestCase):
     def test_empty(self) -> None:
@@ -68,12 +70,6 @@ class Test_undo_escaping_x(unittest.TestCase):
 
 
 class Test_against_recorded(unittest.TestCase):
-    RERECORD = os.environ.get("AAS_CORE_CODEGEN_RERECORD", "").lower() in (
-        "1",
-        "true",
-        "on",
-    )
-
     _REPO_DIR = pathlib.Path(os.path.realpath(__file__)).parent.parent.parent
     PARENT_CASE_DIR = _REPO_DIR / "test_data" / "xsd" / "test_main"
 
@@ -99,7 +95,7 @@ class Test_against_recorded(unittest.TestCase):
             expected_output_dir = case_dir / "expected_output"
 
             with contextlib.ExitStack() as exit_stack:
-                if Test_against_recorded.RERECORD:
+                if tests.common.RERECORD:
                     output_dir = expected_output_dir
                     expected_output_dir.mkdir(exist_ok=True, parents=True)
                 else:
@@ -141,7 +137,7 @@ class Test_against_recorded(unittest.TestCase):
                     str(output_dir), "<output dir>"
                 )
 
-                if Test_against_recorded.RERECORD:
+                if tests.common.RERECORD:
                     stdout_pth.write_text(normalized_stdout, encoding="utf-8")
                 else:
                     self.assertEqual(
@@ -163,7 +159,7 @@ class Test_against_recorded(unittest.TestCase):
                             f"The output file is missing: {output_pth}"
                         )
 
-                    if Test_against_recorded.RERECORD:
+                    if tests.common.RERECORD:
                         expected_pth.write_text(
                             output_pth.read_text(encoding="utf-8"), encoding="utf-8"
                         )


### PR DESCRIPTION
We refactor the environment variable in the common module since now many
tests depend on it. Originally, only a few tests were using it, so there
was no need to encapsulate it in one place.