### PR TITLE
Release 0.0.14

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,17 @@
     Please keep this file at 72 line width so that we can copy-paste
     the release logs directly into commit messages.
 
+0.0.14 (2022-06-19)
+===================
+This version comprises minor fixes so that we can publish
+a pre-release of the C# SDK.
+
+C#
+--
+* Fix C# for InspectCode (#197)
+* Prefix all ``cref``'s with ``Aas.`` in C# (#196)
+* Reduce interfaces if descendants in C# (#195)
+
 0.0.13 (2022-06-19)
 ===================
 * Adapt and re-record for aas-core-meta 2022.6.19 (#192)

--- a/aas_core_codegen/__init__.py
+++ b/aas_core_codegen/__init__.py
@@ -1,6 +1,6 @@
 """Generate different implementations and schemas based on an AAS meta-model."""
 
-__version__ = "0.0.13"
+__version__ = "0.0.14"
 __author__ = "Marko Ristin, Nico Braunisch, Robert Lehmann"
 __license__ = "License :: OSI Approved :: MIT License"
 __status__ = "Production/Stable"

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open(os.path.join(here, "requirements.txt"), encoding="utf-8") as fid:
 
 setup(
     name="aas-core-codegen",
-    version="0.0.13",
+    version="0.0.14",
     description="Generate different implementations and schemas based on an AAS meta-model.",
     long_description=long_description,
     url="https://github.com/aas-core-works/aas-core-codegen",


### PR DESCRIPTION
This version comprises minor fixes so that we can publish
a pre-release of the C# SDK.

C#
--
* Fix C# for InspectCode (#197)
* Prefix all ``cref``'s with ``Aas.`` in C# (#196)
* Reduce interfaces if descendants in C# (#195)