### PR TITLE
Fix or disable PyCharm warnings

### DIFF
--- a/.idea/dictionaries/rist.xml
+++ b/.idea/dictionaries/rist.xml
@@ -30,6 +30,7 @@
       <w>descendability</w>
       <w>descendable</w>
       <w>deserializing</w>
+      <w>dfff</w>
       <w>doctree</w>
       <w>dotnet</w>
       <w>dumpable</w>

--- a/aas_core_codegen/__main__.py
+++ b/aas_core_codegen/__main__.py
@@ -4,5 +4,5 @@ import aas_core_codegen.main
 
 if __name__ == "__main__":
     # The ``prog`` needs to be set in the argparse.
-    # Otherwise the program name in the help shown to the user will be ``__main__``.
+    # Otherwise, the program name in the help shown to the user will be ``__main__``.
     aas_core_codegen.main.main(prog="aas_core_codegen")

--- a/aas_core_codegen/common.py
+++ b/aas_core_codegen/common.py
@@ -21,6 +21,7 @@ from typing import (
 import asttokens
 from icontract import require, DBC
 
+# noinspection RegExpSimplifiable
 IDENTIFIER_RE = re.compile(r"[a-zA-Z_][a-zA-Z_0-9]*")
 
 
@@ -254,7 +255,7 @@ def assert_union_of_descendants_exhaustive(union: Any, base_class: Any) -> None:
     else:
         raise NotImplementedError(f"We do not know how to handle the union: {union}")
 
-    # We have to recursively figure out the sub-classes.
+    # We have to recursively figure out the subclasses.
     concrete_subclasses = []  # type: List[Any]
 
     stack = base_class.__subclasses__()  # type: List[Any]

--- a/aas_core_codegen/csharp/common.py
+++ b/aas_core_codegen/csharp/common.py
@@ -155,6 +155,7 @@ INDENT4 = INDENT * 4
 INDENT5 = INDENT * 5
 INDENT6 = INDENT * 6
 
+# noinspection RegExpSimplifiable
 NAMESPACE_IDENTIFIER_RE = re.compile(
     r"[a-zA-Z_][a-zA-Z_0-9]*(\.[a-zA-Z_][a-zA-Z_0-9]*)*"
 )

--- a/aas_core_codegen/csharp/jsonization/_generate.py
+++ b/aas_core_codegen/csharp/jsonization/_generate.py
@@ -1036,7 +1036,7 @@ def _generate_transform_property(
     # NOTE (mristin, 2022-03-12):
     # For some unexplainable reason, C# compiler can not infer that properties which
     # are enumerations are not null after an ``if (that.someProperty != null)``.
-    # Hence we need to add a null-coalescing for these particular cases.
+    # Hence, we need to add a null-coalescing for these particular cases.
     # Otherwise, we can just stick to ``that.someProperty``.
 
     needs_null_coalescing = (

--- a/aas_core_codegen/csharp/reporting/_generate.py
+++ b/aas_core_codegen/csharp/reporting/_generate.py
@@ -73,7 +73,7 @@ private static readonly System.Text.RegularExpressions.Regex VariableNameRe = (
 {I}new System.Text.RegularExpressions.Regex(
 {II}@"^[a-zA-Z_][a-zA-Z_0-9]*$"));"""
         ),
-        # We have to indent a lot so we do not use textwrap.dedent for better
+        # We have to indent a lot, so we do not use textwrap.dedent for better
         # readability.
         Stripped(
             f"""\

--- a/aas_core_codegen/csharp/verification/_generate.py
+++ b/aas_core_codegen/csharp/verification/_generate.py
@@ -78,7 +78,7 @@ class _FixForUTF16Regex(parse_retree.BaseVisitor):
     Specifically, we need to split UTF-32 characters in the two surrogates since
     C# regex engine only works with UTF-16.
 
-    The characters in the range ``\\uD800`` to ``\\uDFFF`` are reserved so they can
+    The characters in the range ``\\uD800`` to ``\\uDFFF`` are reserved, so they can
     be used as high surrogates. However, it is still valid to use them as standalone
     characters. Hence, if you use them in your pattern, and the pattern also involves
     UTF-32 characters, the transformed pattern might be more permissive than
@@ -531,6 +531,8 @@ class _PatternVerificationTranspiler(
                 Stripped(csharp_common.string_literal("".join(values))),  # type: ignore
                 None,
             )
+
+        needs_interpolation = False
 
         parts = []  # type: List[str]
         for value in values:
@@ -1782,7 +1784,7 @@ def _generate_transform_property(
     # NOTE (mristin, 2022-03-12):
     # For some unexplainable reason, C# compiler can not infer that properties which
     # are enumerations are not null after an ``if (that.someProperty != null)``.
-    # Hence we need to add a null-coalescing for these particular cases.
+    # Hence, we need to add a null-coalescing for these particular cases.
     # Otherwise, we can just stick to ``that.someProperty``.
 
     needs_null_coalescing = (

--- a/aas_core_codegen/csharp/xmlization/_generate.py
+++ b/aas_core_codegen/csharp/xmlization/_generate.py
@@ -338,9 +338,7 @@ if (error != null)
     )
 
 
-def _generate_deserialize_cls_property(
-    cls: intermediate.ConcreteClass, prop: intermediate.Property
-) -> Stripped:
+def _generate_deserialize_cls_property(prop: intermediate.Property) -> Stripped:
     """Generate the snippet to deserialize a property ``prop`` as a concrete class."""
     type_anno = intermediate.beneath_optional(prop.type_annotation)
 
@@ -474,7 +472,7 @@ def _generate_deserialize_property(
                     _generate_deserialize_interface_property(prop=prop, cls=cls)
                 )
             else:
-                blocks.append(_generate_deserialize_cls_property(cls=cls, prop=prop))
+                blocks.append(_generate_deserialize_cls_property(prop=prop))
         else:
             assert_never(symbol)
 

--- a/aas_core_codegen/infer_for_schema/_common.py
+++ b/aas_core_codegen/infer_for_schema/_common.py
@@ -13,7 +13,7 @@ from aas_core_codegen.parse import tree as parse_tree
 
 def match_property(node: parse_tree.Node) -> Optional[Identifier]:
     """
-    Match an access to a property.
+    Match access to a property.
 
     For example, matching ``self.something`` will be a ``"something"``.
     """

--- a/aas_core_codegen/infer_for_schema/_inline.py
+++ b/aas_core_codegen/infer_for_schema/_inline.py
@@ -377,7 +377,7 @@ def merge_constraints_with_ancestors(
     Merge the constraints over all the classes with their ancestors.
 
     Usually, when you generate a schema, you do *not* want to inherit the constraints
-    over the properties. Most schema engines will do that for you and you want to be
+    over the properties. Most schema engines will do that for you, and you want to be
     as explicit as possible in the schema for readability (whereas merged constraints
     might not be as readable, since you do not explicitly see their origin).
 

--- a/aas_core_codegen/infer_for_schema/_stringify.py
+++ b/aas_core_codegen/infer_for_schema/_stringify.py
@@ -47,7 +47,7 @@ def _stringify_constraints_by_property(that: ConstraintsByProperty) -> stringify
                     [
                         # NOTE (mristin, 2022-05-18):
                         # Mypy could not infer that an identifier is also a string.
-                        # Hence we need to explicitly convert to a str here.
+                        # Hence, we need to explicitly convert to a str here.
                         (str(prop.name), _stringify_len_constraint(len_constraint))
                         for prop, len_constraint in that.len_constraints_by_property.items()
                     ]
@@ -60,7 +60,7 @@ def _stringify_constraints_by_property(that: ConstraintsByProperty) -> stringify
                         (
                             # NOTE (mristin, 2022-05-18):
                             # Mypy could not infer that an identifier is also a string.
-                            # Hence we need to explicitly convert to a str here.
+                            # Hence, we need to explicitly convert to a str here.
                             str(prop.name),
                             [
                                 _stringify_pattern_constraint(pattern_constraint)

--- a/aas_core_codegen/intermediate/_translate.py
+++ b/aas_core_codegen/intermediate/_translate.py
@@ -106,6 +106,7 @@ def _symbol_reference_role(  # type: ignore
     if options is None:
         options = {}
 
+    # noinspection PyUnresolvedReferences
     docutils.parsers.rst.roles.set_classes(options)
 
     # NOTE (mristin, 2021-12-27):
@@ -126,6 +127,7 @@ def _symbol_reference_role(  # type: ignore
     return [node], []
 
 
+# noinspection RegExpSimplifiable
 _ATTRIBUTE_REFERENCE_RE = re.compile(
     r"[a-zA-Z_][a-zA-Z_0-9]*(\.[a-zA-Z_][a-zA-Z_0-9]*)?"
 )
@@ -161,6 +163,7 @@ def _attribute_reference_role(  # type: ignore
     if options is None:
         options = {}
 
+    # noinspection PyUnresolvedReferences
     docutils.parsers.rst.roles.set_classes(options)
 
     # We strip the tilde based on the convention as we ignore the appearance.
@@ -197,6 +200,7 @@ def _argument_reference_role(  # type: ignore
     if options is None:
         options = {}
 
+    # noinspection PyUnresolvedReferences
     docutils.parsers.rst.roles.set_classes(options)
 
     reference = text
@@ -219,6 +223,7 @@ def _constraint_reference_role(  # type: ignore
     if options is None:
         options = {}
 
+    # noinspection PyUnresolvedReferences
     docutils.parsers.rst.roles.set_classes(options)
 
     reference = text
@@ -235,9 +240,13 @@ def _constraint_reference_role(  # type: ignore
 # other modules, but it is the only way to register the roles.
 #
 # See: https://docutils.sourceforge.io/docs/howto/rst-roles.html
+# noinspection PyUnresolvedReferences
 docutils.parsers.rst.roles.register_local_role("class", _symbol_reference_role)
+# noinspection PyUnresolvedReferences
 docutils.parsers.rst.roles.register_local_role("attr", _attribute_reference_role)
+# noinspection PyUnresolvedReferences
 docutils.parsers.rst.roles.register_local_role("paramref", _argument_reference_role)
+# noinspection PyUnresolvedReferences
 docutils.parsers.rst.roles.register_local_role(
     "constraintref", _constraint_reference_role
 )
@@ -903,7 +912,7 @@ class _DefaultPlaceholder:
     constructing the symbol table as they might reference, *e.g.*, enumeration
     literals which we still did not observe.
 
-    Therefore we insert a placeholder and resolve the default values in the second
+    Therefore, we insert a placeholder and resolve the default values in the second
     translation pass.
     """
 
@@ -1177,7 +1186,7 @@ def _determine_constrained_primitives_by_name(
     while len(stack) > 0 and len(errors) == 0:
         # NOTE (mristin, 2021-12-23):
         # Since we operate on the ontology, we know that the cycles in the inheritance
-        # graph would have been already reported as errors and we would not get
+        # graph would have been already reported as errors, and we would not get
         # thus far.
 
         identifier, constrainee, ancestor = stack.pop()
@@ -1237,7 +1246,8 @@ def _determine_constrained_primitives_by_name(
 
     # BEFORE-RELEASE (mristin, 2021-12-23): test this
     for identifier in extended_map.keys():
-        # We know for sure that the initial set is valid so we can skip it in the check.
+        # We know for sure that the initial set is valid, so we can skip it in
+        # the check.
         if identifier in initial_map:
             continue
 
@@ -1327,7 +1337,7 @@ def _to_constrained_primitive(
     """
     Translate a concrete class to a constrained primitive.
 
-    The ``parsed`` is expected to be tested for being a valid constrained primitive
+    The ``parsed`` is expected to be tested for a valid constrained primitive
     before calling this function.
 
     The ``constrainee`` is determined by propagation in
@@ -1796,6 +1806,7 @@ def _find_all_in_symbol_description(
         yield from remark.findall(element_type)
 
     for constraint in symbol_description.constraints_by_identifier.values():
+        # noinspection PyUnresolvedReferences
         yield from constraint.findall(element_type)
 
 
@@ -1820,6 +1831,7 @@ def _find_all_in_property_description(
         yield from remark.findall(element_type)
 
     for body in property_description.constraints_by_identifier.values():
+        # noinspection PyUnresolvedReferences
         yield from body.findall(element_type)
 
 
@@ -1837,6 +1849,7 @@ def _find_all_in_signature_description(
         yield from remark.findall(element_type)
 
     for arg_description in signature_description.arguments_by_name.values():
+        # noinspection PyUnresolvedReferences
         yield from arg_description.findall(element_type)
 
     if signature_description.returns is not None:
@@ -1858,6 +1871,7 @@ def _find_all_in_meta_model_description(
             yield element
 
     for constraint in meta_model_description.constraints_by_identifier.values():
+        # noinspection PyUnresolvedReferences
         for element in constraint.findall(element_type):
             yield element
 
@@ -1956,7 +1970,7 @@ def _second_pass_to_resolve_symbol_references_in_the_descriptions_in_place(
     for symbol_ref_in_doc, description, _ in _find_all_in_descriptions(
         element_type=doc.SymbolReference, symbol_table=symbol_table
     ):
-        # Symbol references can be repeated as docutils will cache them
+        # Symbol references can be repeated as docutils will cache them,
         # so we need to skip them.
         if not isinstance(symbol_ref_in_doc.symbol, _PlaceholderSymbol):
             continue
@@ -2008,7 +2022,7 @@ def _second_pass_to_resolve_symbol_references_in_the_descriptions_in_place(
 def _fill_in_default_placeholder(
     default: _DefaultPlaceholder, symbol_table: SymbolTable
 ) -> Tuple[Optional[Default], Optional[Error]]:
-    """Resolve the default values to references using the constructed symbol table."""
+    """Resolve the default values to reference using the constructed symbol table."""
     # If we do not preemptively return, signal that we do not know how to handle
     # the default
 
@@ -2259,7 +2273,7 @@ def _second_pass_to_resolve_specified_for_in_invariants(
             for invariant in symbol.invariants:
                 # NOTE (mristin, 2022-01-02):
                 # Since we stack invariants, it might be that we already resolved
-                # the invariants coming from the parent. Hence we need to check that
+                # the invariants coming from the parent. Hence, we need to check that
                 # we haven't resolved ``specified_for`` here.
 
                 if isinstance(invariant.specified_for, _PlaceholderSymbol):
@@ -2367,7 +2381,7 @@ def _second_pass_to_resolve_descendants_in_place(
     All abstract classes as well as concrete classes with at least one descendant
     are mapped to an interface.
 
-    Mind that the concept of the interface is not used in the meta-model and we
+    Mind that the concept of the interface is not used in the meta-model, and we
     introduce it only as a convenience for the code generation.
     """
     for symbol in symbol_table.symbols:
@@ -2534,7 +2548,7 @@ def _second_pass_to_stack_invariants_in_place(symbol_table: SymbolTable) -> None
     for symbol in symbol_table.symbols_topologically_sorted:
         # NOTE (mristin, 2022-03-18):
         # Assume that the parents have all the invariants stacked already due to
-        # the topological order of the iteration..
+        # the topological order of the iteration.
 
         # Propagate the invariants from the parents to this symbol.
         if isinstance(symbol, Enumeration):
@@ -2565,7 +2579,7 @@ def _second_pass_to_stack_properties_in_place(symbol_table: SymbolTable) -> List
     for symbol in symbol_table.symbols_topologically_sorted:
         # NOTE (mristin, 2022-03-18):
         # Assume that the parents have all the invariants stacked already due to
-        # the topological order of the iteration..
+        # the topological order of the iteration.
 
         # Propagate the properties from the parents to this symbol.
         if isinstance(symbol, (Enumeration, ConstrainedPrimitive)):
@@ -2599,7 +2613,7 @@ def _second_pass_to_stack_methods_in_place(symbol_table: SymbolTable) -> List[Er
     for symbol in symbol_table.symbols_topologically_sorted:
         # NOTE (mristin, 2022-03-18):
         # Assume that the parents have all the invariants stacked already due to
-        # the topological order of the iteration..
+        # the topological order of the iteration.
 
         # Propagate the methods from the parents to this symbol.
         if isinstance(symbol, (Enumeration, ConstrainedPrimitive)):
@@ -2608,7 +2622,7 @@ def _second_pass_to_stack_methods_in_place(symbol_table: SymbolTable) -> List[Er
             inherited_methods = []  # type: List[MethodUnion]
 
             # NOTE (mristin, 2022-03-19):
-            # We have to disallow diamond inheritance of the methods so we keep track
+            # We have to disallow diamond inheritance of the methods, so we keep track
             # of the inherited methods and report an error in case of conflicts.
 
             method_specified_for = dict()  # type: Dict[Identifier, Identifier]
@@ -2632,7 +2646,7 @@ def _second_pass_to_stack_methods_in_place(symbol_table: SymbolTable) -> List[Er
                     method_specified_for[method.name] = inheritance.name
 
             # NOTE (mristin, 2022-03-19):
-            # We still haven't updated the ``methods`` in the symbol so it only
+            # We still haven't updated the ``methods`` in the symbol, so it only
             # contains methods specified for that particular class and does not
             # include any inherited methods.
 
@@ -2673,7 +2687,7 @@ def _second_pass_to_stack_constructors_in_place(
     for symbol in symbol_table.symbols:
         # NOTE (mristin, 2022-03-18):
         # Assume that the parents have all been processed already due to
-        # the topological order of the iteration..
+        # the topological order of the iteration.
 
         if isinstance(symbol, (Enumeration, ConstrainedPrimitive)):
             continue
@@ -2810,7 +2824,7 @@ def _second_pass_to_resolve_attribute_references_in_the_descriptions_in_place(
     """Resolve the attribute references in the descriptions in-place."""
     errors = []  # type: List[Error]
 
-    # The ``symbol`` is None if the description is in the context outside of a symbol.
+    # The ``symbol`` is None if the description is in the context outside a symbol.
     for attr_ref_in_doc, description, symbol in _find_all_in_descriptions(
         element_type=doc.AttributeReference, symbol_table=symbol_table
     ):
@@ -2983,7 +2997,7 @@ def _second_pass_to_resolve_interfaces_in_place(
     All abstract classes as well as concrete classes with at least one descendant
     are mapped to an interface.
 
-    Mind that the concept of the interface is not used in the meta-model and we
+    Mind that the concept of the interface is not used in the meta-model, and we
     introduce it only as a convenience for the code generation.
     """
     for parsed_cls in ontology.classes:
@@ -3257,7 +3271,7 @@ def _verify_all_non_optional_properties_initialized(cls: Class) -> List[Error]:
                     (construction.EmptyList, construction.DefaultEnumLiteral),
                 ):
                     # The property is mandatory, but a non-None default value is given
-                    # in the assign statement so we know that the property is properly
+                    # in the assign statement, so we know that the property is properly
                     # initialized.
                     prop_initialized[prop.name] = True
                 else:
@@ -3364,6 +3378,7 @@ def _verify_orders_of_constructors_arguments_and_properties_match(
 def _verify_all_argument_references_occur_in_valid_context(
     symbol_table: SymbolTable,
 ) -> List[Error]:
+    # noinspection GrazieInspection
     """Verify that all the argument references occur where they should."""
     errors = []  # type: List[Error]
     for arg_ref_in_doc, description, _ in _find_all_in_descriptions(
@@ -3921,10 +3936,10 @@ def translate(
 
     # NOTE (mristin, 2021-12-14):
     # At first we in-lined all these second-pass code. However, since Python keeps
-    # all the variables in the function scope, the code became quite unreadable and
+    # all the variables in the function scope, the code became quite unreadable, and
     # we were never sure which variables are re-used between the passes.
     #
-    # Hence we refactored the second passes in the separate functions. Please keep the
+    # Hence, we refactored the second passes in the separate functions. Please keep the
     # order of the functions with their call order here, and do not call them elsewhere
     # in code.
 
@@ -4004,7 +4019,7 @@ def translate(
     # region Second passes which assume the inheritance of the heritage
 
     # NOTE (mristin, 2022-03-18):
-    # We might reference inherited properties of a symbol so we need to apply
+    # We might reference inherited properties of a symbol, so we need to apply
     # this second pass only after the properties have been stacked.
     underlying_errors.extend(
         _second_pass_to_resolve_attribute_references_in_the_descriptions_in_place(
@@ -4013,7 +4028,7 @@ def translate(
     )
 
     # NOTE (mristin, 2022-03-18):
-    # We need to include all the properties and methods in the interface so they need
+    # We need to include all the properties and methods in the interface, so they need
     # to be inherited first.
     _second_pass_to_resolve_interfaces_in_place(
         symbol_table=symbol_table, ontology=ontology
@@ -4036,7 +4051,7 @@ def errors_if_contracts_for_functions_or_methods_defined(
     Generate an error if one or more contracts for functions or methods defined.
 
     This does *not* apply to implementation-specific functions as they are going to
-    be manually implemented and we do not have to transpile them.
+    be manually implemented, and we do not have to transpile them.
 
     We added some support for the pre-conditions, post-conditions and snapshots
     already and keep maintaining it as it is only a matter of time when we will

--- a/aas_core_codegen/intermediate/_types.py
+++ b/aas_core_codegen/intermediate/_types.py
@@ -630,7 +630,7 @@ class Contracts:
     # conjunctions correspond to the levels of the inheritance hierarchy.
     #
     # However, we have not touched methods at the moment nor their proper inheritance.
-    # Therefore we leave the pre-conditions in the intermediate representation as they
+    # Therefore, we leave the pre-conditions in the intermediate representation as they
     # would appear in the code, without inheritance and hence without disjunctions.
     # In the future, once we want to tackle the methods as a feature, we need to change
     # the way how we model and resolve the pre-conditions through
@@ -753,8 +753,8 @@ class Method(SignatureLike):
     # The ``parsed`` must be optional in the parent class, ``SignatureLike``, since
     # constructors can be synthesized without being defined in the original meta-model.
     #
-    # However, methods are never synthesized so we always have a clear link to the parse
-    # stage.
+    # However, methods are never synthesized, so we always have a clear link to
+    # the parse stage.
 
     parsed: parse.Method
 
@@ -827,7 +827,7 @@ class Method(SignatureLike):
 
 # NOTE (mristin, 2021-12-19):
 # At the moment, we support only implementation-specific methods. However, we anticipate
-# that we will try to understand the methods in the very near future so we already
+# that we will try to understand the methods in the very near future, so we already
 # prepare the class hierarchy for it.
 
 
@@ -838,8 +838,8 @@ class ImplementationSpecificMethod(Method):
     # The ``parsed`` must be optional in the parent class, ``SignatureLike``, since
     # constructors can be synthesized without being defined in the original meta-model.
     #
-    # However, methods are never synthesized so we always have a clear link to the parse
-    # stage here.
+    # However, methods are never synthesized, so we always have a clear link to
+    # the parse stage here.
 
     #: Relation to parse stage
     parsed: parse.Method
@@ -861,8 +861,8 @@ class UnderstoodMethod(Method):
     # The ``parsed`` must be optional in the parent class, ``SignatureLike``, since
     # constructors can be synthesized without being defined in the original meta-model.
     #
-    # However, methods are never synthesized so we always have a clear link to the parse
-    # stage here.
+    # However, methods are never synthesized, so we always have a clear link to
+    # the parse stage here.
 
     #: Relation to parse stage
     parsed: parse.Method
@@ -909,7 +909,7 @@ class Constructor(SignatureLike):
     #: Interpreted statements of the constructor, stacked over all the ancestors
     statements: Final[Sequence[construction.AssignArgument]]
 
-    #: If set, the constructor is implementation-specific and we need to provide
+    #: If set, the constructor is implementation-specific, and we need to provide
     #: a snippet for it.
     is_implementation_specific: Final[bool]
 
@@ -1074,7 +1074,7 @@ class ConstrainedPrimitive:
     #: Which primitive type is constrained
     constrainee: PrimitiveType
 
-    #: If set, this class is implementation-specific and we need to provide a snippet
+    #: If set, this class is implementation-specific, and we need to provide a snippet
     #: for each implementation target
     is_implementation_specific: Final[bool]
 
@@ -1175,7 +1175,7 @@ class ConstrainedPrimitive:
         This method is expected to be called only during the translation phase.
         """
         self._invariants = invariants
-        self._invariant_id_set = frozenset(id(invariant) for invariant in invariants)
+        self._invariant_id_set = frozenset(id(inv) for inv in invariants)
 
     def __repr__(self) -> str:
         """Represent the instance as a string for easier debugging."""
@@ -1231,9 +1231,9 @@ class Class(DBC):
 
     def is_subclass_of(self, cls: "ClassUnion") -> bool:
         """
-        Check recursively whether this class is a sub-class of ``cls``.
+        Check recursively whether this class is a subclass of ``cls``.
 
-        Every class is a sub-class of itself.
+        Every class is a subclass of itself.
         """
         # NOTE (mristin, 2022-05-13):
         # This function is not used by the aas-core-codegen, but by downstream clients
@@ -1254,7 +1254,7 @@ class Class(DBC):
 
     # endregion
 
-    #: If set, this class is implementation-specific and we need to provide a snippet
+    #: If set, this class is implementation-specific, and we need to provide a snippet
     #: for each implementation target
     is_implementation_specific: Final[bool]
 
@@ -1485,7 +1485,7 @@ class Class(DBC):
         This method is expected to be called only during the translation phase.
         """
         self._invariants = invariants
-        self._invariant_id_set = frozenset(id(invariant) for invariant in invariants)
+        self._invariant_id_set = frozenset(id(inv) for inv in invariants)
 
     @abc.abstractmethod
     def __repr__(self) -> str:
@@ -1735,7 +1735,7 @@ class Signature(SignatureLike):
 
 class Interface:
     """
-    Represent an interface of some of the abstract and/or concrete classes.
+    Represent an interface of some abstract and/or concrete classes.
 
     Mind that the concept of interfaces is *not* used in the meta-model. We introduce
     it at the intermediate stage to facilitate generation of the code, especially for

--- a/aas_core_codegen/intermediate/construction.py
+++ b/aas_core_codegen/intermediate/construction.py
@@ -388,6 +388,7 @@ def _understand_assignment(
         default_node = None  # type: Optional[ast.AST]
 
         if_exp = assign.value
+        # noinspection PyUnresolvedReferences
         if (
             isinstance(if_exp.test, ast.Compare)
             and isinstance(if_exp.test.left, ast.Name)
@@ -578,6 +579,7 @@ class ConstructorTable:
 
     def entries(self) -> AbstractSet[Tuple[parse.Class, Sequence[Statement]]]:
         """Retrieve all the entries in the table."""
+        # noinspection PyTypeChecker
         return self._mapping.items()
 
 

--- a/aas_core_codegen/intermediate/doc.py
+++ b/aas_core_codegen/intermediate/doc.py
@@ -62,7 +62,7 @@ class AttributeReference(
     Represent a reference in the documentation to an "attribute".
 
     The attribute, in this context, refers to the role ``:attr:``. The references
-    implies either a reference to a property of a class or a literal of an enumeration.
+    imply either a reference to a property of a class or a literal of an enumeration.
     """
 
     def __init__(  # type: ignore

--- a/aas_core_codegen/intermediate/type_inference.py
+++ b/aas_core_codegen/intermediate/type_inference.py
@@ -102,7 +102,7 @@ class FunctionTypeAnnotation(AtomicTypeAnnotation):
 
 
 class VerificationTypeAnnotation(FunctionTypeAnnotation):
-    """Represent a type of a verification function."""
+    """Represent a type of verification function."""
 
     def __init__(self, func: _types.Verification):
         """Initialize with the given values."""
@@ -122,7 +122,7 @@ class BuiltinFunction:
 
 
 class BuiltinFunctionTypeAnnotation(FunctionTypeAnnotation):
-    """Represent a type of a built-in function."""
+    """Represent a type of built-in function."""
 
     def __init__(self, func: BuiltinFunction):
         """Initialize with the given values."""
@@ -133,7 +133,7 @@ class BuiltinFunctionTypeAnnotation(FunctionTypeAnnotation):
 
 
 class MethodTypeAnnotation(AtomicTypeAnnotation):
-    """Represent a type of a class method."""
+    """Represent a type of class method."""
 
     def __init__(self, method: _types.Method):
         """Initialize with the given values."""
@@ -523,7 +523,7 @@ class Canonicalizer(parse_tree.RestrictedTransformer[str]):
         """
         Check if the representation needs brackets for unambiguity.
 
-        While we could always put brackets, they harm readability in later debugging so
+        While we could always put brackets, they harm readability in later debugging, so
         we try to make the representation as readable as possible.
         """
         return isinstance(
@@ -688,6 +688,8 @@ class Canonicalizer(parse_tree.RestrictedTransformer[str]):
         if not Canonicalizer._needs_no_brackets(node.condition):
             condition = f"({condition})"
 
+        result = None  # type: Optional[str]
+
         if isinstance(node, parse_tree.Any):
             result = f"any({condition} {for_each})"
         elif isinstance(node, parse_tree.All):
@@ -695,6 +697,7 @@ class Canonicalizer(parse_tree.RestrictedTransformer[str]):
         else:
             assert_never(node)
 
+        assert result is not None
         self.representation_map[node] = result
         return result
 

--- a/aas_core_codegen/jsonschema/main.py
+++ b/aas_core_codegen/jsonschema/main.py
@@ -10,11 +10,11 @@ from typing import (
     List,
     Sequence,
     Mapping,
-    Set,
 )
 
 from icontract import ensure
 
+import aas_core_codegen.jsonschema
 from aas_core_codegen import (
     naming,
     specific_implementations,
@@ -23,7 +23,6 @@ from aas_core_codegen import (
     infer_for_schema,
 )
 from aas_core_codegen.common import Stripped, Error, assert_never, Identifier
-import aas_core_codegen.jsonschema
 
 assert aas_core_codegen.jsonschema.__doc__ == __doc__
 

--- a/aas_core_codegen/naming.py
+++ b/aas_core_codegen/naming.py
@@ -1,4 +1,4 @@
-"""Generate names from our ``Pasal_case`` for the respective targets."""
+"""Generate names from our ``Pascal_case`` for the respective targets."""
 from typing import List
 
 from icontract import ensure

--- a/aas_core_codegen/parse/_rules.py
+++ b/aas_core_codegen/parse/_rules.py
@@ -12,13 +12,14 @@ import abc
 import ast
 import os
 import pathlib
-from typing import Tuple, Optional, List, Mapping, Type, Sequence, Union
+from typing import Tuple, Optional, List, Mapping, Type, Sequence, Union, cast
 
 from icontract import ensure
 
 from aas_core_codegen.common import Identifier, Error, assert_never
 from aas_core_codegen.parse import tree
 
+# noinspection PyTypeChecker
 _AST_COMPARATOR_TO_OURS = {
     ast.Lt: tree.Comparator.LT,
     ast.LtE: tree.Comparator.LE,
@@ -55,10 +56,11 @@ class _ParseComparison(_Parse):
             and len(node.comparators) == 1
         )
 
+    # noinspection PyTypeChecker
     def transform(self, node: ast.AST) -> Tuple[Optional[tree.Node], Optional[Error]]:
         assert isinstance(node, ast.Compare)
 
-        left, error = ast_node_to_our_node(node.left)
+        left, error = ast_node_to_our_node(cast(ast.AST, node.left))
         if error is not None:
             return None, error
 
@@ -83,6 +85,7 @@ class _ParseAnyOrAll(_Parse):
             and node.func.id in ("any", "all")
         )
 
+    # noinspection PyUnresolvedReferences,PyTypeChecker
     def transform(self, node: ast.AST) -> Tuple[Optional[tree.Node], Optional[Error]]:
         assert (
             isinstance(node, ast.Call)
@@ -113,6 +116,7 @@ class _ParseAnyOrAll(_Parse):
 
         generator_exp = node.args[0]
 
+        # noinspection PyUnresolvedReferences
         condition, error = ast_node_to_our_node(generator_exp.elt)
         if error is not None:
             return None, error
@@ -150,6 +154,7 @@ class _ParseAnyOrAll(_Parse):
 
         assert isinstance(an_iter, tree.Expression), f"{an_iter=}"
 
+        # noinspection PyUnusedLocal
         factory_to_use = None  # type: Optional[Union[Type[tree.Any], Type[tree.All]]]
         if node.func.id == "any":
             factory_to_use = tree.Any
@@ -174,6 +179,7 @@ class _ParseCall(_Parse):
     def matches(self, node: ast.AST) -> bool:
         return isinstance(node, ast.Call)
 
+    # noinspection PyTypeChecker
     def transform(self, node: ast.AST) -> Tuple[Optional[tree.Node], Optional[Error]]:
         assert isinstance(node, ast.Call)
 
@@ -237,6 +243,7 @@ class _ParseConstant(_Parse):
 
 
 class _ParseImplication(_Parse):
+    # noinspection PyUnresolvedReferences
     def matches(self, node: ast.AST) -> bool:
         return (
             isinstance(node, ast.BoolOp)
@@ -246,6 +253,7 @@ class _ParseImplication(_Parse):
             and isinstance(node.values[0].op, ast.Not)
         )
 
+    # noinspection PyUnresolvedReferences,PyTypeChecker
     def transform(self, node: ast.AST) -> Tuple[Optional[tree.Node], Optional[Error]]:
         assert (
             isinstance(node, ast.BoolOp)
@@ -279,6 +287,7 @@ class _ParseMember(_Parse):
     def matches(self, node: ast.AST) -> bool:
         return isinstance(node, ast.Attribute)
 
+    # noinspection PyTypeChecker
     def transform(self, node: ast.AST) -> Tuple[Optional[tree.Node], Optional[Error]]:
         assert isinstance(node, ast.Attribute)
 
@@ -300,6 +309,7 @@ class _ParseName(_Parse):
     def matches(self, node: ast.AST) -> bool:
         return isinstance(node, ast.Name)
 
+    # noinspection PyTypeChecker
     def transform(self, node: ast.AST) -> Tuple[Optional[tree.Node], Optional[Error]]:
         assert isinstance(node, ast.Name)
 
@@ -307,6 +317,7 @@ class _ParseName(_Parse):
 
 
 class _ParseIsNoneOrIsNotNone(_Parse):
+    # noinspection PyUnresolvedReferences
     def matches(self, node: ast.AST) -> bool:
         return (
             isinstance(node, ast.Compare)
@@ -317,6 +328,7 @@ class _ParseIsNoneOrIsNotNone(_Parse):
             and node.comparators[0].value is None
         )
 
+    # noinspection PyUnresolvedReferences,PyTypeChecker
     def transform(self, node: ast.AST) -> Tuple[Optional[tree.Node], Optional[Error]]:
         assert (
             isinstance(node, ast.Compare)
@@ -346,6 +358,7 @@ class _ParseAndOrOr(_Parse):
     def matches(self, node: ast.AST) -> bool:
         return isinstance(node, ast.BoolOp) and isinstance(node.op, (ast.And, ast.Or))
 
+    # noinspection PyTypeChecker
     def transform(self, node: ast.AST) -> Tuple[Optional[tree.Node], Optional[Error]]:
         assert isinstance(node, ast.BoolOp) and isinstance(node.op, (ast.And, ast.Or))
 
@@ -372,6 +385,7 @@ class _ParseExpression(_Parse):
     def matches(self, node: ast.AST) -> bool:
         return isinstance(node, ast.Expr)
 
+    # noinspection PyTypeChecker
     def transform(self, node: ast.AST) -> Tuple[Optional[tree.Node], Optional[Error]]:
         assert isinstance(node, ast.Expr)
 
@@ -388,6 +402,7 @@ class _ParseJoinedStr(_Parse):
     def matches(self, node: ast.AST) -> bool:
         return isinstance(node, ast.JoinedStr)
 
+    # noinspection PyTypeChecker
     def transform(self, node: ast.AST) -> Tuple[Optional[tree.Node], Optional[Error]]:
         assert isinstance(node, ast.JoinedStr)
 
@@ -448,6 +463,7 @@ class _ParseAssignment(_Parse):
     def matches(self, node: ast.AST) -> bool:
         return isinstance(node, ast.Assign) and len(node.targets) == 1
 
+    # noinspection PyTypeChecker
     def transform(self, node: ast.AST) -> Tuple[Optional[tree.Node], Optional[Error]]:
         assert isinstance(node, ast.Assign) and len(node.targets) == 1
 
@@ -475,6 +491,7 @@ class _ParseReturn(_Parse):
     def matches(self, node: ast.AST) -> bool:
         return isinstance(node, ast.Return)
 
+    # noinspection PyTypeChecker
     def transform(self, node: ast.AST) -> Tuple[Optional[tree.Node], Optional[Error]]:
         assert isinstance(node, ast.Return)
 

--- a/aas_core_codegen/parse/_translate.py
+++ b/aas_core_codegen/parse/_translate.py
@@ -24,6 +24,8 @@ import asttokens
 import docutils.io
 import docutils.core
 import docutils.nodes
+
+# noinspection PyUnresolvedReferences
 import docutils.utils.error_reporting
 from icontract import ensure, require
 
@@ -70,6 +72,7 @@ from aas_core_codegen.parse._types import (
 )
 
 
+# noinspection GrazieInspection
 @ensure(lambda result: (result[0] is None) ^ (result[1] is None))
 def source_to_atok(
     source: str,
@@ -122,6 +125,7 @@ class _ExpectedImportsVisitor(ast.NodeVisitor):
         ]
     )
 
+    # noinspection PyTypeChecker
     def visit_ImportFrom(self, node: ast.ImportFrom) -> Any:
         for name in node.names:
             assert isinstance(name, ast.alias)
@@ -170,6 +174,7 @@ def check_expected_imports(atok: asttokens.ASTTokens) -> List[str]:
     return [lineno_columner.error_message(error) for error in visitor.errors]
 
 
+# noinspection PyTypeChecker
 @ensure(lambda result: (result[0] is None) ^ (result[1] is None))
 def _type_annotation(
     node: ast.AST, atok: asttokens.ASTTokens
@@ -211,7 +216,7 @@ def _type_annotation(
         # ``ast.Index`` and ``ast.ExtSlice`` which is replaced with their actual value
         # and ``ast.Tuple``, respectively.
         #
-        # Hence we need to switch on Python version and get the underlying slice value
+        # Hence, we need to switch on Python version and get the underlying slice value
         # explicitly.
         #
         # See deprecation notes just at the end of:
@@ -244,6 +249,7 @@ def _type_annotation(
 
         # NOTE (mristin, 2022-01-22):
         # Please see the note about the deprecation of ``ast.Index`` above.
+        # noinspection PyUnusedLocal
         index_node = None  # type: Optional[ast.AST]
         if sys.version_info < (3, 9):
             # noinspection PyUnresolvedReferences
@@ -316,6 +322,7 @@ def _type_annotation(
         )
 
 
+# noinspection PyTypeChecker
 @ensure(lambda result: (result[0] is None) ^ (result[1] is None))
 def _ann_assign_to_property(
     node: ast.AnnAssign, description: Optional[Description], atok: asttokens.ASTTokens
@@ -368,6 +375,7 @@ def _ann_assign_to_property(
     )
 
 
+# noinspection PyTypeChecker
 @ensure(lambda result: (result[0] is None) ^ (result[1] is None))
 def _args_to_arguments(
     node: ast.arguments, atok: asttokens.ASTTokens
@@ -504,6 +512,7 @@ def _args_to_arguments(
     return arguments, None
 
 
+# noinspection PyTypeChecker
 @ensure(lambda result: (result[0] is None) ^ (result[1] is None))
 def _parse_contract_condition(
     node: ast.Call, atok: asttokens.ASTTokens
@@ -586,6 +595,7 @@ def _parse_contract_condition(
     )
 
 
+# noinspection PyTypeChecker
 @ensure(lambda result: (result[0] is None) ^ (result[1] is None))
 def _parse_snapshot(
     node: ast.Call, atok: asttokens.ASTTokens
@@ -685,13 +695,14 @@ def _parse_snapshot(
 
 
 # BEFORE-RELEASE (mristin, 2021-12-13):
-#  include severity levels for contracts in the meta model and
+#  include severity levels for contracts in the metamodel and
 #  consider them in the imports
 
 # BEFORE-RELEASE (mristin, 2021-12-13):
 #  test for unknown severity level
 
 # fmt: off
+# noinspection PyTypeChecker,PyUnresolvedReferences
 @ensure(
     lambda expect_self, result:
     not (result[0] is not None and not expect_self)
@@ -1171,6 +1182,7 @@ class _IsSupersetOf:
 
 
 # fmt: off
+# noinspection PyTypeChecker
 @require(
     lambda decorator:
     isinstance(decorator.func, ast.Name)
@@ -1223,6 +1235,7 @@ def _class_decorator_to_is_superset_of(
 
 
 # fmt: off
+# noinspection PyTypeChecker
 @require(
     lambda decorator:
     isinstance(decorator.func, ast.Name)
@@ -1282,6 +1295,7 @@ def _class_decorator_to_serialization(
 
 
 # fmt: off
+# noinspection PyTypeChecker
 @require(
     lambda decorator:
     isinstance(decorator.func, ast.Name)
@@ -1399,6 +1413,7 @@ def _class_decorator_to_reference_in_the_book(
 
 
 # fmt: off
+# noinspection PyTypeChecker
 @require(
     lambda decorator:
     isinstance(decorator.func, ast.Name)
@@ -1503,6 +1518,7 @@ _ClassDecoratorUnion = Union[
 ]
 
 
+# noinspection PyTypeChecker
 @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
 def _parse_class_decorator(
     decorator: ast.AST, atok: asttokens.ASTTokens
@@ -1554,6 +1570,7 @@ def _parse_class_decorator(
         )
 
 
+# noinspection PyTypeChecker,PyUnresolvedReferences
 @ensure(lambda result: (result[0] is None) ^ (result[1] is None))
 def _enum_to_symbol(
     node: ast.ClassDef, atok: asttokens.ASTTokens
@@ -1732,6 +1749,7 @@ def _enum_to_symbol(
     )
 
 
+# noinspection PyTypeChecker
 @ensure(lambda result: (result[0] is None) ^ (result[1] is None))
 def _classdef_to_symbol(
     node: ast.ClassDef, atok: asttokens.ASTTokens
@@ -1808,7 +1826,7 @@ def _classdef_to_symbol(
             elif decorator is _ClassMarker.TEMPLATE:
                 # NOTE (mristin, 2021-11-28):
                 # We ignore the template marker at this moment. However, we will most
-                # probably have to consider them in the future so we leave them in the
+                # probably have to consider them in the future, so we leave them in the
                 # meta-model, but ignore them in the code generation.
                 pass
 
@@ -2412,6 +2430,7 @@ def _verify_symbol_table(
     return cast(SymbolTable, symbol_table), None
 
 
+# noinspection PyTypeChecker,PyUnresolvedReferences
 @require(lambda atok: isinstance(atok.tree, ast.Module))
 @ensure(lambda result: (result[0] is None) ^ (result[1] is None))
 def _atok_to_symbol_table(
@@ -2434,6 +2453,7 @@ def _atok_to_symbol_table(
         if isinstance(node, ast.Pass):
             continue
 
+        # noinspection PyUnusedLocal
         matched = False
 
         if isinstance(node, ast.ClassDef):

--- a/aas_core_codegen/parse/_types.py
+++ b/aas_core_codegen/parse/_types.py
@@ -346,7 +346,7 @@ class UnderstoodMethod(Method):
     We use :py:mod:`aas_core_codegen.parse._rules` to understand it.
     """
 
-    #: Body as a our AST that we could understand with
+    #: Body as an AST that we could understand with
     #: :py:mod:`aas_core_codegen.parse._rules`
     body: Final[Sequence[tree.Node]]
 
@@ -472,7 +472,7 @@ class Class(DBC):
     #: Name of the class
     name: Final[Identifier]
 
-    #: If set, the class is implementation-specific and we need to provide a snippet
+    #: If set, the class is implementation-specific, and we need to provide a snippet
     #: for it
     is_implementation_specific: Final[bool]
 
@@ -762,6 +762,7 @@ class UnverifiedSymbolTable(DBC):
 
         return symbol
 
+    # noinspection GrazieInspection
     def must_find_class(self, name: Identifier) -> Class:
         """
         Find the class with the given name.

--- a/aas_core_codegen/parse/retree/_parse.py
+++ b/aas_core_codegen/parse/retree/_parse.py
@@ -265,7 +265,7 @@ class Cursor:
 
     def peek_substring(self, length: int) -> Optional[str]:
         """
-        Try to read a substring of ``lentgh`` characters.
+        Try to read a substring of ``length`` characters.
 
         If the remainder of the stream contains less than ``length`` characters,
         return ``None``, or the pointed value is not a string, return ``None``.
@@ -363,7 +363,7 @@ class Cursor:
             else:
                 if self.minor_cursor is None and other.minor_cursor is None:
                     # NOTE (mristin, 2022-06-02):
-                    # Both major cursors point to the formatted value so they
+                    # Both major cursors point to the formatted value, so they
                     # point to the same position.
                     assert isinstance(self.pointed_value(), FormattedValue)
                     assert isinstance(other.pointed_value(), FormattedValue)
@@ -473,6 +473,7 @@ def render_pointer(cursor: Cursor) -> Tuple[str, str]:
 
 
 # fmt: off
+# noinspection RegExpSimplifiable
 @require(
     lambda cursor: not cursor.peek_literal("-"),
     "The dash (``-``) handled before, outside of this function"
@@ -490,6 +491,7 @@ def _parse_range_char(cursor: Cursor) -> Tuple[Optional[Char], Optional[Error]]:
         if substring is None:
             return None, Error("Expected two hexadecimal digits after \\x", cursor)
 
+        # noinspection RegExpSimplifiable
         if not re.fullmatch(r"[a-fA-F0-9]{2}", substring):
             return None, Error(
                 f"Expected two hexadecimal digits after \\x, " f"but got {substring!r}",
@@ -598,6 +600,7 @@ def _parse_range_char(cursor: Cursor) -> Tuple[Optional[Char], Optional[Error]]:
 def _parse_ranges_and_closing(
     cursor: Cursor,
 ) -> Tuple[Optional[List[Range]], Optional[Error]]:
+    # noinspection GrazieInspection
     """Parse one or more ranges in a character set and the closing ``]``."""
     ranges = []  # type: List[Range]
 
@@ -649,6 +652,7 @@ def _parse_ranges_and_closing(
     return ranges, None
 
 
+# noinspection RegExpSimplifiable
 def _parse_char_literal(cursor: Cursor) -> Tuple[Optional[Char], Optional[Error]]:
     """
     Parse a character literal in a concatenation.
@@ -657,6 +661,7 @@ def _parse_char_literal(cursor: Cursor) -> Tuple[Optional[Char], Optional[Error]
     For example, if there is a quantifier (such as ``*``, ``+`` or ``?``) following
     a literal. In those cases, return ``None`` and no error.
     """
+    # noinspection PyUnusedLocal
     result = None  # type: Optional[Char]
 
     if cursor.done():
@@ -820,8 +825,8 @@ def _parse_char_literal(cursor: Cursor) -> Tuple[Optional[Char], Optional[Error]
 
     elif cursor.peek_literal(")") or cursor.peek_literal("|"):
         # NOTE (mristin, 2022-06-08):
-        # We encountered a closing bracket or a delimiter in an union,
-        # so no concatenation is possible any more and we need to match an "empty"
+        # We encountered a closing bracket or a delimiter in a union,
+        # so no concatenation is possible anymore, and we need to match an "empty"
         # character literal.
         return None, None
 
@@ -864,8 +869,10 @@ def _parse_concatenation(
         if cursor.peek_literal("|"):
             break
 
+        # noinspection PyUnusedLocal
         value = None  # type: Optional[TermValueUnion]
 
+        # noinspection GrazieInspection
         if cursor.try_literal("^"):
             value = Symbol(kind=SymbolKind.START)
 
@@ -1086,7 +1093,7 @@ def _parse_regex(cursor: Cursor) -> Tuple[Optional[Regex], Optional[Error]]:
 def parse(
     values: Sequence[Union[str, FormattedValue]]
 ) -> Tuple[Optional[Regex], Optional[Error]]:
-    """Try to parse the ``values`` into an AST representing the regural expression."""
+    """Try to parse the ``values`` into an AST representing the regular expression."""
     cursor = Cursor(values=values)
     parsed, error = _parse_regex(cursor)
     return parsed, error

--- a/aas_core_codegen/parse/retree/_types.py
+++ b/aas_core_codegen/parse/retree/_types.py
@@ -25,7 +25,7 @@ class Node(DBC):
 
 
 class Regex(Node):
-    """Represent the root of the AST of an regex."""
+    """Represent the root of the AST of a regex."""
 
     #: List of concatenations joined by "|"
     union: "UnionExpr"
@@ -110,7 +110,7 @@ TermValueUnion = Union["Group", "Char", "CharSet", FormattedValue, "Symbol"]
 
 
 class Term(Node):
-    """Represent a term in an regex concatenation."""
+    """Represent a term in a regex concatenation."""
 
     # fmt: off
     @require(

--- a/aas_core_codegen/parse/tree.py
+++ b/aas_core_codegen/parse/tree.py
@@ -162,7 +162,7 @@ class MethodCall(Expression):
 
 
 class Name(Expression):
-    """Represent an access to a variable with the given name."""
+    """Represent access to a variable with the given name."""
 
     def __init__(self, identifier: Identifier, original_node: ast.AST) -> None:
         """Initialize with the given values."""
@@ -496,7 +496,7 @@ class Visitor(DBC):
                 assert_never(value)
 
     def visit_for_each(self, node: ForEach) -> None:
-        """Visit an ``for`` in an generator."""
+        """Visit an ``for`` in a generator."""
         self.visit(node.iteration)
 
     def visit_any(self, node: Any) -> None:
@@ -569,7 +569,7 @@ class Transformer(Generic[T], DBC):
 
     @abc.abstractmethod
     def transform_name(self, node: Name) -> T:
-        """Transform a variable access into something."""
+        """Transform variable access into something."""
         raise NotImplementedError(f"{node=}")
 
     @abc.abstractmethod
@@ -594,7 +594,7 @@ class Transformer(Generic[T], DBC):
 
     @abc.abstractmethod
     def transform_for_each(self, node: ForEach) -> T:
-        """Transform the ``for`` in an generator into something."""
+        """Transform the ``for`` in a generator into something."""
         raise NotImplementedError(f"{node=}")
 
     @abc.abstractmethod
@@ -659,7 +659,7 @@ class RestrictedTransformer(Transformer[T], DBC):
         raise AssertionError(f"Unexpected node: {dump(node)}")
 
     def transform_name(self, node: Name) -> T:
-        """Transform a variable access into something."""
+        """Transform variable access into something."""
         raise AssertionError(f"Unexpected node: {dump(node)}")
 
     def transform_and(self, node: And) -> T:
@@ -679,7 +679,7 @@ class RestrictedTransformer(Transformer[T], DBC):
         raise AssertionError(f"Unexpected node: {dump(node)}")
 
     def transform_for_each(self, node: ForEach) -> T:
-        """Transform an ``for`` in an generator expression into something."""
+        """Transform an ``for`` in a generator expression into something."""
         raise AssertionError(f"Unexpected node: {dump(node)}")
 
     def transform_any(self, node: Any) -> T:

--- a/aas_core_codegen/rdf_shacl/_description.py
+++ b/aas_core_codegen/rdf_shacl/_description.py
@@ -13,7 +13,7 @@ from aas_core_codegen.rdf_shacl import naming as rdf_shacl_naming
 
 # NOTE (mristin, 2022-03-23):
 # The representation of the documentation as tokens was definitely a wrong decision.
-# However, we do not prioritize descriptions in RDF+SHACL at the moment so we leave out
+# However, we do not prioritize descriptions in RDF+SHACL at the moment, so we leave out
 # the refactoring for now. A better approach would be to first transform
 # into a nested structure similar to HTML (paragraph, unordered list, ordered list,
 # *etc.*) and then render this nested structure in a separate step.

--- a/aas_core_codegen/specific_implementations.py
+++ b/aas_core_codegen/specific_implementations.py
@@ -8,6 +8,7 @@ from icontract import require, ensure
 
 from aas_core_codegen.common import Stripped
 
+# noinspection RegExpSimplifiable
 IMPLEMENTATION_KEY_RE = re.compile("[a-zA-Z_][a-zA-Z_0-9.]*(/[a-zA-Z_][a-zA-Z_0-9.]*)*")
 
 

--- a/aas_core_codegen/xsd/main.py
+++ b/aas_core_codegen/xsd/main.py
@@ -50,6 +50,7 @@ _PRIMITIVE_MAP = {
 }
 assert all(literal in _PRIMITIVE_MAP for literal in intermediate.PrimitiveType)
 
+# noinspection RegExpSimplifiable
 _ESCAPE_BACKSLASH_X_RE = re.compile(r"\\x([a-fA-f0-9]{2})")
 
 
@@ -255,7 +256,9 @@ def _generate_xs_element_for_a_primitive_property(
     # NOTE (mristin, 2022-06-18):
     # xs_restriction may be None here if there are no constraints.
 
+    # noinspection PyUnusedLocal
     xs_element = None  # type: Optional[ET.Element]
+
     if xs_restriction is None:
         xs_element = ET.Element(
             "xs:element",
@@ -441,7 +444,7 @@ def _generate_xs_element_for_a_property(
         ):
             # NOTE (mristin, 2022-05-26):
             # We generate choices only if there are at least one concrete descendant.
-            # Otherwise, the choice is not generated. Hence we need to reference
+            # Otherwise, the choice is not generated. Hence, we need to reference
             # a choice only if there is actually one.
             #
             # This is especially necessary for abstract classes with no descendants
@@ -926,7 +929,7 @@ def _generate(
 
     # NOTE (mristin, 2022-03-30):
     # For some unknown reason, ElementTree erases the xmlns property of the root
-    # element. Therefore we need to add it here manually.
+    # element. Therefore, we need to add it here manually.
     root.attrib["xmlns"] = xmlns
 
     text = ET.tostring(root, encoding="unicode", method="xml")


### PR DESCRIPTION
We go through all the files and fix manually PyCharm warnings.

We used PyCharm 2022.1.2 (Community Edition).