### PR TITLE
Encapsulate retrieval of the primitive type

### DIFF
--- a/aas_core_codegen/csharp/xmlization/_generate.py
+++ b/aas_core_codegen/csharp/xmlization/_generate.py
@@ -75,14 +75,8 @@ def _generate_deserialize_primitive_property(
     """Generate the snippet to deserialize a property ``prop`` of primitive type."""
     type_anno = intermediate.beneath_optional(prop.type_annotation)
 
-    if isinstance(type_anno, intermediate.PrimitiveTypeAnnotation):
-        a_type = type_anno.a_type
-    elif isinstance(type_anno, intermediate.OurTypeAnnotation) and isinstance(
-        type_anno.symbol, intermediate.ConstrainedPrimitive
-    ):
-        a_type = type_anno.symbol.constrainee
-    else:
-        raise AssertionError(f"Unexpected type annotation: {prop.type_annotation}")
+    a_type = intermediate.try_primitive_type(type_anno)
+    assert a_type is not None, f"Unexpected type annotation: {prop.type_annotation}"
 
     deserialization_expr = None  # type: Optional[str]
     if a_type is intermediate.PrimitiveType.BOOL:
@@ -1082,16 +1076,10 @@ def _generate_serialize_primitive_property_as_content(
     """Generate the serialization of the primitive-type ``prop`` as XML content."""
     type_anno = intermediate.beneath_optional(prop.type_annotation)
 
-    if isinstance(type_anno, intermediate.PrimitiveTypeAnnotation):
-        a_type = type_anno.a_type
-    elif isinstance(type_anno, intermediate.OurTypeAnnotation) and isinstance(
-        type_anno.symbol, intermediate.ConstrainedPrimitive
-    ):
-        a_type = type_anno.symbol.constrainee
-    else:
-        raise AssertionError(
-            f"Unexpected primitive type " f"of the property {prop.name!r}: {type_anno}"
-        )
+    a_type = intermediate.try_primitive_type(type_anno)
+    assert (
+        a_type is not None
+    ), f"Unexpected non-primitive type of the property {prop.name!r}: {type_anno}"
 
     prop_name = csharp_naming.property_name(prop.name)
     write_value_block = Stripped(

--- a/aas_core_codegen/intermediate/__init__.py
+++ b/aas_core_codegen/intermediate/__init__.py
@@ -51,6 +51,7 @@ SymbolTable = _types.SymbolTable
 type_annotations_equal = _types.type_annotations_equal
 beneath_optional = _types.beneath_optional
 TypeAnnotationExceptOptional = _types.TypeAnnotationExceptOptional
+try_primitive_type = _types.try_primitive_type
 map_descendability = _types.map_descendability
 collect_ids_of_symbols_in_properties = _types.collect_ids_of_symbols_in_properties
 

--- a/aas_core_codegen/intermediate/_types.py
+++ b/aas_core_codegen/intermediate/_types.py
@@ -132,11 +132,9 @@ TypeAnnotationUnion = Union[
     OptionalTypeAnnotation,
 ]
 
-
 assert_union_of_descendants_exhaustive(
     union=TypeAnnotationUnion, base_class=TypeAnnotation
 )
-
 
 TypeAnnotationExceptOptional = Union[
     PrimitiveTypeAnnotation,
@@ -203,6 +201,23 @@ def beneath_optional(
     assert not isinstance(type_anno, OptionalTypeAnnotation)
 
     return type_anno
+
+
+def try_primitive_type(type_annotation: TypeAnnotationUnion) -> Optional[PrimitiveType]:
+    """
+    Try to get the underlying primitive type of the type annotation.
+
+    If it is neither a primitive type annotation nor a constrained primitive,
+    return None.
+    """
+    if isinstance(type_annotation, PrimitiveTypeAnnotation):
+        return type_annotation.a_type
+    elif isinstance(type_annotation, OurTypeAnnotation) and isinstance(
+        type_annotation.symbol, ConstrainedPrimitive
+    ):
+        return type_annotation.symbol.constrainee
+    else:
+        return None
 
 
 # region Descriptions

--- a/aas_core_codegen/xsd/main.py
+++ b/aas_core_codegen/xsd/main.py
@@ -238,22 +238,12 @@ def _generate_xs_element_for_a_primitive_property(
     # NOTE (mristin, 2022-03-30):
     # Specify the type of the ``type_anno`` here with assert instead of specifying it
     # in the pre-condition to help mypy a bit.
-    assert isinstance(type_anno, intermediate.PrimitiveTypeAnnotation) or (
-        isinstance(type_anno, intermediate.OurTypeAnnotation)
-        and isinstance(type_anno.symbol, intermediate.ConstrainedPrimitive)
-    ), f"Expected a primitive or a constrained primitive, but got: {type_anno}"
 
-    base_type = None  # type: Optional[intermediate.PrimitiveType]
-    if isinstance(type_anno, intermediate.PrimitiveTypeAnnotation):
-        base_type = type_anno.a_type
-    elif isinstance(type_anno, intermediate.OurTypeAnnotation) and isinstance(
-        type_anno.symbol, intermediate.ConstrainedPrimitive
-    ):
-        base_type = type_anno.symbol.constrainee
-    else:
-        raise AssertionError(
-            f"Unexpected type_anno type {type(type_anno)}: {type_anno}"
-        )
+    base_type = intermediate.try_primitive_type(type_anno)
+
+    assert (
+        base_type is not None
+    ), f"Expected a primitive or a constrained primitive, but got: {type_anno}"
 
     xs_restriction, error = _generate_xs_restriction(
         base_type=base_type,


### PR DESCRIPTION
We often have to check for a primitive type over either primitive type
annotation or a constrained primitive. Therefore, we introduce a
function that encapsulates this logic.

This is also used in downstream clients such as testgen.