### PR TITLE
Fix duplicate bracket in C# constructor

### DIFF
--- a/aas_core_codegen/csharp/structure/_generate.py
+++ b/aas_core_codegen/csharp/structure/_generate.py
@@ -718,8 +718,7 @@ def _generate_constructor(
             f"""\
 public {cls_name}()
 {{
-{I}// Intentionally empty.
-}}"""
+{I}// Intentionally empty."""
         )
 
     elif len(arg_codes) == 1:

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/types.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/types.cs
@@ -10065,7 +10065,6 @@ namespace AasCore.Aas3_0_RC02
         public DataSpecificationContent()
         {
             // Intentionally empty.
-        }
 
         }
     }

--- a/test_data/csharp/test_structure/concrete_class_with_descendants/expected_types.cs
+++ b/test_data/csharp/test_structure/concrete_class_with_descendants/expected_types.cs
@@ -125,7 +125,6 @@ namespace dummyNamespace
         public Parent()
         {
             // Intentionally empty.
-        }
 
         }
     }
@@ -194,7 +193,6 @@ namespace dummyNamespace
         public Child()
         {
             // Intentionally empty.
-        }
 
         }
     }

--- a/test_data/csharp/test_structure/constructor_without_arguments/no_properties/expected_types.cs
+++ b/test_data/csharp/test_structure/constructor_without_arguments/no_properties/expected_types.cs
@@ -120,7 +120,6 @@ namespace dummyNamespace
         public Something()
         {
             // Intentionally empty.
-        }
 
         }
     }


### PR DESCRIPTION
We erroneously added a double bracket in the constructor which doesn't
have any arguments.