### PR TITLE
Transpile general verification functions

### DIFF
--- a/aas_core_codegen/csharp/transpilation.py
+++ b/aas_core_codegen/csharp/transpilation.py
@@ -1,0 +1,990 @@
+"""Transpile Python to C# code."""
+import abc
+import io
+from typing import (
+    Tuple,
+    Optional,
+    List,
+    Mapping,
+    Union,
+    Set,
+)
+
+from icontract import ensure
+
+from aas_core_codegen import intermediate
+from aas_core_codegen.common import (
+    Error,
+    Stripped,
+    assert_never,
+    Identifier,
+    indent_but_first_line,
+)
+from aas_core_codegen.csharp import (
+    common as csharp_common,
+    naming as csharp_naming,
+)
+from aas_core_codegen.csharp.common import (
+    INDENT as I,
+    INDENT2 as II,
+)
+from aas_core_codegen.intermediate import type_inference as intermediate_type_inference
+from aas_core_codegen.parse import tree as parse_tree
+
+
+class Transpiler(
+    parse_tree.RestrictedTransformer[Tuple[Optional[Stripped], Optional[Error]]]
+):
+    """Transpile a node of our AST to C# code, or return an error."""
+
+    def __init__(
+        self,
+        type_map: Mapping[
+            parse_tree.Node, intermediate_type_inference.TypeAnnotationUnion
+        ],
+        environment: intermediate_type_inference.Environment,
+    ) -> None:
+        """Initialize with the given values."""
+        self.type_map = type_map
+        self._environment = intermediate_type_inference.MutableEnvironment(
+            parent=environment
+        )
+
+        # Keep track whenever we define a variable name, so that we can know how to
+        # generate the reference in the C# code.
+        self._variable_name_set = set()  # type: Set[Identifier]
+
+    @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
+    def transform_member(
+        self, node: parse_tree.Member
+    ) -> Tuple[Optional[Stripped], Optional[Error]]:
+        instance, error = self.transform(node.instance)
+        if error is not None:
+            return None, error
+
+        # Ignore optionals as they need to be checked before in the code
+        instance_type = intermediate_type_inference.beneath_optional(
+            self.type_map[node.instance]
+        )
+        member_type = intermediate_type_inference.beneath_optional(self.type_map[node])
+
+        # noinspection PyUnusedLocal
+        member_name = None  # type: Optional[str]
+
+        if isinstance(
+            instance_type, intermediate_type_inference.OurTypeAnnotation
+        ) and isinstance(instance_type.our_type, intermediate.Enumeration):
+            # The member denotes a literal of an enumeration.
+            member_name = csharp_naming.enum_literal_name(node.name)
+
+        elif isinstance(member_type, intermediate_type_inference.MethodTypeAnnotation):
+            member_name = csharp_naming.method_name(node.name)
+
+        elif isinstance(
+            instance_type, intermediate_type_inference.OurTypeAnnotation
+        ) and isinstance(instance_type.our_type, intermediate.Class):
+            if node.name in instance_type.our_type.properties_by_name:
+                member_name = csharp_naming.property_name(node.name)
+            else:
+                return None, Error(
+                    node.original_node,
+                    f"The property {node.name!r} has not been defined "
+                    f"in the class {instance_type.our_type.name!r}",
+                )
+
+        elif isinstance(
+            instance_type, intermediate_type_inference.EnumerationAsTypeTypeAnnotation
+        ):
+            if node.name in instance_type.enumeration.literals_by_name:
+                member_name = csharp_naming.enum_literal_name(node.name)
+            else:
+                return None, Error(
+                    node.original_node,
+                    f"The property {node.name!r} has not been defined "
+                    f"in the class {instance_type.enumeration.name!r}",
+                )
+        else:
+            return None, Error(
+                node.original_node,
+                f"We do not know how to generate the member access. The inferred type "
+                f"of the instance was {instance_type}, while the member type "
+                f"was {member_type}. However, we do not know how to resolve "
+                f"the member {node.name!r} in {instance_type}.",
+            )
+
+        assert member_name is not None
+
+        return Stripped(f"{instance}.{member_name}"), None
+
+    @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
+    def transform_index(
+        self, node: parse_tree.Index
+    ) -> Tuple[Optional[Stripped], Optional[Error]]:
+        collection, error = self.transform(node.collection)
+        if error is not None:
+            return None, error
+
+        index, error = self.transform(node.index)
+        if error is not None:
+            return None, error
+        assert index is not None
+
+        index_as_int = None  # type: Optional[int]
+        try:
+            index_as_int = int(index)
+        except ValueError:
+            pass
+
+        if index_as_int is not None and index_as_int < 0:
+            # pylint: disable=invalid-unary-operand-type
+            index = Stripped(f"^{-index_as_int}")
+
+        no_parentheses_types = (
+            parse_tree.Member,
+            parse_tree.FunctionCall,
+            parse_tree.MethodCall,
+            parse_tree.Name,
+            parse_tree.Constant,
+            parse_tree.Index,
+            parse_tree.IsIn,
+        )
+
+        if not isinstance(node.collection, no_parentheses_types):
+            collection = Stripped(f"({collection})")
+
+        return Stripped(f"{collection}[{index}]"), None
+
+    _CSHARP_COMPARISON_MAP = {
+        parse_tree.Comparator.LT: "<",
+        parse_tree.Comparator.LE: "<=",
+        parse_tree.Comparator.GT: ">",
+        parse_tree.Comparator.GE: ">=",
+        parse_tree.Comparator.EQ: "==",
+        parse_tree.Comparator.NE: "!=",
+    }
+
+    @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
+    def transform_comparison(
+        self, node: parse_tree.Comparison
+    ) -> Tuple[Optional[Stripped], Optional[Error]]:
+        comparator = Transpiler._CSHARP_COMPARISON_MAP[node.op]
+
+        errors = []
+
+        left, error = self.transform(node.left)
+        if error is not None:
+            errors.append(error)
+
+        right, error = self.transform(node.right)
+        if error is not None:
+            errors.append(error)
+
+        if len(errors) > 0:
+            return None, Error(
+                node.original_node, "Failed to transpile the comparison", errors
+            )
+
+        no_parentheses_types = (
+            parse_tree.Member,
+            parse_tree.FunctionCall,
+            parse_tree.MethodCall,
+            parse_tree.Name,
+            parse_tree.Constant,
+            parse_tree.IsIn,
+            parse_tree.Index,
+        )
+
+        if isinstance(node.left, no_parentheses_types) and isinstance(
+            node.right, no_parentheses_types
+        ):
+            return Stripped(f"{left} {comparator} {right}"), None
+
+        return Stripped(f"({left}) {comparator} ({right})"), None
+
+    @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
+    def transform_is_in(
+        self, node: parse_tree.IsIn
+    ) -> Tuple[Optional[Stripped], Optional[Error]]:
+        errors = []
+
+        member, error = self.transform(node.member)
+        if error is not None:
+            errors.append(error)
+
+        container, error = self.transform(node.container)
+        if error is not None:
+            errors.append(error)
+
+        if len(errors) > 0:
+            return None, Error(
+                node.original_node,
+                "Failed to transpile the membership relation",
+                errors,
+            )
+
+        no_parentheses_types = (
+            parse_tree.Member,
+            parse_tree.FunctionCall,
+            parse_tree.MethodCall,
+            parse_tree.Name,
+            parse_tree.Constant,
+            parse_tree.IsIn,
+            parse_tree.Index,
+        )
+
+        if not isinstance(node.container, no_parentheses_types):
+            container = Stripped(f"({container})")
+
+        return Stripped(f"{container}.Contains({member})"), None
+
+    @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
+    def transform_implication(
+        self, node: parse_tree.Implication
+    ) -> Tuple[Optional[Stripped], Optional[Error]]:
+        errors = []
+
+        antecedent, error = self.transform(node.antecedent)
+        if error is not None:
+            errors.append(error)
+
+        consequent, error = self.transform(node.consequent)
+        if error is not None:
+            errors.append(error)
+
+        if len(errors) > 0:
+            return None, Error(
+                node.original_node, "Failed to transpile the implication", errors
+            )
+
+        assert antecedent is not None
+        assert consequent is not None
+
+        no_parentheses_types_in_this_context = (
+            parse_tree.Member,
+            parse_tree.FunctionCall,
+            parse_tree.MethodCall,
+            parse_tree.Name,
+            parse_tree.IsIn,
+            parse_tree.Index,
+        )
+
+        if isinstance(node.antecedent, no_parentheses_types_in_this_context):
+            not_antecedent = f"!{antecedent}"
+        else:
+            # NOTE (mristin, 2022-04-07):
+            # This is a very rudimentary heuristic for breaking the lines, and can be
+            # greatly improved by rendering into C# code. However, at this point, we
+            # lack time for more sophisticated reformatting approaches.
+            if "\n" in antecedent:
+                not_antecedent = f"""\
+!(
+{I}{indent_but_first_line(antecedent, I)}
+)"""
+            else:
+                not_antecedent = f"!({antecedent})"
+
+        if not isinstance(node.consequent, no_parentheses_types_in_this_context):
+            # NOTE (mristin, 2022-04-07):
+            # This is a very rudimentary heuristic for breaking the lines, and can be
+            # greatly improved by rendering into C# code. However, at this point, we
+            # lack time for more sophisticated reformatting approaches.
+            if "\n" in consequent:
+                consequent = Stripped(
+                    f"""\
+(
+{I}{indent_but_first_line(consequent, I)}
+)"""
+                )
+            else:
+                consequent = Stripped(f"({consequent})")
+
+        return Stripped(f"{not_antecedent}\n|| {consequent}"), None
+
+    @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
+    def transform_method_call(
+        self, node: parse_tree.MethodCall
+    ) -> Tuple[Optional[Stripped], Optional[Error]]:
+        errors = []  # type: List[Error]
+
+        instance, error = self.transform(node.member.instance)
+        if error is not None:
+            errors.append(error)
+
+        args = []  # type: List[Stripped]
+        for arg_node in node.args:
+            arg, error = self.transform(arg_node)
+            if error is not None:
+                errors.append(error)
+                continue
+
+            assert arg is not None
+
+            args.append(arg)
+
+        if len(errors) > 0:
+            return None, Error(
+                node.original_node, "Failed to transpile the method call", errors
+            )
+
+        assert instance is not None
+
+        if not isinstance(node.member.instance, (parse_tree.Name, parse_tree.Member)):
+            instance = Stripped(f"({instance})")
+
+        method_name = csharp_naming.method_name(node.member.name)
+
+        joined_args = ", ".join(args)
+
+        # Apply heuristic for breaking the lines
+        if len(joined_args) > 50:
+            writer = io.StringIO()
+            writer.write(f"{instance}.{method_name}(\n")
+
+            for i, arg in enumerate(args):
+                writer.write(f"{I}{arg}")
+
+                if i == len(args) - 1:
+                    writer.write(")")
+                else:
+                    writer.write(",\n")
+
+            return Stripped(writer.getvalue()), None
+        else:
+            return Stripped(f"{instance}.{method_name}({joined_args})"), None
+
+    @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
+    def transform_function_call(
+        self, node: parse_tree.FunctionCall
+    ) -> Tuple[Optional[Stripped], Optional[Error]]:
+        errors = []  # type: List[Error]
+
+        args = []  # type: List[Stripped]
+        for arg_node in node.args:
+            arg, error = self.transform(arg_node)
+            if error is not None:
+                errors.append(error)
+                continue
+
+            assert arg is not None
+
+            args.append(arg)
+
+        if len(errors) > 0:
+            return None, Error(
+                node.original_node, "Failed to transpile the function call", errors
+            )
+
+        # NOTE (mristin, 2021-12-16):
+        # The validity of the arguments is checked in
+        # :py:func:`aas_core_codegen.intermediate._translate.translate`, so we do not
+        # have to test for argument arity here.
+
+        func_type = self.type_map[node.name]
+
+        if not isinstance(
+            func_type, intermediate_type_inference.FunctionTypeAnnotationUnionAsTuple
+        ):
+            return None, Error(
+                node.name.original_node,
+                f"Expected the name to refer to a function, "
+                f"but its inferred type was {func_type}",
+            )
+
+        if isinstance(
+            func_type, intermediate_type_inference.VerificationTypeAnnotation
+        ):
+            method_name = csharp_naming.method_name(func_type.func.name)
+
+            joined_args = ", ".join(args)
+
+            # Apply heuristic for breaking the lines
+            if len(joined_args) > 50:
+                writer = io.StringIO()
+                writer.write(f"Verification.{method_name}(\n")
+
+                for i, arg in enumerate(args):
+                    writer.write(f"{I}{arg}")
+
+                    if i == len(args) - 1:
+                        writer.write(")")
+                    else:
+                        writer.write(",\n")
+
+                return Stripped(writer.getvalue()), None
+            else:
+                return Stripped(f"Verification.{method_name}({joined_args})"), None
+
+        elif isinstance(
+            func_type, intermediate_type_inference.BuiltinFunctionTypeAnnotation
+        ):
+            if func_type.func.name == "len":
+                assert len(args) == 1, (
+                    f"Expected exactly one argument, but got: {args}; "
+                    f"this should have been caught before."
+                )
+
+                collection_node = node.args[0]
+                if not isinstance(
+                    collection_node,
+                    (parse_tree.Name, parse_tree.Member, parse_tree.MethodCall),
+                ):
+                    collection = f"({args[0]})"
+                else:
+                    collection = args[0]
+
+                arg_type = self.type_map[node.args[0]]
+                while isinstance(
+                    arg_type, intermediate_type_inference.OptionalTypeAnnotation
+                ):
+                    arg_type = arg_type.value
+
+                if (
+                    isinstance(
+                        arg_type, intermediate_type_inference.PrimitiveTypeAnnotation
+                    )
+                    and arg_type.a_type == intermediate_type_inference.PrimitiveType.STR
+                ):
+                    return Stripped(f"{collection}.Length"), None
+
+                elif (
+                    isinstance(arg_type, intermediate_type_inference.OurTypeAnnotation)
+                    and isinstance(arg_type.our_type, intermediate.ConstrainedPrimitive)
+                    and arg_type.our_type.constrainee == intermediate.PrimitiveType.STR
+                ):
+                    return Stripped(f"{collection}.Length"), None
+
+                elif isinstance(
+                    arg_type, intermediate_type_inference.ListTypeAnnotation
+                ):
+                    return Stripped(f"{collection}.Count"), None
+
+                else:
+                    return None, Error(
+                        node.original_node,
+                        f"We do not know how to compute the length on type {arg_type}",
+                        errors,
+                    )
+            else:
+                return None, Error(
+                    node.original_node,
+                    f"The handling of the built-in function {node.name!r} has not "
+                    f"been implemented",
+                )
+        else:
+            assert_never(func_type)
+
+        raise AssertionError("Should not have gotten here")
+
+    def transform_constant(
+        self, node: parse_tree.Constant
+    ) -> Tuple[Optional[Stripped], Optional[Error]]:
+        if isinstance(node.value, bool):
+            return Stripped("true" if node.value else "false"), None
+        elif isinstance(node.value, (int, float)):
+            return Stripped(str(node.value)), None
+        elif isinstance(node.value, str):
+            return Stripped(csharp_common.string_literal(node.value)), None
+        else:
+            assert_never(node.value)
+
+        raise AssertionError("Should not have gotten here")
+
+    def transform_is_none(
+        self, node: parse_tree.IsNone
+    ) -> Tuple[Optional[Stripped], Optional[Error]]:
+        value, error = self.transform(node.value)
+        if error is not None:
+            return None, error
+
+        no_parentheses_types = (
+            parse_tree.Name,
+            parse_tree.Member,
+            parse_tree.MethodCall,
+            parse_tree.FunctionCall,
+            parse_tree.IsIn,
+            parse_tree.Index,
+        )
+        if isinstance(node.value, no_parentheses_types):
+            return Stripped(f"{value} == null"), None
+        else:
+            return Stripped(f"({value}) == null"), None
+
+    def transform_is_not_none(
+        self, node: parse_tree.IsNotNone
+    ) -> Tuple[Optional[Stripped], Optional[Error]]:
+        value, error = self.transform(node.value)
+        if error is not None:
+            return None, error
+
+        no_parentheses_types_in_this_context = (
+            parse_tree.Name,
+            parse_tree.Member,
+            parse_tree.MethodCall,
+            parse_tree.FunctionCall,
+            parse_tree.IsIn,
+            parse_tree.Index,
+        )
+        if isinstance(node.value, no_parentheses_types_in_this_context):
+            return Stripped(f"{value} != null"), None
+        else:
+            return Stripped(f"({value}) != null"), None
+
+    @abc.abstractmethod
+    def transform_name(
+        self, node: parse_tree.Name
+    ) -> Tuple[Optional[Stripped], Optional[Error]]:
+        raise NotImplementedError()
+
+    def transform_not(
+        self, node: parse_tree.Not
+    ) -> Tuple[Optional[Stripped], Optional[Error]]:
+        operand, error = self.transform(node.operand)
+        if error is not None:
+            return None, error
+
+        no_parentheses_types_in_this_context = (
+            parse_tree.Name,
+            parse_tree.Member,
+            parse_tree.MethodCall,
+            parse_tree.FunctionCall,
+            parse_tree.IsIn,
+            parse_tree.Index,
+        )
+        if not isinstance(node.operand, no_parentheses_types_in_this_context):
+            return Stripped(f"!({operand})"), None
+        else:
+            return Stripped(f"!{operand}"), None
+
+    def transform_and(
+        self, node: parse_tree.And
+    ) -> Tuple[Optional[Stripped], Optional[Error]]:
+        errors = []  # type: List[Error]
+        values = []  # type: List[Stripped]
+
+        for value_node in node.values:
+            value, error = self.transform(value_node)
+            if error is not None:
+                errors.append(error)
+                continue
+
+            assert value is not None
+
+            no_parentheses_types_in_this_context = (
+                parse_tree.Member,
+                parse_tree.MethodCall,
+                parse_tree.FunctionCall,
+                parse_tree.Comparison,
+                parse_tree.Name,
+                parse_tree.IsIn,
+                parse_tree.Index,
+            )
+
+            if not isinstance(value_node, no_parentheses_types_in_this_context):
+                # NOTE (mristin, 2022-04-07):
+                # This is a very rudimentary heuristic for breaking the lines, and can
+                # be greatly improved by rendering into C# code. However, at this point,
+                # we lack time for more sophisticated reformatting approaches.
+                if "\n" in value:
+                    value = Stripped(
+                        f"""\
+(
+{I}{indent_but_first_line(value, I)}
+)"""
+                    )
+                else:
+                    value = Stripped(f"({value})")
+
+            values.append(value)
+
+        if len(errors) > 0:
+            return None, Error(
+                node.original_node, "Failed to transpile the conjunction", errors
+            )
+
+        writer = io.StringIO()
+        for i, value in enumerate(values):
+            if i == 0:
+                writer.write(value)
+            else:
+                writer.write(f"\n&& {value}")
+
+        return Stripped(writer.getvalue()), None
+
+    def transform_or(
+        self, node: parse_tree.Or
+    ) -> Tuple[Optional[Stripped], Optional[Error]]:
+        errors = []  # type: List[Error]
+        values = []  # type: List[Stripped]
+
+        for value_node in node.values:
+            value, error = self.transform(value_node)
+            if error is not None:
+                errors.append(error)
+                continue
+
+            assert value is not None
+
+            no_parentheses_types_in_this_context = (
+                parse_tree.Member,
+                parse_tree.MethodCall,
+                parse_tree.FunctionCall,
+                parse_tree.Comparison,
+                parse_tree.Name,
+                parse_tree.IsIn,
+                parse_tree.Index,
+            )
+
+            if not isinstance(value_node, no_parentheses_types_in_this_context):
+                # NOTE (mristin, 2022-04-07):
+                # This is a very rudimentary heuristic for breaking the lines, and can
+                # be greatly improved by rendering into C# code. However, at this point,
+                # we lack time for more sophisticated reformatting approaches.
+                if "\n" in value:
+                    value = Stripped(
+                        f"""\
+(
+{I}{indent_but_first_line(value, I)}
+)"""
+                    )
+                else:
+                    value = Stripped(f"({value})")
+
+            values.append(value)
+
+        if len(errors) > 0:
+            return None, Error(
+                node.original_node, "Failed to transpile the conjunction", errors
+            )
+
+        writer = io.StringIO()
+        for i, value in enumerate(values):
+            if i == 0:
+                writer.write(value)
+            else:
+                writer.write(f"\n|| {value}")
+
+        return Stripped(writer.getvalue()), None
+
+    def _transform_add_or_sub(
+        self, node: Union[parse_tree.Add, parse_tree.Sub]
+    ) -> Tuple[Optional[Stripped], Optional[Error]]:
+        errors = []  # type: List[Error]
+
+        left, error = self.transform(node.left)
+        if error is not None:
+            errors.append(error)
+
+        right, error = self.transform(node.right)
+        if error is not None:
+            errors.append(error)
+
+        if len(errors) > 0:
+            operation_name = None  # type: Optional[str]
+            if isinstance(node, parse_tree.Add):
+                operation_name = "the addition"
+            elif isinstance(node, parse_tree.Sub):
+                operation_name = "the subtraction"
+            else:
+                assert_never(node)
+
+            return None, Error(
+                node.original_node, f"Failed to transpile {operation_name}", errors
+            )
+
+        no_parentheses_types_in_this_context = (
+            parse_tree.Member,
+            parse_tree.MethodCall,
+            parse_tree.FunctionCall,
+            parse_tree.Constant,
+            parse_tree.Name,
+            parse_tree.IsIn,
+            parse_tree.Index,
+        )
+
+        if not isinstance(node.left, no_parentheses_types_in_this_context):
+            left = Stripped(f"({left})")
+
+        if not isinstance(node.right, no_parentheses_types_in_this_context):
+            right = Stripped(f"({right})")
+
+        if isinstance(node, parse_tree.Add):
+            return Stripped(f"{left} + {right}"), None
+        elif isinstance(node, parse_tree.Sub):
+            return Stripped(f"{left} - {right}"), None
+        else:
+            assert_never(node)
+            raise AssertionError("Unexpected execution path")
+
+    def transform_add(
+        self, node: parse_tree.Add
+    ) -> Tuple[Optional[Stripped], Optional[Error]]:
+        return self._transform_add_or_sub(node)
+
+    def transform_sub(
+        self, node: parse_tree.Sub
+    ) -> Tuple[Optional[Stripped], Optional[Error]]:
+        return self._transform_add_or_sub(node)
+
+    def transform_joined_str(
+        self, node: parse_tree.JoinedStr
+    ) -> Tuple[Optional[Stripped], Optional[Error]]:
+        parts = []  # type: List[str]
+        needs_interpolation = False
+        for value in node.values:
+            if isinstance(value, str):
+                string_literal = csharp_common.string_literal(
+                    value.replace("{", "{{").replace("}", "}}")
+                )
+
+                # We need to remove double-quotes since we are joining everything
+                # ourselves later.
+
+                assert string_literal.startswith('"') and string_literal.endswith('"')
+
+                string_literal_wo_quotes = string_literal[1:-1]
+                parts.append(string_literal_wo_quotes)
+
+            elif isinstance(value, parse_tree.FormattedValue):
+                code, error = self.transform(value.value)
+                if error is not None:
+                    return None, error
+
+                assert code is not None
+
+                assert (
+                    "\n" not in code
+                ), f"New-lines are not expected in formatted values, but got: {code}"
+
+                needs_interpolation = True
+                parts.append(f"{{{code}}}")
+            else:
+                assert_never(value)
+
+        writer = io.StringIO()
+        if needs_interpolation:
+            writer.write('$"')
+        else:
+            writer.write('"')
+
+        for part in parts:
+            writer.write(part)
+
+        writer.write('"')
+
+        return Stripped(writer.getvalue()), None
+
+    def _transform_any_or_all(
+        self, node: Union[parse_tree.Any, parse_tree.All]
+    ) -> Tuple[Optional[Stripped], Optional[Error]]:
+        errors = []  # type: List[Error]
+
+        iteration = None  # type: Optional[Stripped]
+        start = None  # type: Optional[Stripped]
+        end = None  # type: Optional[Stripped]
+
+        if isinstance(node.generator, parse_tree.ForEach):
+            iteration, error = self.transform(node.generator.iteration)
+            if error is not None:
+                errors.append(error)
+        elif isinstance(node.generator, parse_tree.ForRange):
+            start, error = self.transform(node.generator.start)
+            if error is not None:
+                errors.append(error)
+
+            end, error = self.transform(node.generator.end)
+            if error is not None:
+                errors.append(error)
+
+        else:
+            assert_never(node.generator)
+
+        if len(errors) > 0:
+            return None, Error(
+                node.original_node,
+                "Failed to transpile the generator expression",
+                errors,
+            )
+
+        assert (iteration is not None) ^ (start is not None and end is not None)
+
+        variable_name = node.generator.variable.identifier
+        variable_type = self.type_map[node.generator.variable]
+
+        try:
+            self._environment.set(
+                identifier=variable_name, type_annotation=variable_type
+            )
+            self._variable_name_set.add(variable_name)
+
+            condition, error = self.transform(node.condition)
+            if error is not None:
+                errors.append(error)
+
+            variable, error = self.transform(node.generator.variable)
+            if error is not None:
+                errors.append(error)
+
+        finally:
+            self._variable_name_set.remove(variable_name)
+            self._environment.remove(variable_name)
+
+        if len(errors) > 0:
+            return None, Error(
+                node.original_node,
+                "Failed to transpile the generator expression",
+                errors,
+            )
+
+        assert variable is not None
+        assert condition is not None
+
+        qualifier_function = None  # type: Optional[str]
+        if isinstance(node, parse_tree.Any):
+            qualifier_function = "Any"
+        elif isinstance(node, parse_tree.All):
+            qualifier_function = "All"
+        else:
+            assert_never(node)
+
+        source = None  # type: Optional[Stripped]
+        if isinstance(node.generator, parse_tree.ForEach):
+            no_parentheses_types_in_this_context = (
+                parse_tree.Member,
+                parse_tree.MethodCall,
+                parse_tree.FunctionCall,
+                parse_tree.Name,
+                parse_tree.IsIn,
+                parse_tree.Index,
+            )
+
+            if not isinstance(
+                node.generator.iteration, no_parentheses_types_in_this_context
+            ):
+                source = Stripped(f"({iteration})")
+            else:
+                source = iteration
+        elif isinstance(node.generator, parse_tree.ForRange):
+            assert start is not None
+            assert end is not None
+
+            if start == "0":
+                end_minus_start = end
+            else:
+                end_minus_start = Stripped(f"{end} - {start}")
+
+            source = Stripped(
+                f"""\
+Enumerable.Range(
+{I}{indent_but_first_line(start, I)},
+{I}{indent_but_first_line(end_minus_start, I)}
+)"""
+            )
+
+        else:
+            assert_never(node.generator)
+
+        return (
+            Stripped(
+                f"""\
+{source}.{qualifier_function}(
+{I}{variable} => {indent_but_first_line(condition, II)})"""
+            ),
+            None,
+        )
+
+    def transform_any(
+        self, node: parse_tree.Any
+    ) -> Tuple[Optional[Stripped], Optional[Error]]:
+        return self._transform_any_or_all(node)
+
+    def transform_all(
+        self, node: parse_tree.All
+    ) -> Tuple[Optional[Stripped], Optional[Error]]:
+        return self._transform_any_or_all(node)
+
+    def transform_assignment(
+        self, node: parse_tree.Assignment
+    ) -> Tuple[Optional[Stripped], Optional[Error]]:
+        errors = []  # type: List[Error]
+
+        value, error = self.transform(node.value)
+        if error is not None:
+            errors.append(error)
+
+        target = None  # type: Optional[Stripped]
+        if isinstance(node.target, parse_tree.Name):
+            type_anno = self._environment.find(identifier=node.target.identifier)
+            if type_anno is None:
+                # NOTE (mristin, 2022-07-12):
+                # This is a variable definition as we did not specify the identifier
+                # in the environment.
+
+                type_anno = self.type_map[node.value]
+                self._variable_name_set.add(node.target.identifier)
+                self._environment.set(
+                    identifier=node.target.identifier, type_annotation=type_anno
+                )
+
+                target, error = self.transform_name(node=node.target)
+                if error is not None:
+                    errors.append(error)
+                else:
+                    target = Stripped(f"var {target}")
+            else:
+                target, error = self.transform(node=node.target)
+                if error is not None:
+                    errors.append(error)
+
+        if len(errors) > 0:
+            return None, Error(
+                node.original_node, "Failed to transpile the assignment", errors
+            )
+
+        assert target is not None
+        assert value is not None
+
+        # NOTE (mristin, 2022-07-12):
+        # This is a rudimentary heuristic for basic line breaks, but works well in
+        # practice.
+        if "\n" not in value and len(value) > 50:
+            return (
+                Stripped(
+                    f"""\
+{target} = (
+{I}{indent_but_first_line(value, I)});"""
+                ),
+                None,
+            )
+
+        return Stripped(f"{target} = {value};"), None
+
+    def transform_return(
+        self, node: parse_tree.Return
+    ) -> Tuple[Optional[Stripped], Optional[Error]]:
+        if node.value is None:
+            return Stripped("return;"), None
+
+        value, error = self.transform(node.value)
+        if error is not None:
+            return None, error
+
+        assert value is not None
+
+        # NOTE (mristin, 2022-07-12):
+        # This is a rudimentary heuristic for basic line breaks, but works well in
+        # practice.
+        if "\n" not in value and len(value) > 50:
+            return (
+                Stripped(
+                    f"""\
+return (
+{I}{indent_but_first_line(value, I)});"""
+                ),
+                None,
+            )
+
+        return Stripped(f"return {value};"), None
+
+
+# noinspection PyProtectedMember,PyProtectedMember
+assert all(op in Transpiler._CSHARP_COMPARISON_MAP for op in parse_tree.Comparator)

--- a/aas_core_codegen/intermediate/__init__.py
+++ b/aas_core_codegen/intermediate/__init__.py
@@ -51,6 +51,7 @@ ConstantUnion = _types.ConstantUnion
 Verification = _types.Verification
 ImplementationSpecificVerification = _types.ImplementationSpecificVerification
 PatternVerification = _types.PatternVerification
+TranspilableVerification = _types.TranspilableVerification
 Signature = _types.Signature
 Interface = _types.Interface
 SymbolTable = _types.SymbolTable

--- a/aas_core_codegen/intermediate/_stringify.py
+++ b/aas_core_codegen/intermediate/_stringify.py
@@ -47,6 +47,7 @@ from aas_core_codegen.intermediate._types import (
     ConstantSetOfEnumerationLiterals,
     PrimitiveSetLiteral,
     DescriptionOfConstant,
+    TranspilableVerification,
 )
 from aas_core_codegen.parse import tree as parse_tree
 
@@ -745,6 +746,18 @@ def _stringify_pattern_verification(
     return result
 
 
+def _stringify_transpilable_verification(
+    that: TranspilableVerification,
+) -> stringify_mod.Entity:
+    signature_like = _stringify_a_signature_like(that)
+
+    result = stringify_mod.Entity(
+        name=that.__class__.__name__, properties=list(signature_like.properties)
+    )
+
+    return result
+
+
 def _stringify_signature(
     that: Signature,
 ) -> stringify_mod.Entity:
@@ -863,6 +876,7 @@ Dumpable = Union[
     OptionalTypeAnnotation,
     OurTypeAnnotation,
     PatternVerification,
+    TranspilableVerification,
     PrimitiveSetLiteral,
     PrimitiveTypeAnnotation,
     Property,
@@ -917,6 +931,7 @@ _DISPATCH = {
     Signature: _stringify_signature,
     Snapshot: _stringify_snapshot,
     SymbolTable: _stringify_symbol_table,
+    TranspilableVerification: _stringify_transpilable_verification,
     UnderstoodMethod: _stringify_understood_method,
 }
 

--- a/aas_core_codegen/intermediate/_types.py
+++ b/aas_core_codegen/intermediate/_types.py
@@ -2002,6 +2002,45 @@ class PatternVerification(Verification):
         )
 
 
+class TranspilableVerification(Verification):
+    """
+    Represent a function that needs to be transpiled into the native code.
+
+    Unlike :class:`.PatternVerification`, we do not understand this verification
+    function at the higher level, and can not use it further in the inference.
+    Nevertheless, we can still transpile it into different target implementations.
+    """
+
+    #: Method as we understood it in the parse stage
+    parsed: parse.UnderstoodMethod
+
+    def __init__(
+        self,
+        name: Identifier,
+        arguments: Sequence[Argument],
+        returns: Optional[TypeAnnotationUnion],
+        description: Optional[DescriptionOfSignature],
+        contracts: Contracts,
+        parsed: parse.UnderstoodMethod,
+    ) -> None:
+        """Initialize with the given values."""
+        Verification.__init__(
+            self,
+            name=name,
+            arguments=arguments,
+            returns=returns,
+            description=description,
+            contracts=contracts,
+            parsed=parsed,
+        )
+
+    def __repr__(self) -> str:
+        """Represent the instance as a string for easier debugging."""
+        return (
+            f"<{_MODULE_NAME}.{self.__class__.__name__} {self.name} at 0x{id(self):x}>"
+        )
+
+
 # endregion
 
 
@@ -2571,5 +2610,9 @@ ConstantUnion = Union[
 ]
 assert_union_of_descendants_exhaustive(union=ConstantUnion, base_class=Constant)
 
-VerificationUnion = Union[ImplementationSpecificVerification, PatternVerification]
+VerificationUnion = Union[
+    ImplementationSpecificVerification,
+    PatternVerification,
+    TranspilableVerification,
+]
 assert_union_of_descendants_exhaustive(union=VerificationUnion, base_class=Verification)

--- a/aas_core_codegen/parse/tree.py
+++ b/aas_core_codegen/parse/tree.py
@@ -796,7 +796,7 @@ class Transformer(Generic[T], DBC):
         raise NotImplementedError(f"{node=}")
 
 
-class RestrictedTransformer(Transformer[T], DBC):
+class RestrictedTransformer(Transformer[T]):
     """
     Transform our AST into something where only a part of the tree is handled.
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
             "twine",
             "jsonschema==3.2.0",
             "xmlschema==1.10.0",
-            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@99ce5f0#egg=aas-core-meta",
+            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@ab276a8#egg=aas-core-meta",
         ]
     },
     # fmt: on

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/verification.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/verification.cs
@@ -1954,47 +1954,29 @@ namespace AasCore.Aas3_0_RC02
         }
 
         /// <summary>
-        /// Check that the target of the model <paramref name="reference" /> matches
-        /// the <paramref name="expectedType" />.
+        /// Check that the target of the model reference matches the <paramref name="expectedType" />.
         /// </summary>
         public static bool IsModelReferenceTo(
-            Aas.Reference reference,
-            Aas.KeyTypes expectedType
+            Reference reference,
+            KeyTypes expectedType
         )
         {
-            if (reference.Type != Aas.ReferenceTypes.ModelReference)
-            {
-                return false;
-            }
-
-            if (reference.Keys.Count == 0)
-            {
-                return false;
-            }
-
-            return reference.Keys[^1].Type == expectedType;
-        }
+            return reference.Type == ReferenceTypes.ModelReference
+            && reference.Keys.Count != 0
+            && reference.Keys[^1].Type == expectedType;
+        }  // public static bool IsModelReferenceTo
 
         /// <summary>
-        /// Check that the target of the model <paramref name="reference" /> matches
-        /// a <see cref="Aas.Constants.AasReferables" />.
+        /// Check that the target of the reference matches a <see cref="Aas.Constants.AasReferables" />.
         /// </summary>
         public static bool IsModelReferenceToReferable(
-            Aas.Reference reference
+            Reference reference
         )
         {
-            if (reference.Type != Aas.ReferenceTypes.ModelReference)
-            {
-                return false;
-            }
-
-            if (reference.Keys.Count == 0)
-            {
-                return false;
-            }
-
-            return Aas.Constants.AasReferables.Contains(reference.Keys[^1].Type);
-        }
+            return reference.Type == ReferenceTypes.ModelReference
+            && reference.Keys.Count != 0
+            && Aas.Constants.AasReferables.Contains(reference.Keys[^1].Type);
+        }  // public static bool IsModelReferenceToReferable
 
         /// <summary>
         /// Check that all <see cref="Aas.IReferable.IdShort" /> are unique among

--- a/test_data/intermediate/real_meta_models/aas_core_meta.v3rc2/expected_symbol_table.txt
+++ b/test_data/intermediate/real_meta_models/aas_core_meta.v3rc2/expected_symbol_table.txt
@@ -23178,7 +23178,7 @@ SymbolTable(
       parsed=...,
       arguments_by_name=...,
       pattern='^[gG][lL][oO][bB][aA][lL][aA][sS][sS][eE][tT][iI][dD]$'),
-    ImplementationSpecificVerification(
+    TranspilableVerification(
       name='is_model_reference_to',
       arguments=[
         Argument(
@@ -23199,7 +23199,7 @@ SymbolTable(
         a_type='BOOL',
         parsed=...),
       description=DescriptionOfSignature(
-        summary='<paragraph>Check that the target of the model reference matches the <literal>expected_type</literal>.</paragraph>',
+        summary='<paragraph>Check that the target of the model reference matches the <ReferenceToArgument refuri="expected_type">expected_type</ReferenceToArgument>.</paragraph>',
         remarks=[],
         arguments_by_name=[],
         returns=None,
@@ -23210,7 +23210,7 @@ SymbolTable(
         postconditions=[]),
       parsed=...,
       arguments_by_name=...),
-    ImplementationSpecificVerification(
+    TranspilableVerification(
       name='is_model_reference_to_referable',
       arguments=[
         Argument(

--- a/test_data/intermediate/unexpected/invariant/class_invariant_uses_re/expected_error.txt
+++ b/test_data/intermediate/unexpected/invariant/class_invariant_uses_re/expected_error.txt
@@ -1,0 +1,1 @@
+We can not transpile the usage of ``re`` directly to the target implementation. Please refactor the invariant such that it calls a pattern verification function.

--- a/test_data/intermediate/unexpected/invariant/class_invariant_uses_re/meta_model.py
+++ b/test_data/intermediate/unexpected/invariant/class_invariant_uses_re/meta_model.py
@@ -1,0 +1,10 @@
+@invariant(lambda self: re.match(r"^hello$", self.x))
+class Something:
+    x: str
+
+    def __init__(self, x: str) -> None:
+        self.x = x
+
+
+__book_url__ = "dummy"
+__book_version__ = "dummy"

--- a/test_data/intermediate/unexpected/invariant/invariant_of_constrained_primitive_uses_re/expected_error.txt
+++ b/test_data/intermediate/unexpected/invariant/invariant_of_constrained_primitive_uses_re/expected_error.txt
@@ -1,0 +1,1 @@
+We can not transpile the usage of ``re`` directly to the target implementation. Please refactor the invariant such that it calls a pattern verification function.

--- a/test_data/intermediate/unexpected/invariant/invariant_of_constrained_primitive_uses_re/meta_model.py
+++ b/test_data/intermediate/unexpected/invariant/invariant_of_constrained_primitive_uses_re/meta_model.py
@@ -1,0 +1,7 @@
+@invariant(lambda self: re.match(r"^hello$", self))
+class Something(str):
+    pass
+
+
+__book_url__ = "dummy"
+__book_version__ = "dummy"

--- a/test_data/parse/real_meta_models/aas_core_meta.v3rc2/expected_symbol_table.txt
+++ b/test_data/parse/real_meta_models/aas_core_meta.v3rc2/expected_symbol_table.txt
@@ -15750,7 +15750,7 @@ UnverifiedSymbolTable(
             original_node=...)""")],
       node=...,
       arguments_by_name=...),
-    ImplementationSpecificMethod(
+    UnderstoodMethod(
       name='is_model_reference_to',
       verification=True,
       arguments=[
@@ -15778,9 +15778,67 @@ UnverifiedSymbolTable(
         preconditions=[],
         snapshots=[],
         postconditions=[]),
+      body=[
+        textwrap.dedent("""\
+          Return(
+            value=And(
+              values=[
+                Comparison(
+                  left=Member(
+                    instance=Name(
+                      identifier='reference',
+                      original_node=...),
+                    name='type',
+                    original_node=...),
+                  op='EQ',
+                  right=Member(
+                    instance=Name(
+                      identifier='Reference_types',
+                      original_node=...),
+                    name='Model_reference',
+                    original_node=...),
+                  original_node=...),
+                Comparison(
+                  left=FunctionCall(
+                    name='len',
+                    args=[
+                      Member(
+                        instance=Name(
+                          identifier='reference',
+                          original_node=...),
+                        name='keys',
+                        original_node=...)],
+                    original_node=...),
+                  op='NE',
+                  right=Constant(
+                    value=0,
+                    original_node=...),
+                  original_node=...),
+                Comparison(
+                  left=Member(
+                    instance=Index(
+                      collection=Member(
+                        instance=Name(
+                          identifier='reference',
+                          original_node=...),
+                        name='keys',
+                        original_node=...),
+                      index=Constant(
+                        value=-1,
+                        original_node=...),
+                      original_node=...),
+                    name='type',
+                    original_node=...),
+                  op='EQ',
+                  right=Name(
+                    identifier='expected_type',
+                    original_node=...),
+                  original_node=...)],
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
-    ImplementationSpecificMethod(
+    UnderstoodMethod(
       name='is_model_reference_to_referable',
       verification=True,
       arguments=[
@@ -15801,6 +15859,63 @@ UnverifiedSymbolTable(
         preconditions=[],
         snapshots=[],
         postconditions=[]),
+      body=[
+        textwrap.dedent("""\
+          Return(
+            value=And(
+              values=[
+                Comparison(
+                  left=Member(
+                    instance=Name(
+                      identifier='reference',
+                      original_node=...),
+                    name='type',
+                    original_node=...),
+                  op='EQ',
+                  right=Member(
+                    instance=Name(
+                      identifier='Reference_types',
+                      original_node=...),
+                    name='Model_reference',
+                    original_node=...),
+                  original_node=...),
+                Comparison(
+                  left=FunctionCall(
+                    name='len',
+                    args=[
+                      Member(
+                        instance=Name(
+                          identifier='reference',
+                          original_node=...),
+                        name='keys',
+                        original_node=...)],
+                    original_node=...),
+                  op='NE',
+                  right=Constant(
+                    value=0,
+                    original_node=...),
+                  original_node=...),
+                IsIn(
+                  member=Member(
+                    instance=Index(
+                      collection=Member(
+                        instance=Name(
+                          identifier='reference',
+                          original_node=...),
+                        name='keys',
+                        original_node=...),
+                      index=Constant(
+                        value=-1,
+                        original_node=...),
+                      original_node=...),
+                    name='type',
+                    original_node=...),
+                  container=Name(
+                    identifier='AAS_referables',
+                    original_node=...),
+                  original_node=...)],
+              original_node=...),
+            original_node=...)""")],
       node=...,
       arguments_by_name=...),
     ImplementationSpecificMethod(

--- a/test_data/smoke/test_main/unexpected/pattern_verification_unparsable_regex/direct_match/expected_stderr.txt
+++ b/test_data/smoke/test_main/unexpected/pattern_verification_unparsable_regex/direct_match/expected_stderr.txt
@@ -1,5 +1,5 @@
 Failed to translate the parsed symbol table to intermediate symbol table based on <meta_model.py>:
 * At line 1 and column 1: Failed to translate the parsed symbol table to an intermediate symbol table
     At line 1 and column 1: Failed to translate the verification function 'match_something'
-      At line 1 and column 1: We do not know how to interpret the verification function 'match_something' as it does not match our pre-defined interpretation rules. Please contact the developers if you expect this function to be understood.
+      At line 4 and column 13: The function uses ``re`` module, but we could not match it as a pattern verification function. We can not transpile the code which relies on regular expressions directly to targets. Please make sure that your function can be understood as a pattern matching function.
         At line 1 and column 1: Expected a ``bool`` return value


### PR DESCRIPTION
We refactor the transpilation so that it works on general verification
functions, not only on pattern matching.

This is important in particular for code re-use in constraints, such as
``is_model_reference_to``.