### PR TITLE
Infer non-nullness in the intermediate

### DIFF
--- a/.idea/dictionaries/rist.xml
+++ b/.idea/dictionaries/rist.xml
@@ -9,6 +9,7 @@
       <w>atok</w>
       <w>braunisch</w>
       <w>bytearray</w>
+      <w>canonicalizer</w>
       <w>cardinalities</w>
       <w>classdef</w>
       <w>clses</w>
@@ -69,6 +70,8 @@
       <w>nameof</w>
       <w>netcore</w>
       <w>nist</w>
+      <w>nullies</w>
+      <w>nullness</w>
       <w>opcode</w>
       <w>paramref</w>
       <w>pathed</w>
@@ -84,6 +87,7 @@
       <w>recursing</w>
       <w>referables</w>
       <w>reformattable</w>
+      <w>representer</w>
       <w>retree</w>
       <w>ristin</w>
       <w>rstripped</w>

--- a/aas_core_codegen/csharp/verification/_generate.py
+++ b/aas_core_codegen/csharp/verification/_generate.py
@@ -1541,10 +1541,17 @@ def _transpile_invariant(
     # of languages, we hope to have a much better understanding about the necessary
     # abstractions.
 
+    canonicalizer = intermediate_type_inference.Canonicalizer()
+    _ = canonicalizer.transform(invariant.body)
+
     type_inferrer = intermediate_type_inference.Inferrer(
-        symbol_table=symbol_table, environment=environment
+        symbol_table=symbol_table,
+        environment=environment,
+        representation_map=canonicalizer.representation_map,
     )
+
     _ = type_inferrer.transform(invariant.body)
+
     if len(type_inferrer.errors):
         return None, Error(
             invariant.parsed.node,

--- a/tests/intermediate/test_type_inference.py
+++ b/tests/intermediate/test_type_inference.py
@@ -26,20 +26,25 @@ class Test_with_smoke(unittest.TestCase):
         )
 
         for symbol in symbol_table.symbols:
-            if isinstance(symbol, intermediate.Class):
+            if isinstance(
+                symbol, (intermediate.AbstractClass, intermediate.ConcreteClass)
+            ):
                 environment = intermediate_type_inference.MutableEnvironment(
                     parent=base_environment
                 )
                 environment.set(
                     Identifier("self"),
-                    intermediate_type_inference.OurTypeAnnotation(
-                        symbol=symbol_table.must_find(Identifier("Some_class"))
-                    ),
+                    intermediate_type_inference.OurTypeAnnotation(symbol=symbol),
                 )
 
                 for invariant in symbol.invariants:
+                    canonicalizer = intermediate_type_inference.Canonicalizer()
+                    canonicalizer.transform(invariant.body)
+
                     inferrer = intermediate_type_inference.Inferrer(
-                        symbol_table=symbol_table, environment=environment
+                        symbol_table=symbol_table,
+                        environment=environment,
+                        representation_map=canonicalizer.representation_map,
                     )
 
                     inferrer.transform(invariant.body)
@@ -86,6 +91,67 @@ class Test_with_smoke(unittest.TestCase):
 
                 def __init__(self, something: int) -> None:
                     self.something = something
+
+
+            __book_url__ = "dummy"
+            __book_version__ = "dummy"
+            """
+        )
+
+        Test_with_smoke.execute(source=source)
+
+    def test_non_nullness_of_members_member_in_implication(self) -> None:
+        source = textwrap.dedent(
+            """\
+            class Some_class:
+                something: Optional[str]
+
+                def __init__(self, something: Optional[str] = None) -> None:
+                    self.something = something
+
+            @invariant(
+                lambda self:
+                not (
+                    self.some_instance is not None
+                    and self.some_instance.something is not None
+                ) or (
+                    self.some_instance.something == "some-literal"
+                )
+            )
+            class Another_class:
+                some_instance: Optional[Some_class]
+
+                def __init__(self, some_instance: Optional[Some_class] = None) -> None:
+                    self.some_instance = some_instance
+
+
+            __book_url__ = "dummy"
+            __book_version__ = "dummy"
+            """
+        )
+
+        Test_with_smoke.execute(source=source)
+
+    def test_non_nullness_of_members_member_in_conjunction(self) -> None:
+        source = textwrap.dedent(
+            """\
+            class Some_class:
+                something: Optional[str]
+
+                def __init__(self, something: Optional[str] = None) -> None:
+                    self.something = something
+
+            @invariant(
+                lambda self:
+                self.some_instance is not None
+                and self.some_instance.something is not None
+                and self.some_instance.something == "some-literal"
+            )
+            class Another_class:
+                some_instance: Optional[Some_class]
+
+                def __init__(self, some_instance: Optional[Some_class] = None) -> None:
+                    self.some_instance = some_instance
 
 
             __book_url__ = "dummy"


### PR DESCRIPTION
We infer the non-nullness by agressively making assumptions in
conjunctions and implications on "is not None"'s.

Word of caution. This might be too aggressive since we assume that
function calls and method calls do not alter the values observed in the
implications or conjunctions. This indeed holds true as long as you
observe query-command separation, but only that long.