### PR TITLE
Fix parsing of book URL and version

### DIFF
--- a/aas_core_codegen/parse/_translate.py
+++ b/aas_core_codegen/parse/_translate.py
@@ -2531,9 +2531,9 @@ def _atok_to_symbol_table(
             matched = True
 
             if node.targets[0].id == "__book_url__":
-                book_url = node.targets[0].id
+                book_url = node.value.value
             elif node.targets[0].id == "__book_version__":
-                book_version = node.targets[0].id
+                book_version = node.value.value
             else:
                 underlying_errors.append(
                     Error(

--- a/test_data/intermediate/expected/class/empty/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/class/empty/expected_symbol_table.txt
@@ -39,5 +39,5 @@ SymbolTable(
   verification_functions_by_name=...,
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/intermediate/expected/class/implementation_specific_method/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/class/implementation_specific_method/expected_symbol_table.txt
@@ -60,5 +60,5 @@ SymbolTable(
   verification_functions_by_name=...,
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/intermediate/expected/class/inheritance/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/class/inheritance/expected_symbol_table.txt
@@ -463,5 +463,5 @@ SymbolTable(
   verification_functions_by_name=...,
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/intermediate/expected/class/methods_with_contracts/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/class/methods_with_contracts/expected_symbol_table.txt
@@ -134,5 +134,5 @@ SymbolTable(
   verification_functions_by_name=...,
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/intermediate/expected/class/only_method_no_property/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/class/only_method_no_property/expected_symbol_table.txt
@@ -61,5 +61,5 @@ SymbolTable(
   verification_functions_by_name=...,
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/intermediate/expected/class/only_property_no_method/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/class/only_property_no_method/expected_symbol_table.txt
@@ -59,5 +59,5 @@ SymbolTable(
   verification_functions_by_name=...,
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/intermediate/expected/empty/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/empty/expected_symbol_table.txt
@@ -5,5 +5,5 @@ SymbolTable(
   verification_functions_by_name=...,
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/intermediate/expected/enumeration/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/enumeration/expected_symbol_table.txt
@@ -26,5 +26,5 @@ SymbolTable(
   verification_functions_by_name=...,
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/intermediate/expected/interface/basic/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/interface/basic/expected_symbol_table.txt
@@ -116,5 +116,5 @@ SymbolTable(
   verification_functions_by_name=...,
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/intermediate/expected/interface/empty/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/interface/empty/expected_symbol_table.txt
@@ -49,5 +49,5 @@ SymbolTable(
   verification_functions_by_name=...,
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/intermediate/expected/interface/inheritance/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/interface/inheritance/expected_symbol_table.txt
@@ -270,5 +270,5 @@ SymbolTable(
   verification_functions_by_name=...,
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/intermediate/expected/interface/method_signature/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/interface/method_signature/expected_symbol_table.txt
@@ -121,5 +121,5 @@ SymbolTable(
   verification_functions_by_name=...,
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/intermediate/expected/interface/only_constructor/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/interface/only_constructor/expected_symbol_table.txt
@@ -77,5 +77,5 @@ SymbolTable(
   verification_functions_by_name=...,
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/intermediate/expected/type_annotation/atomic/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/type_annotation/atomic/expected_symbol_table.txt
@@ -59,5 +59,5 @@ SymbolTable(
   verification_functions_by_name=...,
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/intermediate/expected/type_annotation/subscripted/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/type_annotation/subscripted/expected_symbol_table.txt
@@ -101,5 +101,5 @@ SymbolTable(
   verification_functions_by_name=...,
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/intermediate/real_meta_models/aas_core_meta.v3rc2/expected_symbol_table.txt
+++ b/test_data/intermediate/real_meta_models/aas_core_meta.v3rc2/expected_symbol_table.txt
@@ -23438,5 +23438,5 @@ SymbolTable(
           'AASd-003',
           '<field_body><paragraph><ReferenceToAttribute refuri="Referable.id_short">Referable.id_short</ReferenceToAttribute> of <ReferenceToOurType refuri=".Referable">.Referable</ReferenceToOurType>\'s shall be matched case-sensitive.</paragraph></field_body>']],
       parsed=...),
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/Details_of_the_Asset_Administration_Shell_Part1_V3.pdf?__blob=publicationFile&v=10',
+    book_version='V3.0RC02'))

--- a/test_data/parse/expected/enum/ok/expected_symbol_table.txt
+++ b/test_data/parse/expected/enum/ok/expected_symbol_table.txt
@@ -25,5 +25,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/expected/implementation_specific_class/properties_and_methods_in_implementation_specific_class/expected_symbol_table.txt
+++ b/test_data/parse/expected/implementation_specific_class/properties_and_methods_in_implementation_specific_class/expected_symbol_table.txt
@@ -41,5 +41,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/expected/inheritance/basic/expected_symbol_table.txt
+++ b/test_data/parse/expected/inheritance/basic/expected_symbol_table.txt
@@ -30,5 +30,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/expected/inheritance/diamond/expected_symbol_table.txt
+++ b/test_data/parse/expected/inheritance/diamond/expected_symbol_table.txt
@@ -74,5 +74,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/expected/inheritance/inheritance_from_concrete_class/expected_symbol_table.txt
+++ b/test_data/parse/expected/inheritance/inheritance_from_concrete_class/expected_symbol_table.txt
@@ -30,5 +30,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/expected/method/arguments/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/arguments/expected_symbol_table.txt
@@ -41,5 +41,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/expected/method/basic/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/basic/expected_symbol_table.txt
@@ -34,5 +34,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/expected/method/contracts/condition_as_keyword_argument/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/contracts/condition_as_keyword_argument/expected_symbol_table.txt
@@ -50,5 +50,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/expected/method/contracts/condition_as_positional_argument/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/contracts/condition_as_positional_argument/expected_symbol_table.txt
@@ -50,5 +50,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/expected/method/contracts/description_as_keyword_argument/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/contracts/description_as_keyword_argument/expected_symbol_table.txt
@@ -50,5 +50,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/expected/method/contracts/description_as_positional_argument/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/contracts/description_as_positional_argument/expected_symbol_table.txt
@@ -50,5 +50,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/expected/method/contracts/multiple_contracts_in_order/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/contracts/multiple_contracts_in_order/expected_symbol_table.txt
@@ -85,5 +85,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/expected/method/contracts/postcondition/basic/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/contracts/postcondition/basic/expected_symbol_table.txt
@@ -57,5 +57,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/expected/method/contracts/postcondition/snapshot/with_keyword_arguments/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/contracts/postcondition/snapshot/with_keyword_arguments/expected_symbol_table.txt
@@ -67,5 +67,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/expected/method/contracts/postcondition/snapshot/with_positional_arguments/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/contracts/postcondition/snapshot/with_positional_arguments/expected_symbol_table.txt
@@ -67,5 +67,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/expected/method/default/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/default/expected_symbol_table.txt
@@ -62,5 +62,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/expected/method/description/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/description/expected_symbol_table.txt
@@ -36,5 +36,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/expected/method/is_implementation_specific/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/is_implementation_specific/expected_symbol_table.txt
@@ -33,5 +33,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/expected/method/returns_none/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/returns_none/expected_symbol_table.txt
@@ -34,5 +34,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/expected/method/returns_something/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/returns_something/expected_symbol_table.txt
@@ -36,5 +36,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/expected/reference_in_the_book/on_all_symbols/expected_symbol_table.txt
+++ b/test_data/parse/expected/reference_in_the_book/on_all_symbols/expected_symbol_table.txt
@@ -59,5 +59,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/expected/reference_in_the_book/only_section/expected_symbol_table.txt
+++ b/test_data/parse/expected/reference_in_the_book/only_section/expected_symbol_table.txt
@@ -39,5 +39,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/expected/reference_in_the_book/section_and_index/expected_symbol_table.txt
+++ b/test_data/parse/expected/reference_in_the_book/section_and_index/expected_symbol_table.txt
@@ -39,5 +39,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/expected/reference_in_the_book/section_index_and_fragment/expected_symbol_table.txt
+++ b/test_data/parse/expected/reference_in_the_book/section_index_and_fragment/expected_symbol_table.txt
@@ -39,5 +39,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/expected/single_class/description/expected_symbol_table.txt
+++ b/test_data/parse/expected/single_class/description/expected_symbol_table.txt
@@ -18,5 +18,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/expected/single_class/empty/expected_symbol_table.txt
+++ b/test_data/parse/expected/single_class/empty/expected_symbol_table.txt
@@ -16,5 +16,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/expected/single_class/property/description/expected_symbol_table.txt
+++ b/test_data/parse/expected/single_class/property/description/expected_symbol_table.txt
@@ -43,5 +43,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/expected/single_class/property/mandatory/expected_symbol_table.txt
+++ b/test_data/parse/expected/single_class/property/mandatory/expected_symbol_table.txt
@@ -23,5 +23,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/expected/single_class/property/optional/expected_symbol_table.txt
+++ b/test_data/parse/expected/single_class/property/optional/expected_symbol_table.txt
@@ -27,5 +27,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/expected/single_class/property/recursion_to_entity/expected_symbol_table.txt
+++ b/test_data/parse/expected/single_class/property/recursion_to_entity/expected_symbol_table.txt
@@ -23,5 +23,5 @@ UnverifiedSymbolTable(
   verification_functions=[],
   meta_model=MetaModel(
     description=None,
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='dummy',
+    book_version='dummy'))

--- a/test_data/parse/real_meta_models/aas_core_meta.v3rc2/expected_symbol_table.txt
+++ b/test_data/parse/real_meta_models/aas_core_meta.v3rc2/expected_symbol_table.txt
@@ -15808,5 +15808,5 @@ UnverifiedSymbolTable(
     description=Description(
       document=...,
       node=...),
-    book_url='__book_url__',
-    book_version='__book_version__'))
+    book_url='https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/Details_of_the_Asset_Administration_Shell_Part1_V3.pdf?__blob=publicationFile&v=10',
+    book_version='V3.0RC02'))


### PR DESCRIPTION
We wrongly wired the target and the value when parsing the assingment of
the book URL and version at the parse stage. This patch fixes the issue.