### PR TITLE
Fix C# generation for CodeInspect and testgen

### DIFF
--- a/aas_core_codegen/csharp/stringification/_generate.py
+++ b/aas_core_codegen/csharp/stringification/_generate.py
@@ -23,15 +23,19 @@ def _generate_enum_to_and_from_string(
 
     # region To-string-map
 
-    to_str_map_name = csharp_naming.private_property_name(
+    # NOTE (mristin, 2022-05-05):
+    # We make the property look "public" by the name since it is a static and read-only.
+    to_str_map_name = csharp_naming.property_name(
         Identifier(f"{enumeration.name}_to_string")
     )
 
     to_str_map_writer = io.StringIO()
     to_str_map_writer.write(
-        f"private static readonly Dictionary<Aas.{name}, string> {to_str_map_name} = (\n"
-        f"{I}new Dictionary<Aas.{name}, string>()\n"
-        f"{I}{{\n"
+        f"""\
+private static readonly Dictionary<Aas.{name}, string> {to_str_map_name} = (
+{I}new Dictionary<Aas.{name}, string>()
+{I}{{
+"""
     )
 
     for i, literal in enumerate(enumeration.literals):
@@ -97,9 +101,12 @@ public static string? {to_str_name}(Aas.{name}? that)
 
     from_str_map_writer = io.StringIO()
     from_str_map_writer.write(
-        f"private static readonly Dictionary<string, Aas.{name}> {from_str_map_name} = (\n"
-        f"{I}new Dictionary<string, Aas.{name}>()\n"
-        f"{I}{{\n"
+        f"""\
+[CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+private static readonly Dictionary<string, Aas.{name}> {from_str_map_name} = (
+{I}new Dictionary<string, Aas.{name}>()
+{I}{{
+"""
     )
 
     for i, literal in enumerate(enumeration.literals):
@@ -177,6 +184,7 @@ def generate(
         csharp_common.WARNING,
         Stripped(
             f"""\
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using System.Collections.Generic;  // can't alias
 
 using Aas = {namespace};"""

--- a/aas_core_codegen/csharp/visitation/_generate.py
+++ b/aas_core_codegen/csharp/visitation/_generate.py
@@ -206,7 +206,9 @@ def _generate_ivisitor_with_context(symbol_table: intermediate.SymbolTable) -> S
 
         elif isinstance(symbol, intermediate.ConcreteClass):
             cls_name = csharp_naming.class_name(symbol.name)
-            blocks.append(Stripped(f"public void Visit({cls_name} that, C context);"))
+            blocks.append(
+                Stripped(f"public void Visit({cls_name} that, TContext context);")
+            )
 
         else:
             assert_never(symbol)
@@ -217,10 +219,10 @@ def _generate_ivisitor_with_context(symbol_table: intermediate.SymbolTable) -> S
 /// <summary>
 /// Define the interface for a visitor which visits the instances of the model.
 /// </summary>
-/// <typeparam name="C">Context type</typeparam>
-public interface IVisitorWithContext<C>
+/// <typeparam name="TContext">Context type</typeparam>
+public interface IVisitorWithContext<in TContext>
 {{
-{I}public void Visit(IClass that, C context);
+{I}public void Visit(IClass that, TContext context);
 """
     )
 
@@ -241,7 +243,7 @@ def _generate_abstract_visitor_with_context(
     blocks = [
         Stripped(
             f"""\
-public void Visit(IClass that, C context)
+public void Visit(IClass that, TContext context)
 {{
 {I}that.Accept(this, context);
 }}"""
@@ -265,7 +267,9 @@ public void Visit(IClass that, C context)
         elif isinstance(symbol, intermediate.Class):
             cls_name = csharp_naming.class_name(symbol.name)
             blocks.append(
-                Stripped(f"public abstract void Visit({cls_name} that, C context);")
+                Stripped(
+                    f"public abstract void Visit({cls_name} that, TContext context);"
+                )
             )
 
         else:
@@ -278,9 +282,9 @@ public void Visit(IClass that, C context)
 /// Perform double-dispatch to visit the concrete instances
 /// with context.
 /// </summary>
-/// <typeparam name="C">Context type</typeparam>
-public abstract class AbstractVisitorWithContext<C>
-{I}: IVisitorWithContext<C>
+/// <typeparam name="TContext">Context type</typeparam>
+public abstract class AbstractVisitorWithContext<TContext>
+{I}: IVisitorWithContext<TContext>
 {{
 """
     )
@@ -328,7 +332,7 @@ def _generate_itransformer(symbol_table: intermediate.SymbolTable) -> Stripped:
 /// the instances into something else.
 /// </summary>
 /// <typeparam name="T">The type of the transformation result</typeparam>
-public interface ITransformer<T>
+public interface ITransformer<out T>
 {{
 {I}public T Transform(IClass that);
 """
@@ -422,7 +426,9 @@ def _generate_itransformer_with_context(
 
         elif isinstance(symbol, intermediate.ConcreteClass):
             cls_name = csharp_naming.class_name(symbol.name)
-            blocks.append(Stripped(f"public T Transform({cls_name} that, C context);"))
+            blocks.append(
+                Stripped(f"public T Transform({cls_name} that, TContext context);")
+            )
 
         else:
             assert_never(symbol)
@@ -434,11 +440,11 @@ def _generate_itransformer_with_context(
 /// Define the interface for a transformer which recursively transforms
 /// the instances into something else while the context is passed along.
 /// </summary>
-/// <typeparam name="C">Type of the transformation context</typeparam>
+/// <typeparam name="TContext">Type of the transformation context</typeparam>
 /// <typeparam name="T">The type of the transformation result</typeparam>
-public interface ITransformerWithContext<C, T>
+public interface ITransformerWithContext<in TContext, out T>
 {{
-{I}public T Transform(IClass that, C context);
+{I}public T Transform(IClass that, TContext context);
 """
     )
 
@@ -459,7 +465,7 @@ def _generate_abstract_transformer_with_context(
     blocks = [
         Stripped(
             f"""\
-public T Transform(IClass that, C context)
+public T Transform(IClass that, TContext context)
 {{
 {I}return that.Transform(this, context);
 }}"""
@@ -483,7 +489,9 @@ public T Transform(IClass that, C context)
         elif isinstance(symbol, intermediate.ConcreteClass):
             cls_name = csharp_naming.class_name(symbol.name)
             blocks.append(
-                Stripped(f"public abstract T Transform({cls_name} that, C context);")
+                Stripped(
+                    f"public abstract T Transform({cls_name} that, TContext context);"
+                )
             )
 
         else:
@@ -496,10 +504,10 @@ public T Transform(IClass that, C context)
 /// Perform double-dispatch to transform recursively
 /// the instances into something else.
 /// </summary>
-/// <typeparam name="C">The type of the transformation context</typeparam>
+/// <typeparam name="TContext">The type of the transformation context</typeparam>
 /// <typeparam name="T">The type of the transformation result</typeparam>
-public abstract class AbstractTransformerWithContext<C, T>
-{I}: ITransformerWithContext<C, T>
+public abstract class AbstractTransformerWithContext<TContext, T>
+{I}: ITransformerWithContext<TContext, T>
 {{
 """
     )

--- a/aas_core_codegen/csharp/xmlization/_generate.py
+++ b/aas_core_codegen/csharp/xmlization/_generate.py
@@ -119,7 +119,7 @@ catch (System.FormatException exception)
 {I}error = new Reporting.Error(
 {II}"The property {prop_name} of an instance of class {cls_name} " +
 {II}$"could not be de-serialized: {{exception}}");
-{I}error._pathSegments.AddFirst(
+{I}error.PrependSegment(
 {II}new Reporting.NameSegment(
 {III}{xml_prop_name_literal}));
 {I}return null;
@@ -158,7 +158,7 @@ catch (System.FormatException exception)
 {I}error = new Reporting.Error(
 {II}"The property {prop_name} of an instance of class {cls_name} " +
 {II}$"could not be de-serialized as a string: {{exception}}");
-{I}error._pathSegments.AddFirst(
+{I}error.PrependSegment(
 {II}new Reporting.NameSegment(
 {III}{xml_prop_name_literal}));
 {I}return null;
@@ -173,7 +173,7 @@ if ({target_var} == null)
 {II}"The property {prop_name} of an instance of class {cls_name} " +
 {II}"could not be de-serialized from an unexpected enumeration literal: " +
 {II}{text_var});
-{I}error._pathSegments.AddFirst(
+{I}error.PrependSegment(
 {II}new Reporting.NameSegment(
 {III}{xml_prop_name_literal}));
 {I}return null;
@@ -206,7 +206,7 @@ def _generate_deserialize_interface_property(
 
 if (error != null)
 {{
-{I}error._pathSegments.AddFirst(
+{I}error.PrependSegment(
 {II}new Reporting.NameSegment(
 {III}{xml_prop_name_literal}));
 {I}return null;
@@ -236,7 +236,7 @@ def _generate_deserialize_cls_property(prop: intermediate.Property) -> Stripped:
 
 if (error != null)
 {{
-{I}error._pathSegments.AddFirst(
+{I}error.PrependSegment(
 {II}new Reporting.NameSegment(
 {III}{xml_prop_name_literal}));
 {I}return null;
@@ -291,7 +291,7 @@ while (reader.NodeType == Xml.XmlNodeType.Element)
 
 {I}if (error != null)
 {I}{{
-{II}error._pathSegments.AddFirst(
+{II}error.PrependSegment(
 {III}new Reporting.IndexSegment(
 {IIII}{index_var}));
 {II}return null;
@@ -472,14 +472,14 @@ while (reader.NodeType == Xml.XmlNodeType.Element)
 {I}if (reader.EOF)
 {I}{{
 {II}error = new Reporting.Error(
-{III}$"Expected an XML end element to conclude a property of class {name} " +
+{III}"Expected an XML end element to conclude a property of class {name} " +
 {III}$"with the element name {{elementName}}, " +
-{III}$"but got the end-of-file.");
+{III}"but got the end-of-file.");
 {I}}}
 {I}if (reader.NodeType != Xml.XmlNodeType.EndElement)
 {I}{{
 {II}error = new Reporting.Error(
-{III}$"Expected an XML end element to conclude a property of class {name} " +
+{III}"Expected an XML end element to conclude a property of class {name} " +
 {III}$"with the element name {{elementName}}, " +
 {III}$"but got the node of type {{reader.NodeType}} " +
 {III}$"with the value {{reader.Value}}");
@@ -487,7 +487,7 @@ while (reader.NodeType == Xml.XmlNodeType.Element)
 {I}if (reader.Name != elementName)
 {I}{{
 {II}error = new Reporting.Error(
-{III}$"Expected an XML end element to conclude a property of class {name} " +
+{III}"Expected an XML end element to conclude a property of class {name} " +
 {III}$"with the element name {{elementName}}, " +
 {III}$"but got the end element with the name {{reader.Name}}");
 {I}}}
@@ -654,7 +654,7 @@ if (reader.EOF)
 if (reader.NodeType != Xml.XmlNodeType.Element)
 {{
 {I}error = new Reporting.Error(
-{II}$"Expected an XML element representing an instance of class {name}, " +
+{II}"Expected an XML element representing an instance of class {name}, " +
 {II}$"but got a node of type {{reader.NodeType}} " +
 {II}$"with value {{reader.Value}}");
 {I}return null;
@@ -693,7 +693,7 @@ if (reader.EOF)
 if (reader.NodeType != Xml.XmlNodeType.EndElement)
 {{
 {I}error = new Reporting.Error(
-{II}$"Expected an XML end element concluding an instance of class {name}, " +
+{II}"Expected an XML end element concluding an instance of class {name}, " +
 {II}$"but got a node of type {{reader.NodeType}} " +
 {II}$"with value {{reader.Value}}");
 {I}return null;
@@ -739,7 +739,7 @@ if (reader.EOF)
 if (reader.NodeType != Xml.XmlNodeType.Element)
 {{
 {I}error = new Reporting.Error(
-{II}$"Expected an XML element, " +
+{II}"Expected an XML element, " +
 {II}$"but got a node of type {{reader.NodeType}} " +
 {II}$"with value {{reader.Value}}");
 {I}return null;
@@ -795,8 +795,9 @@ switch (reader.Name)
     writer.write(
         f"""\
 /// <summary>
-/// Deserialize an instance of class {name} from an XML element.
+/// Deserialize an instance of {name} from an XML element.
 /// </summary>
+[CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
 internal static Aas.{name}? {name}FromElement(
 {I}Xml.XmlReader reader,
 {I}out Reporting.Error? error)
@@ -911,16 +912,17 @@ def _generate_deserialize_impl(
 /// Implement the deserialization of meta-model classes from XML.
 /// </summary>
 /// <remarks>
-/// The implementation propagates an <see cref="Error" /> instead of relying
-/// on exceptions. Under the assumption that incorrect data is much less
+/// The implementation propagates an <see cref="Reporting.Error" /> instead of
+/// relying on exceptions. Under the assumption that incorrect data is much less
 /// frequent than correct data, this makes the deserialization more
 /// efficient.
 ///
 /// However, we do not want to force the client to deal with
-/// the <see cref="Error" /> class as this is not intuitive. Therefore
-/// we distinguish the implementation, realized in
+/// the <see cref="Reporting.Error" /> class as this is not intuitive.
+/// Therefore we distinguish the implementation, realized in
 /// <see cref="DeserializeImplementation" />, and the facade given in
 /// <see cref="Deserialize" /> class.
+/// </remarks>
 internal static class DeserializeImplementation
 {
 """
@@ -938,16 +940,29 @@ internal static class DeserializeImplementation
 
 def _generate_deserialize_from(name: Identifier) -> Stripped:
     """Generate the facade method for deserialization of the class or interface."""
-    return Stripped(
+    writer = io.StringIO()
+
+    writer.write(
         f"""\
 /// <summary>
-/// Deserialize an instance of class {name} from <paramref name="reader" />.
+/// Deserialize an instance of {name} from <paramref name="reader" />.
 /// </summary>
 /// <param name="reader">Initialized XML reader with cursor set to the element</param>
 /// <exception cref="Xmlization.Exception">
-/// Thrown when <paramref name="node" /> is not a valid XML
+/// Thrown when the element is not a valid XML
 /// representation of {name}.
 /// </exception>
+"""
+    )
+
+    if name.startswith("I"):
+        writer.write(
+            """\
+[CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]"""
+        )
+
+    writer.write(
+        f"""\
 public static Aas.{name} {name}From(
 {I}Xml.XmlReader reader)
 {{
@@ -966,6 +981,8 @@ public static Aas.{name} {name}From(
 {III}"Unexpected output null when error is null");
 }}"""
     )
+
+    return Stripped(writer.getvalue())
 
 
 def _generate_deserialize(symbol_table: intermediate.SymbolTable) -> Stripped:
@@ -1415,7 +1432,8 @@ def _generate_serialize(
     blocks = [
         Stripped(
             f"""\
-private static VisitorWithWriter _visitorWithWriter = (
+[CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+private static readonly VisitorWithWriter _visitorWithWriter = (
 {I}new VisitorWithWriter());"""
         ),
         Stripped(
@@ -1586,6 +1604,7 @@ namespace {namespace}
         csharp_common.WARNING,
         Stripped(
             """\
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Xml = System.Xml;
 using System.Collections.Generic;  // can't alias"""
         ),

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/jsonization.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/jsonization.cs
@@ -3,6 +3,7 @@
  * Do NOT edit or append.
  */
 
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Nodes = System.Text.Json.Nodes;
 using System.Collections.Generic;  // can't alias
 
@@ -24,16 +25,17 @@ namespace AasCore.Aas3
         /// Implement the deserialization of meta-model classes from JSON nodes.
         /// </summary>
         /// <remarks>
-        /// The implementation propagates an <see cref="Error" /> instead of relying
+        /// The implementation propagates an <see cref="Reporting.Error" /> instead of relying
         /// on exceptions. Under the assumption that incorrect data is much less
         /// frequent than correct data, this makes the deserialization more
         /// efficient.
         ///
         /// However, we do not want to force the client to deal with
-        /// the <see cref="Error" /> class as this is not intuitive. Therefore
+        /// the <see cref="Reporting.Error" /> class as this is not intuitive. Therefore
         /// we distinguish the implementation, realized in
         /// <see cref="DeserializeImplementation" />, and the facade given in
         /// <see cref="Deserialize" /> class.
+        /// </remarks>
         internal static class DeserializeImplementation
         {
             /// <summary>Convert <paramref name="node" /> to a boolean.</summary>
@@ -55,7 +57,7 @@ namespace AasCore.Aas3
                 if (!ok)
                 {
                     error = new Reporting.Error(
-                        $"Expected a boolean, but the conversion failed " +
+                        "Expected a boolean, but the conversion failed " +
                         $"from {value.ToJsonString()}");
                     return null;
                 }
@@ -83,7 +85,7 @@ namespace AasCore.Aas3
                 if (!ok)
                 {
                     error = new Reporting.Error(
-                        $"Expected a 64-bit long integer, but the conversion failed " +
+                        "Expected a 64-bit long integer, but the conversion failed " +
                         $"from {value.ToJsonString()}");
                     return null;
                 }
@@ -140,7 +142,7 @@ namespace AasCore.Aas3
                 if (!ok)
                 {
                     error = new Reporting.Error(
-                        $"Expected a string, but the conversion failed " +
+                        "Expected a string, but the conversion failed " +
                         $"from {value.ToJsonString()}");
                     return null;
                 }
@@ -174,7 +176,7 @@ namespace AasCore.Aas3
                 if (!ok)
                 {
                     error = new Reporting.Error(
-                        $"Expected a string, but the conversion failed " +
+                        "Expected a string, but the conversion failed " +
                         $"from {value.ToJsonString()}");
                     return null;
                 }
@@ -228,7 +230,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "path"));
                     return null;
@@ -248,7 +250,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "contentType"));
                         return null;
@@ -273,6 +275,7 @@ namespace AasCore.Aas3
             /// </summary>
             /// <param name="node">JSON node to be parsed</param>
             /// <param name="error">Error, if any, during the deserialization</param>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             public static Aas.IHasSemantics? IHasSemanticsFrom(
                 Nodes.JsonNode node,
                 out Reporting.Error? error)
@@ -399,7 +402,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         return null;
@@ -423,7 +426,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "name"));
                     return null;
@@ -443,7 +446,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "valueType"));
                         return null;
@@ -464,7 +467,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "value"));
                         return null;
@@ -485,7 +488,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "refersTo"));
                         return null;
@@ -513,6 +516,7 @@ namespace AasCore.Aas3
             /// </summary>
             /// <param name="node">JSON node to be parsed</param>
             /// <param name="error">Error, if any, during the deserialization</param>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             public static Aas.IHasExtensions? IHasExtensionsFrom(
                 Nodes.JsonNode node,
                 out Reporting.Error? error)
@@ -614,6 +618,7 @@ namespace AasCore.Aas3
             /// </summary>
             /// <param name="node">JSON node to be parsed</param>
             /// <param name="error">Error, if any, during the deserialization</param>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             public static Aas.IReferable? IReferableFrom(
                 Nodes.JsonNode node,
                 out Reporting.Error? error)
@@ -715,6 +720,7 @@ namespace AasCore.Aas3
             /// </summary>
             /// <param name="node">JSON node to be parsed</param>
             /// <param name="error">Error, if any, during the deserialization</param>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             public static Aas.IIdentifiable? IIdentifiableFrom(
                 Nodes.JsonNode node,
                 out Reporting.Error? error)
@@ -807,6 +813,7 @@ namespace AasCore.Aas3
             /// </summary>
             /// <param name="node">JSON node to be parsed</param>
             /// <param name="error">Error, if any, during the deserialization</param>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             public static Aas.IHasKind? IHasKindFrom(
                 Nodes.JsonNode node,
                 out Reporting.Error? error)
@@ -902,6 +909,7 @@ namespace AasCore.Aas3
             /// </summary>
             /// <param name="node">JSON node to be parsed</param>
             /// <param name="error">Error, if any, during the deserialization</param>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             public static Aas.IHasDataSpecification? IHasDataSpecificationFrom(
                 Nodes.JsonNode node,
                 out Reporting.Error? error)
@@ -1028,7 +1036,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "dataSpecifications"));
                         return null;
@@ -1042,10 +1050,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                         }
@@ -1054,10 +1062,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             return null;
@@ -1079,7 +1087,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "version"));
                         return null;
@@ -1100,7 +1108,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "revision"));
                         return null;
@@ -1124,6 +1132,7 @@ namespace AasCore.Aas3
             /// </summary>
             /// <param name="node">JSON node to be parsed</param>
             /// <param name="error">Error, if any, during the deserialization</param>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             public static Aas.IQualifiable? IQualifiableFrom(
                 Nodes.JsonNode node,
                 out Reporting.Error? error)
@@ -1241,7 +1250,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         return null;
@@ -1265,7 +1274,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "type"));
                     return null;
@@ -1288,7 +1297,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "valueType"));
                     return null;
@@ -1308,7 +1317,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "value"));
                         return null;
@@ -1329,7 +1338,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "valueId"));
                         return null;
@@ -1381,7 +1390,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeExtensions.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "extensions"));
                         return null;
@@ -1395,10 +1404,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                         }
@@ -1407,10 +1416,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             return null;
@@ -1432,7 +1441,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         return null;
@@ -1453,7 +1462,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         return null;
@@ -1474,7 +1483,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         return null;
@@ -1495,7 +1504,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         return null;
@@ -1516,7 +1525,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         return null;
@@ -1540,7 +1549,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "id"));
                     return null;
@@ -1560,7 +1569,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "administration"));
                         return null;
@@ -1581,7 +1590,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "dataSpecifications"));
                         return null;
@@ -1595,10 +1604,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                         }
@@ -1607,10 +1616,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             return null;
@@ -1635,7 +1644,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "assetInformation"));
                     return null;
@@ -1655,7 +1664,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeSubmodels.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "submodels"));
                         return null;
@@ -1669,10 +1678,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexSubmodels));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "submodels"));
                         }
@@ -1681,10 +1690,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexSubmodels));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "submodels"));
                             return null;
@@ -1706,7 +1715,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "derivedFrom"));
                         return null;
@@ -1768,7 +1777,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "assetKind"));
                     return null;
@@ -1788,7 +1797,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "globalAssetId"));
                         return null;
@@ -1809,7 +1818,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "specificAssetId"));
                         return null;
@@ -1830,7 +1839,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "defaultThumbnail"));
                         return null;
@@ -1909,7 +1918,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         return null;
@@ -1933,7 +1942,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "key"));
                     return null;
@@ -1956,7 +1965,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "value"));
                     return null;
@@ -1976,7 +1985,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "externalSubjectId"));
                         return null;
@@ -2027,7 +2036,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeExtensions.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "extensions"));
                         return null;
@@ -2041,10 +2050,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                         }
@@ -2053,10 +2062,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             return null;
@@ -2078,7 +2087,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         return null;
@@ -2099,7 +2108,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         return null;
@@ -2120,7 +2129,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         return null;
@@ -2141,7 +2150,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         return null;
@@ -2162,7 +2171,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         return null;
@@ -2186,7 +2195,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "id"));
                     return null;
@@ -2206,7 +2215,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "administration"));
                         return null;
@@ -2227,7 +2236,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "kind"));
                         return null;
@@ -2248,7 +2257,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         return null;
@@ -2269,7 +2278,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeQualifiers.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "qualifiers"));
                         return null;
@@ -2283,10 +2292,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                         }
@@ -2295,10 +2304,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                             return null;
@@ -2320,7 +2329,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "dataSpecifications"));
                         return null;
@@ -2334,10 +2343,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                         }
@@ -2346,10 +2355,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             return null;
@@ -2371,7 +2380,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeSubmodelElements.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "submodelElements"));
                         return null;
@@ -2385,10 +2394,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexSubmodelElements));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "submodelElements"));
                         }
@@ -2397,10 +2406,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexSubmodelElements));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "submodelElements"));
                             return null;
@@ -2437,6 +2446,7 @@ namespace AasCore.Aas3
             /// </summary>
             /// <param name="node">JSON node to be parsed</param>
             /// <param name="error">Error, if any, during the deserialization</param>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             public static Aas.ISubmodelElement? ISubmodelElementFrom(
                 Nodes.JsonNode node,
                 out Reporting.Error? error)
@@ -2529,6 +2539,7 @@ namespace AasCore.Aas3
             /// </summary>
             /// <param name="node">JSON node to be parsed</param>
             /// <param name="error">Error, if any, during the deserialization</param>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             public static Aas.IRelationshipElement? IRelationshipElementFrom(
                 Nodes.JsonNode node,
                 out Reporting.Error? error)
@@ -2607,7 +2618,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeExtensions.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "extensions"));
                         return null;
@@ -2621,10 +2632,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                         }
@@ -2633,10 +2644,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             return null;
@@ -2658,7 +2669,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         return null;
@@ -2679,7 +2690,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         return null;
@@ -2700,7 +2711,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         return null;
@@ -2721,7 +2732,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         return null;
@@ -2742,7 +2753,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         return null;
@@ -2763,7 +2774,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "kind"));
                         return null;
@@ -2784,7 +2795,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         return null;
@@ -2805,7 +2816,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeQualifiers.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "qualifiers"));
                         return null;
@@ -2819,10 +2830,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                         }
@@ -2831,10 +2842,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                             return null;
@@ -2856,7 +2867,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "dataSpecifications"));
                         return null;
@@ -2870,10 +2881,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                         }
@@ -2882,10 +2893,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             return null;
@@ -2910,7 +2921,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "typeValueListElement"));
                     return null;
@@ -2930,7 +2941,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "orderRelevant"));
                         return null;
@@ -2951,7 +2962,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeValue.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "value"));
                         return null;
@@ -2965,10 +2976,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexValue));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "value"));
                         }
@@ -2977,10 +2988,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexValue));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "value"));
                             return null;
@@ -3002,7 +3013,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticIdListElement"));
                         return null;
@@ -3023,7 +3034,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "valueTypeListElement"));
                         return null;
@@ -3083,7 +3094,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeExtensions.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "extensions"));
                         return null;
@@ -3097,10 +3108,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                         }
@@ -3109,10 +3120,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             return null;
@@ -3134,7 +3145,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         return null;
@@ -3155,7 +3166,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         return null;
@@ -3176,7 +3187,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         return null;
@@ -3197,7 +3208,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         return null;
@@ -3218,7 +3229,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         return null;
@@ -3239,7 +3250,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "kind"));
                         return null;
@@ -3260,7 +3271,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         return null;
@@ -3281,7 +3292,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeQualifiers.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "qualifiers"));
                         return null;
@@ -3295,10 +3306,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                         }
@@ -3307,10 +3318,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                             return null;
@@ -3332,7 +3343,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "dataSpecifications"));
                         return null;
@@ -3346,10 +3357,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                         }
@@ -3358,10 +3369,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             return null;
@@ -3383,7 +3394,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeValue.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "value"));
                         return null;
@@ -3397,10 +3408,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexValue));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "value"));
                         }
@@ -3409,10 +3420,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexValue));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "value"));
                             return null;
@@ -3445,6 +3456,7 @@ namespace AasCore.Aas3
             /// </summary>
             /// <param name="node">JSON node to be parsed</param>
             /// <param name="error">Error, if any, during the deserialization</param>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             public static Aas.IDataElement? IDataElementFrom(
                 Nodes.JsonNode node,
                 out Reporting.Error? error)
@@ -3538,7 +3550,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeExtensions.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "extensions"));
                         return null;
@@ -3552,10 +3564,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                         }
@@ -3564,10 +3576,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             return null;
@@ -3589,7 +3601,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         return null;
@@ -3610,7 +3622,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         return null;
@@ -3631,7 +3643,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         return null;
@@ -3652,7 +3664,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         return null;
@@ -3673,7 +3685,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         return null;
@@ -3694,7 +3706,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "kind"));
                         return null;
@@ -3715,7 +3727,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         return null;
@@ -3736,7 +3748,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeQualifiers.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "qualifiers"));
                         return null;
@@ -3750,10 +3762,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                         }
@@ -3762,10 +3774,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                             return null;
@@ -3787,7 +3799,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "dataSpecifications"));
                         return null;
@@ -3801,10 +3813,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                         }
@@ -3813,10 +3825,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             return null;
@@ -3841,7 +3853,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "valueType"));
                     return null;
@@ -3861,7 +3873,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "value"));
                         return null;
@@ -3882,7 +3894,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "valueId"));
                         return null;
@@ -3940,7 +3952,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeExtensions.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "extensions"));
                         return null;
@@ -3954,10 +3966,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                         }
@@ -3966,10 +3978,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             return null;
@@ -3991,7 +4003,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         return null;
@@ -4012,7 +4024,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         return null;
@@ -4033,7 +4045,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         return null;
@@ -4054,7 +4066,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         return null;
@@ -4075,7 +4087,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         return null;
@@ -4096,7 +4108,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "kind"));
                         return null;
@@ -4117,7 +4129,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         return null;
@@ -4138,7 +4150,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeQualifiers.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "qualifiers"));
                         return null;
@@ -4152,10 +4164,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                         }
@@ -4164,10 +4176,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                             return null;
@@ -4189,7 +4201,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "dataSpecifications"));
                         return null;
@@ -4203,10 +4215,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                         }
@@ -4215,10 +4227,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             return null;
@@ -4240,7 +4252,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "value"));
                         return null;
@@ -4261,7 +4273,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "valueId"));
                         return null;
@@ -4316,7 +4328,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeExtensions.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "extensions"));
                         return null;
@@ -4330,10 +4342,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                         }
@@ -4342,10 +4354,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             return null;
@@ -4367,7 +4379,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         return null;
@@ -4388,7 +4400,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         return null;
@@ -4409,7 +4421,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         return null;
@@ -4430,7 +4442,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         return null;
@@ -4451,7 +4463,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         return null;
@@ -4472,7 +4484,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "kind"));
                         return null;
@@ -4493,7 +4505,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         return null;
@@ -4514,7 +4526,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeQualifiers.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "qualifiers"));
                         return null;
@@ -4528,10 +4540,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                         }
@@ -4540,10 +4552,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                             return null;
@@ -4565,7 +4577,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "dataSpecifications"));
                         return null;
@@ -4579,10 +4591,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                         }
@@ -4591,10 +4603,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             return null;
@@ -4619,7 +4631,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "valueType"));
                     return null;
@@ -4639,7 +4651,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "min"));
                         return null;
@@ -4660,7 +4672,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "max"));
                         return null;
@@ -4718,7 +4730,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeExtensions.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "extensions"));
                         return null;
@@ -4732,10 +4744,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                         }
@@ -4744,10 +4756,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             return null;
@@ -4769,7 +4781,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         return null;
@@ -4790,7 +4802,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         return null;
@@ -4811,7 +4823,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         return null;
@@ -4832,7 +4844,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         return null;
@@ -4853,7 +4865,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         return null;
@@ -4874,7 +4886,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "kind"));
                         return null;
@@ -4895,7 +4907,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         return null;
@@ -4916,7 +4928,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeQualifiers.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "qualifiers"));
                         return null;
@@ -4930,10 +4942,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                         }
@@ -4942,10 +4954,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                             return null;
@@ -4967,7 +4979,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "dataSpecifications"));
                         return null;
@@ -4981,10 +4993,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                         }
@@ -4993,10 +5005,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             return null;
@@ -5018,7 +5030,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "value"));
                         return null;
@@ -5072,7 +5084,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeExtensions.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "extensions"));
                         return null;
@@ -5086,10 +5098,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                         }
@@ -5098,10 +5110,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             return null;
@@ -5123,7 +5135,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         return null;
@@ -5144,7 +5156,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         return null;
@@ -5165,7 +5177,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         return null;
@@ -5186,7 +5198,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         return null;
@@ -5207,7 +5219,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         return null;
@@ -5228,7 +5240,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "kind"));
                         return null;
@@ -5249,7 +5261,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         return null;
@@ -5270,7 +5282,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeQualifiers.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "qualifiers"));
                         return null;
@@ -5284,10 +5296,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                         }
@@ -5296,10 +5308,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                             return null;
@@ -5321,7 +5333,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "dataSpecifications"));
                         return null;
@@ -5335,10 +5347,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                         }
@@ -5347,10 +5359,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             return null;
@@ -5375,7 +5387,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "mimeType"));
                     return null;
@@ -5395,7 +5407,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "value"));
                         return null;
@@ -5452,7 +5464,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeExtensions.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "extensions"));
                         return null;
@@ -5466,10 +5478,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                         }
@@ -5478,10 +5490,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             return null;
@@ -5503,7 +5515,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         return null;
@@ -5524,7 +5536,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         return null;
@@ -5545,7 +5557,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         return null;
@@ -5566,7 +5578,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         return null;
@@ -5587,7 +5599,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         return null;
@@ -5608,7 +5620,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "kind"));
                         return null;
@@ -5629,7 +5641,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         return null;
@@ -5650,7 +5662,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeQualifiers.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "qualifiers"));
                         return null;
@@ -5664,10 +5676,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                         }
@@ -5676,10 +5688,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                             return null;
@@ -5701,7 +5713,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "dataSpecifications"));
                         return null;
@@ -5715,10 +5727,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                         }
@@ -5727,10 +5739,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             return null;
@@ -5755,7 +5767,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "contentType"));
                     return null;
@@ -5775,7 +5787,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "value"));
                         return null;
@@ -5832,7 +5844,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeExtensions.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "extensions"));
                         return null;
@@ -5846,10 +5858,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                         }
@@ -5858,10 +5870,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             return null;
@@ -5883,7 +5895,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         return null;
@@ -5904,7 +5916,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         return null;
@@ -5925,7 +5937,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         return null;
@@ -5946,7 +5958,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         return null;
@@ -5967,7 +5979,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         return null;
@@ -5988,7 +6000,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "kind"));
                         return null;
@@ -6009,7 +6021,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         return null;
@@ -6030,7 +6042,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeQualifiers.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "qualifiers"));
                         return null;
@@ -6044,10 +6056,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                         }
@@ -6056,10 +6068,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                             return null;
@@ -6081,7 +6093,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "dataSpecifications"));
                         return null;
@@ -6095,10 +6107,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                         }
@@ -6107,10 +6119,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             return null;
@@ -6135,7 +6147,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "first"));
                     return null;
@@ -6158,7 +6170,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "second"));
                     return null;
@@ -6178,7 +6190,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeAnnotation.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "annotation"));
                         return null;
@@ -6192,10 +6204,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexAnnotation));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "annotation"));
                         }
@@ -6204,10 +6216,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexAnnotation));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "annotation"));
                             return null;
@@ -6298,7 +6310,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeExtensions.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "extensions"));
                         return null;
@@ -6312,10 +6324,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                         }
@@ -6324,10 +6336,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             return null;
@@ -6349,7 +6361,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         return null;
@@ -6370,7 +6382,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         return null;
@@ -6391,7 +6403,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         return null;
@@ -6412,7 +6424,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         return null;
@@ -6433,7 +6445,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         return null;
@@ -6454,7 +6466,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "kind"));
                         return null;
@@ -6475,7 +6487,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         return null;
@@ -6496,7 +6508,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeQualifiers.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "qualifiers"));
                         return null;
@@ -6510,10 +6522,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                         }
@@ -6522,10 +6534,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                             return null;
@@ -6547,7 +6559,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "dataSpecifications"));
                         return null;
@@ -6561,10 +6573,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                         }
@@ -6573,10 +6585,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             return null;
@@ -6601,7 +6613,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "entityType"));
                     return null;
@@ -6621,7 +6633,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeStatements.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "statements"));
                         return null;
@@ -6635,10 +6647,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexStatements));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "statements"));
                         }
@@ -6647,10 +6659,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexStatements));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "statements"));
                             return null;
@@ -6672,7 +6684,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "globalAssetId"));
                         return null;
@@ -6693,7 +6705,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "specificAssetId"));
                         return null;
@@ -6815,7 +6827,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "source"));
                     return null;
@@ -6835,7 +6847,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "sourceSemanticId"));
                         return null;
@@ -6859,7 +6871,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "observableReference"));
                     return null;
@@ -6879,7 +6891,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "observableSemanticId"));
                         return null;
@@ -6900,7 +6912,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "topic"));
                         return null;
@@ -6921,7 +6933,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "subjectId"));
                         return null;
@@ -6945,7 +6957,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "timeStamp"));
                     return null;
@@ -6965,7 +6977,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "payload"));
                         return null;
@@ -7000,6 +7012,7 @@ namespace AasCore.Aas3
             /// </summary>
             /// <param name="node">JSON node to be parsed</param>
             /// <param name="error">Error, if any, during the deserialization</param>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             public static Aas.IEventElement? IEventElementFrom(
                 Nodes.JsonNode node,
                 out Reporting.Error? error)
@@ -7078,7 +7091,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeExtensions.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "extensions"));
                         return null;
@@ -7092,10 +7105,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                         }
@@ -7104,10 +7117,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             return null;
@@ -7129,7 +7142,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         return null;
@@ -7150,7 +7163,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         return null;
@@ -7171,7 +7184,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         return null;
@@ -7192,7 +7205,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         return null;
@@ -7213,7 +7226,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         return null;
@@ -7234,7 +7247,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "kind"));
                         return null;
@@ -7255,7 +7268,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         return null;
@@ -7276,7 +7289,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeQualifiers.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "qualifiers"));
                         return null;
@@ -7290,10 +7303,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                         }
@@ -7302,10 +7315,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                             return null;
@@ -7327,7 +7340,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "dataSpecifications"));
                         return null;
@@ -7341,10 +7354,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                         }
@@ -7353,10 +7366,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             return null;
@@ -7381,7 +7394,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "observed"));
                     return null;
@@ -7404,7 +7417,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "direction"));
                     return null;
@@ -7427,7 +7440,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "state"));
                     return null;
@@ -7447,7 +7460,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "messageTopic"));
                         return null;
@@ -7468,7 +7481,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "messageBroker"));
                         return null;
@@ -7489,7 +7502,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "lastUpdate"));
                         return null;
@@ -7510,7 +7523,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "minInterval"));
                         return null;
@@ -7531,7 +7544,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "maxInterval"));
                         return null;
@@ -7598,7 +7611,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeExtensions.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "extensions"));
                         return null;
@@ -7612,10 +7625,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                         }
@@ -7624,10 +7637,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             return null;
@@ -7649,7 +7662,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         return null;
@@ -7670,7 +7683,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         return null;
@@ -7691,7 +7704,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         return null;
@@ -7712,7 +7725,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         return null;
@@ -7733,7 +7746,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         return null;
@@ -7754,7 +7767,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "kind"));
                         return null;
@@ -7775,7 +7788,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         return null;
@@ -7796,7 +7809,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeQualifiers.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "qualifiers"));
                         return null;
@@ -7810,10 +7823,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                         }
@@ -7822,10 +7835,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                             return null;
@@ -7847,7 +7860,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "dataSpecifications"));
                         return null;
@@ -7861,10 +7874,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                         }
@@ -7873,10 +7886,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             return null;
@@ -7898,7 +7911,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeInputVariables.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "inputVariables"));
                         return null;
@@ -7912,10 +7925,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexInputVariables));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "inputVariables"));
                         }
@@ -7924,10 +7937,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexInputVariables));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "inputVariables"));
                             return null;
@@ -7949,7 +7962,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeOutputVariables.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "outputVariables"));
                         return null;
@@ -7963,10 +7976,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexOutputVariables));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "outputVariables"));
                         }
@@ -7975,10 +7988,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexOutputVariables));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "outputVariables"));
                             return null;
@@ -8000,7 +8013,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeInoutputVariables.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "inoutputVariables"));
                         return null;
@@ -8014,10 +8027,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexInoutputVariables));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "inoutputVariables"));
                         }
@@ -8026,10 +8039,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexInoutputVariables));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "inoutputVariables"));
                             return null;
@@ -8089,7 +8102,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "value"));
                     return null;
@@ -8134,7 +8147,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeExtensions.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "extensions"));
                         return null;
@@ -8148,10 +8161,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                         }
@@ -8160,10 +8173,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             return null;
@@ -8185,7 +8198,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         return null;
@@ -8206,7 +8219,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         return null;
@@ -8227,7 +8240,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         return null;
@@ -8248,7 +8261,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         return null;
@@ -8269,7 +8282,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         return null;
@@ -8290,7 +8303,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "kind"));
                         return null;
@@ -8311,7 +8324,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         return null;
@@ -8332,7 +8345,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeQualifiers.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "qualifiers"));
                         return null;
@@ -8346,10 +8359,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                         }
@@ -8358,10 +8371,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                             return null;
@@ -8383,7 +8396,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "dataSpecifications"));
                         return null;
@@ -8397,10 +8410,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                         }
@@ -8409,10 +8422,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             return null;
@@ -8466,7 +8479,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeExtensions.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "extensions"));
                         return null;
@@ -8480,10 +8493,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                         }
@@ -8492,10 +8505,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             return null;
@@ -8517,7 +8530,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         return null;
@@ -8538,7 +8551,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         return null;
@@ -8559,7 +8572,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         return null;
@@ -8580,7 +8593,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         return null;
@@ -8601,7 +8614,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         return null;
@@ -8625,7 +8638,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "id"));
                     return null;
@@ -8645,7 +8658,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "administration"));
                         return null;
@@ -8666,7 +8679,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeDataSpecifications.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "dataSpecifications"));
                         return null;
@@ -8680,10 +8693,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                         }
@@ -8692,10 +8705,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             return null;
@@ -8717,7 +8730,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeIsCaseOf.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "isCaseOf"));
                         return null;
@@ -8731,10 +8744,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexIsCaseOf));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "isCaseOf"));
                         }
@@ -8743,10 +8756,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexIsCaseOf));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "isCaseOf"));
                             return null;
@@ -8780,6 +8793,7 @@ namespace AasCore.Aas3
             /// </summary>
             /// <param name="node">JSON node to be parsed</param>
             /// <param name="error">Error, if any, during the deserialization</param>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             public static Aas.IReference? IReferenceFrom(
                 Nodes.JsonNode node,
                 out Reporting.Error? error)
@@ -8864,7 +8878,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "value"));
                     return null;
@@ -8912,7 +8926,7 @@ namespace AasCore.Aas3
                 {
                     error = new Reporting.Error(
                         $"Expected a JsonArray, but got {nodeKeys.GetType()}");
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "keys"));
                     return null;
@@ -8926,10 +8940,10 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             "Expected a non-null item, but got a null");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.IndexSegment(
                                 indexKeys));
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "keys"));
                     }
@@ -8938,10 +8952,10 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.IndexSegment(
                                 indexKeys));
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "keys"));
                         return null;
@@ -8962,7 +8976,7 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "referredSemanticId"));
                         return null;
@@ -9012,7 +9026,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "type"));
                     return null;
@@ -9035,7 +9049,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "value"));
                     return null;
@@ -9296,7 +9310,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "language"));
                     return null;
@@ -9319,7 +9333,7 @@ namespace AasCore.Aas3
                     out error);
                 if (error != null)
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "text"));
                     return null;
@@ -9370,7 +9384,7 @@ namespace AasCore.Aas3
                 {
                     error = new Reporting.Error(
                         $"Expected a JsonArray, but got {nodeLangStrings.GetType()}");
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "langStrings"));
                     return null;
@@ -9384,10 +9398,10 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             "Expected a non-null item, but got a null");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.IndexSegment(
                                 indexLangStrings));
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "langStrings"));
                     }
@@ -9396,10 +9410,10 @@ namespace AasCore.Aas3
                         out error);
                     if (error != null)
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.IndexSegment(
                                 indexLangStrings));
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "langStrings"));
                         return null;
@@ -9445,7 +9459,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeAssetAdministrationShells.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "assetAdministrationShells"));
                         return null;
@@ -9459,10 +9473,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexAssetAdministrationShells));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "assetAdministrationShells"));
                         }
@@ -9471,10 +9485,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexAssetAdministrationShells));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "assetAdministrationShells"));
                             return null;
@@ -9496,7 +9510,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeSubmodels.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "submodels"));
                         return null;
@@ -9510,10 +9524,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexSubmodels));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "submodels"));
                         }
@@ -9522,10 +9536,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexSubmodels));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "submodels"));
                             return null;
@@ -9547,7 +9561,7 @@ namespace AasCore.Aas3
                     {
                         error = new Reporting.Error(
                             $"Expected a JsonArray, but got {nodeConceptDescriptions.GetType()}");
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "conceptDescriptions"));
                         return null;
@@ -9561,10 +9575,10 @@ namespace AasCore.Aas3
                         {
                             error = new Reporting.Error(
                                 "Expected a non-null item, but got a null");
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexConceptDescriptions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "conceptDescriptions"));
                         }
@@ -9573,10 +9587,10 @@ namespace AasCore.Aas3
                             out error);
                         if (error != null)
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexConceptDescriptions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "conceptDescriptions"));
                             return null;
@@ -9658,6 +9672,7 @@ namespace AasCore.Aas3
             /// Thrown when <paramref name="node" /> is not a valid JSON
             /// representation of IHasSemantics.
             /// </exception>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             public static Aas.IHasSemantics IHasSemanticsFrom(
                 Nodes.JsonNode node)
             {
@@ -9708,6 +9723,7 @@ namespace AasCore.Aas3
             /// Thrown when <paramref name="node" /> is not a valid JSON
             /// representation of IHasExtensions.
             /// </exception>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             public static Aas.IHasExtensions IHasExtensionsFrom(
                 Nodes.JsonNode node)
             {
@@ -9733,6 +9749,7 @@ namespace AasCore.Aas3
             /// Thrown when <paramref name="node" /> is not a valid JSON
             /// representation of IReferable.
             /// </exception>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             public static Aas.IReferable IReferableFrom(
                 Nodes.JsonNode node)
             {
@@ -9758,6 +9775,7 @@ namespace AasCore.Aas3
             /// Thrown when <paramref name="node" /> is not a valid JSON
             /// representation of IIdentifiable.
             /// </exception>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             public static Aas.IIdentifiable IIdentifiableFrom(
                 Nodes.JsonNode node)
             {
@@ -9808,6 +9826,7 @@ namespace AasCore.Aas3
             /// Thrown when <paramref name="node" /> is not a valid JSON
             /// representation of IHasKind.
             /// </exception>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             public static Aas.IHasKind IHasKindFrom(
                 Nodes.JsonNode node)
             {
@@ -9833,6 +9852,7 @@ namespace AasCore.Aas3
             /// Thrown when <paramref name="node" /> is not a valid JSON
             /// representation of IHasDataSpecification.
             /// </exception>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             public static Aas.IHasDataSpecification IHasDataSpecificationFrom(
                 Nodes.JsonNode node)
             {
@@ -9883,6 +9903,7 @@ namespace AasCore.Aas3
             /// Thrown when <paramref name="node" /> is not a valid JSON
             /// representation of IQualifiable.
             /// </exception>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             public static Aas.IQualifiable IQualifiableFrom(
                 Nodes.JsonNode node)
             {
@@ -10008,6 +10029,7 @@ namespace AasCore.Aas3
             /// Thrown when <paramref name="node" /> is not a valid JSON
             /// representation of IdentifierKeyValuePair.
             /// </exception>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             public static Aas.IdentifierKeyValuePair IdentifierKeyValuePairFrom(
                 Nodes.JsonNode node)
             {
@@ -10058,6 +10080,7 @@ namespace AasCore.Aas3
             /// Thrown when <paramref name="node" /> is not a valid JSON
             /// representation of ISubmodelElement.
             /// </exception>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             public static Aas.ISubmodelElement ISubmodelElementFrom(
                 Nodes.JsonNode node)
             {
@@ -10083,6 +10106,7 @@ namespace AasCore.Aas3
             /// Thrown when <paramref name="node" /> is not a valid JSON
             /// representation of IRelationshipElement.
             /// </exception>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             public static Aas.IRelationshipElement IRelationshipElementFrom(
                 Nodes.JsonNode node)
             {
@@ -10158,6 +10182,7 @@ namespace AasCore.Aas3
             /// Thrown when <paramref name="node" /> is not a valid JSON
             /// representation of IDataElement.
             /// </exception>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             public static Aas.IDataElement IDataElementFrom(
                 Nodes.JsonNode node)
             {
@@ -10483,6 +10508,7 @@ namespace AasCore.Aas3
             /// Thrown when <paramref name="node" /> is not a valid JSON
             /// representation of IEventElement.
             /// </exception>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             public static Aas.IEventElement IEventElementFrom(
                 Nodes.JsonNode node)
             {
@@ -10633,6 +10659,7 @@ namespace AasCore.Aas3
             /// Thrown when <paramref name="node" /> is not a valid JSON
             /// representation of IReference.
             /// </exception>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             public static Aas.IReference IReferenceFrom(
                 Nodes.JsonNode node)
             {
@@ -10733,6 +10760,7 @@ namespace AasCore.Aas3
             /// Thrown when <paramref name="node" /> is not a valid JSON
             /// representation of IdentifiableElements.
             /// </exception>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             public static Aas.IdentifiableElements IdentifiableElementsFrom(
                 Nodes.JsonNode node)
             {
@@ -10983,10 +11011,11 @@ namespace AasCore.Aas3
             /// Convert <paramref name="that" /> 64-bit long integer to a JSON value.
             /// </summary>
             /// <param name="that">value to be converted</param>
-            /// <exception name="System.ArgumentException>
-            /// Thrown if <paramref name="that"> is not within the range where it
+            /// <exception name="System.ArgumentException">
+            /// Thrown if <paramref name="that" /> is not within the range where it
             /// can be losslessly converted to a double floating number.
             /// </exception>
+            [CodeAnalysis.SuppressMessage("ReSharper", "UnusedMember.Local")]
             private static Nodes.JsonValue ToJsonValue(long that)
             {
                 // We need to check that we can perform a lossless conversion.
@@ -11110,6 +11139,8 @@ namespace AasCore.Aas3
                         that.ValueId);
                 }
 
+                result["modelType"] = "Qualifier";
+
                 return result;
             }
 
@@ -11200,6 +11231,8 @@ namespace AasCore.Aas3
                     result["derivedFrom"] = Transform(
                         that.DerivedFrom);
                 }
+
+                result["modelType"] = "AssetAdministrationShell";
 
                 return result;
             }
@@ -11363,6 +11396,8 @@ namespace AasCore.Aas3
                     result["submodelElements"] = arraySubmodelElements;
                 }
 
+                result["modelType"] = "Submodel";
+
                 return result;
             }
 
@@ -11487,6 +11522,8 @@ namespace AasCore.Aas3
                         value);
                 }
 
+                result["modelType"] = "SubmodelElementList";
+
                 return result;
             }
 
@@ -11586,6 +11623,8 @@ namespace AasCore.Aas3
                     }
                     result["value"] = arrayValue;
                 }
+
+                result["modelType"] = "SubmodelElementStruct";
 
                 return result;
             }
@@ -11690,6 +11729,8 @@ namespace AasCore.Aas3
                         that.ValueId);
                 }
 
+                result["modelType"] = "Property";
+
                 return result;
             }
 
@@ -11789,6 +11830,8 @@ namespace AasCore.Aas3
                     result["valueId"] = Transform(
                         that.ValueId);
                 }
+
+                result["modelType"] = "MultiLanguageProperty";
 
                 return result;
             }
@@ -11893,6 +11936,8 @@ namespace AasCore.Aas3
                         that.Max);
                 }
 
+                result["modelType"] = "Range";
+
                 return result;
             }
 
@@ -11986,6 +12031,8 @@ namespace AasCore.Aas3
                     result["value"] = Transform(
                         that.Value);
                 }
+
+                result["modelType"] = "ReferenceElement";
 
                 return result;
             }
@@ -12085,6 +12132,8 @@ namespace AasCore.Aas3
                             that.Value));
                 }
 
+                result["modelType"] = "Blob";
+
                 return result;
             }
 
@@ -12181,6 +12230,8 @@ namespace AasCore.Aas3
                     result["value"] = Nodes.JsonValue.Create(
                         that.Value);
                 }
+
+                result["modelType"] = "File";
 
                 return result;
             }
@@ -12287,6 +12338,8 @@ namespace AasCore.Aas3
                     }
                     result["annotation"] = arrayAnnotation;
                 }
+
+                result["modelType"] = "AnnotatedRelationshipElement";
 
                 return result;
             }
@@ -12402,6 +12455,8 @@ namespace AasCore.Aas3
                     result["specificAssetId"] = Transform(
                         that.SpecificAssetId);
                 }
+
+                result["modelType"] = "Entity";
 
                 return result;
             }
@@ -12576,6 +12631,8 @@ namespace AasCore.Aas3
                         that.MaxInterval);
                 }
 
+                result["modelType"] = "BasicEventElement";
+
                 return result;
             }
 
@@ -12700,6 +12757,8 @@ namespace AasCore.Aas3
                     result["inoutputVariables"] = arrayInoutputVariables;
                 }
 
+                result["modelType"] = "Operation";
+
                 return result;
             }
 
@@ -12798,6 +12857,8 @@ namespace AasCore.Aas3
                     result["dataSpecifications"] = arrayDataSpecifications;
                 }
 
+                result["modelType"] = "Capability";
+
                 return result;
             }
 
@@ -12880,6 +12941,8 @@ namespace AasCore.Aas3
                     result["isCaseOf"] = arrayIsCaseOf;
                 }
 
+                result["modelType"] = "ConceptDescription";
+
                 return result;
             }
 
@@ -12889,6 +12952,8 @@ namespace AasCore.Aas3
 
                 result["value"] = Nodes.JsonValue.Create(
                     that.Value);
+
+                result["modelType"] = "GlobalReference";
 
                 return result;
             }
@@ -12911,6 +12976,8 @@ namespace AasCore.Aas3
                     result["referredSemanticId"] = Transform(
                         that.ReferredSemanticId);
                 }
+
+                result["modelType"] = "ModelReference";
 
                 return result;
             }
@@ -13017,14 +13084,14 @@ namespace AasCore.Aas3
         /// </example>
         public static class Serialize
         {
-            private static Transformer _transformer = new Transformer();
+            private static readonly Transformer Transformer = new Transformer();
 
             /// <summary>
             /// Serialize an instance of the meta-model into a JSON object.
             /// </summary>
             public static Nodes.JsonObject ToJsonObject(Aas.IClass that)
             {
-                return Serialize._transformer.Transform(that);
+                return Serialize.Transformer.Transform(that);
             }
 
             /// <summary>

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/reporting.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/reporting.cs
@@ -3,6 +3,7 @@
  * Do NOT edit or append.
  */
 
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using System.Collections.Generic;  // can't alias
 
 using Aas = AasCore.Aas3;
@@ -16,28 +17,28 @@ namespace AasCore.Aas3
     {
         /// <summary>
         /// Capture a path segment of a value in a model.
-        /// </summary
+        /// </summary>
         public abstract class Segment {
             // Intentionally empty.
         }
 
         public class NameSegment : Segment {
-            internal readonly string Name;
-            internal NameSegment(string name)
+            public readonly string Name;
+            public NameSegment(string name)
             {
                 Name = name;
             }
         }
 
         public class IndexSegment : Segment {
-            internal readonly int Index;
-            internal IndexSegment(int index)
+            public readonly int Index;
+            public IndexSegment(int index)
             {
                 Index = index;
             }
         }
 
-        internal static System.Text.RegularExpressions.Regex VariableNameRe = (
+        private static readonly System.Text.RegularExpressions.Regex VariableNameRe = (
             new  System.Text.RegularExpressions.Regex(
                 @"^[a-zA-Z_][a-zA-Z_0-9]*$"));
 
@@ -55,7 +56,7 @@ namespace AasCore.Aas3
             int i = 0;
             foreach(var segment in segments)
             {
-                string? part = null;
+                string? part;
                 switch (segment)
                 {
                     case NameSegment nameSegment:
@@ -84,6 +85,7 @@ namespace AasCore.Aas3
                             $"Unexpected segment type: {segment.GetType()}");
                 }
                 parts.Add(part);
+                i++;
             }
             return string.Join("", parts);
         }
@@ -121,7 +123,7 @@ namespace AasCore.Aas3
             var parts = new List<string>(segments.Count);
             foreach(var segment in segments)
             {
-                string? part = null;
+                string? part;
                 switch (segment)
                 {
                     case NameSegment nameSegment:
@@ -144,14 +146,18 @@ namespace AasCore.Aas3
         /// </summary>
         public class Error
         {
-            internal LinkedList<Segment> _pathSegments = new LinkedList<Segment>();
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+            internal readonly LinkedList<Segment> _pathSegments = new LinkedList<Segment>();
             public readonly string Cause;
-            public ICollection<Segment> PathSegments {
-                get { return _pathSegments; }
-            }
-            internal Error(string cause)
+            public ICollection<Segment> PathSegments => _pathSegments;
+            public Error(string cause)
             {
                 Cause = cause;
+            }
+
+            public void PrependSegment(Segment segment)
+            {
+                _pathSegments.AddFirst(segment);
             }
         }
     }  // public static class Reporting

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/stringification.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/stringification.cs
@@ -3,6 +3,7 @@
  * Do NOT edit or append.
  */
 
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using System.Collections.Generic;  // can't alias
 
 using Aas = AasCore.Aas3;
@@ -11,7 +12,7 @@ namespace AasCore.Aas3
 {
     public static class Stringification
     {
-        private static readonly Dictionary<Aas.ModelingKind, string> _modelingKindToString = (
+        private static readonly Dictionary<Aas.ModelingKind, string> ModelingKindToString = (
             new Dictionary<Aas.ModelingKind, string>()
             {
                 { Aas.ModelingKind.Template, "TEMPLATE" },
@@ -32,7 +33,7 @@ namespace AasCore.Aas3
             }
             else
             {
-                if (_modelingKindToString.TryGetValue(that.Value, out string? value))
+                if (ModelingKindToString.TryGetValue(that.Value, out string? value))
                 {
                     return value;
                 }
@@ -43,6 +44,7 @@ namespace AasCore.Aas3
             }
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Dictionary<string, Aas.ModelingKind> _modelingKindFromString = (
             new Dictionary<string, Aas.ModelingKind>()
             {
@@ -70,7 +72,7 @@ namespace AasCore.Aas3
             }
         }
 
-        private static readonly Dictionary<Aas.AssetKind, string> _assetKindToString = (
+        private static readonly Dictionary<Aas.AssetKind, string> AssetKindToString = (
             new Dictionary<Aas.AssetKind, string>()
             {
                 { Aas.AssetKind.Type, "Type" },
@@ -91,7 +93,7 @@ namespace AasCore.Aas3
             }
             else
             {
-                if (_assetKindToString.TryGetValue(that.Value, out string? value))
+                if (AssetKindToString.TryGetValue(that.Value, out string? value))
                 {
                     return value;
                 }
@@ -102,6 +104,7 @@ namespace AasCore.Aas3
             }
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Dictionary<string, Aas.AssetKind> _assetKindFromString = (
             new Dictionary<string, Aas.AssetKind>()
             {
@@ -129,7 +132,7 @@ namespace AasCore.Aas3
             }
         }
 
-        private static readonly Dictionary<Aas.EntityType, string> _entityTypeToString = (
+        private static readonly Dictionary<Aas.EntityType, string> EntityTypeToString = (
             new Dictionary<Aas.EntityType, string>()
             {
                 { Aas.EntityType.CoManagedEntity, "COMANAGEDENTITY" },
@@ -150,7 +153,7 @@ namespace AasCore.Aas3
             }
             else
             {
-                if (_entityTypeToString.TryGetValue(that.Value, out string? value))
+                if (EntityTypeToString.TryGetValue(that.Value, out string? value))
                 {
                     return value;
                 }
@@ -161,6 +164,7 @@ namespace AasCore.Aas3
             }
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Dictionary<string, Aas.EntityType> _entityTypeFromString = (
             new Dictionary<string, Aas.EntityType>()
             {
@@ -188,7 +192,7 @@ namespace AasCore.Aas3
             }
         }
 
-        private static readonly Dictionary<Aas.Direction, string> _directionToString = (
+        private static readonly Dictionary<Aas.Direction, string> DirectionToString = (
             new Dictionary<Aas.Direction, string>()
             {
                 { Aas.Direction.Input, "INPUT" },
@@ -209,7 +213,7 @@ namespace AasCore.Aas3
             }
             else
             {
-                if (_directionToString.TryGetValue(that.Value, out string? value))
+                if (DirectionToString.TryGetValue(that.Value, out string? value))
                 {
                     return value;
                 }
@@ -220,6 +224,7 @@ namespace AasCore.Aas3
             }
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Dictionary<string, Aas.Direction> _directionFromString = (
             new Dictionary<string, Aas.Direction>()
             {
@@ -247,7 +252,7 @@ namespace AasCore.Aas3
             }
         }
 
-        private static readonly Dictionary<Aas.StateOfEvent, string> _stateOfEventToString = (
+        private static readonly Dictionary<Aas.StateOfEvent, string> StateOfEventToString = (
             new Dictionary<Aas.StateOfEvent, string>()
             {
                 { Aas.StateOfEvent.On, "ON" },
@@ -268,7 +273,7 @@ namespace AasCore.Aas3
             }
             else
             {
-                if (_stateOfEventToString.TryGetValue(that.Value, out string? value))
+                if (StateOfEventToString.TryGetValue(that.Value, out string? value))
                 {
                     return value;
                 }
@@ -279,6 +284,7 @@ namespace AasCore.Aas3
             }
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Dictionary<string, Aas.StateOfEvent> _stateOfEventFromString = (
             new Dictionary<string, Aas.StateOfEvent>()
             {
@@ -306,7 +312,7 @@ namespace AasCore.Aas3
             }
         }
 
-        private static readonly Dictionary<Aas.IdentifiableElements, string> _identifiableElementsToString = (
+        private static readonly Dictionary<Aas.IdentifiableElements, string> IdentifiableElementsToString = (
             new Dictionary<Aas.IdentifiableElements, string>()
             {
                 { Aas.IdentifiableElements.AssetAdministrationShell, "AssetAdministrationShell" },
@@ -328,7 +334,7 @@ namespace AasCore.Aas3
             }
             else
             {
-                if (_identifiableElementsToString.TryGetValue(that.Value, out string? value))
+                if (IdentifiableElementsToString.TryGetValue(that.Value, out string? value))
                 {
                     return value;
                 }
@@ -339,6 +345,7 @@ namespace AasCore.Aas3
             }
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Dictionary<string, Aas.IdentifiableElements> _identifiableElementsFromString = (
             new Dictionary<string, Aas.IdentifiableElements>()
             {
@@ -367,7 +374,7 @@ namespace AasCore.Aas3
             }
         }
 
-        private static readonly Dictionary<Aas.SubmodelElementElements, string> _submodelElementElementsToString = (
+        private static readonly Dictionary<Aas.SubmodelElementElements, string> SubmodelElementElementsToString = (
             new Dictionary<Aas.SubmodelElementElements, string>()
             {
                 { Aas.SubmodelElementElements.AnnotatedRelationshipElement, "AnnotatedRelationshipElement" },
@@ -403,7 +410,7 @@ namespace AasCore.Aas3
             }
             else
             {
-                if (_submodelElementElementsToString.TryGetValue(that.Value, out string? value))
+                if (SubmodelElementElementsToString.TryGetValue(that.Value, out string? value))
                 {
                     return value;
                 }
@@ -414,6 +421,7 @@ namespace AasCore.Aas3
             }
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Dictionary<string, Aas.SubmodelElementElements> _submodelElementElementsFromString = (
             new Dictionary<string, Aas.SubmodelElementElements>()
             {
@@ -456,7 +464,7 @@ namespace AasCore.Aas3
             }
         }
 
-        private static readonly Dictionary<Aas.ReferableElements, string> _referableElementsToString = (
+        private static readonly Dictionary<Aas.ReferableElements, string> ReferableElementsToString = (
             new Dictionary<Aas.ReferableElements, string>()
             {
                 { Aas.ReferableElements.AnnotatedRelationshipElement, "AnnotatedRelationshipElement" },
@@ -495,7 +503,7 @@ namespace AasCore.Aas3
             }
             else
             {
-                if (_referableElementsToString.TryGetValue(that.Value, out string? value))
+                if (ReferableElementsToString.TryGetValue(that.Value, out string? value))
                 {
                     return value;
                 }
@@ -506,6 +514,7 @@ namespace AasCore.Aas3
             }
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Dictionary<string, Aas.ReferableElements> _referableElementsFromString = (
             new Dictionary<string, Aas.ReferableElements>()
             {
@@ -551,7 +560,7 @@ namespace AasCore.Aas3
             }
         }
 
-        private static readonly Dictionary<Aas.KeyElements, string> _keyElementsToString = (
+        private static readonly Dictionary<Aas.KeyElements, string> KeyElementsToString = (
             new Dictionary<Aas.KeyElements, string>()
             {
                 { Aas.KeyElements.FragmentReference, "FragmentReference" },
@@ -592,7 +601,7 @@ namespace AasCore.Aas3
             }
             else
             {
-                if (_keyElementsToString.TryGetValue(that.Value, out string? value))
+                if (KeyElementsToString.TryGetValue(that.Value, out string? value))
                 {
                     return value;
                 }
@@ -603,6 +612,7 @@ namespace AasCore.Aas3
             }
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Dictionary<string, Aas.KeyElements> _keyElementsFromString = (
             new Dictionary<string, Aas.KeyElements>()
             {
@@ -650,7 +660,7 @@ namespace AasCore.Aas3
             }
         }
 
-        private static readonly Dictionary<Aas.DataTypeDefXsd, string> _dataTypeDefXsdToString = (
+        private static readonly Dictionary<Aas.DataTypeDefXsd, string> DataTypeDefXsdToString = (
             new Dictionary<Aas.DataTypeDefXsd, string>()
             {
                 { Aas.DataTypeDefXsd.AnyUri, "xs:anyURI" },
@@ -702,7 +712,7 @@ namespace AasCore.Aas3
             }
             else
             {
-                if (_dataTypeDefXsdToString.TryGetValue(that.Value, out string? value))
+                if (DataTypeDefXsdToString.TryGetValue(that.Value, out string? value))
                 {
                     return value;
                 }
@@ -713,6 +723,7 @@ namespace AasCore.Aas3
             }
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Dictionary<string, Aas.DataTypeDefXsd> _dataTypeDefXsdFromString = (
             new Dictionary<string, Aas.DataTypeDefXsd>()
             {
@@ -771,7 +782,7 @@ namespace AasCore.Aas3
             }
         }
 
-        private static readonly Dictionary<Aas.DataTypeDefRdf, string> _dataTypeDefRdfToString = (
+        private static readonly Dictionary<Aas.DataTypeDefRdf, string> DataTypeDefRdfToString = (
             new Dictionary<Aas.DataTypeDefRdf, string>()
             {
                 { Aas.DataTypeDefRdf.LangString, "rdf:langString" }
@@ -791,7 +802,7 @@ namespace AasCore.Aas3
             }
             else
             {
-                if (_dataTypeDefRdfToString.TryGetValue(that.Value, out string? value))
+                if (DataTypeDefRdfToString.TryGetValue(that.Value, out string? value))
                 {
                     return value;
                 }
@@ -802,6 +813,7 @@ namespace AasCore.Aas3
             }
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Dictionary<string, Aas.DataTypeDefRdf> _dataTypeDefRdfFromString = (
             new Dictionary<string, Aas.DataTypeDefRdf>()
             {
@@ -828,7 +840,7 @@ namespace AasCore.Aas3
             }
         }
 
-        private static readonly Dictionary<Aas.DataTypeDef, string> _dataTypeDefToString = (
+        private static readonly Dictionary<Aas.DataTypeDef, string> DataTypeDefToString = (
             new Dictionary<Aas.DataTypeDef, string>()
             {
                 { Aas.DataTypeDef.AnyUri, "xs:anyURI" },
@@ -881,7 +893,7 @@ namespace AasCore.Aas3
             }
             else
             {
-                if (_dataTypeDefToString.TryGetValue(that.Value, out string? value))
+                if (DataTypeDefToString.TryGetValue(that.Value, out string? value))
                 {
                     return value;
                 }
@@ -892,6 +904,7 @@ namespace AasCore.Aas3
             }
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Dictionary<string, Aas.DataTypeDef> _dataTypeDefFromString = (
             new Dictionary<string, Aas.DataTypeDef>()
             {

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/types.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/types.cs
@@ -35,7 +35,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context);
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context);
 
         /// <summary>
         /// Accept the <paramref name="transformer" /> to transform this instance
@@ -47,8 +49,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context);
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context);
     }
 
     /// <summary>
@@ -101,7 +104,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -119,8 +124,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }
@@ -149,9 +155,7 @@ namespace AasCore.Aas3
     /// <summary>
     /// Single extension of an element.
     /// </summary>
-    public class Extension :
-            IHasSemantics,
-            IClass
+    public class Extension : IHasSemantics
     {
         /// <summary>
         /// Identifier of the semantic definition of the element. It is called semantic ID
@@ -258,7 +262,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -276,8 +282,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }
@@ -318,9 +325,7 @@ namespace AasCore.Aas3
     /// This identifier is not globally unique.
     /// This identifier is unique within the name space of the element.
     /// </remarks>
-    public interface IReferable :
-            IHasExtensions,
-            IClass
+    public interface IReferable : IHasExtensions
     {
         /// <summary>
         /// In case of identifiables this attribute is a short name of the element.
@@ -411,9 +416,7 @@ namespace AasCore.Aas3
     /// <summary>
     /// An element that has a globally unique identifier.
     /// </summary>
-    public interface IIdentifiable :
-            IReferable,
-            IClass
+    public interface IIdentifiable : IReferable
     {
         /// <summary>
         /// The globally unique identification of the element.
@@ -512,9 +515,7 @@ namespace AasCore.Aas3
     ///     </li>
     /// </ul>
     /// </remarks>
-    public class AdministrativeInformation :
-            IHasDataSpecification,
-            IClass
+    public class AdministrativeInformation : IHasDataSpecification
     {
         /// <summary>
         /// Global reference to the data specification template used by the element.
@@ -579,7 +580,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -597,8 +600,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }
@@ -657,9 +661,7 @@ namespace AasCore.Aas3
     ///     </li>
     /// </ul>
     /// </remarks>
-    public class Qualifier :
-            IHasSemantics,
-            IClass
+    public class Qualifier : IHasSemantics
     {
         /// <summary>
         /// Identifier of the semantic definition of the element. It is called semantic ID
@@ -746,7 +748,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -764,8 +768,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }
@@ -790,8 +795,7 @@ namespace AasCore.Aas3
     /// </summary>
     public class AssetAdministrationShell :
             IIdentifiable,
-            IHasDataSpecification,
-            IClass
+            IHasDataSpecification
     {
         /// <summary>
         /// An extension of the element.
@@ -1088,7 +1092,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -1106,8 +1112,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }
@@ -1262,7 +1269,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -1280,8 +1289,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }
@@ -1334,9 +1344,7 @@ namespace AasCore.Aas3
     /// An <see cref="IdentifierKeyValuePair" /> describes a generic identifier as
     /// key-value pair.
     /// </summary>
-    public class IdentifierKeyValuePair :
-            IHasSemantics,
-            IClass
+    public class IdentifierKeyValuePair : IHasSemantics
     {
         /// <summary>
         /// Identifier of the semantic definition of the element. It is called semantic ID
@@ -1417,7 +1425,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -1435,8 +1445,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }
@@ -1468,8 +1479,7 @@ namespace AasCore.Aas3
             IHasKind,
             IHasSemantics,
             IQualifiable,
-            IHasDataSpecification,
-            IClass
+            IHasDataSpecification
     {
         /// <summary>
         /// An extension of the element.
@@ -1801,7 +1811,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -1819,8 +1831,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }
@@ -1868,8 +1881,7 @@ namespace AasCore.Aas3
             IHasKind,
             IHasSemantics,
             IQualifiable,
-            IHasDataSpecification,
-            IClass
+            IHasDataSpecification
     {
 
     }
@@ -1878,9 +1890,7 @@ namespace AasCore.Aas3
     /// A relationship element is used to define a relationship between two elements
     /// being either referable (model reference) or external (global reference).
     /// </summary>
-    public interface IRelationshipElement :
-            ISubmodelElement,
-            IClass
+    public interface IRelationshipElement : ISubmodelElement
     {
         /// <summary>
         /// Reference to the first element in the relationship taking the role of the subject.
@@ -1932,9 +1942,7 @@ namespace AasCore.Aas3
     ///     </li>
     /// </ul>
     /// </remarks>
-    public class SubmodelElementList :
-            ISubmodelElement,
-            IClass
+    public class SubmodelElementList : ISubmodelElement
     {
         /// <summary>
         /// An extension of the element.
@@ -2286,7 +2294,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -2304,8 +2314,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }
@@ -2349,9 +2360,7 @@ namespace AasCore.Aas3
     /// A submodel element struct is is a logical encapsulation of multiple values. It has
     /// a number of of submodel elements.
     /// </summary>
-    public class SubmodelElementStruct :
-            ISubmodelElement,
-            IClass
+    public class SubmodelElementStruct : ISubmodelElement
     {
         /// <summary>
         /// An extension of the element.
@@ -2653,7 +2662,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -2671,8 +2682,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }
@@ -2724,9 +2736,7 @@ namespace AasCore.Aas3
     ///     </li>
     /// </ul>
     /// </remarks>
-    public interface IDataElement :
-            ISubmodelElement,
-            IClass
+    public interface IDataElement : ISubmodelElement
     {
 
     }
@@ -2745,9 +2755,7 @@ namespace AasCore.Aas3
     ///     </li>
     /// </ul>
     /// </remarks>
-    public class Property :
-            IDataElement,
-            IClass
+    public class Property : IDataElement
     {
         /// <summary>
         /// An extension of the element.
@@ -3053,7 +3061,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -3071,8 +3081,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }
@@ -3122,9 +3133,7 @@ namespace AasCore.Aas3
     ///     </li>
     /// </ul>
     /// </remarks>
-    public class MultiLanguageProperty :
-            IDataElement,
-            IClass
+    public class MultiLanguageProperty : IDataElement
     {
         /// <summary>
         /// An extension of the element.
@@ -3441,7 +3450,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -3459,8 +3470,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }
@@ -3497,9 +3509,7 @@ namespace AasCore.Aas3
     /// <summary>
     /// A range data element is a data element that defines a range with min and max.
     /// </summary>
-    public class Range :
-            IDataElement,
-            IClass
+    public class Range : IDataElement
     {
         /// <summary>
         /// An extension of the element.
@@ -3791,7 +3801,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -3809,8 +3821,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }
@@ -3851,9 +3864,7 @@ namespace AasCore.Aas3
     /// element within the same or another AAS or a reference to an external object or
     /// entity.
     /// </summary>
-    public class ReferenceElement :
-            IDataElement,
-            IClass
+    public class ReferenceElement : IDataElement
     {
         /// <summary>
         /// An extension of the element.
@@ -4151,7 +4162,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -4169,8 +4182,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }
@@ -4206,9 +4220,7 @@ namespace AasCore.Aas3
     /// A <see cref="Blob" /> is a data element that represents a file that is contained with its
     /// source code in the value attribute.
     /// </summary>
-    public class Blob :
-            IDataElement,
-            IClass
+    public class Blob : IDataElement
     {
         /// <summary>
         /// An extension of the element.
@@ -4502,7 +4514,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -4520,8 +4534,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }
@@ -4561,9 +4576,7 @@ namespace AasCore.Aas3
     /// <remarks>
     /// The value is an URI that can represent an absolute or relative path.
     /// </remarks>
-    public class File :
-            IDataElement,
-            IClass
+    public class File : IDataElement
     {
         /// <summary>
         /// An extension of the element.
@@ -4852,7 +4865,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -4870,8 +4885,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }
@@ -4909,9 +4925,7 @@ namespace AasCore.Aas3
     /// An annotated relationship element is a relationship element that can be annotated
     /// with additional data elements.
     /// </summary>
-    public class AnnotatedRelationshipElement :
-            IRelationshipElement,
-            IClass
+    public class AnnotatedRelationshipElement : IRelationshipElement
     {
         /// <summary>
         /// An extension of the element.
@@ -5244,7 +5258,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -5262,8 +5278,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }
@@ -5335,9 +5352,7 @@ namespace AasCore.Aas3
     ///     </li>
     /// </ul>
     /// </remarks>
-    public class Entity :
-            ISubmodelElement,
-            IClass
+    public class Entity : ISubmodelElement
     {
         /// <summary>
         /// An extension of the element.
@@ -5688,7 +5703,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -5706,8 +5723,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }
@@ -5932,7 +5950,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -5950,8 +5970,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }
@@ -5980,9 +6001,7 @@ namespace AasCore.Aas3
     /// <summary>
     /// An event element.
     /// </summary>
-    public interface IEventElement :
-            ISubmodelElement,
-            IClass
+    public interface IEventElement : ISubmodelElement
     {
 
     }
@@ -5990,9 +6009,7 @@ namespace AasCore.Aas3
     /// <summary>
     /// A basic event element.
     /// </summary>
-    public class BasicEventElement :
-            IEventElement,
-            IClass
+    public class BasicEventElement : IEventElement
     {
         /// <summary>
         /// An extension of the element.
@@ -6356,7 +6373,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -6374,8 +6393,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }
@@ -6424,9 +6444,7 @@ namespace AasCore.Aas3
     /// <summary>
     /// An operation is a submodel element with input and output variables.
     /// </summary>
-    public class Operation :
-            ISubmodelElement,
-            IClass
+    public class Operation : ISubmodelElement
     {
         /// <summary>
         /// An extension of the element.
@@ -6782,7 +6800,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -6800,8 +6820,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }
@@ -6888,7 +6909,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -6906,8 +6929,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }
@@ -6926,9 +6950,7 @@ namespace AasCore.Aas3
     /// The <see cref="Capability.SemanticId" /> of a capability is typically an ontology.
     /// Thus, reasoning on capabilities is enabled.
     /// </remarks>
-    public class Capability :
-            ISubmodelElement,
-            IClass
+    public class Capability : ISubmodelElement
     {
         /// <summary>
         /// An extension of the element.
@@ -7203,7 +7225,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -7221,8 +7245,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }
@@ -7273,8 +7298,7 @@ namespace AasCore.Aas3
     /// </remarks>
     public class ConceptDescription :
             IIdentifiable,
-            IHasDataSpecification,
-            IClass
+            IHasDataSpecification
     {
         /// <summary>
         /// An extension of the element.
@@ -7554,7 +7578,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -7572,8 +7598,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }
@@ -7615,9 +7642,7 @@ namespace AasCore.Aas3
     /// <summary>
     /// Reference to an external entity.
     /// </summary>
-    public class GlobalReference :
-            IReference,
-            IClass
+    public class GlobalReference : IReference
     {
         /// <summary>
         /// Unique identifier
@@ -7660,7 +7685,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -7678,8 +7705,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }
@@ -7698,9 +7726,7 @@ namespace AasCore.Aas3
     /// The complete list of keys may for example be concatenated to a path that then gives
     /// unique access to an element.
     /// </remarks>
-    public class ModelReference :
-            IReference,
-            IClass
+    public class ModelReference : IReference
     {
         /// <summary>
         /// Unique references in their name space.
@@ -7770,7 +7796,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -7788,8 +7816,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }
@@ -7857,7 +7886,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -7875,8 +7906,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }
@@ -8499,7 +8531,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -8517,8 +8551,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }
@@ -8591,7 +8626,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -8609,8 +8646,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }
@@ -8738,7 +8776,9 @@ namespace AasCore.Aas3
         /// Accept the visitor to visit this instance for double dispatch
         /// with the <paramref name="context" />.
         /// </summary>
-        public void Accept<C>(Visitation.IVisitorWithContext<C> visitor, C context)
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
         {
             visitor.Visit(this, context);
         }
@@ -8756,8 +8796,9 @@ namespace AasCore.Aas3
         /// Accept the <paramref name="transformer" /> to visit this instance
         /// for double dispatch with the <paramref name="context" />.
         /// </summary>
-        public T Transform<C, T>(
-            Visitation.ITransformerWithContext<C, T> transformer, C context)
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
         {
             return transformer.Transform(this, context);
         }

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/verification.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/verification.cs
@@ -3,13 +3,12 @@
  * Do NOT edit or append.
  */
 
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
 
 using Aas = AasCore.Aas3;
-using Reporting = AasCore.Aas3.Reporting;
-using Visitation = AasCore.Aas3.Visitation;
 
 namespace AasCore.Aas3
 {
@@ -32,6 +31,9 @@ namespace AasCore.Aas3
     /// </example>
     public static class Verification
     {
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsDateTimeStampUtc()
         {
             var digit = "[0-9]";
@@ -49,7 +51,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsDateTimeStampUtc = _constructMatchesXsDateTimeStampUtc();
+        private static readonly Regex RegexMatchesXsDateTimeStampUtc = _constructMatchesXsDateTimeStampUtc();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:dateTimeStamp</c>.
@@ -69,7 +71,7 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsDateTimeStampUtc(string text)
         {
-            return _regexMatchesXsDateTimeStampUtc.IsMatch(text);
+            return RegexMatchesXsDateTimeStampUtc.IsMatch(text);
         }
 
         public static bool IsXsDateTimeStampUtc(
@@ -79,6 +81,9 @@ namespace AasCore.Aas3
             throw new System.NotImplementedException("TODO");
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesMimeType()
         {
             var tchar = "[!#$%&'*+\\-.^_`|~0-9a-zA-Z]";
@@ -96,7 +101,7 @@ namespace AasCore.Aas3
             return new Regex(mediaType);
         }
 
-        private static readonly Regex _regexMatchesMimeType = _constructMatchesMimeType();
+        private static readonly Regex RegexMatchesMimeType = _constructMatchesMimeType();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of MIME type.
@@ -115,9 +120,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesMimeType(string text)
         {
-            return _regexMatchesMimeType.IsMatch(text);
+            return RegexMatchesMimeType.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesRfc8089Path()
         {
             var h16 = "[0-9A-Fa-f]{1,4}";
@@ -147,7 +155,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesRfc8089Path = _constructMatchesRfc8089Path();
+        private static readonly Regex RegexMatchesRfc8089Path = _constructMatchesRfc8089Path();
 
         /// <summary>
         /// Check that <paramref name="text" /> is a path conforming to the pattern of RFC 8089.
@@ -164,9 +172,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesRfc8089Path(string text)
         {
-            return _regexMatchesRfc8089Path.IsMatch(text);
+            return RegexMatchesRfc8089Path.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesBcp47()
         {
             var alphanum = "[a-zA-Z0-9]";
@@ -188,7 +199,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesBcp47 = _constructMatchesBcp47();
+        private static readonly Regex RegexMatchesBcp47 = _constructMatchesBcp47();
 
         /// <summary>
         /// Check that <paramref name="text" /> is a valid BCP 47 language tag.
@@ -198,7 +209,7 @@ namespace AasCore.Aas3
         /// </remarks>
         public static bool MatchesBcp47(string text)
         {
-            return _regexMatchesBcp47.IsMatch(text);
+            return RegexMatchesBcp47.IsMatch(text);
         }
 
         public static bool LangStringsHaveUniqueLanguages(
@@ -215,6 +226,9 @@ namespace AasCore.Aas3
             throw new System.NotImplementedException("TODO");
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsAnyUri()
         {
             var scheme = "[a-zA-Z][a-zA-Z0-9+\\-.]*";
@@ -257,7 +271,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsAnyUri = _constructMatchesXsAnyUri();
+        private static readonly Regex RegexMatchesXsAnyUri = _constructMatchesXsAnyUri();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:anyURI</c>.
@@ -274,9 +288,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsAnyUri(string text)
         {
-            return _regexMatchesXsAnyUri.IsMatch(text);
+            return RegexMatchesXsAnyUri.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsBase64Binary()
         {
             var b04Char = "[AQgw]";
@@ -296,7 +313,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsBase64Binary = _constructMatchesXsBase64Binary();
+        private static readonly Regex RegexMatchesXsBase64Binary = _constructMatchesXsBase64Binary();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:base64Binary</c>.
@@ -312,9 +329,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsBase64Binary(string text)
         {
-            return _regexMatchesXsBase64Binary.IsMatch(text);
+            return RegexMatchesXsBase64Binary.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsBoolean()
         {
             var pattern = "^(true|false|1|0)$";
@@ -322,7 +342,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsBoolean = _constructMatchesXsBoolean();
+        private static readonly Regex RegexMatchesXsBoolean = _constructMatchesXsBoolean();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:boolean</c>.
@@ -338,9 +358,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsBoolean(string text)
         {
-            return _regexMatchesXsBoolean.IsMatch(text);
+            return RegexMatchesXsBoolean.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsDate()
         {
             var digit = "[0-9]";
@@ -355,7 +378,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsDate = _constructMatchesXsDate();
+        private static readonly Regex RegexMatchesXsDate = _constructMatchesXsDate();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:date</c>.
@@ -371,9 +394,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsDate(string text)
         {
-            return _regexMatchesXsDate.IsMatch(text);
+            return RegexMatchesXsDate.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsDateTime()
         {
             var digit = "[0-9]";
@@ -391,7 +417,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsDateTime = _constructMatchesXsDateTime();
+        private static readonly Regex RegexMatchesXsDateTime = _constructMatchesXsDateTime();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:dateTime</c>.
@@ -407,9 +433,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsDateTime(string text)
         {
-            return _regexMatchesXsDateTime.IsMatch(text);
+            return RegexMatchesXsDateTime.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsDateTimeStamp()
         {
             var digit = "[0-9]";
@@ -427,7 +456,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsDateTimeStamp = _constructMatchesXsDateTimeStamp();
+        private static readonly Regex RegexMatchesXsDateTimeStamp = _constructMatchesXsDateTimeStamp();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:dateTimeStamp</c>.
@@ -443,9 +472,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsDateTimeStamp(string text)
         {
-            return _regexMatchesXsDateTimeStamp.IsMatch(text);
+            return RegexMatchesXsDateTimeStamp.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsDecimal()
         {
             var digit = "[0-9]";
@@ -460,7 +492,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsDecimal = _constructMatchesXsDecimal();
+        private static readonly Regex RegexMatchesXsDecimal = _constructMatchesXsDecimal();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:decimal</c>.
@@ -476,9 +508,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsDecimal(string text)
         {
-            return _regexMatchesXsDecimal.IsMatch(text);
+            return RegexMatchesXsDecimal.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsDouble()
         {
             var doubleRep = "(\\+|-)?([0-9]+(\\.[0-9]*)?|\\.[0-9]+)([Ee](\\+|-)?[0-9]+)?|(\\+|-)?INF|NaN";
@@ -487,7 +522,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsDouble = _constructMatchesXsDouble();
+        private static readonly Regex RegexMatchesXsDouble = _constructMatchesXsDouble();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:double</c>.
@@ -503,9 +538,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsDouble(string text)
         {
-            return _regexMatchesXsDouble.IsMatch(text);
+            return RegexMatchesXsDouble.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsDuration()
         {
             var durationRep = "-?P((([0-9]+Y([0-9]+M)?([0-9]+D)?|([0-9]+M)([0-9]+D)?|([0-9]+D))(T(([0-9]+H)([0-9]+M)?([0-9]+(\\.[0-9]+)?S)?|([0-9]+M)([0-9]+(\\.[0-9]+)?S)?|([0-9]+(\\.[0-9]+)?S)))?)|(T(([0-9]+H)([0-9]+M)?([0-9]+(\\.[0-9]+)?S)?|([0-9]+M)([0-9]+(\\.[0-9]+)?S)?|([0-9]+(\\.[0-9]+)?S))))";
@@ -514,7 +552,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsDuration = _constructMatchesXsDuration();
+        private static readonly Regex RegexMatchesXsDuration = _constructMatchesXsDuration();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:duration</c>.
@@ -530,9 +568,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsDuration(string text)
         {
-            return _regexMatchesXsDuration.IsMatch(text);
+            return RegexMatchesXsDuration.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsFloat()
         {
             var floatRep = "(\\+|-)?([0-9]+(\\.[0-9]*)?|\\.[0-9]+)([Ee](\\+|-)?[0-9]+)?|(\\+|-)?INF|NaN";
@@ -541,7 +582,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsFloat = _constructMatchesXsFloat();
+        private static readonly Regex RegexMatchesXsFloat = _constructMatchesXsFloat();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:float</c>.
@@ -557,9 +598,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsFloat(string text)
         {
-            return _regexMatchesXsFloat.IsMatch(text);
+            return RegexMatchesXsFloat.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsGDay()
         {
             var gDayLexicalRep = "---(0[1-9]|[12][0-9]|3[01])(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?";
@@ -568,7 +612,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsGDay = _constructMatchesXsGDay();
+        private static readonly Regex RegexMatchesXsGDay = _constructMatchesXsGDay();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:gDay</c>.
@@ -584,9 +628,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsGDay(string text)
         {
-            return _regexMatchesXsGDay.IsMatch(text);
+            return RegexMatchesXsGDay.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsGMonth()
         {
             var gMonthLexicalRep = "--(0[1-9]|1[0-2])(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?";
@@ -595,7 +642,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsGMonth = _constructMatchesXsGMonth();
+        private static readonly Regex RegexMatchesXsGMonth = _constructMatchesXsGMonth();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:gMonth</c>.
@@ -611,9 +658,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsGMonth(string text)
         {
-            return _regexMatchesXsGMonth.IsMatch(text);
+            return RegexMatchesXsGMonth.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsGMonthDay()
         {
             var gMonthDayRep = "--(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?";
@@ -622,7 +672,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsGMonthDay = _constructMatchesXsGMonthDay();
+        private static readonly Regex RegexMatchesXsGMonthDay = _constructMatchesXsGMonthDay();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:gMonthDay</c>.
@@ -638,9 +688,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsGMonthDay(string text)
         {
-            return _regexMatchesXsGMonthDay.IsMatch(text);
+            return RegexMatchesXsGMonthDay.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsGYear()
         {
             var gYearRep = "-?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?";
@@ -649,7 +702,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsGYear = _constructMatchesXsGYear();
+        private static readonly Regex RegexMatchesXsGYear = _constructMatchesXsGYear();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:gYear</c>.
@@ -665,9 +718,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsGYear(string text)
         {
-            return _regexMatchesXsGYear.IsMatch(text);
+            return RegexMatchesXsGYear.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsGYearMonth()
         {
             var gYearMonthRep = "-?([1-9][0-9]{3,}|0[0-9]{3})-(0[1-9]|1[0-2])(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?";
@@ -676,7 +732,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsGYearMonth = _constructMatchesXsGYearMonth();
+        private static readonly Regex RegexMatchesXsGYearMonth = _constructMatchesXsGYearMonth();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:gYearMonth</c>.
@@ -692,9 +748,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsGYearMonth(string text)
         {
-            return _regexMatchesXsGYearMonth.IsMatch(text);
+            return RegexMatchesXsGYearMonth.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsHexBinary()
         {
             var hexBinary = "([0-9a-fA-F]{2})*";
@@ -703,7 +762,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsHexBinary = _constructMatchesXsHexBinary();
+        private static readonly Regex RegexMatchesXsHexBinary = _constructMatchesXsHexBinary();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:hexBinary</c>.
@@ -719,9 +778,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsHexBinary(string text)
         {
-            return _regexMatchesXsHexBinary.IsMatch(text);
+            return RegexMatchesXsHexBinary.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsTime()
         {
             var timeRep = "(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\\.[0-9]+)?|(24:00:00(\\.0+)?))(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?";
@@ -730,7 +792,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsTime = _constructMatchesXsTime();
+        private static readonly Regex RegexMatchesXsTime = _constructMatchesXsTime();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:time</c>.
@@ -746,9 +808,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsTime(string text)
         {
-            return _regexMatchesXsTime.IsMatch(text);
+            return RegexMatchesXsTime.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsDayTimeDuration()
         {
             var dayTimeDurationRep = "-?P((([0-9]+D)(T(([0-9]+H)([0-9]+M)?([0-9]+(\\.[0-9]+)?S)?|([0-9]+M)([0-9]+(\\.[0-9]+)?S)?|([0-9]+(\\.[0-9]+)?S)))?)|(T(([0-9]+H)([0-9]+M)?([0-9]+(\\.[0-9]+)?S)?|([0-9]+M)([0-9]+(\\.[0-9]+)?S)?|([0-9]+(\\.[0-9]+)?S))))";
@@ -757,7 +822,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsDayTimeDuration = _constructMatchesXsDayTimeDuration();
+        private static readonly Regex RegexMatchesXsDayTimeDuration = _constructMatchesXsDayTimeDuration();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:dayTimeDuration</c>.
@@ -773,9 +838,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsDayTimeDuration(string text)
         {
-            return _regexMatchesXsDayTimeDuration.IsMatch(text);
+            return RegexMatchesXsDayTimeDuration.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsYearMonthDuration()
         {
             var yearMonthDurationRep = "-?P((([0-9]+Y)([0-9]+M)?)|([0-9]+M))";
@@ -784,7 +852,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsYearMonthDuration = _constructMatchesXsYearMonthDuration();
+        private static readonly Regex RegexMatchesXsYearMonthDuration = _constructMatchesXsYearMonthDuration();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:yearMonthDuration</c>.
@@ -800,9 +868,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsYearMonthDuration(string text)
         {
-            return _regexMatchesXsYearMonthDuration.IsMatch(text);
+            return RegexMatchesXsYearMonthDuration.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsInteger()
         {
             var integerRep = "[-+]?[0-9]+";
@@ -811,7 +882,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsInteger = _constructMatchesXsInteger();
+        private static readonly Regex RegexMatchesXsInteger = _constructMatchesXsInteger();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:integer</c>.
@@ -827,9 +898,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsInteger(string text)
         {
-            return _regexMatchesXsInteger.IsMatch(text);
+            return RegexMatchesXsInteger.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsLong()
         {
             var longRep = "[-+]?[0-9]+";
@@ -838,7 +912,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsLong = _constructMatchesXsLong();
+        private static readonly Regex RegexMatchesXsLong = _constructMatchesXsLong();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:long</c>.
@@ -854,9 +928,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsLong(string text)
         {
-            return _regexMatchesXsLong.IsMatch(text);
+            return RegexMatchesXsLong.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsInt()
         {
             var intRep = "[-+]?[0-9]+";
@@ -865,7 +942,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsInt = _constructMatchesXsInt();
+        private static readonly Regex RegexMatchesXsInt = _constructMatchesXsInt();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:int</c>.
@@ -881,9 +958,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsInt(string text)
         {
-            return _regexMatchesXsInt.IsMatch(text);
+            return RegexMatchesXsInt.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsShort()
         {
             var shortRep = "[-+]?[0-9]+";
@@ -892,7 +972,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsShort = _constructMatchesXsShort();
+        private static readonly Regex RegexMatchesXsShort = _constructMatchesXsShort();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:short</c>.
@@ -908,9 +988,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsShort(string text)
         {
-            return _regexMatchesXsShort.IsMatch(text);
+            return RegexMatchesXsShort.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsByte()
         {
             var byteRep = "[-+]?[0-9]+";
@@ -919,7 +1002,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsByte = _constructMatchesXsByte();
+        private static readonly Regex RegexMatchesXsByte = _constructMatchesXsByte();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:byte</c>.
@@ -935,9 +1018,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsByte(string text)
         {
-            return _regexMatchesXsByte.IsMatch(text);
+            return RegexMatchesXsByte.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsNonNegativeInteger()
         {
             var nonNegativeIntegerRep = "(-0|\\+?[0-9]+)";
@@ -946,7 +1032,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsNonNegativeInteger = _constructMatchesXsNonNegativeInteger();
+        private static readonly Regex RegexMatchesXsNonNegativeInteger = _constructMatchesXsNonNegativeInteger();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:nonNegativeInteger</c>.
@@ -962,9 +1048,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsNonNegativeInteger(string text)
         {
-            return _regexMatchesXsNonNegativeInteger.IsMatch(text);
+            return RegexMatchesXsNonNegativeInteger.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsPositiveInteger()
         {
             var positiveIntegerRep = "\\+?0*[1-9][0-9]*";
@@ -973,7 +1062,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsPositiveInteger = _constructMatchesXsPositiveInteger();
+        private static readonly Regex RegexMatchesXsPositiveInteger = _constructMatchesXsPositiveInteger();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:positiveInteger</c>.
@@ -989,9 +1078,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsPositiveInteger(string text)
         {
-            return _regexMatchesXsPositiveInteger.IsMatch(text);
+            return RegexMatchesXsPositiveInteger.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsUnsignedLong()
         {
             var unsignedLongRep = "(-0|\\+?[0-9]+)";
@@ -1000,7 +1092,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsUnsignedLong = _constructMatchesXsUnsignedLong();
+        private static readonly Regex RegexMatchesXsUnsignedLong = _constructMatchesXsUnsignedLong();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:unsignedLong</c>.
@@ -1016,9 +1108,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsUnsignedLong(string text)
         {
-            return _regexMatchesXsUnsignedLong.IsMatch(text);
+            return RegexMatchesXsUnsignedLong.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsUnsignedInt()
         {
             var unsignedIntRep = "(-0|\\+?[0-9]+)";
@@ -1027,7 +1122,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsUnsignedInt = _constructMatchesXsUnsignedInt();
+        private static readonly Regex RegexMatchesXsUnsignedInt = _constructMatchesXsUnsignedInt();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:unsignedInt</c>.
@@ -1043,9 +1138,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsUnsignedInt(string text)
         {
-            return _regexMatchesXsUnsignedInt.IsMatch(text);
+            return RegexMatchesXsUnsignedInt.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsUnsignedShort()
         {
             var unsignedShortRep = "(-0|\\+?[0-9]+)";
@@ -1054,7 +1152,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsUnsignedShort = _constructMatchesXsUnsignedShort();
+        private static readonly Regex RegexMatchesXsUnsignedShort = _constructMatchesXsUnsignedShort();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:unsignedShort</c>.
@@ -1070,9 +1168,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsUnsignedShort(string text)
         {
-            return _regexMatchesXsUnsignedShort.IsMatch(text);
+            return RegexMatchesXsUnsignedShort.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsUnsignedByte()
         {
             var unsignedByteRep = "(-0|\\+?[0-9]+)";
@@ -1081,7 +1182,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsUnsignedByte = _constructMatchesXsUnsignedByte();
+        private static readonly Regex RegexMatchesXsUnsignedByte = _constructMatchesXsUnsignedByte();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:unsignedByte</c>.
@@ -1097,9 +1198,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsUnsignedByte(string text)
         {
-            return _regexMatchesXsUnsignedByte.IsMatch(text);
+            return RegexMatchesXsUnsignedByte.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsNonPositiveInteger()
         {
             var nonPositiveIntegerRep = "(\\+0|0|-[0-9]+)";
@@ -1108,7 +1212,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsNonPositiveInteger = _constructMatchesXsNonPositiveInteger();
+        private static readonly Regex RegexMatchesXsNonPositiveInteger = _constructMatchesXsNonPositiveInteger();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:nonPositiveInteger</c>.
@@ -1124,9 +1228,12 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsNonPositiveInteger(string text)
         {
-            return _regexMatchesXsNonPositiveInteger.IsMatch(text);
+            return RegexMatchesXsNonPositiveInteger.IsMatch(text);
         }
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchesXsNegativeInteger()
         {
             var negativeIntegerRep = "(-0*[1-9][0-9]*)";
@@ -1135,7 +1242,7 @@ namespace AasCore.Aas3
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchesXsNegativeInteger = _constructMatchesXsNegativeInteger();
+        private static readonly Regex RegexMatchesXsNegativeInteger = _constructMatchesXsNegativeInteger();
 
         /// <summary>
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:negativeInteger</c>.
@@ -1151,7 +1258,7 @@ namespace AasCore.Aas3
         /// </returns>
         public static bool MatchesXsNegativeInteger(string text)
         {
-            return _regexMatchesXsNegativeInteger.IsMatch(text);
+            return RegexMatchesXsNegativeInteger.IsMatch(text);
         }
 
         public static bool ValueConsistentWithXsdType(
@@ -1230,45 +1337,52 @@ namespace AasCore.Aas3
         /// </summary>
         internal static class EnumValueSet
         {
-            internal static HashSet<int> ForModelingKind = new HashSet<int>
+            internal static readonly HashSet<int> ForModelingKind = new HashSet<int>
             {
+
                 (int)Aas.ModelingKind.Template,
                 (int)Aas.ModelingKind.Instance
             };
 
-            internal static HashSet<int> ForAssetKind = new HashSet<int>
+            internal static readonly HashSet<int> ForAssetKind = new HashSet<int>
             {
+
                 (int)Aas.AssetKind.Type,
                 (int)Aas.AssetKind.Instance
             };
 
-            internal static HashSet<int> ForEntityType = new HashSet<int>
+            internal static readonly HashSet<int> ForEntityType = new HashSet<int>
             {
+
                 (int)Aas.EntityType.CoManagedEntity,
                 (int)Aas.EntityType.SelfManagedEntity
             };
 
-            internal static HashSet<int> ForDirection = new HashSet<int>
+            internal static readonly HashSet<int> ForDirection = new HashSet<int>
             {
+
                 (int)Aas.Direction.Input,
                 (int)Aas.Direction.Output
             };
 
-            internal static HashSet<int> ForStateOfEvent = new HashSet<int>
+            internal static readonly HashSet<int> ForStateOfEvent = new HashSet<int>
             {
+
                 (int)Aas.StateOfEvent.On,
                 (int)Aas.StateOfEvent.Off
             };
 
-            internal static HashSet<int> ForIdentifiableElements = new HashSet<int>
+            internal static readonly HashSet<int> ForIdentifiableElements = new HashSet<int>
             {
+
                 (int)Aas.IdentifiableElements.AssetAdministrationShell,
                 (int)Aas.IdentifiableElements.ConceptDescription,
                 (int)Aas.IdentifiableElements.Submodel
             };
 
-            internal static HashSet<int> ForSubmodelElementElements = new HashSet<int>
+            internal static readonly HashSet<int> ForSubmodelElementElements = new HashSet<int>
             {
+
                 (int)Aas.SubmodelElementElements.AnnotatedRelationshipElement,
                 (int)Aas.SubmodelElementElements.BasicEventElement,
                 (int)Aas.SubmodelElementElements.Blob,
@@ -1288,8 +1402,9 @@ namespace AasCore.Aas3
                 (int)Aas.SubmodelElementElements.SubmodelElementStruct
             };
 
-            internal static HashSet<int> ForReferableElements = new HashSet<int>
+            internal static readonly HashSet<int> ForReferableElements = new HashSet<int>
             {
+
                 (int)Aas.ReferableElements.AnnotatedRelationshipElement,
                 (int)Aas.ReferableElements.AssetAdministrationShell,
                 (int)Aas.ReferableElements.BasicEventElement,
@@ -1312,8 +1427,9 @@ namespace AasCore.Aas3
                 (int)Aas.ReferableElements.SubmodelElementStruct
             };
 
-            internal static HashSet<int> ForKeyElements = new HashSet<int>
+            internal static readonly HashSet<int> ForKeyElements = new HashSet<int>
             {
+
                 (int)Aas.KeyElements.FragmentReference,
                 (int)Aas.KeyElements.GlobalReference,
                 (int)Aas.KeyElements.AnnotatedRelationshipElement,
@@ -1338,8 +1454,9 @@ namespace AasCore.Aas3
                 (int)Aas.KeyElements.SubmodelElementStruct
             };
 
-            internal static HashSet<int> ForDataTypeDefXsd = new HashSet<int>
+            internal static readonly HashSet<int> ForDataTypeDefXsd = new HashSet<int>
             {
+
                 (int)Aas.DataTypeDefXsd.AnyUri,
                 (int)Aas.DataTypeDefXsd.Base64Binary,
                 (int)Aas.DataTypeDefXsd.Boolean,
@@ -1375,13 +1492,15 @@ namespace AasCore.Aas3
                 (int)Aas.DataTypeDefXsd.NegativeInteger
             };
 
-            internal static HashSet<int> ForDataTypeDefRdf = new HashSet<int>
+            internal static readonly HashSet<int> ForDataTypeDefRdf = new HashSet<int>
             {
+
                 (int)Aas.DataTypeDefRdf.LangString
             };
 
-            internal static HashSet<int> ForDataTypeDef = new HashSet<int>
+            internal static readonly HashSet<int> ForDataTypeDef = new HashSet<int>
             {
+
                 (int)Aas.DataTypeDef.AnyUri,
                 (int)Aas.DataTypeDef.Base64Binary,
                 (int)Aas.DataTypeDef.Boolean,
@@ -1419,18 +1538,20 @@ namespace AasCore.Aas3
             };
         }  // internal static class EnumValueSet
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Verification.Transformer _transformer = (
             new Verification.Transformer());
 
         private class Transformer
             : Visitation.AbstractTransformer<IEnumerable<Reporting.Error>>
         {
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.Resource that)
             {
                 foreach (var error in Verification.VerifyAssetKind(that.Path))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "path"));
                     yield return error;
@@ -1440,7 +1561,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyContentType(that.ContentType))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "contentType"));
                         yield return error;
@@ -1448,6 +1569,7 @@ namespace AasCore.Aas3
                 }
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.Extension that)
             {
@@ -1455,7 +1577,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.SemanticId))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         yield return error;
@@ -1464,7 +1586,7 @@ namespace AasCore.Aas3
 
                 foreach (var error in Verification.VerifyNonEmptyString(that.Name))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "name"));
                     yield return error;
@@ -1477,7 +1599,7 @@ namespace AasCore.Aas3
                         ?? throw new System.InvalidOperationException();
                     foreach (var error in Verification.VerifyDataTypeDefXsd(value))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "valueType"));
                         yield return error;
@@ -1488,7 +1610,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyValueDataType(that.Value))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "value"));
                         yield return error;
@@ -1499,7 +1621,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.RefersTo))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "refersTo"));
                         yield return error;
@@ -1507,6 +1629,7 @@ namespace AasCore.Aas3
                 }
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.AdministrativeInformation that)
             {
@@ -1531,10 +1654,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             yield return error;
@@ -1547,7 +1670,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Version))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "version"));
                         yield return error;
@@ -1558,7 +1681,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Revision))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "revision"));
                         yield return error;
@@ -1566,6 +1689,7 @@ namespace AasCore.Aas3
                 }
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.Qualifier that)
             {
@@ -1585,7 +1709,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.SemanticId))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         yield return error;
@@ -1594,7 +1718,7 @@ namespace AasCore.Aas3
 
                 foreach (var error in Verification.VerifyQualifierType(that.Type))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "type"));
                     yield return error;
@@ -1602,7 +1726,7 @@ namespace AasCore.Aas3
 
                 foreach (var error in Verification.VerifyDataTypeDefXsd(that.ValueType))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "valueType"));
                     yield return error;
@@ -1612,7 +1736,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyValueDataType(that.Value))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "value"));
                         yield return error;
@@ -1623,7 +1747,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.ValueId))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "valueId"));
                         yield return error;
@@ -1631,6 +1755,7 @@ namespace AasCore.Aas3
                 }
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.AssetAdministrationShell that)
             {
@@ -1695,10 +1820,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             yield return error;
@@ -1711,7 +1836,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.IdShort))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         yield return error;
@@ -1722,7 +1847,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.DisplayName))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         yield return error;
@@ -1733,7 +1858,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Category))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         yield return error;
@@ -1744,7 +1869,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.Description))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         yield return error;
@@ -1755,7 +1880,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Checksum))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         yield return error;
@@ -1764,7 +1889,7 @@ namespace AasCore.Aas3
 
                 foreach (var error in Verification.VerifyIdentifier(that.Id))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "id"));
                     yield return error;
@@ -1774,7 +1899,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.Administration))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "administration"));
                         yield return error;
@@ -1788,10 +1913,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             yield return error;
@@ -1802,7 +1927,7 @@ namespace AasCore.Aas3
 
                 foreach (var error in Verification.Verify(that.AssetInformation))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "assetInformation"));
                     yield return error;
@@ -1815,10 +1940,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexSubmodels));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "submodels"));
                             yield return error;
@@ -1831,7 +1956,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.DerivedFrom))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "derivedFrom"));
                         yield return error;
@@ -1839,12 +1964,13 @@ namespace AasCore.Aas3
                 }
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.AssetInformation that)
             {
                 foreach (var error in Verification.VerifyAssetKind(that.AssetKind))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "assetKind"));
                     yield return error;
@@ -1854,7 +1980,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.GlobalAssetId))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "globalAssetId"));
                         yield return error;
@@ -1865,7 +1991,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.SpecificAssetId))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "specificAssetId"));
                         yield return error;
@@ -1876,7 +2002,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.DefaultThumbnail))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "defaultThumbnail"));
                         yield return error;
@@ -1884,6 +2010,7 @@ namespace AasCore.Aas3
                 }
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.IdentifierKeyValuePair that)
             {
@@ -1891,7 +2018,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.SemanticId))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         yield return error;
@@ -1900,7 +2027,7 @@ namespace AasCore.Aas3
 
                 foreach (var error in Verification.VerifyNonEmptyString(that.Key))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "key"));
                     yield return error;
@@ -1908,7 +2035,7 @@ namespace AasCore.Aas3
 
                 foreach (var error in Verification.VerifyNonEmptyString(that.Value))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "value"));
                     yield return error;
@@ -1918,7 +2045,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.ExternalSubjectId))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "externalSubjectId"));
                         yield return error;
@@ -1926,6 +2053,7 @@ namespace AasCore.Aas3
                 }
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.Submodel that)
             {
@@ -1999,10 +2127,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             yield return error;
@@ -2015,7 +2143,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.IdShort))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         yield return error;
@@ -2026,7 +2154,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.DisplayName))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         yield return error;
@@ -2037,7 +2165,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Category))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         yield return error;
@@ -2048,7 +2176,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.Description))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         yield return error;
@@ -2059,7 +2187,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Checksum))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         yield return error;
@@ -2068,7 +2196,7 @@ namespace AasCore.Aas3
 
                 foreach (var error in Verification.VerifyIdentifier(that.Id))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "id"));
                     yield return error;
@@ -2078,7 +2206,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.Administration))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "administration"));
                         yield return error;
@@ -2092,7 +2220,7 @@ namespace AasCore.Aas3
                         ?? throw new System.InvalidOperationException();
                     foreach (var error in Verification.VerifyModelingKind(value))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "kind"));
                         yield return error;
@@ -2103,7 +2231,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.SemanticId))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         yield return error;
@@ -2117,10 +2245,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                             yield return error;
@@ -2136,10 +2264,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             yield return error;
@@ -2155,10 +2283,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexSubmodelElements));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "submodelElements"));
                             yield return error;
@@ -2168,6 +2296,7 @@ namespace AasCore.Aas3
                 }
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.SubmodelElementList that)
             {
@@ -2331,10 +2460,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             yield return error;
@@ -2347,7 +2476,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.IdShort))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         yield return error;
@@ -2358,7 +2487,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.DisplayName))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         yield return error;
@@ -2369,7 +2498,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Category))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         yield return error;
@@ -2380,7 +2509,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.Description))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         yield return error;
@@ -2391,7 +2520,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Checksum))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         yield return error;
@@ -2405,7 +2534,7 @@ namespace AasCore.Aas3
                         ?? throw new System.InvalidOperationException();
                     foreach (var error in Verification.VerifyModelingKind(value))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "kind"));
                         yield return error;
@@ -2416,7 +2545,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.SemanticId))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         yield return error;
@@ -2430,10 +2559,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                             yield return error;
@@ -2449,10 +2578,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             yield return error;
@@ -2465,7 +2594,7 @@ namespace AasCore.Aas3
                         var error in Verification.VerifySubmodelElementElements(
                             that.TypeValueListElement))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "typeValueListElement"));
                     yield return error;
@@ -2478,10 +2607,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexValue));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "value"));
                             yield return error;
@@ -2494,7 +2623,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.SemanticIdListElement))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticIdListElement"));
                         yield return error;
@@ -2508,7 +2637,7 @@ namespace AasCore.Aas3
                         ?? throw new System.InvalidOperationException();
                     foreach (var error in Verification.VerifyDataTypeDefXsd(value))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "valueTypeListElement"));
                         yield return error;
@@ -2516,6 +2645,7 @@ namespace AasCore.Aas3
                 }
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.SubmodelElementStruct that)
             {
@@ -2589,10 +2719,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             yield return error;
@@ -2605,7 +2735,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.IdShort))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         yield return error;
@@ -2616,7 +2746,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.DisplayName))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         yield return error;
@@ -2627,7 +2757,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Category))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         yield return error;
@@ -2638,7 +2768,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.Description))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         yield return error;
@@ -2649,7 +2779,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Checksum))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         yield return error;
@@ -2663,7 +2793,7 @@ namespace AasCore.Aas3
                         ?? throw new System.InvalidOperationException();
                     foreach (var error in Verification.VerifyModelingKind(value))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "kind"));
                         yield return error;
@@ -2674,7 +2804,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.SemanticId))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         yield return error;
@@ -2688,10 +2818,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                             yield return error;
@@ -2707,10 +2837,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             yield return error;
@@ -2726,10 +2856,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexValue));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "value"));
                             yield return error;
@@ -2739,6 +2869,7 @@ namespace AasCore.Aas3
                 }
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.Property that)
             {
@@ -2815,10 +2946,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             yield return error;
@@ -2831,7 +2962,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.IdShort))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         yield return error;
@@ -2842,7 +2973,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.DisplayName))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         yield return error;
@@ -2853,7 +2984,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Category))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         yield return error;
@@ -2864,7 +2995,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.Description))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         yield return error;
@@ -2875,7 +3006,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Checksum))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         yield return error;
@@ -2889,7 +3020,7 @@ namespace AasCore.Aas3
                         ?? throw new System.InvalidOperationException();
                     foreach (var error in Verification.VerifyModelingKind(value))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "kind"));
                         yield return error;
@@ -2900,7 +3031,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.SemanticId))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         yield return error;
@@ -2914,10 +3045,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                             yield return error;
@@ -2933,10 +3064,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             yield return error;
@@ -2947,7 +3078,7 @@ namespace AasCore.Aas3
 
                 foreach (var error in Verification.VerifyDataTypeDefXsd(that.ValueType))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "valueType"));
                     yield return error;
@@ -2957,7 +3088,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyValueDataType(that.Value))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "value"));
                         yield return error;
@@ -2968,7 +3099,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.ValueId))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "valueId"));
                         yield return error;
@@ -2976,6 +3107,7 @@ namespace AasCore.Aas3
                 }
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.MultiLanguageProperty that)
             {
@@ -3042,10 +3174,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             yield return error;
@@ -3058,7 +3190,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.IdShort))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         yield return error;
@@ -3069,7 +3201,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.DisplayName))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         yield return error;
@@ -3080,7 +3212,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Category))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         yield return error;
@@ -3091,7 +3223,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.Description))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         yield return error;
@@ -3102,7 +3234,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Checksum))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         yield return error;
@@ -3116,7 +3248,7 @@ namespace AasCore.Aas3
                         ?? throw new System.InvalidOperationException();
                     foreach (var error in Verification.VerifyModelingKind(value))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "kind"));
                         yield return error;
@@ -3127,7 +3259,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.SemanticId))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         yield return error;
@@ -3141,10 +3273,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                             yield return error;
@@ -3160,10 +3292,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             yield return error;
@@ -3176,7 +3308,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.Value))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "value"));
                         yield return error;
@@ -3187,7 +3319,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.ValueId))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "valueId"));
                         yield return error;
@@ -3195,6 +3327,7 @@ namespace AasCore.Aas3
                 }
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.Range that)
             {
@@ -3281,10 +3414,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             yield return error;
@@ -3297,7 +3430,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.IdShort))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         yield return error;
@@ -3308,7 +3441,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.DisplayName))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         yield return error;
@@ -3319,7 +3452,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Category))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         yield return error;
@@ -3330,7 +3463,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.Description))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         yield return error;
@@ -3341,7 +3474,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Checksum))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         yield return error;
@@ -3355,7 +3488,7 @@ namespace AasCore.Aas3
                         ?? throw new System.InvalidOperationException();
                     foreach (var error in Verification.VerifyModelingKind(value))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "kind"));
                         yield return error;
@@ -3366,7 +3499,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.SemanticId))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         yield return error;
@@ -3380,10 +3513,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                             yield return error;
@@ -3399,10 +3532,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             yield return error;
@@ -3413,7 +3546,7 @@ namespace AasCore.Aas3
 
                 foreach (var error in Verification.VerifyDataTypeDefXsd(that.ValueType))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "valueType"));
                     yield return error;
@@ -3423,7 +3556,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyValueDataType(that.Min))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "min"));
                         yield return error;
@@ -3434,7 +3567,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyValueDataType(that.Max))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "max"));
                         yield return error;
@@ -3442,6 +3575,7 @@ namespace AasCore.Aas3
                 }
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.ReferenceElement that)
             {
@@ -3508,10 +3642,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             yield return error;
@@ -3524,7 +3658,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.IdShort))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         yield return error;
@@ -3535,7 +3669,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.DisplayName))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         yield return error;
@@ -3546,7 +3680,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Category))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         yield return error;
@@ -3557,7 +3691,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.Description))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         yield return error;
@@ -3568,7 +3702,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Checksum))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         yield return error;
@@ -3582,7 +3716,7 @@ namespace AasCore.Aas3
                         ?? throw new System.InvalidOperationException();
                     foreach (var error in Verification.VerifyModelingKind(value))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "kind"));
                         yield return error;
@@ -3593,7 +3727,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.SemanticId))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         yield return error;
@@ -3607,10 +3741,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                             yield return error;
@@ -3626,10 +3760,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             yield return error;
@@ -3642,7 +3776,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.Value))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "value"));
                         yield return error;
@@ -3650,6 +3784,7 @@ namespace AasCore.Aas3
                 }
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.Blob that)
             {
@@ -3716,10 +3851,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             yield return error;
@@ -3732,7 +3867,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.IdShort))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         yield return error;
@@ -3743,7 +3878,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.DisplayName))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         yield return error;
@@ -3754,7 +3889,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Category))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         yield return error;
@@ -3765,7 +3900,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.Description))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         yield return error;
@@ -3776,7 +3911,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Checksum))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         yield return error;
@@ -3790,7 +3925,7 @@ namespace AasCore.Aas3
                         ?? throw new System.InvalidOperationException();
                     foreach (var error in Verification.VerifyModelingKind(value))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "kind"));
                         yield return error;
@@ -3801,7 +3936,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.SemanticId))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         yield return error;
@@ -3815,10 +3950,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                             yield return error;
@@ -3834,10 +3969,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             yield return error;
@@ -3848,7 +3983,7 @@ namespace AasCore.Aas3
 
                 foreach (var error in Verification.VerifyContentType(that.MimeType))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "mimeType"));
                     yield return error;
@@ -3858,7 +3993,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyBlobType(that.Value))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "value"));
                         yield return error;
@@ -3866,6 +4001,7 @@ namespace AasCore.Aas3
                 }
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.File that)
             {
@@ -3932,10 +4068,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             yield return error;
@@ -3948,7 +4084,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.IdShort))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         yield return error;
@@ -3959,7 +4095,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.DisplayName))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         yield return error;
@@ -3970,7 +4106,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Category))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         yield return error;
@@ -3981,7 +4117,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.Description))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         yield return error;
@@ -3992,7 +4128,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Checksum))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         yield return error;
@@ -4006,7 +4142,7 @@ namespace AasCore.Aas3
                         ?? throw new System.InvalidOperationException();
                     foreach (var error in Verification.VerifyModelingKind(value))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "kind"));
                         yield return error;
@@ -4017,7 +4153,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.SemanticId))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         yield return error;
@@ -4031,10 +4167,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                             yield return error;
@@ -4050,10 +4186,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             yield return error;
@@ -4064,7 +4200,7 @@ namespace AasCore.Aas3
 
                 foreach (var error in Verification.VerifyContentType(that.ContentType))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "contentType"));
                     yield return error;
@@ -4074,7 +4210,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyPathType(that.Value))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "value"));
                         yield return error;
@@ -4082,6 +4218,7 @@ namespace AasCore.Aas3
                 }
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.AnnotatedRelationshipElement that)
             {
@@ -4128,10 +4265,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             yield return error;
@@ -4144,7 +4281,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.IdShort))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         yield return error;
@@ -4155,7 +4292,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.DisplayName))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         yield return error;
@@ -4166,7 +4303,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Category))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         yield return error;
@@ -4177,7 +4314,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.Description))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         yield return error;
@@ -4188,7 +4325,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Checksum))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         yield return error;
@@ -4202,7 +4339,7 @@ namespace AasCore.Aas3
                         ?? throw new System.InvalidOperationException();
                     foreach (var error in Verification.VerifyModelingKind(value))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "kind"));
                         yield return error;
@@ -4213,7 +4350,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.SemanticId))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         yield return error;
@@ -4227,10 +4364,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                             yield return error;
@@ -4246,10 +4383,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             yield return error;
@@ -4260,7 +4397,7 @@ namespace AasCore.Aas3
 
                 foreach (var error in Verification.Verify(that.First))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "first"));
                     yield return error;
@@ -4268,7 +4405,7 @@ namespace AasCore.Aas3
 
                 foreach (var error in Verification.Verify(that.Second))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "second"));
                     yield return error;
@@ -4281,10 +4418,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexAnnotation));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "annotation"));
                             yield return error;
@@ -4294,6 +4431,7 @@ namespace AasCore.Aas3
                 }
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.Entity that)
             {
@@ -4383,10 +4521,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             yield return error;
@@ -4399,7 +4537,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.IdShort))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         yield return error;
@@ -4410,7 +4548,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.DisplayName))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         yield return error;
@@ -4421,7 +4559,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Category))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         yield return error;
@@ -4432,7 +4570,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.Description))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         yield return error;
@@ -4443,7 +4581,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Checksum))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         yield return error;
@@ -4457,7 +4595,7 @@ namespace AasCore.Aas3
                         ?? throw new System.InvalidOperationException();
                     foreach (var error in Verification.VerifyModelingKind(value))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "kind"));
                         yield return error;
@@ -4468,7 +4606,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.SemanticId))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         yield return error;
@@ -4482,10 +4620,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                             yield return error;
@@ -4501,10 +4639,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             yield return error;
@@ -4515,7 +4653,7 @@ namespace AasCore.Aas3
 
                 foreach (var error in Verification.VerifyEntityType(that.EntityType))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "entityType"));
                     yield return error;
@@ -4528,10 +4666,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexStatements));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "statements"));
                             yield return error;
@@ -4544,7 +4682,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.GlobalAssetId))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "globalAssetId"));
                         yield return error;
@@ -4555,7 +4693,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.SpecificAssetId))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "specificAssetId"));
                         yield return error;
@@ -4563,12 +4701,13 @@ namespace AasCore.Aas3
                 }
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.EventPayload that)
             {
                 foreach (var error in Verification.Verify(that.Source))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "source"));
                     yield return error;
@@ -4578,7 +4717,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.SourceSemanticId))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "sourceSemanticId"));
                         yield return error;
@@ -4587,7 +4726,7 @@ namespace AasCore.Aas3
 
                 foreach (var error in Verification.Verify(that.ObservableReference))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "observableReference"));
                     yield return error;
@@ -4597,7 +4736,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.ObservableSemanticId))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "observableSemanticId"));
                         yield return error;
@@ -4608,7 +4747,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Topic))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "topic"));
                         yield return error;
@@ -4619,7 +4758,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.SubjectId))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "subjectId"));
                         yield return error;
@@ -4628,7 +4767,7 @@ namespace AasCore.Aas3
 
                 foreach (var error in Verification.VerifyDateTimeStampUtc(that.TimeStamp))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "timeStamp"));
                     yield return error;
@@ -4638,7 +4777,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Payload))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "payload"));
                         yield return error;
@@ -4646,6 +4785,7 @@ namespace AasCore.Aas3
                 }
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.BasicEventElement that)
             {
@@ -4692,10 +4832,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             yield return error;
@@ -4708,7 +4848,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.IdShort))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         yield return error;
@@ -4719,7 +4859,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.DisplayName))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         yield return error;
@@ -4730,7 +4870,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Category))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         yield return error;
@@ -4741,7 +4881,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.Description))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         yield return error;
@@ -4752,7 +4892,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Checksum))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         yield return error;
@@ -4766,7 +4906,7 @@ namespace AasCore.Aas3
                         ?? throw new System.InvalidOperationException();
                     foreach (var error in Verification.VerifyModelingKind(value))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "kind"));
                         yield return error;
@@ -4777,7 +4917,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.SemanticId))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         yield return error;
@@ -4791,10 +4931,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                             yield return error;
@@ -4810,10 +4950,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             yield return error;
@@ -4824,7 +4964,7 @@ namespace AasCore.Aas3
 
                 foreach (var error in Verification.Verify(that.Observed))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "observed"));
                     yield return error;
@@ -4832,7 +4972,7 @@ namespace AasCore.Aas3
 
                 foreach (var error in Verification.VerifyDirection(that.Direction))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "direction"));
                     yield return error;
@@ -4840,7 +4980,7 @@ namespace AasCore.Aas3
 
                 foreach (var error in Verification.VerifyStateOfEvent(that.State))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "state"));
                     yield return error;
@@ -4850,7 +4990,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.MessageTopic))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "messageTopic"));
                         yield return error;
@@ -4861,7 +5001,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.MessageBroker))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "messageBroker"));
                         yield return error;
@@ -4872,7 +5012,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyDateTimeStampUtc(that.LastUpdate))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "lastUpdate"));
                         yield return error;
@@ -4883,7 +5023,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyDateTimeStampUtc(that.MinInterval))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "minInterval"));
                         yield return error;
@@ -4894,7 +5034,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyDateTimeStampUtc(that.MaxInterval))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "maxInterval"));
                         yield return error;
@@ -4902,6 +5042,7 @@ namespace AasCore.Aas3
                 }
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.Operation that)
             {
@@ -4948,10 +5089,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             yield return error;
@@ -4964,7 +5105,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.IdShort))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         yield return error;
@@ -4975,7 +5116,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.DisplayName))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         yield return error;
@@ -4986,7 +5127,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Category))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         yield return error;
@@ -4997,7 +5138,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.Description))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         yield return error;
@@ -5008,7 +5149,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Checksum))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         yield return error;
@@ -5022,7 +5163,7 @@ namespace AasCore.Aas3
                         ?? throw new System.InvalidOperationException();
                     foreach (var error in Verification.VerifyModelingKind(value))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "kind"));
                         yield return error;
@@ -5033,7 +5174,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.SemanticId))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         yield return error;
@@ -5047,10 +5188,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                             yield return error;
@@ -5066,10 +5207,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             yield return error;
@@ -5085,10 +5226,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexInputVariables));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "inputVariables"));
                             yield return error;
@@ -5104,10 +5245,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexOutputVariables));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "outputVariables"));
                             yield return error;
@@ -5123,10 +5264,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexInoutputVariables));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "inoutputVariables"));
                             yield return error;
@@ -5136,18 +5277,20 @@ namespace AasCore.Aas3
                 }
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.OperationVariable that)
             {
                 foreach (var error in Verification.Verify(that.Value))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "value"));
                     yield return error;
                 }
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.Capability that)
             {
@@ -5194,10 +5337,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             yield return error;
@@ -5210,7 +5353,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.IdShort))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         yield return error;
@@ -5221,7 +5364,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.DisplayName))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         yield return error;
@@ -5232,7 +5375,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Category))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         yield return error;
@@ -5243,7 +5386,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.Description))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         yield return error;
@@ -5254,7 +5397,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Checksum))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         yield return error;
@@ -5268,7 +5411,7 @@ namespace AasCore.Aas3
                         ?? throw new System.InvalidOperationException();
                     foreach (var error in Verification.VerifyModelingKind(value))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "kind"));
                         yield return error;
@@ -5279,7 +5422,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.SemanticId))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "semanticId"));
                         yield return error;
@@ -5293,10 +5436,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexQualifiers));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "qualifiers"));
                             yield return error;
@@ -5312,10 +5455,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             yield return error;
@@ -5325,6 +5468,7 @@ namespace AasCore.Aas3
                 }
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.ConceptDescription that)
             {
@@ -5374,10 +5518,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexExtensions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "extensions"));
                             yield return error;
@@ -5390,7 +5534,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.IdShort))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "idShort"));
                         yield return error;
@@ -5401,7 +5545,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.DisplayName))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "displayName"));
                         yield return error;
@@ -5412,7 +5556,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Category))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "category"));
                         yield return error;
@@ -5423,7 +5567,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.Description))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "description"));
                         yield return error;
@@ -5434,7 +5578,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.VerifyNonEmptyString(that.Checksum))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "checksum"));
                         yield return error;
@@ -5443,7 +5587,7 @@ namespace AasCore.Aas3
 
                 foreach (var error in Verification.VerifyIdentifier(that.Id))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "id"));
                     yield return error;
@@ -5453,7 +5597,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.Administration))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "administration"));
                         yield return error;
@@ -5467,10 +5611,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexDataSpecifications));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "dataSpecifications"));
                             yield return error;
@@ -5486,10 +5630,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexIsCaseOf));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "isCaseOf"));
                             yield return error;
@@ -5499,18 +5643,20 @@ namespace AasCore.Aas3
                 }
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.GlobalReference that)
             {
                 foreach (var error in Verification.VerifyIdentifier(that.Value))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "value"));
                     yield return error;
                 }
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.ModelReference that)
             {
@@ -5526,10 +5672,10 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(item))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.IndexSegment(
                                 indexKeys));
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "keys"));
                         yield return error;
@@ -5541,7 +5687,7 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(that.ReferredSemanticId))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "referredSemanticId"));
                         yield return error;
@@ -5549,12 +5695,13 @@ namespace AasCore.Aas3
                 }
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.Key that)
             {
                 foreach (var error in Verification.VerifyKeyElements(that.Type))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "type"));
                     yield return error;
@@ -5562,25 +5709,27 @@ namespace AasCore.Aas3
 
                 foreach (var error in Verification.VerifyNonEmptyString(that.Value))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "value"));
                     yield return error;
                 }
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.LangString that)
             {
                 foreach (var error in Verification.VerifyBcp47LanguageTag(that.Language))
                 {
-                    error._pathSegments.AddFirst(
+                    error.PrependSegment(
                         new Reporting.NameSegment(
                             "language"));
                     yield return error;
                 }
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.LangStringSet that)
             {
@@ -5604,10 +5753,10 @@ namespace AasCore.Aas3
                 {
                     foreach (var error in Verification.Verify(item))
                     {
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.IndexSegment(
                                 indexLangStrings));
-                        error._pathSegments.AddFirst(
+                        error.PrependSegment(
                             new Reporting.NameSegment(
                                 "langStrings"));
                         yield return error;
@@ -5616,6 +5765,7 @@ namespace AasCore.Aas3
                 }
             }
 
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.Environment that)
             {
@@ -5626,10 +5776,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexAssetAdministrationShells));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "assetAdministrationShells"));
                             yield return error;
@@ -5645,10 +5795,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexSubmodels));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "submodels"));
                             yield return error;
@@ -5664,10 +5814,10 @@ namespace AasCore.Aas3
                     {
                         foreach (var error in Verification.Verify(item))
                         {
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.IndexSegment(
                                     indexConceptDescriptions));
-                            error._pathSegments.AddFirst(
+                            error.PrependSegment(
                                 new Reporting.NameSegment(
                                     "conceptDescriptions"));
                             yield return error;

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/visitation.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/visitation.cs
@@ -375,84 +375,84 @@ namespace AasCore.Aas3
         /// <summary>
         /// Define the interface for a visitor which visits the instances of the model.
         /// </summary>
-        /// <typeparam name="C">Context type</typeparam>
-        public interface IVisitorWithContext<C>
+        /// <typeparam name="TContext">Context type</typeparam>
+        public interface IVisitorWithContext<in TContext>
         {
-            public void Visit(IClass that, C context);
-            public void Visit(Resource that, C context);
-            public void Visit(Extension that, C context);
-            public void Visit(AdministrativeInformation that, C context);
-            public void Visit(Qualifier that, C context);
-            public void Visit(AssetAdministrationShell that, C context);
-            public void Visit(AssetInformation that, C context);
-            public void Visit(IdentifierKeyValuePair that, C context);
-            public void Visit(Submodel that, C context);
-            public void Visit(SubmodelElementList that, C context);
-            public void Visit(SubmodelElementStruct that, C context);
-            public void Visit(Property that, C context);
-            public void Visit(MultiLanguageProperty that, C context);
-            public void Visit(Range that, C context);
-            public void Visit(ReferenceElement that, C context);
-            public void Visit(Blob that, C context);
-            public void Visit(File that, C context);
-            public void Visit(AnnotatedRelationshipElement that, C context);
-            public void Visit(Entity that, C context);
-            public void Visit(EventPayload that, C context);
-            public void Visit(BasicEventElement that, C context);
-            public void Visit(Operation that, C context);
-            public void Visit(OperationVariable that, C context);
-            public void Visit(Capability that, C context);
-            public void Visit(ConceptDescription that, C context);
-            public void Visit(GlobalReference that, C context);
-            public void Visit(ModelReference that, C context);
-            public void Visit(Key that, C context);
-            public void Visit(LangString that, C context);
-            public void Visit(LangStringSet that, C context);
-            public void Visit(Environment that, C context);
+            public void Visit(IClass that, TContext context);
+            public void Visit(Resource that, TContext context);
+            public void Visit(Extension that, TContext context);
+            public void Visit(AdministrativeInformation that, TContext context);
+            public void Visit(Qualifier that, TContext context);
+            public void Visit(AssetAdministrationShell that, TContext context);
+            public void Visit(AssetInformation that, TContext context);
+            public void Visit(IdentifierKeyValuePair that, TContext context);
+            public void Visit(Submodel that, TContext context);
+            public void Visit(SubmodelElementList that, TContext context);
+            public void Visit(SubmodelElementStruct that, TContext context);
+            public void Visit(Property that, TContext context);
+            public void Visit(MultiLanguageProperty that, TContext context);
+            public void Visit(Range that, TContext context);
+            public void Visit(ReferenceElement that, TContext context);
+            public void Visit(Blob that, TContext context);
+            public void Visit(File that, TContext context);
+            public void Visit(AnnotatedRelationshipElement that, TContext context);
+            public void Visit(Entity that, TContext context);
+            public void Visit(EventPayload that, TContext context);
+            public void Visit(BasicEventElement that, TContext context);
+            public void Visit(Operation that, TContext context);
+            public void Visit(OperationVariable that, TContext context);
+            public void Visit(Capability that, TContext context);
+            public void Visit(ConceptDescription that, TContext context);
+            public void Visit(GlobalReference that, TContext context);
+            public void Visit(ModelReference that, TContext context);
+            public void Visit(Key that, TContext context);
+            public void Visit(LangString that, TContext context);
+            public void Visit(LangStringSet that, TContext context);
+            public void Visit(Environment that, TContext context);
         }  // public interface IVisitorWithContext
 
         /// <summary>
         /// Perform double-dispatch to visit the concrete instances
         /// with context.
         /// </summary>
-        /// <typeparam name="C">Context type</typeparam>
-        public abstract class AbstractVisitorWithContext<C>
-            : IVisitorWithContext<C>
+        /// <typeparam name="TContext">Context type</typeparam>
+        public abstract class AbstractVisitorWithContext<TContext>
+            : IVisitorWithContext<TContext>
         {
-            public void Visit(IClass that, C context)
+            public void Visit(IClass that, TContext context)
             {
                 that.Accept(this, context);
             }
-            public abstract void Visit(Resource that, C context);
-            public abstract void Visit(Extension that, C context);
-            public abstract void Visit(AdministrativeInformation that, C context);
-            public abstract void Visit(Qualifier that, C context);
-            public abstract void Visit(AssetAdministrationShell that, C context);
-            public abstract void Visit(AssetInformation that, C context);
-            public abstract void Visit(IdentifierKeyValuePair that, C context);
-            public abstract void Visit(Submodel that, C context);
-            public abstract void Visit(SubmodelElementList that, C context);
-            public abstract void Visit(SubmodelElementStruct that, C context);
-            public abstract void Visit(Property that, C context);
-            public abstract void Visit(MultiLanguageProperty that, C context);
-            public abstract void Visit(Range that, C context);
-            public abstract void Visit(ReferenceElement that, C context);
-            public abstract void Visit(Blob that, C context);
-            public abstract void Visit(File that, C context);
-            public abstract void Visit(AnnotatedRelationshipElement that, C context);
-            public abstract void Visit(Entity that, C context);
-            public abstract void Visit(EventPayload that, C context);
-            public abstract void Visit(BasicEventElement that, C context);
-            public abstract void Visit(Operation that, C context);
-            public abstract void Visit(OperationVariable that, C context);
-            public abstract void Visit(Capability that, C context);
-            public abstract void Visit(ConceptDescription that, C context);
-            public abstract void Visit(GlobalReference that, C context);
-            public abstract void Visit(ModelReference that, C context);
-            public abstract void Visit(Key that, C context);
-            public abstract void Visit(LangString that, C context);
-            public abstract void Visit(LangStringSet that, C context);
-            public abstract void Visit(Environment that, C context);
+            public abstract void Visit(Resource that, TContext context);
+            public abstract void Visit(Extension that, TContext context);
+            public abstract void Visit(AdministrativeInformation that, TContext context);
+            public abstract void Visit(Qualifier that, TContext context);
+            public abstract void Visit(AssetAdministrationShell that, TContext context);
+            public abstract void Visit(AssetInformation that, TContext context);
+            public abstract void Visit(IdentifierKeyValuePair that, TContext context);
+            public abstract void Visit(Submodel that, TContext context);
+            public abstract void Visit(SubmodelElementList that, TContext context);
+            public abstract void Visit(SubmodelElementStruct that, TContext context);
+            public abstract void Visit(Property that, TContext context);
+            public abstract void Visit(MultiLanguageProperty that, TContext context);
+            public abstract void Visit(Range that, TContext context);
+            public abstract void Visit(ReferenceElement that, TContext context);
+            public abstract void Visit(Blob that, TContext context);
+            public abstract void Visit(File that, TContext context);
+            public abstract void Visit(AnnotatedRelationshipElement that, TContext context);
+            public abstract void Visit(Entity that, TContext context);
+            public abstract void Visit(EventPayload that, TContext context);
+            public abstract void Visit(BasicEventElement that, TContext context);
+            public abstract void Visit(Operation that, TContext context);
+            public abstract void Visit(OperationVariable that, TContext context);
+            public abstract void Visit(Capability that, TContext context);
+            public abstract void Visit(ConceptDescription that, TContext context);
+            public abstract void Visit(GlobalReference that, TContext context);
+            public abstract void Visit(ModelReference that, TContext context);
+            public abstract void Visit(Key that, TContext context);
+            public abstract void Visit(LangString that, TContext context);
+            public abstract void Visit(LangStringSet that, TContext context);
+            public abstract void Visit(Environment that, TContext context);
         }  // public abstract class AbstractVisitorWithContext
 
         /// <summary>
@@ -460,7 +460,7 @@ namespace AasCore.Aas3
         /// the instances into something else.
         /// </summary>
         /// <typeparam name="T">The type of the transformation result</typeparam>
-        public interface ITransformer<T>
+        public interface ITransformer<out T>
         {
             public T Transform(IClass that);
             public T Transform(Resource that);
@@ -572,116 +572,116 @@ namespace AasCore.Aas3
         /// Define the interface for a transformer which recursively transforms
         /// the instances into something else while the context is passed along.
         /// </summary>
-        /// <typeparam name="C">Type of the transformation context</typeparam>
+        /// <typeparam name="TContext">Type of the transformation context</typeparam>
         /// <typeparam name="T">The type of the transformation result</typeparam>
-        public interface ITransformerWithContext<C, T>
+        public interface ITransformerWithContext<in TContext, out T>
         {
-            public T Transform(IClass that, C context);
-            public T Transform(Resource that, C context);
-            public T Transform(Extension that, C context);
-            public T Transform(AdministrativeInformation that, C context);
-            public T Transform(Qualifier that, C context);
-            public T Transform(AssetAdministrationShell that, C context);
-            public T Transform(AssetInformation that, C context);
-            public T Transform(IdentifierKeyValuePair that, C context);
-            public T Transform(Submodel that, C context);
-            public T Transform(SubmodelElementList that, C context);
-            public T Transform(SubmodelElementStruct that, C context);
-            public T Transform(Property that, C context);
-            public T Transform(MultiLanguageProperty that, C context);
-            public T Transform(Range that, C context);
-            public T Transform(ReferenceElement that, C context);
-            public T Transform(Blob that, C context);
-            public T Transform(File that, C context);
-            public T Transform(AnnotatedRelationshipElement that, C context);
-            public T Transform(Entity that, C context);
-            public T Transform(EventPayload that, C context);
-            public T Transform(BasicEventElement that, C context);
-            public T Transform(Operation that, C context);
-            public T Transform(OperationVariable that, C context);
-            public T Transform(Capability that, C context);
-            public T Transform(ConceptDescription that, C context);
-            public T Transform(GlobalReference that, C context);
-            public T Transform(ModelReference that, C context);
-            public T Transform(Key that, C context);
-            public T Transform(LangString that, C context);
-            public T Transform(LangStringSet that, C context);
-            public T Transform(Environment that, C context);
+            public T Transform(IClass that, TContext context);
+            public T Transform(Resource that, TContext context);
+            public T Transform(Extension that, TContext context);
+            public T Transform(AdministrativeInformation that, TContext context);
+            public T Transform(Qualifier that, TContext context);
+            public T Transform(AssetAdministrationShell that, TContext context);
+            public T Transform(AssetInformation that, TContext context);
+            public T Transform(IdentifierKeyValuePair that, TContext context);
+            public T Transform(Submodel that, TContext context);
+            public T Transform(SubmodelElementList that, TContext context);
+            public T Transform(SubmodelElementStruct that, TContext context);
+            public T Transform(Property that, TContext context);
+            public T Transform(MultiLanguageProperty that, TContext context);
+            public T Transform(Range that, TContext context);
+            public T Transform(ReferenceElement that, TContext context);
+            public T Transform(Blob that, TContext context);
+            public T Transform(File that, TContext context);
+            public T Transform(AnnotatedRelationshipElement that, TContext context);
+            public T Transform(Entity that, TContext context);
+            public T Transform(EventPayload that, TContext context);
+            public T Transform(BasicEventElement that, TContext context);
+            public T Transform(Operation that, TContext context);
+            public T Transform(OperationVariable that, TContext context);
+            public T Transform(Capability that, TContext context);
+            public T Transform(ConceptDescription that, TContext context);
+            public T Transform(GlobalReference that, TContext context);
+            public T Transform(ModelReference that, TContext context);
+            public T Transform(Key that, TContext context);
+            public T Transform(LangString that, TContext context);
+            public T Transform(LangStringSet that, TContext context);
+            public T Transform(Environment that, TContext context);
         }  // public interface ITransformerWithContext
 
         /// <summary>
         /// Perform double-dispatch to transform recursively
         /// the instances into something else.
         /// </summary>
-        /// <typeparam name="C">The type of the transformation context</typeparam>
+        /// <typeparam name="TContext">The type of the transformation context</typeparam>
         /// <typeparam name="T">The type of the transformation result</typeparam>
-        public abstract class AbstractTransformerWithContext<C, T>
-            : ITransformerWithContext<C, T>
+        public abstract class AbstractTransformerWithContext<TContext, T>
+            : ITransformerWithContext<TContext, T>
         {
-            public T Transform(IClass that, C context)
+            public T Transform(IClass that, TContext context)
             {
                 return that.Transform(this, context);
             }
 
-            public abstract T Transform(Resource that, C context);
+            public abstract T Transform(Resource that, TContext context);
 
-            public abstract T Transform(Extension that, C context);
+            public abstract T Transform(Extension that, TContext context);
 
-            public abstract T Transform(AdministrativeInformation that, C context);
+            public abstract T Transform(AdministrativeInformation that, TContext context);
 
-            public abstract T Transform(Qualifier that, C context);
+            public abstract T Transform(Qualifier that, TContext context);
 
-            public abstract T Transform(AssetAdministrationShell that, C context);
+            public abstract T Transform(AssetAdministrationShell that, TContext context);
 
-            public abstract T Transform(AssetInformation that, C context);
+            public abstract T Transform(AssetInformation that, TContext context);
 
-            public abstract T Transform(IdentifierKeyValuePair that, C context);
+            public abstract T Transform(IdentifierKeyValuePair that, TContext context);
 
-            public abstract T Transform(Submodel that, C context);
+            public abstract T Transform(Submodel that, TContext context);
 
-            public abstract T Transform(SubmodelElementList that, C context);
+            public abstract T Transform(SubmodelElementList that, TContext context);
 
-            public abstract T Transform(SubmodelElementStruct that, C context);
+            public abstract T Transform(SubmodelElementStruct that, TContext context);
 
-            public abstract T Transform(Property that, C context);
+            public abstract T Transform(Property that, TContext context);
 
-            public abstract T Transform(MultiLanguageProperty that, C context);
+            public abstract T Transform(MultiLanguageProperty that, TContext context);
 
-            public abstract T Transform(Range that, C context);
+            public abstract T Transform(Range that, TContext context);
 
-            public abstract T Transform(ReferenceElement that, C context);
+            public abstract T Transform(ReferenceElement that, TContext context);
 
-            public abstract T Transform(Blob that, C context);
+            public abstract T Transform(Blob that, TContext context);
 
-            public abstract T Transform(File that, C context);
+            public abstract T Transform(File that, TContext context);
 
-            public abstract T Transform(AnnotatedRelationshipElement that, C context);
+            public abstract T Transform(AnnotatedRelationshipElement that, TContext context);
 
-            public abstract T Transform(Entity that, C context);
+            public abstract T Transform(Entity that, TContext context);
 
-            public abstract T Transform(EventPayload that, C context);
+            public abstract T Transform(EventPayload that, TContext context);
 
-            public abstract T Transform(BasicEventElement that, C context);
+            public abstract T Transform(BasicEventElement that, TContext context);
 
-            public abstract T Transform(Operation that, C context);
+            public abstract T Transform(Operation that, TContext context);
 
-            public abstract T Transform(OperationVariable that, C context);
+            public abstract T Transform(OperationVariable that, TContext context);
 
-            public abstract T Transform(Capability that, C context);
+            public abstract T Transform(Capability that, TContext context);
 
-            public abstract T Transform(ConceptDescription that, C context);
+            public abstract T Transform(ConceptDescription that, TContext context);
 
-            public abstract T Transform(GlobalReference that, C context);
+            public abstract T Transform(GlobalReference that, TContext context);
 
-            public abstract T Transform(ModelReference that, C context);
+            public abstract T Transform(ModelReference that, TContext context);
 
-            public abstract T Transform(Key that, C context);
+            public abstract T Transform(Key that, TContext context);
 
-            public abstract T Transform(LangString that, C context);
+            public abstract T Transform(LangString that, TContext context);
 
-            public abstract T Transform(LangStringSet that, C context);
+            public abstract T Transform(LangStringSet that, TContext context);
 
-            public abstract T Transform(Environment that, C context);
+            public abstract T Transform(Environment that, TContext context);
         }  // public abstract class AbstractTransformerWithContext
     }  // public static class Visitation
 }  // namespace AasCore.Aas3

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/xmlization.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/xmlization.cs
@@ -3,6 +3,7 @@
  * Do NOT edit or append.
  */
 
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Xml = System.Xml;
 using System.Collections.Generic;  // can't alias
 
@@ -19,16 +20,17 @@ namespace AasCore.Aas3
         /// Implement the deserialization of meta-model classes from XML.
         /// </summary>
         /// <remarks>
-        /// The implementation propagates an <see cref="Error" /> instead of relying
-        /// on exceptions. Under the assumption that incorrect data is much less
+        /// The implementation propagates an <see cref="Reporting.Error" /> instead of
+        /// relying on exceptions. Under the assumption that incorrect data is much less
         /// frequent than correct data, this makes the deserialization more
         /// efficient.
         ///
         /// However, we do not want to force the client to deal with
-        /// the <see cref="Error" /> class as this is not intuitive. Therefore
-        /// we distinguish the implementation, realized in
+        /// the <see cref="Reporting.Error" /> class as this is not intuitive.
+        /// Therefore we distinguish the implementation, realized in
         /// <see cref="DeserializeImplementation" />, and the facade given in
         /// <see cref="Deserialize" /> class.
+        /// </remarks>
         internal static class DeserializeImplementation
         {
             internal static void SkipWhitespaceAndComments(
@@ -112,7 +114,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Path of an instance of class Resource " +
                                     $"could not be de-serialized as a string: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "path"));
                                 return null;
@@ -127,7 +129,7 @@ namespace AasCore.Aas3
                                     "The property Path of an instance of class Resource " +
                                     "could not be de-serialized from an unexpected enumeration literal: " +
                                     textPath);
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "path"));
                                 return null;
@@ -154,7 +156,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property ContentType of an instance of class Resource " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "contentType"));
                                 return null;
@@ -172,14 +174,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Resource " +
+                            "Expected an XML end element to conclude a property of class Resource " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Resource " +
+                            "Expected an XML end element to conclude a property of class Resource " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -187,7 +189,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Resource " +
+                            "Expected an XML end element to conclude a property of class Resource " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -237,7 +239,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class Resource, " +
+                        "Expected an XML element representing an instance of class Resource, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -276,7 +278,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class Resource, " +
+                        "Expected an XML end element concluding an instance of class Resource, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -286,8 +288,9 @@ namespace AasCore.Aas3
             }  // internal static Aas.Resource? ResourceFromElement
 
             /// <summary>
-            /// Deserialize an instance of class IHasSemantics from an XML element.
+            /// Deserialize an instance of IHasSemantics from an XML element.
             /// </summary>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             internal static Aas.IHasSemantics? IHasSemanticsFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
@@ -306,7 +309,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element, " +
+                        "Expected an XML element, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -438,7 +441,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "semanticId"));
                                 return null;
@@ -465,7 +468,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Name of an instance of class Extension " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "name"));
                                 return null;
@@ -493,7 +496,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property ValueType of an instance of class Extension " +
                                     $"could not be de-serialized as a string: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "valueType"));
                                 return null;
@@ -508,7 +511,7 @@ namespace AasCore.Aas3
                                     "The property ValueType of an instance of class Extension " +
                                     "could not be de-serialized from an unexpected enumeration literal: " +
                                     textValueType);
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "valueType"));
                                 return null;
@@ -535,7 +538,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Value of an instance of class Extension " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "value"));
                                 return null;
@@ -559,7 +562,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "refersTo"));
                                 return null;
@@ -577,14 +580,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Extension " +
+                            "Expected an XML end element to conclude a property of class Extension " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Extension " +
+                            "Expected an XML end element to conclude a property of class Extension " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -592,7 +595,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Extension " +
+                            "Expected an XML end element to conclude a property of class Extension " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -645,7 +648,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class Extension, " +
+                        "Expected an XML element representing an instance of class Extension, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -684,7 +687,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class Extension, " +
+                        "Expected an XML end element concluding an instance of class Extension, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -694,8 +697,9 @@ namespace AasCore.Aas3
             }  // internal static Aas.Extension? ExtensionFromElement
 
             /// <summary>
-            /// Deserialize an instance of class IHasExtensions from an XML element.
+            /// Deserialize an instance of IHasExtensions from an XML element.
             /// </summary>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             internal static Aas.IHasExtensions? IHasExtensionsFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
@@ -714,7 +718,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element, " +
+                        "Expected an XML element, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -794,8 +798,9 @@ namespace AasCore.Aas3
             }  // internal static Aas.IHasExtensions? IHasExtensionsFromElement
 
             /// <summary>
-            /// Deserialize an instance of class IReferable from an XML element.
+            /// Deserialize an instance of IReferable from an XML element.
             /// </summary>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             internal static Aas.IReferable? IReferableFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
@@ -814,7 +819,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element, " +
+                        "Expected an XML element, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -894,8 +899,9 @@ namespace AasCore.Aas3
             }  // internal static Aas.IReferable? IReferableFromElement
 
             /// <summary>
-            /// Deserialize an instance of class IIdentifiable from an XML element.
+            /// Deserialize an instance of IIdentifiable from an XML element.
             /// </summary>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             internal static Aas.IIdentifiable? IIdentifiableFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
@@ -914,7 +920,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element, " +
+                        "Expected an XML element, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -942,8 +948,9 @@ namespace AasCore.Aas3
             }  // internal static Aas.IIdentifiable? IIdentifiableFromElement
 
             /// <summary>
-            /// Deserialize an instance of class IHasKind from an XML element.
+            /// Deserialize an instance of IHasKind from an XML element.
             /// </summary>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             internal static Aas.IHasKind? IHasKindFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
@@ -962,7 +969,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element, " +
+                        "Expected an XML element, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -1034,8 +1041,9 @@ namespace AasCore.Aas3
             }  // internal static Aas.IHasKind? IHasKindFromElement
 
             /// <summary>
-            /// Deserialize an instance of class IHasDataSpecification from an XML element.
+            /// Deserialize an instance of IHasDataSpecification from an XML element.
             /// </summary>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             internal static Aas.IHasDataSpecification? IHasDataSpecificationFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
@@ -1054,7 +1062,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element, " +
+                        "Expected an XML element, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -1190,7 +1198,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexDataSpecifications));
                                     return null;
@@ -1226,7 +1234,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Version of an instance of class AdministrativeInformation " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "version"));
                                 return null;
@@ -1253,7 +1261,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Revision of an instance of class AdministrativeInformation " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "revision"));
                                 return null;
@@ -1271,14 +1279,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class AdministrativeInformation " +
+                            "Expected an XML end element to conclude a property of class AdministrativeInformation " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class AdministrativeInformation " +
+                            "Expected an XML end element to conclude a property of class AdministrativeInformation " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -1286,7 +1294,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class AdministrativeInformation " +
+                            "Expected an XML end element to conclude a property of class AdministrativeInformation " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -1327,7 +1335,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class AdministrativeInformation, " +
+                        "Expected an XML element representing an instance of class AdministrativeInformation, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -1366,7 +1374,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class AdministrativeInformation, " +
+                        "Expected an XML end element concluding an instance of class AdministrativeInformation, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -1376,8 +1384,9 @@ namespace AasCore.Aas3
             }  // internal static Aas.AdministrativeInformation? AdministrativeInformationFromElement
 
             /// <summary>
-            /// Deserialize an instance of class IQualifiable from an XML element.
+            /// Deserialize an instance of IQualifiable from an XML element.
             /// </summary>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             internal static Aas.IQualifiable? IQualifiableFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
@@ -1396,7 +1405,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element, " +
+                        "Expected an XML element, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -1516,7 +1525,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "semanticId"));
                                 return null;
@@ -1543,7 +1552,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Type of an instance of class Qualifier " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "type"));
                                 return null;
@@ -1571,7 +1580,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property ValueType of an instance of class Qualifier " +
                                     $"could not be de-serialized as a string: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "valueType"));
                                 return null;
@@ -1586,7 +1595,7 @@ namespace AasCore.Aas3
                                     "The property ValueType of an instance of class Qualifier " +
                                     "could not be de-serialized from an unexpected enumeration literal: " +
                                     textValueType);
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "valueType"));
                                 return null;
@@ -1613,7 +1622,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Value of an instance of class Qualifier " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "value"));
                                 return null;
@@ -1637,7 +1646,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "valueId"));
                                 return null;
@@ -1655,14 +1664,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Qualifier " +
+                            "Expected an XML end element to conclude a property of class Qualifier " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Qualifier " +
+                            "Expected an XML end element to conclude a property of class Qualifier " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -1670,7 +1679,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Qualifier " +
+                            "Expected an XML end element to conclude a property of class Qualifier " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -1733,7 +1742,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class Qualifier, " +
+                        "Expected an XML element representing an instance of class Qualifier, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -1772,7 +1781,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class Qualifier, " +
+                        "Expected an XML end element concluding an instance of class Qualifier, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -1843,7 +1852,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexExtensions));
                                     return null;
@@ -1879,7 +1888,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property IdShort of an instance of class AssetAdministrationShell " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "idShort"));
                                 return null;
@@ -1903,7 +1912,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "displayName"));
                                 return null;
@@ -1930,7 +1939,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Category of an instance of class AssetAdministrationShell " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "category"));
                                 return null;
@@ -1954,7 +1963,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "description"));
                                 return null;
@@ -1981,7 +1990,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Checksum of an instance of class AssetAdministrationShell " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "checksum"));
                                 return null;
@@ -2008,7 +2017,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Id of an instance of class AssetAdministrationShell " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "id"));
                                 return null;
@@ -2032,7 +2041,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "administration"));
                                 return null;
@@ -2062,7 +2071,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexDataSpecifications));
                                     return null;
@@ -2095,7 +2104,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "assetInformation"));
                                 return null;
@@ -2125,7 +2134,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexSubmodels));
                                     return null;
@@ -2158,7 +2167,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "derivedFrom"));
                                 return null;
@@ -2176,14 +2185,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class AssetAdministrationShell " +
+                            "Expected an XML end element to conclude a property of class AssetAdministrationShell " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class AssetAdministrationShell " +
+                            "Expected an XML end element to conclude a property of class AssetAdministrationShell " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -2191,7 +2200,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class AssetAdministrationShell " +
+                            "Expected an XML end element to conclude a property of class AssetAdministrationShell " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -2261,7 +2270,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class AssetAdministrationShell, " +
+                        "Expected an XML element representing an instance of class AssetAdministrationShell, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -2300,7 +2309,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class AssetAdministrationShell, " +
+                        "Expected an XML end element concluding an instance of class AssetAdministrationShell, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -2361,7 +2370,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property AssetKind of an instance of class AssetInformation " +
                                     $"could not be de-serialized as a string: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "assetKind"));
                                 return null;
@@ -2376,7 +2385,7 @@ namespace AasCore.Aas3
                                     "The property AssetKind of an instance of class AssetInformation " +
                                     "could not be de-serialized from an unexpected enumeration literal: " +
                                     textAssetKind);
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "assetKind"));
                                 return null;
@@ -2400,7 +2409,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "globalAssetId"));
                                 return null;
@@ -2424,7 +2433,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "specificAssetId"));
                                 return null;
@@ -2448,7 +2457,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "defaultThumbnail"));
                                 return null;
@@ -2466,14 +2475,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class AssetInformation " +
+                            "Expected an XML end element to conclude a property of class AssetInformation " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class AssetInformation " +
+                            "Expected an XML end element to conclude a property of class AssetInformation " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -2481,7 +2490,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class AssetInformation " +
+                            "Expected an XML end element to conclude a property of class AssetInformation " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -2533,7 +2542,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class AssetInformation, " +
+                        "Expected an XML element representing an instance of class AssetInformation, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -2572,7 +2581,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class AssetInformation, " +
+                        "Expected an XML end element concluding an instance of class AssetInformation, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -2629,7 +2638,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "semanticId"));
                                 return null;
@@ -2656,7 +2665,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Key of an instance of class IdentifierKeyValuePair " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "key"));
                                 return null;
@@ -2683,7 +2692,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Value of an instance of class IdentifierKeyValuePair " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "value"));
                                 return null;
@@ -2707,7 +2716,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "externalSubjectId"));
                                 return null;
@@ -2725,14 +2734,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class IdentifierKeyValuePair " +
+                            "Expected an XML end element to conclude a property of class IdentifierKeyValuePair " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class IdentifierKeyValuePair " +
+                            "Expected an XML end element to conclude a property of class IdentifierKeyValuePair " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -2740,7 +2749,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class IdentifierKeyValuePair " +
+                            "Expected an XML end element to conclude a property of class IdentifierKeyValuePair " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -2802,7 +2811,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class IdentifierKeyValuePair, " +
+                        "Expected an XML element representing an instance of class IdentifierKeyValuePair, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -2841,7 +2850,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class IdentifierKeyValuePair, " +
+                        "Expected an XML end element concluding an instance of class IdentifierKeyValuePair, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -2913,7 +2922,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexExtensions));
                                     return null;
@@ -2949,7 +2958,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property IdShort of an instance of class Submodel " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "idShort"));
                                 return null;
@@ -2973,7 +2982,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "displayName"));
                                 return null;
@@ -3000,7 +3009,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Category of an instance of class Submodel " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "category"));
                                 return null;
@@ -3024,7 +3033,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "description"));
                                 return null;
@@ -3051,7 +3060,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Checksum of an instance of class Submodel " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "checksum"));
                                 return null;
@@ -3078,7 +3087,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Id of an instance of class Submodel " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "id"));
                                 return null;
@@ -3102,7 +3111,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "administration"));
                                 return null;
@@ -3130,7 +3139,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Kind of an instance of class Submodel " +
                                     $"could not be de-serialized as a string: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "kind"));
                                 return null;
@@ -3145,7 +3154,7 @@ namespace AasCore.Aas3
                                     "The property Kind of an instance of class Submodel " +
                                     "could not be de-serialized from an unexpected enumeration literal: " +
                                     textKind);
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "kind"));
                                 return null;
@@ -3169,7 +3178,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "semanticId"));
                                 return null;
@@ -3199,7 +3208,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexQualifiers));
                                     return null;
@@ -3238,7 +3247,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexDataSpecifications));
                                     return null;
@@ -3277,7 +3286,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexSubmodelElements));
                                     return null;
@@ -3304,14 +3313,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Submodel " +
+                            "Expected an XML end element to conclude a property of class Submodel " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Submodel " +
+                            "Expected an XML end element to conclude a property of class Submodel " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -3319,7 +3328,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Submodel " +
+                            "Expected an XML end element to conclude a property of class Submodel " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -3380,7 +3389,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class Submodel, " +
+                        "Expected an XML element representing an instance of class Submodel, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -3419,7 +3428,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class Submodel, " +
+                        "Expected an XML end element concluding an instance of class Submodel, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -3429,8 +3438,9 @@ namespace AasCore.Aas3
             }  // internal static Aas.Submodel? SubmodelFromElement
 
             /// <summary>
-            /// Deserialize an instance of class ISubmodelElement from an XML element.
+            /// Deserialize an instance of ISubmodelElement from an XML element.
             /// </summary>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             internal static Aas.ISubmodelElement? ISubmodelElementFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
@@ -3449,7 +3459,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element, " +
+                        "Expected an XML element, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -3517,8 +3527,9 @@ namespace AasCore.Aas3
             }  // internal static Aas.ISubmodelElement? ISubmodelElementFromElement
 
             /// <summary>
-            /// Deserialize an instance of class IRelationshipElement from an XML element.
+            /// Deserialize an instance of IRelationshipElement from an XML element.
             /// </summary>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             internal static Aas.IRelationshipElement? IRelationshipElementFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
@@ -3537,7 +3548,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element, " +
+                        "Expected an XML element, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -3621,7 +3632,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexExtensions));
                                     return null;
@@ -3657,7 +3668,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property IdShort of an instance of class SubmodelElementList " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "idShort"));
                                 return null;
@@ -3681,7 +3692,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "displayName"));
                                 return null;
@@ -3708,7 +3719,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Category of an instance of class SubmodelElementList " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "category"));
                                 return null;
@@ -3732,7 +3743,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "description"));
                                 return null;
@@ -3759,7 +3770,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Checksum of an instance of class SubmodelElementList " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "checksum"));
                                 return null;
@@ -3787,7 +3798,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Kind of an instance of class SubmodelElementList " +
                                     $"could not be de-serialized as a string: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "kind"));
                                 return null;
@@ -3802,7 +3813,7 @@ namespace AasCore.Aas3
                                     "The property Kind of an instance of class SubmodelElementList " +
                                     "could not be de-serialized from an unexpected enumeration literal: " +
                                     textKind);
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "kind"));
                                 return null;
@@ -3826,7 +3837,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "semanticId"));
                                 return null;
@@ -3856,7 +3867,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexQualifiers));
                                     return null;
@@ -3895,7 +3906,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexDataSpecifications));
                                     return null;
@@ -3932,7 +3943,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property TypeValueListElement of an instance of class SubmodelElementList " +
                                     $"could not be de-serialized as a string: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "typeValueListElement"));
                                 return null;
@@ -3947,7 +3958,7 @@ namespace AasCore.Aas3
                                     "The property TypeValueListElement of an instance of class SubmodelElementList " +
                                     "could not be de-serialized from an unexpected enumeration literal: " +
                                     textTypeValueListElement);
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "typeValueListElement"));
                                 return null;
@@ -3974,7 +3985,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property OrderRelevant of an instance of class SubmodelElementList " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "orderRelevant"));
                                 return null;
@@ -4004,7 +4015,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexValue));
                                     return null;
@@ -4037,7 +4048,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "semanticIdListElement"));
                                 return null;
@@ -4065,7 +4076,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property ValueTypeListElement of an instance of class SubmodelElementList " +
                                     $"could not be de-serialized as a string: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "valueTypeListElement"));
                                 return null;
@@ -4080,7 +4091,7 @@ namespace AasCore.Aas3
                                     "The property ValueTypeListElement of an instance of class SubmodelElementList " +
                                     "could not be de-serialized from an unexpected enumeration literal: " +
                                     textValueTypeListElement);
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "valueTypeListElement"));
                                 return null;
@@ -4098,14 +4109,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class SubmodelElementList " +
+                            "Expected an XML end element to conclude a property of class SubmodelElementList " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class SubmodelElementList " +
+                            "Expected an XML end element to conclude a property of class SubmodelElementList " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -4113,7 +4124,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class SubmodelElementList " +
+                            "Expected an XML end element to conclude a property of class SubmodelElementList " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -4176,7 +4187,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class SubmodelElementList, " +
+                        "Expected an XML element representing an instance of class SubmodelElementList, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -4215,7 +4226,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class SubmodelElementList, " +
+                        "Expected an XML end element concluding an instance of class SubmodelElementList, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -4285,7 +4296,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexExtensions));
                                     return null;
@@ -4321,7 +4332,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property IdShort of an instance of class SubmodelElementStruct " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "idShort"));
                                 return null;
@@ -4345,7 +4356,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "displayName"));
                                 return null;
@@ -4372,7 +4383,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Category of an instance of class SubmodelElementStruct " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "category"));
                                 return null;
@@ -4396,7 +4407,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "description"));
                                 return null;
@@ -4423,7 +4434,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Checksum of an instance of class SubmodelElementStruct " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "checksum"));
                                 return null;
@@ -4451,7 +4462,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Kind of an instance of class SubmodelElementStruct " +
                                     $"could not be de-serialized as a string: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "kind"));
                                 return null;
@@ -4466,7 +4477,7 @@ namespace AasCore.Aas3
                                     "The property Kind of an instance of class SubmodelElementStruct " +
                                     "could not be de-serialized from an unexpected enumeration literal: " +
                                     textKind);
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "kind"));
                                 return null;
@@ -4490,7 +4501,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "semanticId"));
                                 return null;
@@ -4520,7 +4531,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexQualifiers));
                                     return null;
@@ -4559,7 +4570,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexDataSpecifications));
                                     return null;
@@ -4598,7 +4609,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexValue));
                                     return null;
@@ -4625,14 +4636,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class SubmodelElementStruct " +
+                            "Expected an XML end element to conclude a property of class SubmodelElementStruct " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class SubmodelElementStruct " +
+                            "Expected an XML end element to conclude a property of class SubmodelElementStruct " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -4640,7 +4651,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class SubmodelElementStruct " +
+                            "Expected an XML end element to conclude a property of class SubmodelElementStruct " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -4689,7 +4700,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class SubmodelElementStruct, " +
+                        "Expected an XML element representing an instance of class SubmodelElementStruct, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -4728,7 +4739,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class SubmodelElementStruct, " +
+                        "Expected an XML end element concluding an instance of class SubmodelElementStruct, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -4738,8 +4749,9 @@ namespace AasCore.Aas3
             }  // internal static Aas.SubmodelElementStruct? SubmodelElementStructFromElement
 
             /// <summary>
-            /// Deserialize an instance of class IDataElement from an XML element.
+            /// Deserialize an instance of IDataElement from an XML element.
             /// </summary>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             internal static Aas.IDataElement? IDataElementFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
@@ -4758,7 +4770,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element, " +
+                        "Expected an XML element, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -4860,7 +4872,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexExtensions));
                                     return null;
@@ -4896,7 +4908,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property IdShort of an instance of class Property " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "idShort"));
                                 return null;
@@ -4920,7 +4932,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "displayName"));
                                 return null;
@@ -4947,7 +4959,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Category of an instance of class Property " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "category"));
                                 return null;
@@ -4971,7 +4983,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "description"));
                                 return null;
@@ -4998,7 +5010,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Checksum of an instance of class Property " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "checksum"));
                                 return null;
@@ -5026,7 +5038,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Kind of an instance of class Property " +
                                     $"could not be de-serialized as a string: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "kind"));
                                 return null;
@@ -5041,7 +5053,7 @@ namespace AasCore.Aas3
                                     "The property Kind of an instance of class Property " +
                                     "could not be de-serialized from an unexpected enumeration literal: " +
                                     textKind);
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "kind"));
                                 return null;
@@ -5065,7 +5077,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "semanticId"));
                                 return null;
@@ -5095,7 +5107,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexQualifiers));
                                     return null;
@@ -5134,7 +5146,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexDataSpecifications));
                                     return null;
@@ -5171,7 +5183,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property ValueType of an instance of class Property " +
                                     $"could not be de-serialized as a string: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "valueType"));
                                 return null;
@@ -5186,7 +5198,7 @@ namespace AasCore.Aas3
                                     "The property ValueType of an instance of class Property " +
                                     "could not be de-serialized from an unexpected enumeration literal: " +
                                     textValueType);
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "valueType"));
                                 return null;
@@ -5213,7 +5225,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Value of an instance of class Property " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "value"));
                                 return null;
@@ -5237,7 +5249,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "valueId"));
                                 return null;
@@ -5255,14 +5267,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Property " +
+                            "Expected an XML end element to conclude a property of class Property " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Property " +
+                            "Expected an XML end element to conclude a property of class Property " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -5270,7 +5282,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Property " +
+                            "Expected an XML end element to conclude a property of class Property " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -5331,7 +5343,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class Property, " +
+                        "Expected an XML element representing an instance of class Property, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -5370,7 +5382,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class Property, " +
+                        "Expected an XML end element concluding an instance of class Property, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -5441,7 +5453,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexExtensions));
                                     return null;
@@ -5477,7 +5489,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property IdShort of an instance of class MultiLanguageProperty " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "idShort"));
                                 return null;
@@ -5501,7 +5513,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "displayName"));
                                 return null;
@@ -5528,7 +5540,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Category of an instance of class MultiLanguageProperty " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "category"));
                                 return null;
@@ -5552,7 +5564,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "description"));
                                 return null;
@@ -5579,7 +5591,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Checksum of an instance of class MultiLanguageProperty " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "checksum"));
                                 return null;
@@ -5607,7 +5619,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Kind of an instance of class MultiLanguageProperty " +
                                     $"could not be de-serialized as a string: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "kind"));
                                 return null;
@@ -5622,7 +5634,7 @@ namespace AasCore.Aas3
                                     "The property Kind of an instance of class MultiLanguageProperty " +
                                     "could not be de-serialized from an unexpected enumeration literal: " +
                                     textKind);
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "kind"));
                                 return null;
@@ -5646,7 +5658,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "semanticId"));
                                 return null;
@@ -5676,7 +5688,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexQualifiers));
                                     return null;
@@ -5715,7 +5727,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexDataSpecifications));
                                     return null;
@@ -5748,7 +5760,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "value"));
                                 return null;
@@ -5772,7 +5784,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "valueId"));
                                 return null;
@@ -5790,14 +5802,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class MultiLanguageProperty " +
+                            "Expected an XML end element to conclude a property of class MultiLanguageProperty " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class MultiLanguageProperty " +
+                            "Expected an XML end element to conclude a property of class MultiLanguageProperty " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -5805,7 +5817,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class MultiLanguageProperty " +
+                            "Expected an XML end element to conclude a property of class MultiLanguageProperty " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -5855,7 +5867,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class MultiLanguageProperty, " +
+                        "Expected an XML element representing an instance of class MultiLanguageProperty, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -5894,7 +5906,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class MultiLanguageProperty, " +
+                        "Expected an XML end element concluding an instance of class MultiLanguageProperty, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -5966,7 +5978,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexExtensions));
                                     return null;
@@ -6002,7 +6014,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property IdShort of an instance of class Range " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "idShort"));
                                 return null;
@@ -6026,7 +6038,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "displayName"));
                                 return null;
@@ -6053,7 +6065,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Category of an instance of class Range " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "category"));
                                 return null;
@@ -6077,7 +6089,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "description"));
                                 return null;
@@ -6104,7 +6116,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Checksum of an instance of class Range " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "checksum"));
                                 return null;
@@ -6132,7 +6144,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Kind of an instance of class Range " +
                                     $"could not be de-serialized as a string: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "kind"));
                                 return null;
@@ -6147,7 +6159,7 @@ namespace AasCore.Aas3
                                     "The property Kind of an instance of class Range " +
                                     "could not be de-serialized from an unexpected enumeration literal: " +
                                     textKind);
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "kind"));
                                 return null;
@@ -6171,7 +6183,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "semanticId"));
                                 return null;
@@ -6201,7 +6213,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexQualifiers));
                                     return null;
@@ -6240,7 +6252,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexDataSpecifications));
                                     return null;
@@ -6277,7 +6289,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property ValueType of an instance of class Range " +
                                     $"could not be de-serialized as a string: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "valueType"));
                                 return null;
@@ -6292,7 +6304,7 @@ namespace AasCore.Aas3
                                     "The property ValueType of an instance of class Range " +
                                     "could not be de-serialized from an unexpected enumeration literal: " +
                                     textValueType);
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "valueType"));
                                 return null;
@@ -6319,7 +6331,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Min of an instance of class Range " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "min"));
                                 return null;
@@ -6346,7 +6358,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Max of an instance of class Range " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "max"));
                                 return null;
@@ -6364,14 +6376,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Range " +
+                            "Expected an XML end element to conclude a property of class Range " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Range " +
+                            "Expected an XML end element to conclude a property of class Range " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -6379,7 +6391,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Range " +
+                            "Expected an XML end element to conclude a property of class Range " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -6440,7 +6452,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class Range, " +
+                        "Expected an XML element representing an instance of class Range, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -6479,7 +6491,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class Range, " +
+                        "Expected an XML end element concluding an instance of class Range, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -6549,7 +6561,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexExtensions));
                                     return null;
@@ -6585,7 +6597,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property IdShort of an instance of class ReferenceElement " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "idShort"));
                                 return null;
@@ -6609,7 +6621,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "displayName"));
                                 return null;
@@ -6636,7 +6648,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Category of an instance of class ReferenceElement " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "category"));
                                 return null;
@@ -6660,7 +6672,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "description"));
                                 return null;
@@ -6687,7 +6699,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Checksum of an instance of class ReferenceElement " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "checksum"));
                                 return null;
@@ -6715,7 +6727,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Kind of an instance of class ReferenceElement " +
                                     $"could not be de-serialized as a string: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "kind"));
                                 return null;
@@ -6730,7 +6742,7 @@ namespace AasCore.Aas3
                                     "The property Kind of an instance of class ReferenceElement " +
                                     "could not be de-serialized from an unexpected enumeration literal: " +
                                     textKind);
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "kind"));
                                 return null;
@@ -6754,7 +6766,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "semanticId"));
                                 return null;
@@ -6784,7 +6796,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexQualifiers));
                                     return null;
@@ -6823,7 +6835,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexDataSpecifications));
                                     return null;
@@ -6856,7 +6868,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "value"));
                                 return null;
@@ -6874,14 +6886,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class ReferenceElement " +
+                            "Expected an XML end element to conclude a property of class ReferenceElement " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class ReferenceElement " +
+                            "Expected an XML end element to conclude a property of class ReferenceElement " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -6889,7 +6901,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class ReferenceElement " +
+                            "Expected an XML end element to conclude a property of class ReferenceElement " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -6938,7 +6950,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class ReferenceElement, " +
+                        "Expected an XML element representing an instance of class ReferenceElement, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -6977,7 +6989,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class ReferenceElement, " +
+                        "Expected an XML end element concluding an instance of class ReferenceElement, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -7048,7 +7060,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexExtensions));
                                     return null;
@@ -7084,7 +7096,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property IdShort of an instance of class Blob " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "idShort"));
                                 return null;
@@ -7108,7 +7120,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "displayName"));
                                 return null;
@@ -7135,7 +7147,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Category of an instance of class Blob " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "category"));
                                 return null;
@@ -7159,7 +7171,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "description"));
                                 return null;
@@ -7186,7 +7198,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Checksum of an instance of class Blob " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "checksum"));
                                 return null;
@@ -7214,7 +7226,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Kind of an instance of class Blob " +
                                     $"could not be de-serialized as a string: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "kind"));
                                 return null;
@@ -7229,7 +7241,7 @@ namespace AasCore.Aas3
                                     "The property Kind of an instance of class Blob " +
                                     "could not be de-serialized from an unexpected enumeration literal: " +
                                     textKind);
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "kind"));
                                 return null;
@@ -7253,7 +7265,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "semanticId"));
                                 return null;
@@ -7283,7 +7295,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexQualifiers));
                                     return null;
@@ -7322,7 +7334,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexDataSpecifications));
                                     return null;
@@ -7358,7 +7370,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property MimeType of an instance of class Blob " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "mimeType"));
                                 return null;
@@ -7386,7 +7398,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Value of an instance of class Blob " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "value"));
                                 return null;
@@ -7404,14 +7416,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Blob " +
+                            "Expected an XML end element to conclude a property of class Blob " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Blob " +
+                            "Expected an XML end element to conclude a property of class Blob " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -7419,7 +7431,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Blob " +
+                            "Expected an XML end element to conclude a property of class Blob " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -7479,7 +7491,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class Blob, " +
+                        "Expected an XML element representing an instance of class Blob, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -7518,7 +7530,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class Blob, " +
+                        "Expected an XML end element concluding an instance of class Blob, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -7589,7 +7601,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexExtensions));
                                     return null;
@@ -7625,7 +7637,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property IdShort of an instance of class File " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "idShort"));
                                 return null;
@@ -7649,7 +7661,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "displayName"));
                                 return null;
@@ -7676,7 +7688,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Category of an instance of class File " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "category"));
                                 return null;
@@ -7700,7 +7712,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "description"));
                                 return null;
@@ -7727,7 +7739,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Checksum of an instance of class File " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "checksum"));
                                 return null;
@@ -7755,7 +7767,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Kind of an instance of class File " +
                                     $"could not be de-serialized as a string: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "kind"));
                                 return null;
@@ -7770,7 +7782,7 @@ namespace AasCore.Aas3
                                     "The property Kind of an instance of class File " +
                                     "could not be de-serialized from an unexpected enumeration literal: " +
                                     textKind);
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "kind"));
                                 return null;
@@ -7794,7 +7806,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "semanticId"));
                                 return null;
@@ -7824,7 +7836,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexQualifiers));
                                     return null;
@@ -7863,7 +7875,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexDataSpecifications));
                                     return null;
@@ -7899,7 +7911,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property ContentType of an instance of class File " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "contentType"));
                                 return null;
@@ -7926,7 +7938,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Value of an instance of class File " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "value"));
                                 return null;
@@ -7944,14 +7956,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class File " +
+                            "Expected an XML end element to conclude a property of class File " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class File " +
+                            "Expected an XML end element to conclude a property of class File " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -7959,7 +7971,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class File " +
+                            "Expected an XML end element to conclude a property of class File " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -8019,7 +8031,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class File, " +
+                        "Expected an XML element representing an instance of class File, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -8058,7 +8070,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class File, " +
+                        "Expected an XML end element concluding an instance of class File, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -8130,7 +8142,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexExtensions));
                                     return null;
@@ -8166,7 +8178,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property IdShort of an instance of class AnnotatedRelationshipElement " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "idShort"));
                                 return null;
@@ -8190,7 +8202,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "displayName"));
                                 return null;
@@ -8217,7 +8229,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Category of an instance of class AnnotatedRelationshipElement " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "category"));
                                 return null;
@@ -8241,7 +8253,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "description"));
                                 return null;
@@ -8268,7 +8280,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Checksum of an instance of class AnnotatedRelationshipElement " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "checksum"));
                                 return null;
@@ -8296,7 +8308,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Kind of an instance of class AnnotatedRelationshipElement " +
                                     $"could not be de-serialized as a string: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "kind"));
                                 return null;
@@ -8311,7 +8323,7 @@ namespace AasCore.Aas3
                                     "The property Kind of an instance of class AnnotatedRelationshipElement " +
                                     "could not be de-serialized from an unexpected enumeration literal: " +
                                     textKind);
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "kind"));
                                 return null;
@@ -8335,7 +8347,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "semanticId"));
                                 return null;
@@ -8365,7 +8377,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexQualifiers));
                                     return null;
@@ -8404,7 +8416,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexDataSpecifications));
                                     return null;
@@ -8437,7 +8449,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "first"));
                                 return null;
@@ -8461,7 +8473,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "second"));
                                 return null;
@@ -8491,7 +8503,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexAnnotation));
                                     return null;
@@ -8518,14 +8530,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class AnnotatedRelationshipElement " +
+                            "Expected an XML end element to conclude a property of class AnnotatedRelationshipElement " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class AnnotatedRelationshipElement " +
+                            "Expected an XML end element to conclude a property of class AnnotatedRelationshipElement " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -8533,7 +8545,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class AnnotatedRelationshipElement " +
+                            "Expected an XML end element to conclude a property of class AnnotatedRelationshipElement " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -8604,7 +8616,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class AnnotatedRelationshipElement, " +
+                        "Expected an XML element representing an instance of class AnnotatedRelationshipElement, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -8643,7 +8655,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class AnnotatedRelationshipElement, " +
+                        "Expected an XML end element concluding an instance of class AnnotatedRelationshipElement, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -8716,7 +8728,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexExtensions));
                                     return null;
@@ -8752,7 +8764,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property IdShort of an instance of class Entity " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "idShort"));
                                 return null;
@@ -8776,7 +8788,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "displayName"));
                                 return null;
@@ -8803,7 +8815,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Category of an instance of class Entity " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "category"));
                                 return null;
@@ -8827,7 +8839,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "description"));
                                 return null;
@@ -8854,7 +8866,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Checksum of an instance of class Entity " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "checksum"));
                                 return null;
@@ -8882,7 +8894,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Kind of an instance of class Entity " +
                                     $"could not be de-serialized as a string: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "kind"));
                                 return null;
@@ -8897,7 +8909,7 @@ namespace AasCore.Aas3
                                     "The property Kind of an instance of class Entity " +
                                     "could not be de-serialized from an unexpected enumeration literal: " +
                                     textKind);
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "kind"));
                                 return null;
@@ -8921,7 +8933,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "semanticId"));
                                 return null;
@@ -8951,7 +8963,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexQualifiers));
                                     return null;
@@ -8990,7 +9002,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexDataSpecifications));
                                     return null;
@@ -9027,7 +9039,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property EntityType of an instance of class Entity " +
                                     $"could not be de-serialized as a string: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "entityType"));
                                 return null;
@@ -9042,7 +9054,7 @@ namespace AasCore.Aas3
                                     "The property EntityType of an instance of class Entity " +
                                     "could not be de-serialized from an unexpected enumeration literal: " +
                                     textEntityType);
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "entityType"));
                                 return null;
@@ -9072,7 +9084,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexStatements));
                                     return null;
@@ -9105,7 +9117,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "globalAssetId"));
                                 return null;
@@ -9129,7 +9141,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "specificAssetId"));
                                 return null;
@@ -9147,14 +9159,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Entity " +
+                            "Expected an XML end element to conclude a property of class Entity " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Entity " +
+                            "Expected an XML end element to conclude a property of class Entity " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -9162,7 +9174,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Entity " +
+                            "Expected an XML end element to conclude a property of class Entity " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -9224,7 +9236,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class Entity, " +
+                        "Expected an XML element representing an instance of class Entity, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -9263,7 +9275,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class Entity, " +
+                        "Expected an XML end element concluding an instance of class Entity, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -9324,7 +9336,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "source"));
                                 return null;
@@ -9348,7 +9360,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "sourceSemanticId"));
                                 return null;
@@ -9372,7 +9384,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "observableReference"));
                                 return null;
@@ -9396,7 +9408,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "observableSemanticId"));
                                 return null;
@@ -9423,7 +9435,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Topic of an instance of class EventPayload " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "topic"));
                                 return null;
@@ -9447,7 +9459,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "subjectId"));
                                 return null;
@@ -9474,7 +9486,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property TimeStamp of an instance of class EventPayload " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "timeStamp"));
                                 return null;
@@ -9501,7 +9513,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Payload of an instance of class EventPayload " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "payload"));
                                 return null;
@@ -9519,14 +9531,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class EventPayload " +
+                            "Expected an XML end element to conclude a property of class EventPayload " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class EventPayload " +
+                            "Expected an XML end element to conclude a property of class EventPayload " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -9534,7 +9546,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class EventPayload " +
+                            "Expected an XML end element to conclude a property of class EventPayload " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -9610,7 +9622,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class EventPayload, " +
+                        "Expected an XML element representing an instance of class EventPayload, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -9649,7 +9661,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class EventPayload, " +
+                        "Expected an XML end element concluding an instance of class EventPayload, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -9659,8 +9671,9 @@ namespace AasCore.Aas3
             }  // internal static Aas.EventPayload? EventPayloadFromElement
 
             /// <summary>
-            /// Deserialize an instance of class IEventElement from an XML element.
+            /// Deserialize an instance of IEventElement from an XML element.
             /// </summary>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             internal static Aas.IEventElement? IEventElementFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
@@ -9679,7 +9692,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element, " +
+                        "Expected an XML element, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -9766,7 +9779,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexExtensions));
                                     return null;
@@ -9802,7 +9815,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property IdShort of an instance of class BasicEventElement " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "idShort"));
                                 return null;
@@ -9826,7 +9839,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "displayName"));
                                 return null;
@@ -9853,7 +9866,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Category of an instance of class BasicEventElement " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "category"));
                                 return null;
@@ -9877,7 +9890,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "description"));
                                 return null;
@@ -9904,7 +9917,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Checksum of an instance of class BasicEventElement " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "checksum"));
                                 return null;
@@ -9932,7 +9945,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Kind of an instance of class BasicEventElement " +
                                     $"could not be de-serialized as a string: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "kind"));
                                 return null;
@@ -9947,7 +9960,7 @@ namespace AasCore.Aas3
                                     "The property Kind of an instance of class BasicEventElement " +
                                     "could not be de-serialized from an unexpected enumeration literal: " +
                                     textKind);
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "kind"));
                                 return null;
@@ -9971,7 +9984,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "semanticId"));
                                 return null;
@@ -10001,7 +10014,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexQualifiers));
                                     return null;
@@ -10040,7 +10053,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexDataSpecifications));
                                     return null;
@@ -10073,7 +10086,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "observed"));
                                 return null;
@@ -10101,7 +10114,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Direction of an instance of class BasicEventElement " +
                                     $"could not be de-serialized as a string: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "direction"));
                                 return null;
@@ -10116,7 +10129,7 @@ namespace AasCore.Aas3
                                     "The property Direction of an instance of class BasicEventElement " +
                                     "could not be de-serialized from an unexpected enumeration literal: " +
                                     textDirection);
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "direction"));
                                 return null;
@@ -10144,7 +10157,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property State of an instance of class BasicEventElement " +
                                     $"could not be de-serialized as a string: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "state"));
                                 return null;
@@ -10159,7 +10172,7 @@ namespace AasCore.Aas3
                                     "The property State of an instance of class BasicEventElement " +
                                     "could not be de-serialized from an unexpected enumeration literal: " +
                                     textState);
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "state"));
                                 return null;
@@ -10186,7 +10199,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property MessageTopic of an instance of class BasicEventElement " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "messageTopic"));
                                 return null;
@@ -10210,7 +10223,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "messageBroker"));
                                 return null;
@@ -10237,7 +10250,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property LastUpdate of an instance of class BasicEventElement " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "lastUpdate"));
                                 return null;
@@ -10264,7 +10277,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property MinInterval of an instance of class BasicEventElement " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "minInterval"));
                                 return null;
@@ -10291,7 +10304,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property MaxInterval of an instance of class BasicEventElement " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "maxInterval"));
                                 return null;
@@ -10309,14 +10322,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class BasicEventElement " +
+                            "Expected an XML end element to conclude a property of class BasicEventElement " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class BasicEventElement " +
+                            "Expected an XML end element to conclude a property of class BasicEventElement " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -10324,7 +10337,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class BasicEventElement " +
+                            "Expected an XML end element to conclude a property of class BasicEventElement " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -10410,7 +10423,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class BasicEventElement, " +
+                        "Expected an XML element representing an instance of class BasicEventElement, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -10449,7 +10462,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class BasicEventElement, " +
+                        "Expected an XML end element concluding an instance of class BasicEventElement, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -10521,7 +10534,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexExtensions));
                                     return null;
@@ -10557,7 +10570,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property IdShort of an instance of class Operation " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "idShort"));
                                 return null;
@@ -10581,7 +10594,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "displayName"));
                                 return null;
@@ -10608,7 +10621,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Category of an instance of class Operation " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "category"));
                                 return null;
@@ -10632,7 +10645,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "description"));
                                 return null;
@@ -10659,7 +10672,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Checksum of an instance of class Operation " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "checksum"));
                                 return null;
@@ -10687,7 +10700,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Kind of an instance of class Operation " +
                                     $"could not be de-serialized as a string: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "kind"));
                                 return null;
@@ -10702,7 +10715,7 @@ namespace AasCore.Aas3
                                     "The property Kind of an instance of class Operation " +
                                     "could not be de-serialized from an unexpected enumeration literal: " +
                                     textKind);
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "kind"));
                                 return null;
@@ -10726,7 +10739,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "semanticId"));
                                 return null;
@@ -10756,7 +10769,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexQualifiers));
                                     return null;
@@ -10795,7 +10808,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexDataSpecifications));
                                     return null;
@@ -10834,7 +10847,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexInputVariables));
                                     return null;
@@ -10873,7 +10886,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexOutputVariables));
                                     return null;
@@ -10912,7 +10925,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexInoutputVariables));
                                     return null;
@@ -10939,14 +10952,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Operation " +
+                            "Expected an XML end element to conclude a property of class Operation " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Operation " +
+                            "Expected an XML end element to conclude a property of class Operation " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -10954,7 +10967,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Operation " +
+                            "Expected an XML end element to conclude a property of class Operation " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -11005,7 +11018,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class Operation, " +
+                        "Expected an XML element representing an instance of class Operation, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -11044,7 +11057,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class Operation, " +
+                        "Expected an XML end element concluding an instance of class Operation, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -11098,7 +11111,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "value"));
                                 return null;
@@ -11116,14 +11129,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class OperationVariable " +
+                            "Expected an XML end element to conclude a property of class OperationVariable " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class OperationVariable " +
+                            "Expected an XML end element to conclude a property of class OperationVariable " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -11131,7 +11144,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class OperationVariable " +
+                            "Expected an XML end element to conclude a property of class OperationVariable " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -11180,7 +11193,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class OperationVariable, " +
+                        "Expected an XML element representing an instance of class OperationVariable, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -11219,7 +11232,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class OperationVariable, " +
+                        "Expected an XML end element concluding an instance of class OperationVariable, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -11288,7 +11301,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexExtensions));
                                     return null;
@@ -11324,7 +11337,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property IdShort of an instance of class Capability " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "idShort"));
                                 return null;
@@ -11348,7 +11361,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "displayName"));
                                 return null;
@@ -11375,7 +11388,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Category of an instance of class Capability " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "category"));
                                 return null;
@@ -11399,7 +11412,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "description"));
                                 return null;
@@ -11426,7 +11439,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Checksum of an instance of class Capability " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "checksum"));
                                 return null;
@@ -11454,7 +11467,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Kind of an instance of class Capability " +
                                     $"could not be de-serialized as a string: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "kind"));
                                 return null;
@@ -11469,7 +11482,7 @@ namespace AasCore.Aas3
                                     "The property Kind of an instance of class Capability " +
                                     "could not be de-serialized from an unexpected enumeration literal: " +
                                     textKind);
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "kind"));
                                 return null;
@@ -11493,7 +11506,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "semanticId"));
                                 return null;
@@ -11523,7 +11536,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexQualifiers));
                                     return null;
@@ -11562,7 +11575,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexDataSpecifications));
                                     return null;
@@ -11589,14 +11602,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Capability " +
+                            "Expected an XML end element to conclude a property of class Capability " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Capability " +
+                            "Expected an XML end element to conclude a property of class Capability " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -11604,7 +11617,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Capability " +
+                            "Expected an XML end element to conclude a property of class Capability " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -11652,7 +11665,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class Capability, " +
+                        "Expected an XML element representing an instance of class Capability, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -11691,7 +11704,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class Capability, " +
+                        "Expected an XML end element concluding an instance of class Capability, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -11760,7 +11773,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexExtensions));
                                     return null;
@@ -11796,7 +11809,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property IdShort of an instance of class ConceptDescription " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "idShort"));
                                 return null;
@@ -11820,7 +11833,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "displayName"));
                                 return null;
@@ -11847,7 +11860,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Category of an instance of class ConceptDescription " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "category"));
                                 return null;
@@ -11871,7 +11884,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "description"));
                                 return null;
@@ -11898,7 +11911,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Checksum of an instance of class ConceptDescription " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "checksum"));
                                 return null;
@@ -11925,7 +11938,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Id of an instance of class ConceptDescription " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "id"));
                                 return null;
@@ -11949,7 +11962,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "administration"));
                                 return null;
@@ -11979,7 +11992,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexDataSpecifications));
                                     return null;
@@ -12018,7 +12031,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexIsCaseOf));
                                     return null;
@@ -12045,14 +12058,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class ConceptDescription " +
+                            "Expected an XML end element to conclude a property of class ConceptDescription " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class ConceptDescription " +
+                            "Expected an XML end element to conclude a property of class ConceptDescription " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -12060,7 +12073,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class ConceptDescription " +
+                            "Expected an XML end element to conclude a property of class ConceptDescription " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -12118,7 +12131,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class ConceptDescription, " +
+                        "Expected an XML element representing an instance of class ConceptDescription, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -12157,7 +12170,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class ConceptDescription, " +
+                        "Expected an XML end element concluding an instance of class ConceptDescription, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -12167,8 +12180,9 @@ namespace AasCore.Aas3
             }  // internal static Aas.ConceptDescription? ConceptDescriptionFromElement
 
             /// <summary>
-            /// Deserialize an instance of class IReference from an XML element.
+            /// Deserialize an instance of IReference from an XML element.
             /// </summary>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             internal static Aas.IReference? IReferenceFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
@@ -12187,7 +12201,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element, " +
+                        "Expected an XML element, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -12258,7 +12272,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Value of an instance of class GlobalReference " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "value"));
                                 return null;
@@ -12276,14 +12290,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class GlobalReference " +
+                            "Expected an XML end element to conclude a property of class GlobalReference " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class GlobalReference " +
+                            "Expected an XML end element to conclude a property of class GlobalReference " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -12291,7 +12305,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class GlobalReference " +
+                            "Expected an XML end element to conclude a property of class GlobalReference " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -12340,7 +12354,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class GlobalReference, " +
+                        "Expected an XML element representing an instance of class GlobalReference, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -12379,7 +12393,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class GlobalReference, " +
+                        "Expected an XML end element concluding an instance of class GlobalReference, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -12440,7 +12454,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexKeys));
                                     return null;
@@ -12473,7 +12487,7 @@ namespace AasCore.Aas3
 
                             if (error != null)
                             {
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "referredSemanticId"));
                                 return null;
@@ -12491,14 +12505,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class ModelReference " +
+                            "Expected an XML end element to conclude a property of class ModelReference " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class ModelReference " +
+                            "Expected an XML end element to conclude a property of class ModelReference " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -12506,7 +12520,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class ModelReference " +
+                            "Expected an XML end element to conclude a property of class ModelReference " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -12556,7 +12570,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class ModelReference, " +
+                        "Expected an XML element representing an instance of class ModelReference, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -12595,7 +12609,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class ModelReference, " +
+                        "Expected an XML end element concluding an instance of class ModelReference, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -12654,7 +12668,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Type of an instance of class Key " +
                                     $"could not be de-serialized as a string: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "type"));
                                 return null;
@@ -12669,7 +12683,7 @@ namespace AasCore.Aas3
                                     "The property Type of an instance of class Key " +
                                     "could not be de-serialized from an unexpected enumeration literal: " +
                                     textType);
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "type"));
                                 return null;
@@ -12696,7 +12710,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Value of an instance of class Key " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "value"));
                                 return null;
@@ -12714,14 +12728,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Key " +
+                            "Expected an XML end element to conclude a property of class Key " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Key " +
+                            "Expected an XML end element to conclude a property of class Key " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -12729,7 +12743,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Key " +
+                            "Expected an XML end element to conclude a property of class Key " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -12789,7 +12803,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class Key, " +
+                        "Expected an XML element representing an instance of class Key, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -12828,7 +12842,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class Key, " +
+                        "Expected an XML end element concluding an instance of class Key, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -12886,7 +12900,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Language of an instance of class LangString " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "language"));
                                 return null;
@@ -12913,7 +12927,7 @@ namespace AasCore.Aas3
                                 error = new Reporting.Error(
                                     "The property Text of an instance of class LangString " +
                                     $"could not be de-serialized: {exception}");
-                                error._pathSegments.AddFirst(
+                                error.PrependSegment(
                                     new Reporting.NameSegment(
                                         "text"));
                                 return null;
@@ -12931,14 +12945,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class LangString " +
+                            "Expected an XML end element to conclude a property of class LangString " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class LangString " +
+                            "Expected an XML end element to conclude a property of class LangString " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -12946,7 +12960,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class LangString " +
+                            "Expected an XML end element to conclude a property of class LangString " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -13006,7 +13020,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class LangString, " +
+                        "Expected an XML element representing an instance of class LangString, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -13045,7 +13059,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class LangString, " +
+                        "Expected an XML end element concluding an instance of class LangString, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -13105,7 +13119,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexLangStrings));
                                     return null;
@@ -13132,14 +13146,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class LangStringSet " +
+                            "Expected an XML end element to conclude a property of class LangStringSet " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class LangStringSet " +
+                            "Expected an XML end element to conclude a property of class LangStringSet " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -13147,7 +13161,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class LangStringSet " +
+                            "Expected an XML end element to conclude a property of class LangStringSet " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -13196,7 +13210,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class LangStringSet, " +
+                        "Expected an XML element representing an instance of class LangStringSet, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -13235,7 +13249,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class LangStringSet, " +
+                        "Expected an XML end element concluding an instance of class LangStringSet, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -13297,7 +13311,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexAssetAdministrationShells));
                                     return null;
@@ -13336,7 +13350,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexSubmodels));
                                     return null;
@@ -13375,7 +13389,7 @@ namespace AasCore.Aas3
 
                                 if (error != null)
                                 {
-                                    error._pathSegments.AddFirst(
+                                    error.PrependSegment(
                                         new Reporting.IndexSegment(
                                             indexConceptDescriptions));
                                     return null;
@@ -13402,14 +13416,14 @@ namespace AasCore.Aas3
                     if (reader.EOF)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Environment " +
+                            "Expected an XML end element to conclude a property of class Environment " +
                             $"with the element name {elementName}, " +
-                            $"but got the end-of-file.");
+                            "but got the end-of-file.");
                     }
                     if (reader.NodeType != Xml.XmlNodeType.EndElement)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Environment " +
+                            "Expected an XML end element to conclude a property of class Environment " +
                             $"with the element name {elementName}, " +
                             $"but got the node of type {reader.NodeType} " +
                             $"with the value {reader.Value}");
@@ -13417,7 +13431,7 @@ namespace AasCore.Aas3
                     if (reader.Name != elementName)
                     {
                         error = new Reporting.Error(
-                            $"Expected an XML end element to conclude a property of class Environment " +
+                            "Expected an XML end element to conclude a property of class Environment " +
                             $"with the element name {elementName}, " +
                             $"but got the end element with the name {reader.Name}");
                     }
@@ -13458,7 +13472,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class Environment, " +
+                        "Expected an XML element representing an instance of class Environment, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -13497,7 +13511,7 @@ namespace AasCore.Aas3
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML end element concluding an instance of class Environment, " +
+                        "Expected an XML end element concluding an instance of class Environment, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return null;
@@ -13536,11 +13550,11 @@ namespace AasCore.Aas3
         public static class Deserialize
         {
             /// <summary>
-            /// Deserialize an instance of class Resource from <paramref name="reader" />.
+            /// Deserialize an instance of Resource from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of Resource.
             /// </exception>
             public static Aas.Resource ResourceFrom(
@@ -13562,14 +13576,14 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class IHasSemantics from <paramref name="reader" />.
+            /// Deserialize an instance of IHasSemantics from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of IHasSemantics.
             /// </exception>
-            public static Aas.IHasSemantics IHasSemanticsFrom(
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]public static Aas.IHasSemantics IHasSemanticsFrom(
                 Xml.XmlReader reader)
             {
                 Aas.IHasSemantics? result = (
@@ -13588,11 +13602,11 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class Extension from <paramref name="reader" />.
+            /// Deserialize an instance of Extension from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of Extension.
             /// </exception>
             public static Aas.Extension ExtensionFrom(
@@ -13614,14 +13628,14 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class IHasExtensions from <paramref name="reader" />.
+            /// Deserialize an instance of IHasExtensions from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of IHasExtensions.
             /// </exception>
-            public static Aas.IHasExtensions IHasExtensionsFrom(
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]public static Aas.IHasExtensions IHasExtensionsFrom(
                 Xml.XmlReader reader)
             {
                 Aas.IHasExtensions? result = (
@@ -13640,14 +13654,14 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class IReferable from <paramref name="reader" />.
+            /// Deserialize an instance of IReferable from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of IReferable.
             /// </exception>
-            public static Aas.IReferable IReferableFrom(
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]public static Aas.IReferable IReferableFrom(
                 Xml.XmlReader reader)
             {
                 Aas.IReferable? result = (
@@ -13666,14 +13680,14 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class IIdentifiable from <paramref name="reader" />.
+            /// Deserialize an instance of IIdentifiable from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of IIdentifiable.
             /// </exception>
-            public static Aas.IIdentifiable IIdentifiableFrom(
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]public static Aas.IIdentifiable IIdentifiableFrom(
                 Xml.XmlReader reader)
             {
                 Aas.IIdentifiable? result = (
@@ -13692,14 +13706,14 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class IHasKind from <paramref name="reader" />.
+            /// Deserialize an instance of IHasKind from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of IHasKind.
             /// </exception>
-            public static Aas.IHasKind IHasKindFrom(
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]public static Aas.IHasKind IHasKindFrom(
                 Xml.XmlReader reader)
             {
                 Aas.IHasKind? result = (
@@ -13718,14 +13732,14 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class IHasDataSpecification from <paramref name="reader" />.
+            /// Deserialize an instance of IHasDataSpecification from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of IHasDataSpecification.
             /// </exception>
-            public static Aas.IHasDataSpecification IHasDataSpecificationFrom(
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]public static Aas.IHasDataSpecification IHasDataSpecificationFrom(
                 Xml.XmlReader reader)
             {
                 Aas.IHasDataSpecification? result = (
@@ -13744,11 +13758,11 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class AdministrativeInformation from <paramref name="reader" />.
+            /// Deserialize an instance of AdministrativeInformation from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of AdministrativeInformation.
             /// </exception>
             public static Aas.AdministrativeInformation AdministrativeInformationFrom(
@@ -13770,14 +13784,14 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class IQualifiable from <paramref name="reader" />.
+            /// Deserialize an instance of IQualifiable from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of IQualifiable.
             /// </exception>
-            public static Aas.IQualifiable IQualifiableFrom(
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]public static Aas.IQualifiable IQualifiableFrom(
                 Xml.XmlReader reader)
             {
                 Aas.IQualifiable? result = (
@@ -13796,11 +13810,11 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class Qualifier from <paramref name="reader" />.
+            /// Deserialize an instance of Qualifier from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of Qualifier.
             /// </exception>
             public static Aas.Qualifier QualifierFrom(
@@ -13822,11 +13836,11 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class AssetAdministrationShell from <paramref name="reader" />.
+            /// Deserialize an instance of AssetAdministrationShell from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of AssetAdministrationShell.
             /// </exception>
             public static Aas.AssetAdministrationShell AssetAdministrationShellFrom(
@@ -13848,11 +13862,11 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class AssetInformation from <paramref name="reader" />.
+            /// Deserialize an instance of AssetInformation from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of AssetInformation.
             /// </exception>
             public static Aas.AssetInformation AssetInformationFrom(
@@ -13874,14 +13888,14 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class IdentifierKeyValuePair from <paramref name="reader" />.
+            /// Deserialize an instance of IdentifierKeyValuePair from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of IdentifierKeyValuePair.
             /// </exception>
-            public static Aas.IdentifierKeyValuePair IdentifierKeyValuePairFrom(
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]public static Aas.IdentifierKeyValuePair IdentifierKeyValuePairFrom(
                 Xml.XmlReader reader)
             {
                 Aas.IdentifierKeyValuePair? result = (
@@ -13900,11 +13914,11 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class Submodel from <paramref name="reader" />.
+            /// Deserialize an instance of Submodel from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of Submodel.
             /// </exception>
             public static Aas.Submodel SubmodelFrom(
@@ -13926,14 +13940,14 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class ISubmodelElement from <paramref name="reader" />.
+            /// Deserialize an instance of ISubmodelElement from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of ISubmodelElement.
             /// </exception>
-            public static Aas.ISubmodelElement ISubmodelElementFrom(
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]public static Aas.ISubmodelElement ISubmodelElementFrom(
                 Xml.XmlReader reader)
             {
                 Aas.ISubmodelElement? result = (
@@ -13952,14 +13966,14 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class IRelationshipElement from <paramref name="reader" />.
+            /// Deserialize an instance of IRelationshipElement from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of IRelationshipElement.
             /// </exception>
-            public static Aas.IRelationshipElement IRelationshipElementFrom(
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]public static Aas.IRelationshipElement IRelationshipElementFrom(
                 Xml.XmlReader reader)
             {
                 Aas.IRelationshipElement? result = (
@@ -13978,11 +13992,11 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class SubmodelElementList from <paramref name="reader" />.
+            /// Deserialize an instance of SubmodelElementList from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of SubmodelElementList.
             /// </exception>
             public static Aas.SubmodelElementList SubmodelElementListFrom(
@@ -14004,11 +14018,11 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class SubmodelElementStruct from <paramref name="reader" />.
+            /// Deserialize an instance of SubmodelElementStruct from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of SubmodelElementStruct.
             /// </exception>
             public static Aas.SubmodelElementStruct SubmodelElementStructFrom(
@@ -14030,14 +14044,14 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class IDataElement from <paramref name="reader" />.
+            /// Deserialize an instance of IDataElement from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of IDataElement.
             /// </exception>
-            public static Aas.IDataElement IDataElementFrom(
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]public static Aas.IDataElement IDataElementFrom(
                 Xml.XmlReader reader)
             {
                 Aas.IDataElement? result = (
@@ -14056,11 +14070,11 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class Property from <paramref name="reader" />.
+            /// Deserialize an instance of Property from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of Property.
             /// </exception>
             public static Aas.Property PropertyFrom(
@@ -14082,11 +14096,11 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class MultiLanguageProperty from <paramref name="reader" />.
+            /// Deserialize an instance of MultiLanguageProperty from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of MultiLanguageProperty.
             /// </exception>
             public static Aas.MultiLanguageProperty MultiLanguagePropertyFrom(
@@ -14108,11 +14122,11 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class Range from <paramref name="reader" />.
+            /// Deserialize an instance of Range from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of Range.
             /// </exception>
             public static Aas.Range RangeFrom(
@@ -14134,11 +14148,11 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class ReferenceElement from <paramref name="reader" />.
+            /// Deserialize an instance of ReferenceElement from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of ReferenceElement.
             /// </exception>
             public static Aas.ReferenceElement ReferenceElementFrom(
@@ -14160,11 +14174,11 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class Blob from <paramref name="reader" />.
+            /// Deserialize an instance of Blob from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of Blob.
             /// </exception>
             public static Aas.Blob BlobFrom(
@@ -14186,11 +14200,11 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class File from <paramref name="reader" />.
+            /// Deserialize an instance of File from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of File.
             /// </exception>
             public static Aas.File FileFrom(
@@ -14212,11 +14226,11 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class AnnotatedRelationshipElement from <paramref name="reader" />.
+            /// Deserialize an instance of AnnotatedRelationshipElement from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of AnnotatedRelationshipElement.
             /// </exception>
             public static Aas.AnnotatedRelationshipElement AnnotatedRelationshipElementFrom(
@@ -14238,11 +14252,11 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class Entity from <paramref name="reader" />.
+            /// Deserialize an instance of Entity from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of Entity.
             /// </exception>
             public static Aas.Entity EntityFrom(
@@ -14264,11 +14278,11 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class EventPayload from <paramref name="reader" />.
+            /// Deserialize an instance of EventPayload from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of EventPayload.
             /// </exception>
             public static Aas.EventPayload EventPayloadFrom(
@@ -14290,14 +14304,14 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class IEventElement from <paramref name="reader" />.
+            /// Deserialize an instance of IEventElement from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of IEventElement.
             /// </exception>
-            public static Aas.IEventElement IEventElementFrom(
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]public static Aas.IEventElement IEventElementFrom(
                 Xml.XmlReader reader)
             {
                 Aas.IEventElement? result = (
@@ -14316,11 +14330,11 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class BasicEventElement from <paramref name="reader" />.
+            /// Deserialize an instance of BasicEventElement from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of BasicEventElement.
             /// </exception>
             public static Aas.BasicEventElement BasicEventElementFrom(
@@ -14342,11 +14356,11 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class Operation from <paramref name="reader" />.
+            /// Deserialize an instance of Operation from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of Operation.
             /// </exception>
             public static Aas.Operation OperationFrom(
@@ -14368,11 +14382,11 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class OperationVariable from <paramref name="reader" />.
+            /// Deserialize an instance of OperationVariable from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of OperationVariable.
             /// </exception>
             public static Aas.OperationVariable OperationVariableFrom(
@@ -14394,11 +14408,11 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class Capability from <paramref name="reader" />.
+            /// Deserialize an instance of Capability from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of Capability.
             /// </exception>
             public static Aas.Capability CapabilityFrom(
@@ -14420,11 +14434,11 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class ConceptDescription from <paramref name="reader" />.
+            /// Deserialize an instance of ConceptDescription from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of ConceptDescription.
             /// </exception>
             public static Aas.ConceptDescription ConceptDescriptionFrom(
@@ -14446,14 +14460,14 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class IReference from <paramref name="reader" />.
+            /// Deserialize an instance of IReference from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of IReference.
             /// </exception>
-            public static Aas.IReference IReferenceFrom(
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]public static Aas.IReference IReferenceFrom(
                 Xml.XmlReader reader)
             {
                 Aas.IReference? result = (
@@ -14472,11 +14486,11 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class GlobalReference from <paramref name="reader" />.
+            /// Deserialize an instance of GlobalReference from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of GlobalReference.
             /// </exception>
             public static Aas.GlobalReference GlobalReferenceFrom(
@@ -14498,11 +14512,11 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class ModelReference from <paramref name="reader" />.
+            /// Deserialize an instance of ModelReference from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of ModelReference.
             /// </exception>
             public static Aas.ModelReference ModelReferenceFrom(
@@ -14524,11 +14538,11 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class Key from <paramref name="reader" />.
+            /// Deserialize an instance of Key from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of Key.
             /// </exception>
             public static Aas.Key KeyFrom(
@@ -14550,11 +14564,11 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class LangString from <paramref name="reader" />.
+            /// Deserialize an instance of LangString from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of LangString.
             /// </exception>
             public static Aas.LangString LangStringFrom(
@@ -14576,11 +14590,11 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class LangStringSet from <paramref name="reader" />.
+            /// Deserialize an instance of LangStringSet from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of LangStringSet.
             /// </exception>
             public static Aas.LangStringSet LangStringSetFrom(
@@ -14602,11 +14616,11 @@ namespace AasCore.Aas3
             }
 
             /// <summary>
-            /// Deserialize an instance of class Environment from <paramref name="reader" />.
+            /// Deserialize an instance of Environment from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
             /// <exception cref="Xmlization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid XML
+            /// Thrown when the element is not a valid XML
             /// representation of Environment.
             /// </exception>
             public static Aas.Environment EnvironmentFrom(
@@ -17728,7 +17742,8 @@ namespace AasCore.Aas3
         /// </example>
         public static class Serialize
         {
-            private static VisitorWithWriter _visitorWithWriter = (
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+            private static readonly VisitorWithWriter _visitorWithWriter = (
                 new VisitorWithWriter());
 
             /// <summary>

--- a/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/as_prefix/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/as_prefix/expected_verification.cs
@@ -3,13 +3,12 @@
  * Do NOT edit or append.
  */
 
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
 
 using Aas = dummyNamespace;
-using Reporting = dummyNamespace.Reporting;
-using Visitation = dummyNamespace.Visitation;
 
 namespace dummyNamespace
 {
@@ -18,6 +17,9 @@ namespace dummyNamespace
     /// </summary>
     public static class Verification
     {
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchSomething()
         {
             var pattern = "^\\ud800\\udc00something$";
@@ -25,11 +27,11 @@ namespace dummyNamespace
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchSomething = _constructMatchSomething();
+        private static readonly Regex RegexMatchSomething = _constructMatchSomething();
 
         public static bool MatchSomething(string text)
         {
-            return _regexMatchSomething.IsMatch(text);
+            return RegexMatchSomething.IsMatch(text);
         }
 
         /// <summary>
@@ -40,6 +42,7 @@ namespace dummyNamespace
 
         }  // internal static class EnumValueSet
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Verification.Transformer _transformer = (
             new Verification.Transformer());
 

--- a/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/as_suffix/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/as_suffix/expected_verification.cs
@@ -3,13 +3,12 @@
  * Do NOT edit or append.
  */
 
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
 
 using Aas = dummyNamespace;
-using Reporting = dummyNamespace.Reporting;
-using Visitation = dummyNamespace.Visitation;
 
 namespace dummyNamespace
 {
@@ -18,6 +17,9 @@ namespace dummyNamespace
     /// </summary>
     public static class Verification
     {
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchSomething()
         {
             var pattern = "^something\\ud800\\udc00$";
@@ -25,11 +27,11 @@ namespace dummyNamespace
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchSomething = _constructMatchSomething();
+        private static readonly Regex RegexMatchSomething = _constructMatchSomething();
 
         public static bool MatchSomething(string text)
         {
-            return _regexMatchSomething.IsMatch(text);
+            return RegexMatchSomething.IsMatch(text);
         }
 
         /// <summary>
@@ -40,6 +42,7 @@ namespace dummyNamespace
 
         }  // internal static class EnumValueSet
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Verification.Transformer _transformer = (
             new Verification.Transformer());
 

--- a/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/in_group_with_quantifier/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/in_group_with_quantifier/expected_verification.cs
@@ -3,13 +3,12 @@
  * Do NOT edit or append.
  */
 
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
 
 using Aas = dummyNamespace;
-using Reporting = dummyNamespace.Reporting;
-using Visitation = dummyNamespace.Visitation;
 
 namespace dummyNamespace
 {
@@ -18,6 +17,9 @@ namespace dummyNamespace
     /// </summary>
     public static class Verification
     {
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchSomething()
         {
             var pattern = "^(\\ud800\\udc00)*$";
@@ -25,11 +27,11 @@ namespace dummyNamespace
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchSomething = _constructMatchSomething();
+        private static readonly Regex RegexMatchSomething = _constructMatchSomething();
 
         public static bool MatchSomething(string text)
         {
-            return _regexMatchSomething.IsMatch(text);
+            return RegexMatchSomething.IsMatch(text);
         }
 
         /// <summary>
@@ -40,6 +42,7 @@ namespace dummyNamespace
 
         }  // internal static class EnumValueSet
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Verification.Transformer _transformer = (
             new Verification.Transformer());
 

--- a/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/in_the_middle/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/in_the_middle/expected_verification.cs
@@ -3,13 +3,12 @@
  * Do NOT edit or append.
  */
 
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
 
 using Aas = dummyNamespace;
-using Reporting = dummyNamespace.Reporting;
-using Visitation = dummyNamespace.Visitation;
 
 namespace dummyNamespace
 {
@@ -18,6 +17,9 @@ namespace dummyNamespace
     /// </summary>
     public static class Verification
     {
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchSomething()
         {
             var pattern = "^some-prefix\\ud800\\udc00some-suffix$";
@@ -25,11 +27,11 @@ namespace dummyNamespace
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchSomething = _constructMatchSomething();
+        private static readonly Regex RegexMatchSomething = _constructMatchSomething();
 
         public static bool MatchSomething(string text)
         {
-            return _regexMatchSomething.IsMatch(text);
+            return RegexMatchSomething.IsMatch(text);
         }
 
         /// <summary>
@@ -40,6 +42,7 @@ namespace dummyNamespace
 
         }  // internal static class EnumValueSet
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Verification.Transformer _transformer = (
             new Verification.Transformer());
 

--- a/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/in_union/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/in_union/expected_verification.cs
@@ -3,13 +3,12 @@
  * Do NOT edit or append.
  */
 
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
 
 using Aas = dummyNamespace;
-using Reporting = dummyNamespace.Reporting;
-using Visitation = dummyNamespace.Visitation;
 
 namespace dummyNamespace
 {
@@ -18,6 +17,9 @@ namespace dummyNamespace
     /// </summary>
     public static class Verification
     {
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchSomething()
         {
             var pattern = "^\\ud800\\udc00|something$";
@@ -25,11 +27,11 @@ namespace dummyNamespace
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchSomething = _constructMatchSomething();
+        private static readonly Regex RegexMatchSomething = _constructMatchSomething();
 
         public static bool MatchSomething(string text)
         {
-            return _regexMatchSomething.IsMatch(text);
+            return RegexMatchSomething.IsMatch(text);
         }
 
         /// <summary>
@@ -40,6 +42,7 @@ namespace dummyNamespace
 
         }  // internal static class EnumValueSet
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Verification.Transformer _transformer = (
             new Verification.Transformer());
 

--- a/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/single_utf32_literal/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/single_utf32_literal/expected_verification.cs
@@ -3,13 +3,12 @@
  * Do NOT edit or append.
  */
 
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
 
 using Aas = dummyNamespace;
-using Reporting = dummyNamespace.Reporting;
-using Visitation = dummyNamespace.Visitation;
 
 namespace dummyNamespace
 {
@@ -18,6 +17,9 @@ namespace dummyNamespace
     /// </summary>
     public static class Verification
     {
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchSomething()
         {
             var pattern = "^\\ud800\\udc00$";
@@ -25,11 +27,11 @@ namespace dummyNamespace
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchSomething = _constructMatchSomething();
+        private static readonly Regex RegexMatchSomething = _constructMatchSomething();
 
         public static bool MatchSomething(string text)
         {
-            return _regexMatchSomething.IsMatch(text);
+            return RegexMatchSomething.IsMatch(text);
         }
 
         /// <summary>
@@ -40,6 +42,7 @@ namespace dummyNamespace
 
         }  // internal static class EnumValueSet
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Verification.Transformer _transformer = (
             new Verification.Transformer());
 

--- a/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/with_quantifier_within_group/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/with_quantifier_within_group/expected_verification.cs
@@ -3,13 +3,12 @@
  * Do NOT edit or append.
  */
 
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
 
 using Aas = dummyNamespace;
-using Reporting = dummyNamespace.Reporting;
-using Visitation = dummyNamespace.Visitation;
 
 namespace dummyNamespace
 {
@@ -18,6 +17,9 @@ namespace dummyNamespace
     /// </summary>
     public static class Verification
     {
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchSomething()
         {
             var pattern = "^((\\ud800\\udc00)*something)?$";
@@ -25,11 +27,11 @@ namespace dummyNamespace
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchSomething = _constructMatchSomething();
+        private static readonly Regex RegexMatchSomething = _constructMatchSomething();
 
         public static bool MatchSomething(string text)
         {
-            return _regexMatchSomething.IsMatch(text);
+            return RegexMatchSomething.IsMatch(text);
         }
 
         /// <summary>
@@ -40,6 +42,7 @@ namespace dummyNamespace
 
         }  // internal static class EnumValueSet
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Verification.Transformer _transformer = (
             new Verification.Transformer());
 

--- a/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/with_quantifier_without_group/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/with_quantifier_without_group/expected_verification.cs
@@ -3,13 +3,12 @@
  * Do NOT edit or append.
  */
 
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
 
 using Aas = dummyNamespace;
-using Reporting = dummyNamespace.Reporting;
-using Visitation = dummyNamespace.Visitation;
 
 namespace dummyNamespace
 {
@@ -18,6 +17,9 @@ namespace dummyNamespace
     /// </summary>
     public static class Verification
     {
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchSomething()
         {
             var pattern = "^(\\ud800\\udc00)*$";
@@ -25,11 +27,11 @@ namespace dummyNamespace
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchSomething = _constructMatchSomething();
+        private static readonly Regex RegexMatchSomething = _constructMatchSomething();
 
         public static bool MatchSomething(string text)
         {
-            return _regexMatchSomething.IsMatch(text);
+            return RegexMatchSomething.IsMatch(text);
         }
 
         /// <summary>
@@ -40,6 +42,7 @@ namespace dummyNamespace
 
         }  // internal static class EnumValueSet
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Verification.Transformer _transformer = (
             new Verification.Transformer());
 

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/at_the_beginning/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/at_the_beginning/expected_verification.cs
@@ -3,13 +3,12 @@
  * Do NOT edit or append.
  */
 
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
 
 using Aas = dummyNamespace;
-using Reporting = dummyNamespace.Reporting;
-using Visitation = dummyNamespace.Visitation;
 
 namespace dummyNamespace
 {
@@ -18,6 +17,9 @@ namespace dummyNamespace
     /// </summary>
     public static class Verification
     {
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchSomething()
         {
             var pattern = "^prefix([a-zA-Z]|\\ud800\\udc00)suffix$";
@@ -25,11 +27,11 @@ namespace dummyNamespace
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchSomething = _constructMatchSomething();
+        private static readonly Regex RegexMatchSomething = _constructMatchSomething();
 
         public static bool MatchSomething(string text)
         {
-            return _regexMatchSomething.IsMatch(text);
+            return RegexMatchSomething.IsMatch(text);
         }
 
         /// <summary>
@@ -40,6 +42,7 @@ namespace dummyNamespace
 
         }  // internal static class EnumValueSet
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Verification.Transformer _transformer = (
             new Verification.Transformer());
 

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/at_the_end/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/at_the_end/expected_verification.cs
@@ -3,13 +3,12 @@
  * Do NOT edit or append.
  */
 
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
 
 using Aas = dummyNamespace;
-using Reporting = dummyNamespace.Reporting;
-using Visitation = dummyNamespace.Visitation;
 
 namespace dummyNamespace
 {
@@ -18,6 +17,9 @@ namespace dummyNamespace
     /// </summary>
     public static class Verification
     {
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchSomething()
         {
             var pattern = "^prefix([a-zA-Z]|\\ud800\\udc00)suffix$";
@@ -25,11 +27,11 @@ namespace dummyNamespace
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchSomething = _constructMatchSomething();
+        private static readonly Regex RegexMatchSomething = _constructMatchSomething();
 
         public static bool MatchSomething(string text)
         {
-            return _regexMatchSomething.IsMatch(text);
+            return RegexMatchSomething.IsMatch(text);
         }
 
         /// <summary>
@@ -40,6 +42,7 @@ namespace dummyNamespace
 
         }  // internal static class EnumValueSet
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Verification.Transformer _transformer = (
             new Verification.Transformer());
 

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/in_the_middle/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/in_the_middle/expected_verification.cs
@@ -3,13 +3,12 @@
  * Do NOT edit or append.
  */
 
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
 
 using Aas = dummyNamespace;
-using Reporting = dummyNamespace.Reporting;
-using Visitation = dummyNamespace.Visitation;
 
 namespace dummyNamespace
 {
@@ -18,6 +17,9 @@ namespace dummyNamespace
     /// </summary>
     public static class Verification
     {
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchSomething()
         {
             var pattern = "^prefix([a-zA-Z]|\\ud800\\udc00)suffix$";
@@ -25,11 +27,11 @@ namespace dummyNamespace
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchSomething = _constructMatchSomething();
+        private static readonly Regex RegexMatchSomething = _constructMatchSomething();
 
         public static bool MatchSomething(string text)
         {
-            return _regexMatchSomething.IsMatch(text);
+            return RegexMatchSomething.IsMatch(text);
         }
 
         /// <summary>
@@ -40,6 +42,7 @@ namespace dummyNamespace
 
         }  // internal static class EnumValueSet
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Verification.Transformer _transformer = (
             new Verification.Transformer());
 

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/multiple/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/multiple/expected_verification.cs
@@ -3,13 +3,12 @@
  * Do NOT edit or append.
  */
 
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
 
 using Aas = dummyNamespace;
-using Reporting = dummyNamespace.Reporting;
-using Visitation = dummyNamespace.Visitation;
 
 namespace dummyNamespace
 {
@@ -18,6 +17,9 @@ namespace dummyNamespace
     /// </summary>
     public static class Verification
     {
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchSomething()
         {
             var pattern = "^prefix(\\ud800\\udc00|\\ud800\\udc01)suffix$";
@@ -25,11 +27,11 @@ namespace dummyNamespace
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchSomething = _constructMatchSomething();
+        private static readonly Regex RegexMatchSomething = _constructMatchSomething();
 
         public static bool MatchSomething(string text)
         {
-            return _regexMatchSomething.IsMatch(text);
+            return RegexMatchSomething.IsMatch(text);
         }
 
         /// <summary>
@@ -40,6 +42,7 @@ namespace dummyNamespace
 
         }  // internal static class EnumValueSet
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Verification.Transformer _transformer = (
             new Verification.Transformer());
 

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/single/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/single/expected_verification.cs
@@ -3,13 +3,12 @@
  * Do NOT edit or append.
  */
 
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
 
 using Aas = dummyNamespace;
-using Reporting = dummyNamespace.Reporting;
-using Visitation = dummyNamespace.Visitation;
 
 namespace dummyNamespace
 {
@@ -18,6 +17,9 @@ namespace dummyNamespace
     /// </summary>
     public static class Verification
     {
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchSomething()
         {
             var pattern = "^prefix(\\ud800\\udc00)suffix$";
@@ -25,11 +27,11 @@ namespace dummyNamespace
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchSomething = _constructMatchSomething();
+        private static readonly Regex RegexMatchSomething = _constructMatchSomething();
 
         public static bool MatchSomething(string text)
         {
-            return _regexMatchSomething.IsMatch(text);
+            return RegexMatchSomething.IsMatch(text);
         }
 
         /// <summary>
@@ -40,6 +42,7 @@ namespace dummyNamespace
 
         }  // internal static class EnumValueSet
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Verification.Transformer _transformer = (
             new Verification.Transformer());
 

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/single_with_quantifier/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/single_with_quantifier/expected_verification.cs
@@ -3,13 +3,12 @@
  * Do NOT edit or append.
  */
 
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
 
 using Aas = dummyNamespace;
-using Reporting = dummyNamespace.Reporting;
-using Visitation = dummyNamespace.Visitation;
 
 namespace dummyNamespace
 {
@@ -18,6 +17,9 @@ namespace dummyNamespace
     /// </summary>
     public static class Verification
     {
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchSomething()
         {
             var pattern = "^prefix(\\ud800\\udc00)*suffix$";
@@ -25,11 +27,11 @@ namespace dummyNamespace
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchSomething = _constructMatchSomething();
+        private static readonly Regex RegexMatchSomething = _constructMatchSomething();
 
         public static bool MatchSomething(string text)
         {
-            return _regexMatchSomething.IsMatch(text);
+            return RegexMatchSomething.IsMatch(text);
         }
 
         /// <summary>
@@ -40,6 +42,7 @@ namespace dummyNamespace
 
         }  // internal static class EnumValueSet
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Verification.Transformer _transformer = (
             new Verification.Transformer());
 

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/mixed_with_non_utf32/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/mixed_with_non_utf32/expected_verification.cs
@@ -3,13 +3,12 @@
  * Do NOT edit or append.
  */
 
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
 
 using Aas = dummyNamespace;
-using Reporting = dummyNamespace.Reporting;
-using Visitation = dummyNamespace.Visitation;
 
 namespace dummyNamespace
 {
@@ -18,6 +17,9 @@ namespace dummyNamespace
     /// </summary>
     public static class Verification
     {
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchSomething()
         {
             var pattern = "^prefix([a-zA-Z]|\\ud800[\\udc00-\\udc0f])suffix$";
@@ -25,11 +27,11 @@ namespace dummyNamespace
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchSomething = _constructMatchSomething();
+        private static readonly Regex RegexMatchSomething = _constructMatchSomething();
 
         public static bool MatchSomething(string text)
         {
-            return _regexMatchSomething.IsMatch(text);
+            return RegexMatchSomething.IsMatch(text);
         }
 
         /// <summary>
@@ -40,6 +42,7 @@ namespace dummyNamespace
 
         }  // internal static class EnumValueSet
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Verification.Transformer _transformer = (
             new Verification.Transformer());
 

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/more_than_two_high_surrogates/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/more_than_two_high_surrogates/expected_verification.cs
@@ -3,13 +3,12 @@
  * Do NOT edit or append.
  */
 
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
 
 using Aas = dummyNamespace;
-using Reporting = dummyNamespace.Reporting;
-using Visitation = dummyNamespace.Visitation;
 
 namespace dummyNamespace
 {
@@ -18,6 +17,9 @@ namespace dummyNamespace
     /// </summary>
     public static class Verification
     {
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchSomething()
         {
             var pattern = "^prefix(\\ud800[\\udc05-\\udfff]|[\\ud801-\\ud83f][\\udc00-\\udfff]|\\ud840[\\udc00-\\udc05])suffix$";
@@ -25,11 +27,11 @@ namespace dummyNamespace
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchSomething = _constructMatchSomething();
+        private static readonly Regex RegexMatchSomething = _constructMatchSomething();
 
         public static bool MatchSomething(string text)
         {
-            return _regexMatchSomething.IsMatch(text);
+            return RegexMatchSomething.IsMatch(text);
         }
 
         /// <summary>
@@ -40,6 +42,7 @@ namespace dummyNamespace
 
         }  // internal static class EnumValueSet
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Verification.Transformer _transformer = (
             new Verification.Transformer());
 

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/multiple_utf32_ranges/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/multiple_utf32_ranges/expected_verification.cs
@@ -3,13 +3,12 @@
  * Do NOT edit or append.
  */
 
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
 
 using Aas = dummyNamespace;
-using Reporting = dummyNamespace.Reporting;
-using Visitation = dummyNamespace.Visitation;
 
 namespace dummyNamespace
 {
@@ -18,6 +17,9 @@ namespace dummyNamespace
     /// </summary>
     public static class Verification
     {
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchSomething()
         {
             var pattern = "^prefix(\\ud800[\\udc00-\\udc05]|\\ud840[\\udc00-\\udc05])suffix$";
@@ -25,11 +27,11 @@ namespace dummyNamespace
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchSomething = _constructMatchSomething();
+        private static readonly Regex RegexMatchSomething = _constructMatchSomething();
 
         public static bool MatchSomething(string text)
         {
-            return _regexMatchSomething.IsMatch(text);
+            return RegexMatchSomething.IsMatch(text);
         }
 
         /// <summary>
@@ -40,6 +42,7 @@ namespace dummyNamespace
 
         }  // internal static class EnumValueSet
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Verification.Transformer _transformer = (
             new Verification.Transformer());
 

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/multiple_utf32_ranges_mixed_with_non_utf32/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/multiple_utf32_ranges_mixed_with_non_utf32/expected_verification.cs
@@ -3,13 +3,12 @@
  * Do NOT edit or append.
  */
 
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
 
 using Aas = dummyNamespace;
-using Reporting = dummyNamespace.Reporting;
-using Visitation = dummyNamespace.Visitation;
 
 namespace dummyNamespace
 {
@@ -18,6 +17,9 @@ namespace dummyNamespace
     /// </summary>
     public static class Verification
     {
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchSomething()
         {
             var pattern = "^prefix([a-zA-Z]|\\ud800[\\udc00-\\udc05]|\\ud840[\\udc00-\\udc05])suffix$";
@@ -25,11 +27,11 @@ namespace dummyNamespace
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchSomething = _constructMatchSomething();
+        private static readonly Regex RegexMatchSomething = _constructMatchSomething();
 
         public static bool MatchSomething(string text)
         {
-            return _regexMatchSomething.IsMatch(text);
+            return RegexMatchSomething.IsMatch(text);
         }
 
         /// <summary>
@@ -40,6 +42,7 @@ namespace dummyNamespace
 
         }  // internal static class EnumValueSet
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Verification.Transformer _transformer = (
             new Verification.Transformer());
 

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/same_high_surrogate/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/same_high_surrogate/expected_verification.cs
@@ -3,13 +3,12 @@
  * Do NOT edit or append.
  */
 
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
 
 using Aas = dummyNamespace;
-using Reporting = dummyNamespace.Reporting;
-using Visitation = dummyNamespace.Visitation;
 
 namespace dummyNamespace
 {
@@ -18,6 +17,9 @@ namespace dummyNamespace
     /// </summary>
     public static class Verification
     {
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchSomething()
         {
             var pattern = "^prefix(\\ud800[\\udc00-\\udc0f])suffix$";
@@ -25,11 +27,11 @@ namespace dummyNamespace
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchSomething = _constructMatchSomething();
+        private static readonly Regex RegexMatchSomething = _constructMatchSomething();
 
         public static bool MatchSomething(string text)
         {
-            return _regexMatchSomething.IsMatch(text);
+            return RegexMatchSomething.IsMatch(text);
         }
 
         /// <summary>
@@ -40,6 +42,7 @@ namespace dummyNamespace
 
         }  // internal static class EnumValueSet
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Verification.Transformer _transformer = (
             new Verification.Transformer());
 

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/same_high_surrogate_with_quantifier/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/same_high_surrogate_with_quantifier/expected_verification.cs
@@ -3,13 +3,12 @@
  * Do NOT edit or append.
  */
 
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
 
 using Aas = dummyNamespace;
-using Reporting = dummyNamespace.Reporting;
-using Visitation = dummyNamespace.Visitation;
 
 namespace dummyNamespace
 {
@@ -18,6 +17,9 @@ namespace dummyNamespace
     /// </summary>
     public static class Verification
     {
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchSomething()
         {
             var pattern = "^prefix(\\ud800[\\udc00-\\udc0f])*suffix$";
@@ -25,11 +27,11 @@ namespace dummyNamespace
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchSomething = _constructMatchSomething();
+        private static readonly Regex RegexMatchSomething = _constructMatchSomething();
 
         public static bool MatchSomething(string text)
         {
-            return _regexMatchSomething.IsMatch(text);
+            return RegexMatchSomething.IsMatch(text);
         }
 
         /// <summary>
@@ -40,6 +42,7 @@ namespace dummyNamespace
 
         }  // internal static class EnumValueSet
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Verification.Transformer _transformer = (
             new Verification.Transformer());
 

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/two_high_surrogates/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/two_high_surrogates/expected_verification.cs
@@ -3,13 +3,12 @@
  * Do NOT edit or append.
  */
 
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
 
 using Aas = dummyNamespace;
-using Reporting = dummyNamespace.Reporting;
-using Visitation = dummyNamespace.Visitation;
 
 namespace dummyNamespace
 {
@@ -18,6 +17,9 @@ namespace dummyNamespace
     /// </summary>
     public static class Verification
     {
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        [CodeAnalysis.SuppressMessageAttribute("ReSharper", "IdentifierTypo")]
+        [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchSomething()
         {
             var pattern = "^prefix(\\ud800[\\udc05-\\udfff]|\\ud801[\\udc00-\\udc05])suffix$";
@@ -25,11 +27,11 @@ namespace dummyNamespace
             return new Regex(pattern);
         }
 
-        private static readonly Regex _regexMatchSomething = _constructMatchSomething();
+        private static readonly Regex RegexMatchSomething = _constructMatchSomething();
 
         public static bool MatchSomething(string text)
         {
-            return _regexMatchSomething.IsMatch(text);
+            return RegexMatchSomething.IsMatch(text);
         }
 
         /// <summary>
@@ -40,6 +42,7 @@ namespace dummyNamespace
 
         }  // internal static class EnumValueSet
 
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
         private static readonly Verification.Transformer _transformer = (
             new Verification.Transformer());
 


### PR DESCRIPTION
We generated the test data for C# automatically and inspected the C#
code with CodeInspect. This patch comprises all the minor fixes so that
both the unit tests and the CodeInspect pass.

Mind that we only tested for JSON, not XML de/serialization.