### PR TITLE
Reformat C# code

### DIFF
--- a/aas_core_codegen/csharp/reporting/_generate.py
+++ b/aas_core_codegen/csharp/reporting/_generate.py
@@ -40,13 +40,15 @@ def generate(namespace: csharp_common.NamespaceIdentifier) -> str:
 /// <summary>
 /// Capture a path segment of a value in a model.
 /// </summary>
-public abstract class Segment {{
+public abstract class Segment
+{{
 {I}// Intentionally empty.
 }}"""
         ),
         Stripped(
             f"""\
-public class NameSegment : Segment {{
+public class NameSegment : Segment
+{{
 {I}public readonly string Name;
 {I}public NameSegment(string name)
 {I}{{
@@ -56,7 +58,8 @@ public class NameSegment : Segment {{
         ),
         Stripped(
             f"""\
-public class IndexSegment : Segment {{
+public class IndexSegment : Segment
+{{
 {I}public readonly int Index;
 {I}public IndexSegment(int index)
 {I}{{
@@ -67,7 +70,7 @@ public class IndexSegment : Segment {{
         Stripped(
             f"""\
 private static readonly System.Text.RegularExpressions.Regex VariableNameRe = (
-{I}new  System.Text.RegularExpressions.Regex(
+{I}new System.Text.RegularExpressions.Regex(
 {II}@"^[a-zA-Z_][a-zA-Z_0-9]*$"));"""
         ),
         # We have to indent a lot so we do not use textwrap.dedent for better
@@ -86,7 +89,7 @@ public static string GenerateJsonPath(
 {{
 {I}var parts = new List<string>(segments.Count);
 {I}int i = 0;
-{I}foreach(var segment in segments)
+{I}foreach (var segment in segments)
 {I}{{
 {II}string? part;
 {II}switch (segment)
@@ -157,7 +160,7 @@ public static string GenerateRelativeXPath(
 {I}ICollection<Segment> segments)
 {{
 {I}var parts = new List<string>(segments.Count);
-{I}foreach(var segment in segments)
+{I}foreach (var segment in segments)
 {I}{{
 {II}string? part;
 {II}switch (segment)

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/reporting.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/reporting.cs
@@ -18,11 +18,13 @@ namespace AasCore.Aas3_0_RC02
         /// <summary>
         /// Capture a path segment of a value in a model.
         /// </summary>
-        public abstract class Segment {
+        public abstract class Segment
+        {
             // Intentionally empty.
         }
 
-        public class NameSegment : Segment {
+        public class NameSegment : Segment
+        {
             public readonly string Name;
             public NameSegment(string name)
             {
@@ -30,7 +32,8 @@ namespace AasCore.Aas3_0_RC02
             }
         }
 
-        public class IndexSegment : Segment {
+        public class IndexSegment : Segment
+        {
             public readonly int Index;
             public IndexSegment(int index)
             {
@@ -39,7 +42,7 @@ namespace AasCore.Aas3_0_RC02
         }
 
         private static readonly System.Text.RegularExpressions.Regex VariableNameRe = (
-            new  System.Text.RegularExpressions.Regex(
+            new System.Text.RegularExpressions.Regex(
                 @"^[a-zA-Z_][a-zA-Z_0-9]*$"));
 
         /// <summary>
@@ -54,7 +57,7 @@ namespace AasCore.Aas3_0_RC02
         {
             var parts = new List<string>(segments.Count);
             int i = 0;
-            foreach(var segment in segments)
+            foreach (var segment in segments)
             {
                 string? part;
                 switch (segment)
@@ -121,7 +124,7 @@ namespace AasCore.Aas3_0_RC02
             ICollection<Segment> segments)
         {
             var parts = new List<string>(segments.Count);
-            foreach(var segment in segments)
+            foreach (var segment in segments)
             {
                 string? part;
                 switch (segment)

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/verification.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/verification.cs
@@ -124,16 +124,16 @@ namespace AasCore.Aas3_0_RC02
             {
                 start++;
             }
-    
+
             int yearEnd = start;
-            for(; value[yearEnd] != '-'; yearEnd++)
+            for (; value[yearEnd] != '-'; yearEnd++)
             {
                 // Intentionally empty.
             }
 
-        	return (yearEnd == 4 && value.Length == 10)
-        		? value
-        		: value.Substring(yearEnd - 4, 10);
+            return (yearEnd == 4 && value.Length == 10)
+                ? value
+                : value.Substring(yearEnd - 4, 10);
         }
 
         /// <summary>
@@ -157,10 +157,10 @@ namespace AasCore.Aas3_0_RC02
             {
                 // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
                 System.DateTime.ParseExact(
-        			ClipToDate(value),
-        			XsDateFormats,
-                	System.Globalization.CultureInfo.InvariantCulture,
-        			System.Globalization.DateTimeStyles.None );
+                    ClipToDate(value),
+                    XsDateFormats,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    System.Globalization.DateTimeStyles.None);
                 return true;
             }
             catch (System.FormatException)
@@ -1619,21 +1619,21 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     var month = int.Parse(value.Substring(2,2));
-        		    var day = int.Parse(value.Substring(5,2));
-        		    switch (month)
-        		    {
-        		        case 1: case 3: case 5: case 7: case 8: case 10: case 12:
-        		            return day <= 31;
-        		        case 4: case 6: case 9: case 11:
-        		            return day <= 30;
-        		        case 2:
-        		            return day <= 29;
-        		        default:
-        		            throw new System.InvalidOperationException(
-        		                $"Unhandled month: {month}; " +
-        		                "is there maybe a bug in MatchesXsGMonthDay?"
-        		            );
-        		    }
+                    var day = int.Parse(value.Substring(5,2));
+                    switch (month)
+                    {
+                        case 1: case 3: case 5: case 7: case 8: case 10: case 12:
+                            return day <= 31;
+                        case 4: case 6: case 9: case 11:
+                            return day <= 30;
+                        case 2:
+                            return day <= 29;
+                        default:
+                            throw new System.InvalidOperationException(
+                                $"Unhandled month: {month}; " +
+                                "is there maybe a bug in MatchesXsGMonthDay?"
+                            );
+                    }
                 }
                 case Aas.DataTypeDefXsd.GYear:
                 {

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/input/snippets/Verification/is_xs_date_time_stamp_utc.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/input/snippets/Verification/is_xs_date_time_stamp_utc.cs
@@ -28,16 +28,16 @@ private static string ClipToDate(string value)
     {
         start++;
     }
-    
+
     int yearEnd = start;
-    for(; value[yearEnd] != '-'; yearEnd++)
+    for (; value[yearEnd] != '-'; yearEnd++)
     {
         // Intentionally empty.
     }
 
-	return (yearEnd == 4 && value.Length == 10)
-		? value
-		: value.Substring(yearEnd - 4, 10);
+    return (yearEnd == 4 && value.Length == 10)
+        ? value
+        : value.Substring(yearEnd - 4, 10);
 }
 
 /// <summary>
@@ -61,10 +61,10 @@ public static bool IsXsDateTimeStampUtc(
     {
         // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
         System.DateTime.ParseExact(
-			ClipToDate(value),
-			XsDateFormats,
-        	System.Globalization.CultureInfo.InvariantCulture,
-			System.Globalization.DateTimeStyles.None );
+            ClipToDate(value),
+            XsDateFormats,
+            System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.None);
         return true;
     }
     catch (System.FormatException)

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/input/snippets/Verification/value_consistent_with_xsd_type.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/input/snippets/Verification/value_consistent_with_xsd_type.cs
@@ -213,21 +213,21 @@ public static bool ValueConsistentWithXsdType(
             }
 
             var month = int.Parse(value.Substring(2,2));
-		    var day = int.Parse(value.Substring(5,2));
-		    switch (month)
-		    {
-		        case 1: case 3: case 5: case 7: case 8: case 10: case 12:
-		            return day <= 31;
-		        case 4: case 6: case 9: case 11:
-		            return day <= 30;
-		        case 2:
-		            return day <= 29;
-		        default:
-		            throw new System.InvalidOperationException(
-		                $"Unhandled month: {month}; " +
-		                "is there maybe a bug in MatchesXsGMonthDay?"
-		            );
-		    }
+            var day = int.Parse(value.Substring(5,2));
+            switch (month)
+            {
+                case 1: case 3: case 5: case 7: case 8: case 10: case 12:
+                    return day <= 31;
+                case 4: case 6: case 9: case 11:
+                    return day <= 30;
+                case 2:
+                    return day <= 29;
+                default:
+                    throw new System.InvalidOperationException(
+                        $"Unhandled month: {month}; " +
+                        "is there maybe a bug in MatchesXsGMonthDay?"
+                    );
+            }
         }
         case Aas.DataTypeDefXsd.GYear:
         {


### PR DESCRIPTION
This is a minor patch that we fix most obvious formatting
inconsistencies. The C# code should still be reformatted with a proper
tool.