### PR TITLE
Fix duplicate inheritance of pattern constraints

### DIFF
--- a/aas_core_codegen/infer_for_schema/_types.py
+++ b/aas_core_codegen/infer_for_schema/_types.py
@@ -42,6 +42,13 @@ class PatternConstraint:
         """Initialize with the given values."""
         self.pattern = pattern
 
+    def __repr__(self) -> str:
+        """Represent the constraint with the pattern."""
+        return (
+            f"<{PatternConstraint.__name__} at 0x{id(self):x} "
+            f"with pattern={self.pattern!r}>"
+        )
+
 
 class ConstraintsByProperty:
     """


### PR DESCRIPTION
In cases where a property is a constrained primitive, the stacking of
pattern constraint over ancestor is broken, as we inherit the
constraints multiple times.

As we do not keep track of where the constraints of the ancestors come
from, we simply de-duplicate by keeping a set of observed patterns.