### PR TITLE
Add ``py.typed`` file

### DIFF
--- a/aas_core_codegen/py.typed
+++ b/aas_core_codegen/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561. The mypy package uses inline types.


### PR DESCRIPTION
We forgot to add ``py.typed`` file to ``aas_core_codegen`` module so
mypy thinks it can not infer the types.