### PR TITLE
Remove unused imports in ``rdf_shacl``

### DIFF
--- a/aas_core_codegen/rdf_shacl/shacl.py
+++ b/aas_core_codegen/rdf_shacl/shacl.py
@@ -1,7 +1,7 @@
 """Generate the SHACL schema based on the meta-model."""
 import io
 import textwrap
-from typing import Tuple, Optional, List, Mapping, MutableMapping
+from typing import Tuple, Optional, List
 
 from icontract import ensure, require
 


### PR DESCRIPTION
We mistakenly forgot to remove the unused imports. Due to time pressure,
we skipped remote CI, while the local CI missed these unused imports.