### PR TITLE
Introduce more of ``must_find_*`` methods

### DIFF
--- a/aas_core_codegen/intermediate/_hierarchy.py
+++ b/aas_core_codegen/intermediate/_hierarchy.py
@@ -260,10 +260,9 @@ def _topologically_sort(
             if an_identifier in parse.PRIMITIVE_TYPES:
                 continue
 
-            another_our_type = parsed_symbol_table.must_find_our_type(an_identifier)
-            assert isinstance(another_our_type, parse.Class)
+            another_cls = parsed_symbol_table.must_find_class(an_identifier)
 
-            visit(cls=another_our_type)
+            visit(cls=another_cls)
 
         temporary_marks.remove(cls)
         permanent_marks.add(cls)

--- a/aas_core_codegen/intermediate/_types.py
+++ b/aas_core_codegen/intermediate/_types.py
@@ -1934,12 +1934,145 @@ class SymbolTable:
         """
         Find our type with the given ``name``.
 
-        :raise: :py:class:`KeyError` if the ``name`` is not in the table.
+        :raise: :py:class:`KeyError` if the ``name`` is not in our types.
         """
         result = self.find_our_type(name)
         if result is None:
-            raise KeyError(
-                f"Could not find our type with the name {name} " f"in the symbol table"
+            raise KeyError(name)
+
+        return result
+
+    def must_find_enumeration(self, name: Identifier) -> "Enumeration":
+        """
+        Find the enumeration with the given ``name``.
+
+        :raise: :py:class:`KeyError` if the ``name`` is not in our types.
+        :raise:
+            :py:class:`TypeError` if the ``name`` is our type,
+            but is not an enumeration.
+        """
+        result = self.find_our_type(name)
+        if result is None:
+            raise KeyError(name)
+
+        if not isinstance(result, Enumeration):
+            raise TypeError(
+                f"Found {name} in our types; "
+                f"expected an instance of {Enumeration.__name__}, "
+                f"but got {type(result)}: {result}"
+            )
+
+        return result
+
+    def must_find_constrained_primitive(
+        self, name: Identifier
+    ) -> "ConstrainedPrimitive":
+        """
+        Find the constrained primitive with the given ``name``.
+
+        :raise: :py:class:`KeyError` if the ``name`` is not in our types.
+        :raise:
+            :py:class:`TypeError` if the ``name`` is our type,
+            but is not a constrained primitive.
+        """
+        result = self.find_our_type(name)
+        if result is None:
+            raise KeyError(name)
+
+        if not isinstance(result, ConstrainedPrimitive):
+            raise TypeError(
+                f"Found {name} in our types; "
+                f"expected an instance of {ConstrainedPrimitive.__name__}, "
+                f"but got {type(result)}: {result}"
+            )
+
+        return result
+
+    def must_find_class(self, name: Identifier) -> "ClassUnion":
+        """
+        Find the class with the given ``name``.
+
+        :raise: :py:class:`KeyError` if the ``name`` is not in our types.
+        :raise: :py:class:`TypeError` if the ``name`` is our type, but is not a class.
+        """
+        result = self.find_our_type(name)
+        if result is None:
+            raise KeyError(name)
+
+        if not isinstance(result, (AbstractClass, ConcreteClass)):
+            raise TypeError(
+                f"Found {name} in our types; "
+                f"expected an instance of {ClassUnion}, "
+                f"but got {type(result)}: {result}"
+            )
+
+        return result
+
+    def must_find_abstract_class(self, name: Identifier) -> "AbstractClass":
+        """
+        Find the abstract class with the given ``name``.
+
+        :raise: :py:class:`KeyError` if the ``name`` is not in our types.
+        :raise:
+            :py:class:`TypeError` if the ``name`` is our type,
+            but is not an abstract class.
+        """
+        result = self.find_our_type(name)
+        if result is None:
+            raise KeyError(name)
+
+        if not isinstance(result, AbstractClass):
+            raise TypeError(
+                f"Found {name} in our types; "
+                f"expected an instance of {AbstractClass.__name__}, "
+                f"but got {type(result)}: {result}"
+            )
+
+        return result
+
+    def must_find_concrete_class(self, name: Identifier) -> "ConcreteClass":
+        """
+        Find the concrete class with the given ``name``.
+
+        :raise: :py:class:`KeyError` if the ``name`` is not in our types.
+        :raise:
+            :py:class:`TypeError` if the ``name`` is our type,
+            but is not a concrete class.
+        """
+        result = self.find_our_type(name)
+        if result is None:
+            raise KeyError(name)
+
+        if not isinstance(result, ConcreteClass):
+            raise TypeError(
+                f"Found {name} in our types; "
+                f"expected an instance of {ConcreteClass.__name__}, "
+                f"but got {type(result)}: {result}"
+            )
+
+        return result
+
+    def must_find_class_or_constrained_primitive(
+        self, name: Identifier
+    ) -> Union["ClassUnion", ConstrainedPrimitive]:
+        """
+        Find the class with the given ``name``.
+
+        :raise: :py:class:`KeyError` if the ``name`` is not in our types.
+        :raise:
+            :py:class:`TypeError` if the ``name`` is our type, but is neither a class
+            nor a constrained primitive
+        """
+        result = self.find_our_type(name)
+        if result is None:
+            raise KeyError(name)
+
+        if not isinstance(result, (AbstractClass, ConcreteClass, ConstrainedPrimitive)):
+            raise TypeError(
+                f"Found {name} in our types; "
+                f"expected an instance of either {AbstractClass.__name__}, "
+                f"{ConcreteClass.__name__} or {ConstrainedPrimitive.__name__},"
+                f"but got {type(result)}: {result}"
             )
 
         return result

--- a/aas_core_codegen/parse/_types.py
+++ b/aas_core_codegen/parse/_types.py
@@ -772,11 +772,7 @@ class UnverifiedSymbolTable(DBC):
         :raise: :py:class:`NameError` if the name is not in the symbol table.
         :raise: :py:class:`TypeError` if our type is not a class.
         """
-        our_type = self._name_to_our_type.get(name, None)
-        if our_type is None:
-            raise NameError(
-                f"Our type {name!r} could not be found in the symbol table."
-            )
+        our_type = self.must_find_our_type(name)
 
         if not isinstance(our_type, Class):
             raise TypeError(

--- a/tests/csharp/test_description.py
+++ b/tests/csharp/test_description.py
@@ -86,11 +86,11 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
         assert error is None, tests.common.most_underlying_messages(error)
         assert symbol_table is not None
 
-        some_class = symbol_table.must_find_our_type(Identifier("Some_class"))
-        assert some_class.description is not None
+        something_type = symbol_table.must_find_our_type(Identifier("Something"))
+        assert something_type.description is not None
 
         code, errors = csharp_description.generate_comment_for_our_type(
-            some_class.description
+            something_type.description
         )
         assert errors is None, tests.common.most_underlying_messages(errors)
 
@@ -175,7 +175,7 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
         comment_code = Test_to_render_description_of_our_types.render(
             textwrap.dedent(
                 '''\
-                class Some_class:
+                class Something:
                     """Do & drink something."""
 
                 __book_url__ = "dummy"
@@ -198,8 +198,8 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
         comment_code = Test_to_render_description_of_our_types.render(
             textwrap.dedent(
                 '''\
-                class Some_class:
-                    """Do & drink :class:`.Some_class`."""
+                class Something:
+                    """Do & drink :class:`.Something`."""
 
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
@@ -211,7 +211,7 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
             textwrap.dedent(
                 """\
                 /// <summary>
-                /// Do &amp; drink <see cref="Aas.SomeClass" />.
+                /// Do &amp; drink <see cref="Aas.Something" />.
                 /// </summary>"""
             ),
             comment_code,
@@ -222,8 +222,8 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
             textwrap.dedent(
                 '''\
                 @abstract
-                class Some_class:
-                    """Do & drink :class:`.Some_class`."""
+                class Something:
+                    """Do & drink :class:`.Something`."""
 
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
@@ -235,7 +235,7 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
             textwrap.dedent(
                 """\
                 /// <summary>
-                /// Do &amp; drink <see cref="Aas.ISomeClass" />.
+                /// Do &amp; drink <see cref="Aas.ISomething" />.
                 /// </summary>"""
             ),
             comment_code,
@@ -245,8 +245,8 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
         comment_code = Test_to_render_description_of_our_types.render(
             textwrap.dedent(
                 '''\
-                class Some_class(Enum):
-                    """Do & drink :class:`.Some_class`."""
+                class Something(Enum):
+                    """Do & drink :class:`.Something`."""
 
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
@@ -258,7 +258,7 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
             textwrap.dedent(
                 """\
                 /// <summary>
-                /// Do &amp; drink <see cref="Aas.SomeClass" />.
+                /// Do &amp; drink <see cref="Aas.Something" />.
                 /// </summary>"""
             ),
             comment_code,
@@ -268,7 +268,7 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
         comment_code = Test_to_render_description_of_our_types.render(
             textwrap.dedent(
                 '''\
-                class Some_class:
+                class Something:
                     """
                     Do & drink something.
 
@@ -302,7 +302,7 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
         comment_code = Test_to_render_description_of_our_types.render(
             textwrap.dedent(
                 '''\
-                class Some_class:
+                class Something:
                     """
                     Do & drink something.
 

--- a/tests/infer_for_schema/common.py
+++ b/tests/infer_for_schema/common.py
@@ -18,10 +18,7 @@ def parse_to_symbol_table_and_something_cls(
     symbol_table, error = tests.common.translate_source_to_intermediate(source=source)
     assert error is None, tests.common.most_underlying_messages(error)
     assert symbol_table is not None
-    something_cls = symbol_table.must_find_our_type(Identifier("Something"))
-    assert isinstance(
-        something_cls, (intermediate.AbstractClass, intermediate.ConcreteClass)
-    )
+    something_cls = symbol_table.must_find_class(Identifier("Something"))
 
     return symbol_table, something_cls
 

--- a/tests/intermediate/test_translate.py
+++ b/tests/intermediate/test_translate.py
@@ -63,8 +63,7 @@ class Test_in_lining_of_constructor_statements(unittest.TestCase):
 
         assert symbol_table is not None
 
-        concrete = symbol_table.must_find_our_type(Identifier("Concrete"))
-        assert isinstance(concrete, intermediate.Class)
+        concrete = symbol_table.must_find_class(Identifier("Concrete"))
 
         self.assertEqual(
             ["some_property", "another_property", "yet_another_property"],
@@ -95,8 +94,7 @@ class Test_parsing_docstrings(unittest.TestCase):
 
         assert symbol_table is not None
 
-        some_class = symbol_table.must_find_our_type(Identifier("Some_class"))
-        assert isinstance(some_class, intermediate.Class)
+        some_class = symbol_table.must_find_class(Identifier("Some_class"))
 
         assert some_class.description is not None
         assert len(some_class.description.remarks) == 1
@@ -135,8 +133,7 @@ class Test_parsing_docstrings(unittest.TestCase):
 
         assert symbol_table is not None
 
-        some_class = symbol_table.must_find_our_type(Identifier("Some_class"))
-        assert isinstance(some_class, intermediate.Class)
+        some_class = symbol_table.must_find_class(Identifier("Some_class"))
 
         assert some_class.description is not None
         assert len(some_class.description.remarks) == 1

--- a/tests/intermediate/test_types.py
+++ b/tests/intermediate/test_types.py
@@ -32,13 +32,11 @@ class TestIsSubclassOf(unittest.TestCase):
 
         assert symbol_table is not None
 
-        concrete = symbol_table.must_find_our_type(Identifier("Concrete"))
-        assert isinstance(concrete, intermediate.ConcreteClass)
+        concrete = symbol_table.must_find_concrete_class(Identifier("Concrete"))
 
-        another_concrete = symbol_table.must_find_our_type(
+        another_concrete = symbol_table.must_find_concrete_class(
             Identifier("AnotherConcrete")
         )
-        assert isinstance(another_concrete, intermediate.ConcreteClass)
 
         self.assertTrue(concrete.is_subclass_of(cls=concrete))
         self.assertFalse(concrete.is_subclass_of(cls=another_concrete))
@@ -70,16 +68,13 @@ class TestIsSubclassOf(unittest.TestCase):
 
         assert symbol_table is not None
 
-        parent = symbol_table.must_find_our_type(Identifier("Parent"))
-        assert isinstance(parent, intermediate.ConcreteClass)
+        parent = symbol_table.must_find_concrete_class(Identifier("Parent"))
 
-        concrete = symbol_table.must_find_our_type(Identifier("Concrete"))
-        assert isinstance(concrete, intermediate.ConcreteClass)
+        concrete = symbol_table.must_find_concrete_class(Identifier("Concrete"))
 
-        another_concrete = symbol_table.must_find_our_type(
+        another_concrete = symbol_table.must_find_concrete_class(
             Identifier("AnotherConcrete")
         )
-        assert isinstance(another_concrete, intermediate.ConcreteClass)
 
         self.assertTrue(concrete.is_subclass_of(cls=concrete))
         self.assertTrue(concrete.is_subclass_of(cls=parent))
@@ -116,19 +111,15 @@ class TestIsSubclassOf(unittest.TestCase):
 
         assert symbol_table is not None
 
-        grand_parent = symbol_table.must_find_our_type(Identifier("GrandParent"))
-        assert isinstance(grand_parent, intermediate.ConcreteClass)
+        grand_parent = symbol_table.must_find_concrete_class(Identifier("GrandParent"))
 
-        parent = symbol_table.must_find_our_type(Identifier("Parent"))
-        assert isinstance(parent, intermediate.ConcreteClass)
+        parent = symbol_table.must_find_concrete_class(Identifier("Parent"))
 
-        concrete = symbol_table.must_find_our_type(Identifier("Concrete"))
-        assert isinstance(concrete, intermediate.ConcreteClass)
+        concrete = symbol_table.must_find_concrete_class(Identifier("Concrete"))
 
-        another_concrete = symbol_table.must_find_our_type(
+        another_concrete = symbol_table.must_find_concrete_class(
             Identifier("AnotherConcrete")
         )
-        assert isinstance(another_concrete, intermediate.ConcreteClass)
 
         self.assertTrue(concrete.is_subclass_of(cls=concrete))
         self.assertTrue(concrete.is_subclass_of(cls=parent))
@@ -162,16 +153,13 @@ class TestIsSubclassOf(unittest.TestCase):
 
         assert symbol_table is not None
 
-        parent = symbol_table.must_find_our_type(Identifier("Parent"))
-        assert isinstance(parent, intermediate.ConcreteClass)
+        parent = symbol_table.must_find_concrete_class(Identifier("Parent"))
 
-        concrete = symbol_table.must_find_our_type(Identifier("Concrete"))
-        assert isinstance(concrete, intermediate.ConcreteClass)
+        concrete = symbol_table.must_find_concrete_class(Identifier("Concrete"))
 
-        another_concrete = symbol_table.must_find_our_type(
+        another_concrete = symbol_table.must_find_concrete_class(
             Identifier("AnotherConcrete")
         )
-        assert isinstance(another_concrete, intermediate.ConcreteClass)
 
         self.assertTrue(concrete.is_subclass_of(cls=concrete))
         self.assertTrue(concrete.is_subclass_of(cls=parent))


### PR DESCRIPTION
We look up our types in the symbol very often. Hence, we implement a
couple of helper methods, ``must_find_*`` to facilitate the typing
around the lookups.