### PR TITLE
Re-format manually ``tests.infer_for_schema``

### DIFF
--- a/tests/infer_for_schema/common.py
+++ b/tests/infer_for_schema/common.py
@@ -37,7 +37,7 @@ def parse_to_symbol_table_and_something_cls_and_constraints_by_class(
     Parse the ``source``.
 
     Return the symbol table and the symbol corresponding to the class ``Something``
-    in the ``source`` as well as the the inferred constraints mapped by classes.
+    in the ``source`` as well as the inferred constraints mapped by classes.
     """
     symbol_table, something_cls = parse_to_symbol_table_and_something_cls(source=source)
 

--- a/tests/infer_for_schema/test_len_on_properties.py
+++ b/tests/infer_for_schema/test_len_on_properties.py
@@ -24,13 +24,18 @@ class Test_expected(unittest.TestCase):
             """
         )
 
+        # fmt: off
         (
             _,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_props = constraints_by_class[something_cls]
 
@@ -61,13 +66,18 @@ class Test_expected(unittest.TestCase):
             """
         )
 
+        # fmt: off
         (
             _,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_props = constraints_by_class[something_cls]
 
@@ -101,13 +111,18 @@ class Test_expected(unittest.TestCase):
             """
         )
 
+        # fmt: off
         (
             _,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_props = constraints_by_class[something_cls]
 
@@ -141,13 +156,18 @@ class Test_expected(unittest.TestCase):
             """
         )
 
+        # fmt: off
         (
             _,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_props = constraints_by_class[something_cls]
 
@@ -181,13 +201,18 @@ class Test_expected(unittest.TestCase):
             """
         )
 
+        # fmt: off
         (
             _,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_props = constraints_by_class[something_cls]
 
@@ -225,13 +250,18 @@ class Test_expected(unittest.TestCase):
             """
         )
 
+        # fmt: off
         (
             _,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_props = constraints_by_class[something_cls]
 
@@ -265,13 +295,18 @@ class Test_expected(unittest.TestCase):
             """
         )
 
+        # fmt: off
         (
             _,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_props = constraints_by_class[something_cls]
 
@@ -305,13 +340,18 @@ class Test_expected(unittest.TestCase):
             """
         )
 
+        # fmt: off
         (
             _,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_props = constraints_by_class[something_cls]
 
@@ -349,13 +389,18 @@ class Test_expected(unittest.TestCase):
             """
         )
 
+        # fmt: off
         (
             _,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_props = constraints_by_class[something_cls]
 
@@ -406,13 +451,18 @@ class Test_expected(unittest.TestCase):
         # This is necessary as we want to use these constraints to generate schemas
         # whereas it is the job of the schema engine to stack the constraints together.
 
+        # fmt: off
         (
             _,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_props = constraints_by_class[something_cls]
 
@@ -557,19 +607,25 @@ class Test_stacking(unittest.TestCase):
 
         # NOTE (mristin, 2022-05-18):
         # This definition here is necessary for mypy.
+        # noinspection PyUnusedLocal
         constraints_by_class: Optional[
             MutableMapping[
                 intermediate.ClassUnion, infer_for_schema.ConstraintsByProperty
             ]
         ] = None
 
+        # fmt: off
         (
             symbol_table,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_class, error = infer_for_schema.merge_constraints_with_ancestors(
             symbol_table=symbol_table, constraints_by_class=constraints_by_class
@@ -619,19 +675,25 @@ class Test_stacking(unittest.TestCase):
 
         # NOTE (mristin, 2022-05-18):
         # This definition here is necessary for mypy.
+        # noinspection PyUnusedLocal
         constraints_by_class: Optional[
             MutableMapping[
                 intermediate.ClassUnion, infer_for_schema.ConstraintsByProperty
             ]
         ] = None
 
+        # fmt: off
         (
             symbol_table,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_class, error = infer_for_schema.merge_constraints_with_ancestors(
             symbol_table=symbol_table, constraints_by_class=constraints_by_class
@@ -682,19 +744,25 @@ class Test_stacking(unittest.TestCase):
 
         # NOTE (mristin, 2022-05-18):
         # This definition here is necessary for mypy.
+        # noinspection PyUnusedLocal
         constraints_by_class: Optional[
             MutableMapping[
                 intermediate.ClassUnion, infer_for_schema.ConstraintsByProperty
             ]
         ] = None
 
+        # fmt: off
         (
             symbol_table,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_class, error = infer_for_schema.merge_constraints_with_ancestors(
             symbol_table=symbol_table, constraints_by_class=constraints_by_class

--- a/tests/infer_for_schema/test_len_on_self.py
+++ b/tests/infer_for_schema/test_len_on_self.py
@@ -28,13 +28,18 @@ class Test_expected(unittest.TestCase):
             """
         )
 
+        # fmt: off
         (
             _,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_props = constraints_by_class[something_cls]
         text = infer_for_schema.dump(constraints_by_props)
@@ -68,13 +73,18 @@ class Test_expected(unittest.TestCase):
             """
         )
 
+        # fmt: off
         (
             _,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_props = constraints_by_class[something_cls]
         text = infer_for_schema.dump(constraints_by_props)
@@ -111,13 +121,18 @@ class Test_expected(unittest.TestCase):
             """
         )
 
+        # fmt: off
         (
             _,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_props = constraints_by_class[something_cls]
         text = infer_for_schema.dump(constraints_by_props)
@@ -154,13 +169,18 @@ class Test_expected(unittest.TestCase):
             """
         )
 
+        # fmt: off
         (
             _,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_props = constraints_by_class[something_cls]
         text = infer_for_schema.dump(constraints_by_props)
@@ -197,13 +217,18 @@ class Test_expected(unittest.TestCase):
             """
         )
 
+        # fmt: off
         (
             _,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_props = constraints_by_class[something_cls]
         text = infer_for_schema.dump(constraints_by_props)
@@ -240,13 +265,18 @@ class Test_expected(unittest.TestCase):
             """
         )
 
+        # fmt: off
         (
             _,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_props = constraints_by_class[something_cls]
         text = infer_for_schema.dump(constraints_by_props)
@@ -283,13 +313,18 @@ class Test_expected(unittest.TestCase):
             """
         )
 
+        # fmt: off
         (
             _,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_props = constraints_by_class[something_cls]
         text = infer_for_schema.dump(constraints_by_props)
@@ -332,16 +367,21 @@ class Test_expected(unittest.TestCase):
         )
 
         # NOTE (mristin, 2022-05-15):
-        # In contrast to classes, we do inherit the constraints among the constrained
+        # In contrast to class, we do inherit the constraints among the constrained
         # primitives as we in-line them later in the schema classes.
 
+        # fmt: off
         (
             _,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_props = constraints_by_class[something_cls]
         text = infer_for_schema.dump(constraints_by_props)

--- a/tests/infer_for_schema/test_patterns_on_properties.py
+++ b/tests/infer_for_schema/test_patterns_on_properties.py
@@ -25,13 +25,18 @@ class Test_expected(unittest.TestCase):
             """
         )
 
+        # fmt: off
         (
             _,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_props = constraints_by_class[something_cls]
         text = infer_for_schema.dump(constraints_by_props)
@@ -67,13 +72,18 @@ class Test_expected(unittest.TestCase):
             """
         )
 
+        # fmt: off
         (
             _,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_props = constraints_by_class[something_cls]
         text = infer_for_schema.dump(constraints_by_props)
@@ -116,13 +126,18 @@ class Test_expected(unittest.TestCase):
             """
         )
 
+        # fmt: off
         (
             _,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_props = constraints_by_class[something_cls]
         text = infer_for_schema.dump(constraints_by_props)
@@ -170,13 +185,18 @@ class Test_expected(unittest.TestCase):
         # ignore the constraints of the ancestors in *this particular kind of
         # inference*.
 
+        # fmt: off
         (
             _,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_props = constraints_by_class[something_cls]
         text = infer_for_schema.dump(constraints_by_props)
@@ -231,13 +251,18 @@ class Test_expected(unittest.TestCase):
         # This is necessary as we want to use these constraints to generate schemas
         # whereas it is the job of the schema engine to stack the constraints together.
 
+        # fmt: off
         (
             _,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_props = constraints_by_class[something_cls]
         text = infer_for_schema.dump(constraints_by_props)
@@ -286,13 +311,18 @@ class Test_stacking(unittest.TestCase):
             ]
         ] = None
 
+        # fmt: off
         (
             symbol_table,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_class, error = infer_for_schema.merge_constraints_with_ancestors(
             symbol_table=symbol_table, constraints_by_class=constraints_by_class
@@ -346,13 +376,18 @@ class Test_stacking(unittest.TestCase):
             ]
         ] = None
 
+        # fmt: off
         (
             symbol_table,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_class, error = infer_for_schema.merge_constraints_with_ancestors(
             symbol_table=symbol_table, constraints_by_class=constraints_by_class
@@ -414,13 +449,18 @@ class Test_stacking(unittest.TestCase):
             ]
         ] = None
 
+        # fmt: off
         (
             symbol_table,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_class, error = infer_for_schema.merge_constraints_with_ancestors(
             symbol_table=symbol_table, constraints_by_class=constraints_by_class
@@ -482,13 +522,18 @@ class Test_stacking(unittest.TestCase):
             ]
         ] = None
 
+        # fmt: off
         (
             symbol_table,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_class, error = infer_for_schema.merge_constraints_with_ancestors(
             symbol_table=symbol_table, constraints_by_class=constraints_by_class
@@ -547,13 +592,18 @@ class Test_stacking(unittest.TestCase):
             ]
         ] = None
 
+        # fmt: off
         (
             symbol_table,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_class, error = infer_for_schema.merge_constraints_with_ancestors(
             symbol_table=symbol_table, constraints_by_class=constraints_by_class

--- a/tests/infer_for_schema/test_patterns_on_self.py
+++ b/tests/infer_for_schema/test_patterns_on_self.py
@@ -28,13 +28,18 @@ class Test_expected(unittest.TestCase):
             """
         )
 
+        # fmt: off
         (
             _,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_props = constraints_by_class[something_cls]
         text = infer_for_schema.dump(constraints_by_props)
@@ -73,13 +78,18 @@ class Test_expected(unittest.TestCase):
             """
         )
 
+        # fmt: off
         (
             _,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_props = constraints_by_class[something_cls]
         text = infer_for_schema.dump(constraints_by_props)
@@ -125,13 +135,18 @@ class Test_expected(unittest.TestCase):
             """
         )
 
+        # fmt: off
         (
             _,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_props = constraints_by_class[something_cls]
         text = infer_for_schema.dump(constraints_by_props)
@@ -185,13 +200,18 @@ class Test_expected(unittest.TestCase):
         # In contrast to classes, we do inherit the constraints among the constrained
         # primitives as we in-line them later in the schema classes.
 
+        # fmt: off
         (
             _,
             something_cls,
             constraints_by_class,
-        ) = tests.infer_for_schema.common.parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-            source=source
+        ) = (
+            tests.infer_for_schema.common
+            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
+                source=source
+            )
         )
+        # fmt: on
 
         constraints_by_props = constraints_by_class[something_cls]
         text = infer_for_schema.dump(constraints_by_props)


### PR DESCRIPTION
There are many long statements which we had to break manually to make
them readable.