### PR TITLE
Re-format manually for line width of 88 characters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,7 +154,7 @@ Call the generator with the appropriate target:
                             SNIPPETS_DIR --output_dir OUTPUT_DIR --target
                             {csharp,jsonschema,rdf_shacl,xsd} [--version]
 
-    Generate different implementations and schemas based on an AAS meta-model.
+    Generate implementations and schemas based on an AAS meta-model.
 
     optional arguments:
       -h, --help            show this help message and exit

--- a/aas_core_codegen/__init__.py
+++ b/aas_core_codegen/__init__.py
@@ -1,4 +1,4 @@
-"""Generate different implementations and schemas based on an AAS meta-model."""
+"""Generate implementations and schemas based on an AAS meta-model."""
 
 __version__ = "0.0.15"
 __author__ = "Marko Ristin, Nico Braunisch, Robert Lehmann"

--- a/aas_core_codegen/csharp/verification/_generate.py
+++ b/aas_core_codegen/csharp/verification/_generate.py
@@ -123,7 +123,7 @@ class _FixForUTF16Regex(parse_retree.BaseVisitor):
 
     @staticmethod
     @require(lambda term: isinstance(term.value, parse_retree.Char))
-    def _expand_character_literal_to_surrogates_if_necessary(
+    def _character_literal_to_surrogates_if_necessary(
         term: parse_retree.Term,
     ) -> List[parse_retree.Term]:
         """Expand the character literal to two surrogate characters if necessary."""
@@ -182,7 +182,7 @@ class _FixForUTF16Regex(parse_retree.BaseVisitor):
         return output
 
     @staticmethod
-    def _produce_concatenation_char_char(
+    def _produce_char_char(
         first_code: int, second_code: int
     ) -> parse_retree.Concatenation:
         """
@@ -210,7 +210,7 @@ class _FixForUTF16Regex(parse_retree.BaseVisitor):
         )
 
     @staticmethod
-    def _produce_concatenation_char_char_set(
+    def _produce_char_char_set(
         code: int, range_start: int, range_end: int
     ) -> parse_retree.Concatenation:
         """
@@ -248,7 +248,7 @@ class _FixForUTF16Regex(parse_retree.BaseVisitor):
         )
 
     @staticmethod
-    def _produce_concatenation_char_set_char_set(
+    def _produce_char_set_char_set(
         first_range_start: int,
         first_range_end: int,
         second_range_start: int,
@@ -373,7 +373,7 @@ class _FixForUTF16Regex(parse_retree.BaseVisitor):
                 a_range.start.character == a_range.end.character
             ):
                 uniates.append(
-                    _FixForUTF16Regex._produce_concatenation_char_char(
+                    _FixForUTF16Regex._produce_char_char(
                         first_code=high_start, second_code=low_start
                     )
                 )
@@ -392,14 +392,14 @@ class _FixForUTF16Regex(parse_retree.BaseVisitor):
                 if high_start == high_end:
                     # {high start}[{low start}-{low end}]
                     uniates.append(
-                        _FixForUTF16Regex._produce_concatenation_char_char_set(
+                        _FixForUTF16Regex._produce_char_char_set(
                             code=high_start, range_start=low_start, range_end=low_end
                         )
                     )
                 else:
                     # {high start}[{low start}-\uDFFF]
                     uniates.append(
-                        _FixForUTF16Regex._produce_concatenation_char_char_set(
+                        _FixForUTF16Regex._produce_char_char_set(
                             code=high_start, range_start=low_start, range_end=0xDFFF
                         )
                     )
@@ -409,7 +409,7 @@ class _FixForUTF16Regex(parse_retree.BaseVisitor):
                         if high_start + 1 == high_end - 1:
                             # {high start + 1}[\uDC00-\uDFFF]
                             uniates.append(
-                                _FixForUTF16Regex._produce_concatenation_char_char_set(
+                                _FixForUTF16Regex._produce_char_char_set(
                                     code=high_start + 1,
                                     range_start=0xDC00,
                                     range_end=0xDFFF,
@@ -418,7 +418,7 @@ class _FixForUTF16Regex(parse_retree.BaseVisitor):
                         else:
                             # [{high start + 1}-{high end - 1}][\uDC00-\uDFFF]
                             uniates.append(
-                                _FixForUTF16Regex._produce_concatenation_char_set_char_set(
+                                _FixForUTF16Regex._produce_char_set_char_set(
                                     first_range_start=high_start + 1,
                                     first_range_end=high_end - 1,
                                     second_range_start=0xDC00,
@@ -427,7 +427,7 @@ class _FixForUTF16Regex(parse_retree.BaseVisitor):
                             )
 
                     uniates.append(
-                        _FixForUTF16Regex._produce_concatenation_char_char_set(
+                        _FixForUTF16Regex._produce_char_char_set(
                             code=high_end, range_start=0xDC00, range_end=low_end
                         )
                     )
@@ -446,7 +446,7 @@ class _FixForUTF16Regex(parse_retree.BaseVisitor):
         for concatenant in node.concatenants:
             if isinstance(concatenant.value, parse_retree.Char):
                 new_concatenants.extend(
-                    _FixForUTF16Regex._expand_character_literal_to_surrogates_if_necessary(
+                    _FixForUTF16Regex._character_literal_to_surrogates_if_necessary(
                         term=concatenant
                     )
                 )

--- a/aas_core_codegen/infer_for_schema/_stringify.py
+++ b/aas_core_codegen/infer_for_schema/_stringify.py
@@ -43,15 +43,18 @@ def _stringify_constraints_by_property(that: ConstraintsByProperty) -> stringify
         properties=[
             stringify.Property(
                 "len_constraints_by_property",
+                # fmt: off
                 collections.OrderedDict(
                     [
                         # NOTE (mristin, 2022-05-18):
                         # Mypy could not infer that an identifier is also a string.
                         # Hence, we need to explicitly convert to a str here.
                         (str(prop.name), _stringify_len_constraint(len_constraint))
-                        for prop, len_constraint in that.len_constraints_by_property.items()
+                        for prop, len_constraint in
+                        that.len_constraints_by_property.items()
                     ]
                 ),
+                # fmt: on
             ),
             stringify.Property(
                 "patterns_by_property",
@@ -67,7 +70,10 @@ def _stringify_constraints_by_property(that: ConstraintsByProperty) -> stringify
                                 for pattern_constraint in pattern_constraints
                             ],
                         )
-                        for prop, pattern_constraints in that.patterns_by_property.items()
+                        # fmt: off
+                        for prop, pattern_constraints in
+                        that.patterns_by_property.items()
+                        # fmt: on
                     ]
                 ),
             ),

--- a/aas_core_codegen/intermediate/_translate.py
+++ b/aas_core_codegen/intermediate/_translate.py
@@ -518,7 +518,8 @@ def _to_summary_remarks_constraints_description(
                 Error(
                     parsed.node,
                     f"Expected all constraints to have unique identifiers, "
-                    f"but two or more constraints share the identifier: {constraint_id}",
+                    f"but two or more constraints share "
+                    f"the identifier: {constraint_id}",
                 )
             )
 
@@ -961,8 +962,8 @@ def _to_property(
             description=description,
             # NOTE (mristin, 2021-12-26):
             # We can only resolve the ``specified_for`` when the class is actually
-            # created. Therefore, we assign here a placeholder and fix it later in a second
-            # pass.
+            # created. Therefore, we assign here a placeholder and fix it later
+            # in a second pass.
             specified_for=_PlaceholderOurType(parsed_cls.name),  # type: ignore
             parsed=parsed,
         ),
@@ -1564,8 +1565,8 @@ def _to_class(
     return (
         factory_to_use(
             name=parsed.name,
-            # Use a placeholder for inheritances, descendants and the interface as we can
-            # not resolve inheritances at this point
+            # Use a placeholder for inheritances, descendants and the interface as we
+            # can not resolve inheritances at this point
             inheritances=[],
             interface=_MaybeInterfacePlaceholder(),  # type: ignore
             descendants=[],
@@ -1659,7 +1660,8 @@ def _to_verification_function(
             errors.append(
                 Error(
                     parsed.node,
-                    f"We do not know how to interpret the verification function {name!r} "
+                    f"We do not know how to interpret "
+                    f"the verification function {name!r} "
                     f"as it does not match our pre-defined interpretation rules. "
                     f"Please contact the developers if you expect this function "
                     f"to be understood.",
@@ -2252,7 +2254,8 @@ def _second_pass_to_resolve_resulting_class_of_specified_for(
             for method in our_type.methods:
                 assert isinstance(method.specified_for, _PlaceholderOurType), (
                     f"Expected the placeholder for our type for ``specified_for`` in "
-                    f"the method {method} of {our_type}, but got: {method.specified_for}"
+                    f"the method {method} of {our_type}, "
+                    f"but got: {method.specified_for}"
                 )
 
                 # NOTE (mristin, 2022-01-02):
@@ -2670,7 +2673,8 @@ def _second_pass_to_stack_methods_in_place(symbol_table: SymbolTable) -> List[Er
                             method.parsed.node,
                             f"We do not support the overriding of the methods, "
                             f"but the method {method.name!r} is specified both in "
-                            f"the class {our_type.name!r} and in {conflicting_parent!r}; "
+                            f"the class {our_type.name!r} "
+                            f"and in {conflicting_parent!r}; "
                             f"if you need this functionality please contact "
                             f"the developers.",
                         )
@@ -3677,7 +3681,8 @@ def _assert_all_class_inheritances_defined_an_interface(
 
         for inheritance in our_type.inheritances:
             assert isinstance(inheritance.interface, Interface), (
-                f"Since the class {our_type.name!r} inherits from {inheritance.name!r}, "
+                f"Since the class {our_type.name!r} inherits "
+                f"from {inheritance.name!r}, "
                 f"we expect that the class {inheritance.name!r} also has an interface "
                 f"defined for it, but it does not."
             )

--- a/aas_core_codegen/intermediate/rendering.py
+++ b/aas_core_codegen/intermediate/rendering.py
@@ -76,7 +76,8 @@ class DocutilsElementTransformer(Generic[T], DBC):
         else:
             return None, [
                 (
-                    f"Handling of the element of a description with type {type(element)} "
+                    f"Handling of the element of a description "
+                    f"with type {type(element)} "
                     f"has not been implemented: {element}"
                 )
             ]

--- a/aas_core_codegen/intermediate/type_inference.py
+++ b/aas_core_codegen/intermediate/type_inference.py
@@ -734,8 +734,8 @@ class Canonicalizer(parse_tree.RestrictedTransformer[str]):
 
             # NOTE (mristin, 2022-06-17):
             # Nested returns are not possible in Python, but who knows where our
-            # intermediate representation will take us. Therefore, we handle this edge case
-            # even though it seems nonsensical at the moment.
+            # intermediate representation will take us. Therefore, we handle
+            # this edge case even though it seems nonsensical at the moment.
             if isinstance(node.value, parse_tree.Return):
                 value = f"({value})"
 
@@ -1000,11 +1000,12 @@ class Inferrer(parse_tree.RestrictedTransformer[Optional["TypeAnnotationUnion"]]
                         canonical_repr = self._representation_map[value.value]
                         self._non_null.increment(canonical_repr)
 
+                        # fmt: off
                         exit_stack.callback(
-                            lambda a_canonical_repr=canonical_repr: self._non_null.decrement(
-                                a_canonical_repr
-                            )
+                            lambda a_canonical_repr=canonical_repr:
+                            self._non_null.decrement(a_canonical_repr)
                         )
+                        # fmt: on
             else:
                 # NOTE (mristin, 2022-06-17):
                 # We do not know how to infer any non-nullness in this case.
@@ -1232,11 +1233,12 @@ class Inferrer(parse_tree.RestrictedTransformer[Optional["TypeAnnotationUnion"]]
                     canonical_repr = self._representation_map[value.value]
                     self._non_null.increment(canonical_repr)
 
+                    # fmt: off
                     exit_stack.callback(
-                        lambda a_canonical_repr=canonical_repr: self._non_null.decrement(
-                            a_canonical_repr
-                        )
+                        lambda a_canonical_repr=canonical_repr:
+                        self._non_null.decrement(a_canonical_repr)
                     )
+                    # fmt: on
 
         result = PrimitiveTypeAnnotation(PrimitiveType.BOOL)
         self.type_map[node] = result

--- a/aas_core_codegen/main.py
+++ b/aas_core_codegen/main.py
@@ -1,4 +1,4 @@
-"""Generate different implementations and schemas based on an AAS meta-model."""
+"""Generate implementations and schemas based on an AAS meta-model."""
 
 import argparse
 import enum

--- a/aas_core_codegen/parse/_translate.py
+++ b/aas_core_codegen/parse/_translate.py
@@ -1166,7 +1166,8 @@ def _class_decorator_to_marker(
             None,
             Error(
                 decorator,
-                f"The handling of the marker has not been implemented: {decorator.id!r}",
+                f"The handling of the marker has not been "
+                f"implemented: {decorator.id!r}",
             ),
         )
 

--- a/aas_core_codegen/rdf_shacl/shacl.py
+++ b/aas_core_codegen/rdf_shacl/shacl.py
@@ -142,9 +142,9 @@ def _define_property_shape(
             return None, Error(
                 prop.parsed.node,
                 f"(mristin, 2022-02-09): "
-                f"We did not implement how to specify the length constraint on the type "
-                f"{type_anno}. If you see this message, it is time to implement "
-                f"this logic.",
+                f"We did not implement how to specify the length constraint "
+                f"on the type {type_anno}. If you see this message, it is time "
+                f"to implement this logic.",
             )
 
     if min_count is not None:

--- a/continuous_integration/check_help_in_readme.py
+++ b/continuous_integration/check_help_in_readme.py
@@ -78,8 +78,8 @@ def capture_output_lines(command: str) -> List[str]:
     """Capture the output of a help command."""
     command_parts = command.split(" ")
     if command_parts[0] in ["python", "python3"]:
-        # We need to replace "python" with "sys.executable" on Windows as the environment
-        # is not properly inherited.
+        # We need to replace "python" with "sys.executable" on Windows as
+        # the environment is not properly inherited.
         command_parts[0] = sys.executable
 
     proc = None  # type: Optional[subprocess.Popen[str]]

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open(os.path.join(here, "requirements.txt"), encoding="utf-8") as fid:
 setup(
     name="aas-core-codegen",
     version="0.0.15",
-    description="Generate different implementations and schemas based on an AAS meta-model.",
+    description="Generate implementations and schemas based on an AAS meta-model.",
     long_description=long_description,
     url="https://github.com/aas-core-works/aas-core-codegen",
     author="Marko Ristin, Nico Braunisch, Robert Lehmann",

--- a/tests/csharp/test_main.py
+++ b/tests/csharp/test_main.py
@@ -45,9 +45,8 @@ class Test_against_recorded(unittest.TestCase):
                         expected_output_dir.exists() and expected_output_dir.is_dir()
                     ), expected_output_dir
 
-                    tmp_dir = (
-                        tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
-                    )
+                    # pylint: disable=consider-using-with
+                    tmp_dir = tempfile.TemporaryDirectory()
                     exit_stack.push(tmp_dir)
                     output_dir = pathlib.Path(tmp_dir.name)
 

--- a/tests/our_jsonschema/test_main.py
+++ b/tests/our_jsonschema/test_main.py
@@ -63,9 +63,8 @@ class Test_against_recorded(unittest.TestCase):
                         expected_output_dir.exists() and expected_output_dir.is_dir()
                     ), expected_output_dir
 
-                    tmp_dir = (
-                        tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
-                    )
+                    # pylint: disable=consider-using-with
+                    tmp_dir = tempfile.TemporaryDirectory()
                     exit_stack.push(tmp_dir)
                     output_dir = pathlib.Path(tmp_dir.name)
 

--- a/tests/rdf_shacl/test_main.py
+++ b/tests/rdf_shacl/test_main.py
@@ -46,9 +46,8 @@ class Test_against_recorded(unittest.TestCase):
                         expected_output_dir.exists() and expected_output_dir.is_dir()
                     ), expected_output_dir
 
-                    tmp_dir = (
-                        tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
-                    )
+                    # pylint: disable=consider-using-with
+                    tmp_dir = tempfile.TemporaryDirectory()
                     exit_stack.push(tmp_dir)
                     output_dir = pathlib.Path(tmp_dir.name)
 


### PR DESCRIPTION
We make a couple of minor reformats and renamings so that the code lines
fit to lines of 88 characters.

We left out URLs as they are since we would lose the ability to click on
them otherwise.