### PR TITLE
Fix parsing for Python 3.9 and 3.10

### DIFF
--- a/.idea/aas-core-csharp-codegen.iml
+++ b/.idea/aas-core-csharp-codegen.iml
@@ -12,7 +12,7 @@
       <excludeFolder url="file://$MODULE_DIR$/venv310" />
       <excludeFolder url="file://$MODULE_DIR$/venv39" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.8 (aas-core-codegen)" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 3.9 (aas-core-codegen)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.8 (aas-core-codegen)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.9 (aas-core-codegen)" project-jdk-type="Python SDK" />
 </project>


### PR DESCRIPTION
The remote CI failed in the previous patch for Python 3.9 and 3.10 due
to breaking changes in the ``ast`` module. This patch fixes the issue by
branching on the Python version.