### PR TITLE
Reduce interfaces if descendants in C#

### DIFF
--- a/aas_core_codegen/csharp/structure/_generate.py
+++ b/aas_core_codegen/csharp/structure/_generate.py
@@ -828,16 +828,20 @@ def _generate_class(
     # ``IClass`` interface.
 
     interface_names = []  # type: List[Identifier]
-    for inheritance in cls.inheritances:
-        assert inheritance.interface is not None, (
-            f"Expected interface in the parent class {inheritance.name!r} "
-            f"of class {cls.name!r}"
-        )
-
-        interface_names.append(csharp_naming.name_of(inheritance.interface))
 
     if len(cls.concrete_descendants) > 0:
+        # NOTE (mristin, 2022-06-19):
+        # We do not have to add any other interfaces, as the interface corresponding
+        # to this concrete class will already entail all the antecedents.
         interface_names.append(csharp_naming.interface_name(cls.name))
+    else:
+        for inheritance in cls.inheritances:
+            assert inheritance.interface is not None, (
+                f"Expected interface in the parent class {inheritance.name!r} "
+                f"of class {cls.name!r}"
+            )
+
+            interface_names.append(csharp_naming.name_of(inheritance.interface))
 
     if len(interface_names) == 0:
         # NOTE (mristin, 2022-05-05):

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/types.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/types.cs
@@ -2140,9 +2140,7 @@ namespace AasCore.Aas3_0_RC02
     /// A relationship element is used to define a relationship between two elements
     /// being either referable (model reference) or external (global reference).
     /// </summary>
-    public class RelationshipElement :
-            ISubmodelElement,
-            IRelationshipElement
+    public class RelationshipElement : IRelationshipElement
     {
         /// <summary>
         /// An extension of the element.


### PR DESCRIPTION
If a concrete class has one or more concrete descendants, there will be
a corresponding interface generated. Hence this concrete class needs to
implement only that interface, and none more, since the interface will
already specify all the antecedent interfaces.