### PR TITLE
Fix paragraph breaks in C# code generation

### DIFF
--- a/aas_core_codegen/csharp/description.py
+++ b/aas_core_codegen/csharp/description.py
@@ -1,20 +1,39 @@
 """Render descriptions to C# documentation comments."""
+import abc
+import collections
 import io
+import itertools
 import textwrap
 import xml.sax.saxutils
-from typing import Tuple, Optional, List
+from typing import (
+    Tuple,
+    Optional,
+    List,
+    OrderedDict,
+    Union,
+    Sequence,
+    TypeVar,
+    Iterator,
+    Iterable,
+)
 
 import docutils.nodes
 import docutils.parsers.rst.roles
 import docutils.utils
-from icontract import require
+from icontract import require, ensure, DBC
 
 from aas_core_codegen import intermediate
-from aas_core_codegen.common import Stripped, Error, assert_never, Identifier
+from aas_core_codegen.common import (
+    Stripped,
+    Error,
+    assert_never,
+    Identifier,
+    assert_union_of_descendants_exhaustive,
+    assert_union_without_excluded,
+)
 from aas_core_codegen.csharp import (
     naming as csharp_naming,
 )
-from aas_core_codegen.csharp.common import INDENT as I
 from aas_core_codegen.intermediate import (
     doc as intermediate_doc,
     rendering as intermediate_rendering,
@@ -22,17 +41,129 @@ from aas_core_codegen.intermediate import (
 )
 
 
-class _ElementRenderer(intermediate_rendering.DocutilsElementTransformer[str]):
+class _Node(DBC):
+    """Represent a node in an AST of a documentation comment."""
+
+    @abc.abstractmethod
+    def accept(self, visitor: "_NodeVisitor") -> None:
+        """Accept the ``visitor`` and dispatch."""
+        raise NotImplementedError()
+
+
+class _Text(_Node):
+    """Represent a text node in a documentation comment."""
+
+    def __init__(self, content: str) -> None:
+        """Initialize with the given values."""
+        self.content = content
+
+    def accept(self, visitor: "_NodeVisitor") -> None:
+        """Accept the ``visitor`` and dispatch."""
+        visitor.visit_text(self)
+
+    def __repr__(self) -> str:
+        """Generate a string representation for easier debugging."""
+        return f"{self.__class__.__name__}({self.content!r})"
+
+
+class _List(_Node):
+    """
+    Represent a sequence of nodes of a C# documentation comment.
+
+    This is necessary so that we can render a concatenation where there is no
+    enclosing element.
+    """
+
+    def __init__(self, items: List["_NodeUnion"]) -> None:
+        self.items = items
+
+    def accept(self, visitor: "_NodeVisitor") -> None:
+        """Accept the ``visitor`` and dispatch."""
+        visitor.visit_list(self)
+
+    def __repr__(self) -> str:
+        """Generate a string representation for easier debugging."""
+        if len(self.items) == 0:
+            return f"{self.__class__.__name__}([])"
+
+        writer = io.StringIO()
+        writer.write(f"{self.__class__.__name__}(\n")
+        writer.write("  [\n")
+
+        for i, item in enumerate(self.items):
+            if i > 0:
+                writer.write(",\n")
+            writer.write(textwrap.indent(repr(item), "    "))
+
+        writer.write("\n  ]\n)")
+        return writer.getvalue()
+
+
+class _Element(_Node):
+    """Represent an element of a C# documentation comment."""
+
+    def __init__(
+        self,
+        name: str,
+        attrs: Optional[OrderedDict[str, str]] = None,
+        children: Optional[_List] = None,
+    ) -> None:
+        self.name = name
+        self.attrs = collections.OrderedDict() if attrs is None else attrs
+        self.children = _List(items=[]) if children is None else children
+
+    def accept(self, visitor: "_NodeVisitor") -> None:
+        """Accept the ``visitor`` and dispatch."""
+        visitor.visit_element(self)
+
+    def __repr__(self) -> str:
+        """Generate a string representation for easier debugging."""
+        indented_name = textwrap.indent(repr(self.name), "  ")
+        indented_attrs = textwrap.indent(repr(self.attrs), "  ")
+        indented_children = textwrap.indent(repr(self.children), "  ")
+
+        return f"""\
+{self.__class__.__name__}(
+{indented_name},
+{indented_attrs},
+{indented_children}
+)"""
+
+
+_NodeUnion = Union[_Text, _Element, _List]
+assert_union_of_descendants_exhaustive(base_class=_Node, union=_NodeUnion)
+
+
+class _NodeVisitor:
+    def visit(self, node: _Node) -> None:
+        """Visit *via* double-dispatch."""
+        node.accept(self)
+
+    def visit_text(self, node: _Text) -> None:
+        """Visit the text node."""
+        pass
+
+    def visit_list(self, node: _List) -> None:
+        """Visit the node list and its items recursively."""
+        for item in node.items:
+            self.visit(item)
+
+    def visit_element(self, node: _Element) -> None:
+        """Visit the element node and its children."""
+        self.visit(node.children)
+
+
+class _ElementRenderer(intermediate_rendering.DocutilsElementTransformer[_NodeUnion]):
     """Render descriptions as C# docstring XML."""
 
     def transform_text(
         self, element: docutils.nodes.Text
-    ) -> Tuple[Optional[str], Optional[List[str]]]:
-        return xml.sax.saxutils.escape(element.astext()), None
+    ) -> Tuple[Optional[_NodeUnion], Optional[List[str]]]:
+        return _Text(element.astext()), None
 
     def transform_reference_to_our_type_in_doc(
         self, element: intermediate_doc.ReferenceToOurType
-    ) -> Tuple[Optional[str], Optional[List[str]]]:
+    ) -> Tuple[Optional[_NodeUnion], Optional[List[str]]]:
         name = None  # type: Optional[str]
 
         if isinstance(element.our_type, intermediate.Enumeration):
@@ -80,11 +211,16 @@ class _ElementRenderer(intermediate_rendering.DocutilsElementTransformer[str]):
         # We need to prefix the cref in case there are naming conflicts.
         prefixed_name = f"Aas.{name}"
 
-        return f"<see cref={xml.sax.saxutils.quoteattr(prefixed_name)} />", None
+        return (
+            _Element(
+                name="see", attrs=collections.OrderedDict([("cref", prefixed_name)])
+            ),
+            None,
+        )
 
     def transform_reference_to_attribute_in_doc(
         self, element: intermediate_doc.ReferenceToAttribute
-    ) -> Tuple[Optional[str], Optional[List[str]]]:
+    ) -> Tuple[Optional[_NodeUnion], Optional[List[str]]]:
         cref = None  # type: Optional[str]
 
         if isinstance(element.reference, intermediate_doc.ReferenceToProperty):
@@ -144,173 +280,363 @@ class _ElementRenderer(intermediate_rendering.DocutilsElementTransformer[str]):
         # We need to prefix the cref in case there are naming conflicts.
         prefixed_cref = f"Aas.{cref}"
 
-        return f"<see cref={xml.sax.saxutils.quoteattr(prefixed_cref)} />", None
+        return (
+            _Element(
+                name="see", attrs=collections.OrderedDict([("cref", prefixed_cref)])
+            ),
+            None,
+        )
 
     def transform_reference_to_argument_in_doc(
         self, element: intermediate_doc.ReferenceToArgument
-    ) -> Tuple[Optional[str], Optional[List[str]]]:
+    ) -> Tuple[Optional[_NodeUnion], Optional[List[str]]]:
         arg_name = csharp_naming.argument_name(Identifier(element.reference))
-        return f"<paramref name={xml.sax.saxutils.quoteattr(arg_name)} />", None
+
+        return (
+            _Element(
+                name="paramref", attrs=collections.OrderedDict([("name", arg_name)])
+            ),
+            None,
+        )
 
     def transform_reference_to_constraint_in_doc(
         self, element: intermediate_doc.ReferenceToConstraint
-    ) -> Tuple[Optional[str], Optional[List[str]]]:
-        return f"Constraint {element.reference}", None
+    ) -> Tuple[Optional[_NodeUnion], Optional[List[str]]]:
+        return _Text(content=f"Constraint {element.reference}"), None
 
     def transform_reference_to_constant_in_doc(
         self, element: intermediate_doc.ReferenceToConstant
-    ) -> Tuple[Optional[str], Optional[List[str]]]:
+    ) -> Tuple[Optional[_NodeUnion], Optional[List[str]]]:
         constant_as_prop_name = csharp_naming.property_name(element.constant.name)
         cref = f"Aas.Constants.{constant_as_prop_name}"
 
-        return f"<see cref={xml.sax.saxutils.quoteattr(cref)} />", None
+        return (
+            _Element(name="see", attrs=collections.OrderedDict([("cref", cref)])),
+            None,
+        )
 
     def transform_literal(
         self, element: docutils.nodes.literal
-    ) -> Tuple[Optional[str], Optional[List[str]]]:
-        return f"<c>{xml.sax.saxutils.escape(element.astext())}</c>", None
+    ) -> Tuple[Optional[_NodeUnion], Optional[List[str]]]:
+        return (
+            _Element(name="c", children=_List(items=[_Text(content=element.astext())])),
+            None,
+        )
+
+    def _transform_children_of(
+        self,
+        element: docutils.nodes.Element,
+    ) -> Tuple[Optional[_List], Optional[List[str]]]:
+        """Transform the children to a Python list."""
+        children = []  # type: List[_NodeUnion]
+
+        errors = []  # type: List[str]
+        for child in element.children:
+            rendered_child, child_errors = self.transform(child)
+            if child_errors is not None:
+                errors.extend(child_errors)
+            else:
+                assert rendered_child is not None
+                children.append(rendered_child)
+
+        if len(errors) > 0:
+            return None, errors
+
+        return _List(items=children), None
 
     def transform_paragraph(
         self, element: docutils.nodes.paragraph
-    ) -> Tuple[Optional[str], Optional[List[str]]]:
-        parts = []  # type: List[str]
-        for child in element.children:
-            text, error = self.transform(child)
-            if error is not None:
-                return None, error
+    ) -> Tuple[Optional[_NodeUnion], Optional[List[str]]]:
+        children, errors = self._transform_children_of(element)
+        if errors is not None:
+            return None, errors
 
-            assert text is not None
-            parts.append(text)
+        assert children is not None
 
-        return "".join(parts), None
+        return _Element(name="para", children=children), None
 
     def transform_emphasis(
         self, element: docutils.nodes.emphasis
-    ) -> Tuple[Optional[str], Optional[List[str]]]:
-        parts = []  # type: List[str]
-        for child in element.children:
-            text, error = self.transform(child)
-            if error is not None:
-                return None, error
+    ) -> Tuple[Optional[_NodeUnion], Optional[List[str]]]:
+        children, errors = self._transform_children_of(element)
+        if errors is not None:
+            return None, errors
 
-            assert text is not None
-            parts.append(text)
+        assert children is not None
 
-        return "<em>{}</em>".format("".join(parts)), None
+        return _Element(name="em", children=children), None
 
     def transform_list_item(
         self, element: docutils.nodes.list_item
-    ) -> Tuple[Optional[str], Optional[List[str]]]:
-        parts = []  # type: List[str]
-        errors = []  # type: List[str]
-
-        for child in element.children:
-            text, child_errors = self.transform(child)
-            if child_errors is not None:
-                errors.extend(child_errors)
-            else:
-                assert text is not None
-                parts.append(text)
-
-        if len(errors) > 0:
+    ) -> Tuple[Optional[_NodeUnion], Optional[List[str]]]:
+        children, errors = self._transform_children_of(element)
+        if errors is not None:
             return None, errors
 
-        return "<li>{}</li>".format("".join(parts)), None
+        assert children is not None
+
+        return _Element(name="li", children=children), None
 
     def transform_bullet_list(
         self, element: docutils.nodes.bullet_list
-    ) -> Tuple[Optional[str], Optional[List[str]]]:
-        parts = ["<ul>\n"]
-        errors = []  # type: List[str]
-
-        for child in element.children:
-            text, child_errors = self.transform(child)
-            if child_errors is not None:
-                errors.extend(child_errors)
-            else:
-                assert text is not None
-                parts.append(f"{text}\n")
-
-        if len(errors) > 0:
+    ) -> Tuple[Optional[_NodeUnion], Optional[List[str]]]:
+        children, errors = self._transform_children_of(element)
+        if errors is not None:
             return None, errors
 
-        parts.append("</ul>")
+        assert children is not None
 
-        return "".join(parts), None
+        return _Element(name="ul", children=children), None
 
     def transform_note(
         self, element: docutils.nodes.note
-    ) -> Tuple[Optional[str], Optional[List[str]]]:
-        parts = []  # type: List[str]
-        errors = []  # type: List[str]
+    ) -> Tuple[Optional[_NodeUnion], Optional[List[str]]]:
+        children, errors = self._transform_children_of(element)
 
-        for child in element.children:
-            text, child_errors = self.transform(child)
-            if child_errors is not None:
-                errors.extend(child_errors)
-            else:
-                assert text is not None
-                parts.append(text)
-
-        if len(errors) > 0:
+        if errors is not None:
             return None, errors
 
-        return "".join(parts), None
+        assert children is not None
+
+        return _Element(name="para", children=children), None
 
     def transform_reference(
         self, element: docutils.nodes.reference
-    ) -> Tuple[Optional[str], Optional[List[str]]]:
-        parts = []  # type: List[str]
-        errors = []  # type: List[str]
-
-        for child in element.children:
-            text, child_errors = self.transform(child)
-            if child_errors is not None:
-                errors.extend(child_errors)
-            else:
-                assert text is not None
-                parts.append(text)
-
-        if len(errors) > 0:
-            return None, errors
-
-        return "".join(parts), None
-
-    def _transform_children_joined_with_double_new_line(
-        self, element: docutils.nodes.Element
-    ) -> Tuple[Optional[str], Optional[List[str]]]:
-        """Transform the ``element``'s children and join them with a double new-line."""
-        if len(element.children) == 0:
-            return "", None
-
-        if len(element.children) == 1:
-            return self.transform(element.children[0])
-
-        parts = []  # type: List[str]
-        errors = []  # type: List[str]
-
-        for child in element.children:
-            part, child_errors = self.transform(child)
-            if child_errors is not None:
-                errors.extend(child_errors)
-            else:
-                assert part is not None
-                parts.append(part)
-
-        if len(errors) > 0:
-            return None, errors
-
-        return "\n\n".join(parts), None
+    ) -> Tuple[Optional[_NodeUnion], Optional[List[str]]]:
+        return self._transform_children_of(element)
 
     def transform_field_body(
         self, element: docutils.nodes.field_body
-    ) -> Tuple[Optional[str], Optional[List[str]]]:
-        return self._transform_children_joined_with_double_new_line(element=element)
+    ) -> Tuple[Optional[_NodeUnion], Optional[List[str]]]:
+        return self._transform_children_of(element)
 
     def transform_document(
-        self, element: docutils.nodes.field_body
-    ) -> Tuple[Optional[str], Optional[List[str]]]:
-        return self._transform_children_joined_with_double_new_line(element=element)
+        self, element: docutils.nodes.document
+    ) -> Tuple[Optional[_NodeUnion], Optional[List[str]]]:
+        return self._transform_children_of(element)
+
+
+class _FlattenListVisitor(_NodeVisitor):
+    """Flatten all the node lists recursively and in-place."""
+
+    def visit_list(self, node: _List) -> None:
+        """Visit the node list and its items recursively."""
+        new_items = []  # type: List[_NodeUnion]
+
+        for item in node.items:
+            self.visit(item)
+
+            if isinstance(item, _List):
+                new_items.extend(item.items)
+            else:
+                new_items.append(item)
+
+        node.items = new_items
+
+
+class _ConcatenateTextVisitor(_NodeVisitor):
+    """Concatenate the consecutive text elements in lists recursively and in-place."""
+
+    def visit_list(self, node: _List) -> None:
+        """Visit the node list and its items recursively."""
+        new_items = []  # type: List[_NodeUnion]
+
+        accumulator = []  # type: List[_Text]
+        for item in node.items:
+            if isinstance(item, _Text):
+                accumulator.append(item)
+            else:
+                self.visit(item)
+
+                if len(accumulator) > 0:
+                    new_items.append(
+                        _Text(
+                            content="".join(
+                                text_element.content for text_element in accumulator
+                            )
+                        )
+                    )
+                    accumulator = []
+
+                new_items.append(item)
+
+        if len(accumulator) > 0:
+            new_items.append(
+                _Text(
+                    content="".join(
+                        text_element.content for text_element in accumulator
+                    )
+                )
+            )
+
+        node.items = new_items
+
+
+class _RemoveRedundantParaVisitor(_NodeVisitor):
+    """Remove the redundant ``<para>`` elements in-place."""
+
+    def visit_element(self, node: _Element) -> None:
+        self.visit(node.children)
+
+        # noinspection PyUnresolvedReferences
+        if (
+            node.name in ("summary", "remarks", "li", "param", "returns", "para")
+            and len(node.children.items) == 1
+            and isinstance(node.children.items[0], _Element)
+            and node.children.items[0].name == "para"
+        ):
+            # noinspection PyUnresolvedReferences
+            node.children = node.children.items[0].children
+
+
+def _compress_node_in_place(node: _NodeUnion) -> None:
+    """Remove redundant nodes for more readability in the rendered text."""
+    flatten_list_visitor = _FlattenListVisitor()
+    flatten_list_visitor.visit(node)
+
+    concatenate_text_visitor = _ConcatenateTextVisitor()
+    concatenate_text_visitor.visit(node)
+
+    remove_redundant_para_visitor = _RemoveRedundantParaVisitor()
+    remove_redundant_para_visitor.visit(node)
+
+
+def _render_summary_remarks(
+    description: intermediate.SummaryRemarksDescription,
+) -> Tuple[Optional[_List], Optional[List[Error]]]:
+    """Render a description to our description node."""
+    result_items = []  # type: List[_NodeUnion]
+    errors = []  # type: List[Error]
+
+    element_renderer = _ElementRenderer()
+
+    summary_node, summary_errors = element_renderer.transform(description.summary)
+    if summary_errors is not None:
+        errors.extend(
+            Error(description.parsed.node, message) for message in summary_errors
+        )
+    else:
+        assert summary_node is not None
+
+        result_items.append(
+            _Element(name="summary", children=_List(items=[summary_node]))
+        )
+
+    remark_nodes = []  # type: List[_NodeUnion]
+    for remark in description.remarks:
+        remark_node, remark_errors = element_renderer.transform(remark)
+        if remark_errors:
+            errors.extend(
+                Error(description.parsed.node, message) for message in remark_errors
+            )
+        else:
+            assert remark_node is not None
+            remark_nodes.append(remark_node)
+
+    if len(errors) > 0:
+        return None, errors
+
+    if len(remark_nodes) > 0:
+        result_items.append(
+            _Element(name="remarks", children=_List(items=remark_nodes))
+        )
+
+    return _List(items=result_items), None
+
+
+def _render_summary_remarks_constraints(
+    description: intermediate.SummaryRemarksConstraintsDescription,
+) -> Tuple[Optional[_List], Optional[List[Error]]]:
+    """Render a description where constraints are put in remarks."""
+    result_items = []  # type: List[_NodeUnion]
+    errors = []  # type: List[Error]
+
+    element_renderer = _ElementRenderer()
+
+    summary_node, summary_errors = element_renderer.transform(description.summary)
+    if summary_errors is not None:
+        errors.extend(
+            Error(description.parsed.node, message) for message in summary_errors
+        )
+    else:
+        assert summary_node is not None
+        result_items.append(
+            _Element(name="summary", children=_List(items=[summary_node]))
+        )
+
+    remark_nodes = []  # type: List[_NodeUnion]
+    for remark in description.remarks:
+        remark_node, remark_errors = element_renderer.transform(remark)
+        if remark_errors:
+            errors.extend(
+                Error(description.parsed.node, message) for message in remark_errors
+            )
+        else:
+            assert remark_node is not None
+            remark_nodes.append(remark_node)
+
+    constraint_nodes = []  # type: List[_NodeUnion]
+    for identifier, docutils_element in description.constraints_by_identifier.items():
+        body, body_errors = element_renderer.transform(docutils_element)
+        if body_errors is not None:
+            errors.extend(
+                Error(description.parsed.node, message) for message in body_errors
+            )
+        else:
+            assert body is not None
+
+            # NOTE (mristin, 2022-07-21):
+            # We in-line the constraint prefix for better readability.
+
+            # noinspection PyUnresolvedReferences
+            if (
+                isinstance(body, _List)
+                and len(body.items) > 0
+                and isinstance(body.items[0], _Element)
+                and body.items[0].name == "para"
+            ):
+                # noinspection PyUnresolvedReferences
+                body.items[0].children.items.insert(
+                    0, _Text(content=f"Constraint {identifier}:\n")
+                )
+
+                constraint_node = _Element(name="li", children=body)
+            else:
+                constraint_node = _Element(
+                    name="li",
+                    children=_List(
+                        items=[
+                            _Element(
+                                name="para",
+                                children=_List(
+                                    items=[_Text(content=f"Constraint {identifier}:\n")]
+                                ),
+                            ),
+                            body,
+                        ]
+                    ),
+                )
+
+            constraint_nodes.append(constraint_node)
+
+    if len(errors) > 0:
+        return None, errors
+
+    if len(constraint_nodes) > 0:
+        remark_nodes.append(
+            _Element(name="para", children=_List(items=[_Text(content="Constraints:")]))
+        )
+
+        ul_node = _Element(name="ul", children=_List(items=constraint_nodes))
+
+        remark_nodes.append(ul_node)
+
+    if len(remark_nodes) > 0:
+        result_items.append(
+            _Element(name="remarks", children=_List(items=remark_nodes))
+        )
+
+    return _List(items=result_items), None
 
 
 @require(lambda line: "\n" not in line)
@@ -322,60 +648,312 @@ def _slash_slash_slash_line(line: str) -> str:
     return f"/// {line}"
 
 
+class _RelativeIndention:
+    """
+    Represent the relative indention.
+
+    Since the indention is *relative*, it can be either positive, neutral or negative.
+    """
+
+    @require(lambda direction: direction in (-1, 0, 1))
+    def __init__(self, direction: int) -> None:
+        self.direction = direction
+
+    def __repr__(self) -> str:
+        """Generate text representation for easier debugging."""
+        return f"{self.__class__.__name__}({self.direction!r})"
+
+
+class _TextBlock(DBC):
+    """
+    Represent a block of text.
+
+    This data structure is expected to be append-only mutable, where you keep adding
+    new parts to the block. The parts are later expected to be joined by an empty
+    string.
+
+    All the text blocks are expected to be joined by empty strings.
+    """
+
+    def __init__(self, parts: List[str]) -> None:
+        """Initialize with the given values."""
+        self.parts = parts
+
+    def __repr__(self) -> str:
+        """Generate text representation for easier debugging."""
+        return f"{self.__class__.__name__}({self.parts!r})"
+
+
+class _EnforceNewLine(DBC):
+    """
+    Enforce that the following text starts on a new line.
+
+    If there is already a new line output before, this text directive has no influence.
+    """
+
+    def __repr__(self) -> str:
+        """Generate text representation for easier debugging."""
+        return f"{self.__class__.__name__}()"
+
+
+_TextDirective = Union[_RelativeIndention, _TextBlock, _EnforceNewLine]
+
+
+class _ToTextDirectivesVisitor(_NodeVisitor):
+    """
+    Convert the nodes to a text as represented by text control directives.
+
+    The text is expected to be valid XML and properly escaped.
+    """
+
+    #: The resulting text control directives
+    directives: List[_TextDirective]
+
+    def __init__(self) -> None:
+        self.directives = []
+
+    def _last_or_new_block(self) -> _TextBlock:
+        """Retrieve the last block, or initialize a new block, if no last block."""
+        if len(self.directives) == 0 or not isinstance(self.directives[-1], _TextBlock):
+            self.directives.append(_TextBlock(parts=[]))
+
+        assert isinstance(self.directives[-1], _TextBlock)
+        return self.directives[-1]
+
+    def visit_text(self, node: _Text) -> None:
+        self._last_or_new_block().parts.append(xml.sax.saxutils.escape(node.content))
+
+    def visit_element(self, node: _Element) -> None:
+        """Visit the element node and its children."""
+        if node.name in ("summary", "remarks", "para", "param", "returns"):
+            # NOTE (mristin, 2022-07-18):
+            # We render these tags without indention for better readability.
+
+            start_element_writer = io.StringIO()
+            start_element_writer.write(f"<{node.name}")
+            if len(node.attrs) > 0:
+                for attr_name, attr_value in node.attrs.items():
+                    start_element_writer.write(
+                        f" {attr_name}={xml.sax.saxutils.quoteattr(attr_value)}"
+                    )
+            start_element_writer.write(">")
+
+            self.directives.append(_EnforceNewLine())
+
+            self.directives.append(_TextBlock(parts=[start_element_writer.getvalue()]))
+
+            self.directives.append(_EnforceNewLine())
+
+            for item in node.children.items:
+                self.visit(item)
+
+            self.directives.append(_EnforceNewLine())
+
+            self.directives.append(_TextBlock(parts=[f"</{node.name}>"]))
+
+        elif node.name in ("ul", "li"):
+            # NOTE (mristin, 2022-07-18):
+            # We put the list elements on new lines and indent them.
+            assert (
+                len(node.attrs) == 0
+            ), f"Unexpected attributes in a node {node.name!r}"
+
+            self.directives.append(_EnforceNewLine())
+
+            self.directives.append(_TextBlock(parts=[f"<{node.name}>"]))
+
+            self.directives.append(_EnforceNewLine())
+
+            self.directives.append(_RelativeIndention(direction=1))
+
+            for item in node.children.items:
+                self.visit(item)
+
+            self.directives.append(_EnforceNewLine())
+
+            self.directives.append(_RelativeIndention(direction=-1))
+
+            self.directives.append(_TextBlock(parts=[f"</{node.name}>"]))
+
+        else:
+            # NOTE (mristin, 2022-07-18):
+            # We inline all the other elements.
+
+            start_element_writer = io.StringIO()
+            start_element_writer.write(f"<{node.name}")
+            if len(node.attrs) > 0:
+                for attr_name, attr_value in node.attrs.items():
+                    start_element_writer.write(
+                        f" {attr_name}={xml.sax.saxutils.quoteattr(attr_value)}"
+                    )
+
+            if len(node.children.items) == 0:
+                start_element_writer.write(" />")
+                self._last_or_new_block().parts.append(start_element_writer.getvalue())
+
+                return
+
+            start_element_writer.write(">")
+            self._last_or_new_block().parts.append(start_element_writer.getvalue())
+
+            for item in node.children.items:
+                self.visit(item)
+
+            self._last_or_new_block().parts.append(f"</{node.name}>")
+
+
+_TextDirectiveExceptEnforceNewLine = Union[_RelativeIndention, _TextBlock]
+assert_union_without_excluded(
+    original_union=_TextDirective,
+    subset_union=_TextDirectiveExceptEnforceNewLine,
+    excluded=[_EnforceNewLine],
+)
+
+T = TypeVar("T")
+
+
+def pairwise(iterable: Iterable[T]) -> Iterator[Tuple[T, T]]:
+    """Iterate pair-wise over the iterator."""
+    a, b = itertools.tee(iterable)
+    next(b, None)
+    return zip(a, b)
+
+
+# fmt: off
+@ensure(
+    lambda result:
+    all(
+        len(directive.parts) > 0
+        for directive in result
+        if isinstance(directive, _TextBlock)
+    ),
+    "No empty text blocks"
+)
+@ensure(
+    lambda result:
+    all(
+        not (
+            isinstance(prev, _TextBlock)
+            and isinstance(current, _TextBlock)
+        )
+        for prev, current in pairwise(result)
+    ),
+    "All text blocks are merged and there are no consecutive text blocks"
+)
+# fmt: on
+def _compress_text_directives(
+    directives: Sequence[_TextDirective],
+) -> List[_TextDirectiveExceptEnforceNewLine]:
+    """Merge consecutive text blocks and enforce the new lines."""
+    # region Remove empty blocks
+
+    directives_wo_empty_blocks = [
+        directive
+        for directive in directives
+        if not (isinstance(directive, _TextBlock) and len(directive.parts) == 0)
+    ]
+
+    # endregion
+
+    # region Fulfill new-line enforcement
+
+    directives_wo_enforce_new_line = (
+        []
+    )  # type: List[_TextDirectiveExceptEnforceNewLine]
+
+    previous_text_block = None  # type: Optional[_TextBlock]
+
+    for directive in directives_wo_empty_blocks:
+        if isinstance(directive, _EnforceNewLine):
+            if previous_text_block is not None:
+                assert len(previous_text_block.parts) > 0
+
+                if not previous_text_block.parts[-1].endswith("\n"):
+                    previous_text_block.parts.append("\n")
+        elif isinstance(directive, _TextBlock):
+            assert len(directive.parts) > 0
+
+            previous_text_block = directive
+            directives_wo_enforce_new_line.append(directive)
+
+        elif isinstance(directive, _RelativeIndention):
+            directives_wo_enforce_new_line.append(directive)
+        else:
+            assert_never(directive)
+
+    # endregion
+
+    # region Merge consecutive text blocks
+
+    directives_w_merged_blocks = []  # type: List[_TextDirectiveExceptEnforceNewLine]
+
+    for directive in directives_wo_enforce_new_line:
+        if isinstance(directive, _TextBlock):
+            assert len(directive.parts) > 0
+
+            if len(directives_w_merged_blocks) > 0 and isinstance(
+                directives_w_merged_blocks[-1], _TextBlock
+            ):
+                directives_w_merged_blocks[-1].parts.extend(directive.parts)
+            else:
+                directives_w_merged_blocks.append(directive)
+        else:
+            directives_w_merged_blocks.append(directive)
+
+    # endregion
+
+    return directives_w_merged_blocks
+
+
+def _to_text(node: _NodeUnion) -> str:
+    """
+    Convert the node to a text representation.
+
+    For readability and no phantom elements, the ``node`` is expected to be compressed
+    before.
+    """
+    to_text_directives_visitor = _ToTextDirectivesVisitor()
+    to_text_directives_visitor.visit(node)
+
+    # NOTE (mristin, 2022-07-18):
+    # We compress to do away with the new-line enforcement and consecutive and empty
+    # blocks, so that the operations below become much easier to write.
+    directives = _compress_text_directives(to_text_directives_visitor.directives)
+
+    writer = io.StringIO()
+    level = 0  # indention level
+
+    for directive in directives:
+        if isinstance(directive, _TextBlock):
+            writer.write(textwrap.indent("".join(directive.parts), level * "  "))
+
+        elif isinstance(directive, _RelativeIndention):
+            assert level + directive.direction >= 0, (
+                f"Negative absolute indention not possible: "
+                f"{level=}, {directive.direction=}"
+            )
+            level += directive.direction
+
+        else:
+            assert_never(directive)
+
+    return writer.getvalue()
+
+
 def _generate_summary_remarks(
     description: intermediate.SummaryRemarksDescription,
 ) -> Tuple[Optional[Stripped], Optional[List[Error]]]:
     """Generate the documentation comment for a summary-remarks-constraints."""
-    errors = []  # type: List[Error]
-    renderer = _ElementRenderer()
-
-    summary, summary_errors = renderer.transform(description.summary)
-    if summary_errors is not None:
-        errors.extend(
-            Error(description.parsed.node, message) for message in summary_errors
-        )
-
-    remarks = []  # type: List[str]
-    for remark in description.remarks:
-        remark, remark_errors = renderer.transform(remark)
-        if remark_errors is not None:
-            errors.extend(
-                Error(description.parsed.node, message) for message in remark_errors
-            )
-        else:
-            assert remark is not None
-            remarks.append(remark)
-
-    if len(errors) > 0:
+    node, errors = _render_summary_remarks(description=description)
+    if errors is not None:
         return None, errors
 
-    assert summary is not None
+    assert node is not None
 
-    # Don't use textwrap.dedent to preserve the formatting
+    _compress_node_in_place(node=node)
+    text = _to_text(node)
 
-    blocks = [
-        Stripped(
-            f"""\
-<summary>
-{summary}
-</summary>"""
-        )
-    ]
-
-    if len(remarks) > 0:
-        remarks_joined = "\n\n".join(remarks)
-        blocks.append(
-            Stripped(
-                f"""\
-<remarks>
-{remarks_joined}
-</remarks>"""
-            )
-        )
-
-    commented_lines = [
-        _slash_slash_slash_line(line) for block in blocks for line in block.splitlines()
-    ]
+    commented_lines = [_slash_slash_slash_line(line) for line in text.splitlines()]
 
     return Stripped("\n".join(commented_lines)), None
 
@@ -384,78 +962,16 @@ def _generate_summary_remarks_constraints(
     description: intermediate.SummaryRemarksConstraintsDescription,
 ) -> Tuple[Optional[Stripped], Optional[List[Error]]]:
     """Generate the documentation comment for a summary-remarks-constraints."""
-    errors = []  # type: List[Error]
-    renderer = _ElementRenderer()
-
-    summary, summary_errors = renderer.transform(description.summary)
-    if summary_errors is not None:
-        errors.extend(
-            Error(description.parsed.node, message) for message in summary_errors
-        )
-
-    remarks = []  # type: List[str]
-    for remark in description.remarks:
-        remark, remark_errors = renderer.transform(remark)
-        if remark_errors is not None:
-            errors.extend(
-                Error(description.parsed.node, message) for message in remark_errors
-            )
-        else:
-            assert remark is not None
-            remarks.append(remark)
-
-    constraints = []  # type: List[str]
-    for identifier, body_element in description.constraints_by_identifier.items():
-        body, body_errors = renderer.transform(body_element)
-        if body_errors is not None:
-            errors.extend(
-                Error(description.parsed.node, message) for message in body_errors
-            )
-        else:
-            assert body is not None
-
-            constraints.append(
-                f"Constraint {xml.sax.saxutils.escape(identifier)}:\n{body}"
-            )
-
-    if len(errors) > 0:
+    node, errors = _render_summary_remarks_constraints(description=description)
+    if errors is not None:
         return None, errors
 
-    assert summary is not None
+    assert node is not None
 
-    # Don't use textwrap.dedent to preserve the formatting
+    _compress_node_in_place(node=node)
+    text = _to_text(node)
 
-    blocks = [
-        Stripped(
-            f"""\
-<summary>
-{summary}
-</summary>"""
-        )
-    ]
-
-    if len(constraints) > 0:
-        constraints_writer = io.StringIO()
-        constraints_writer.write("Constraints:\n<ul>\n")
-        for constraint in constraints:
-            constraints_writer.write(textwrap.indent(f"<li>\n{constraint}\n</li>\n", I))
-        constraints_writer.write("</ul>")
-        remarks.append(constraints_writer.getvalue())
-
-    if len(remarks) > 0:
-        remarks_joined = "\n\n".join(remarks)
-        blocks.append(
-            Stripped(
-                f"""\
-<remarks>
-{remarks_joined}
-</remarks>"""
-            )
-        )
-
-    commented_lines = [
-        _slash_slash_slash_line(line) for block in blocks for line in block.splitlines()
-    ]
+    commented_lines = [_slash_slash_slash_line(line) for line in text.splitlines()]
 
     return Stripped("\n".join(commented_lines)), None
 
@@ -488,56 +1004,60 @@ def generate_comment_for_enumeration_literal(
     return _generate_summary_remarks(description)
 
 
-def generate_comment_for_signature(
+def _render_description_of_signature(
     description: intermediate.DescriptionOfSignature,
-) -> Tuple[Optional[Stripped], Optional[List[Error]]]:
-    """
-    Generate the documentation comment for the given signature.
-
-    A signature, in this context, means a function or a method signature.
-    """
+) -> Tuple[Optional[_List], Optional[List[Error]]]:
+    """Render a description where constraints are put in remarks."""
+    result_items = []  # type: List[_NodeUnion]
     errors = []  # type: List[Error]
+
     renderer = _ElementRenderer()
 
-    summary, summary_errors = renderer.transform(description.summary)
+    summary_node, summary_errors = renderer.transform(description.summary)
     if summary_errors is not None:
         errors.extend(
             Error(description.parsed.node, message) for message in summary_errors
         )
+    else:
+        assert summary_node is not None
+        result_items.append(
+            _Element(name="summary", children=_List(items=[summary_node]))
+        )
 
-    remarks = []  # type: List[str]
+    remark_nodes = []  # type: List[_NodeUnion]
     for remark in description.remarks:
-        remark, remark_errors = renderer.transform(remark)
-        if remark_errors is not None:
+        remark_node, remark_errors = renderer.transform(remark)
+        if remark_errors:
             errors.extend(
                 Error(description.parsed.node, message) for message in remark_errors
             )
         else:
-            assert remark is not None
-            remarks.append(remark)
+            assert remark_node is not None
+            remark_nodes.append(remark_node)
 
-    params = []  # type: List[Stripped]
-    for name, body_element in description.arguments_by_name.items():
-        body, body_errors = renderer.transform(body_element)
+    param_nodes = []  # type: List[_NodeUnion]
+
+    for name, docutils_element in description.arguments_by_name.items():
+        returns, body_errors = renderer.transform(docutils_element)
         if body_errors is not None:
             errors.extend(
                 Error(description.parsed.node, message) for message in body_errors
             )
         else:
-            assert body is not None
+            assert returns is not None
 
-            # Don't use textwrap.dedent to preserve the formatting
-            params.append(
-                Stripped(
-                    f"""\
-<param name={xml.sax.saxutils.quoteattr(name)}>
-{body}
-</param>"""
+            param_nodes.append(
+                _Element(
+                    name="param",
+                    attrs=collections.OrderedDict([("name", name)]),
+                    children=_List(items=[returns]),
                 )
             )
 
-    returns = None  # type: Optional[str]
+    returns_node = None  # type: Optional[_NodeUnion]
+
     if description.returns is not None:
+        # NOTE (mristin, 2022-07-18):
         # We need to help the type checker in PyCharm a bit.
         assert isinstance(description.returns, docutils.nodes.field_body)
 
@@ -549,49 +1069,41 @@ def generate_comment_for_signature(
         else:
             assert returns is not None
 
+            returns_node = _Element(name="returns", children=_List(items=[returns]))
+
     if len(errors) > 0:
         return None, errors
 
-    assert summary is not None
-
-    # Don't use textwrap.dedent to preserve the formatting
-
-    blocks = [
-        Stripped(
-            f"""\
-<summary>
-{summary}
-</summary>"""
-        )
-    ]
-
-    if len(remarks) > 0:
-        remarks_joined = "\n\n".join(remarks)
-        blocks.append(
-            Stripped(
-                f"""\
-<remarks>
-{remarks_joined}
-</remarks>"""
-            )
+    if len(remark_nodes) > 0:
+        result_items.append(
+            _Element(name="remarks", children=_List(items=remark_nodes))
         )
 
-    if len(params) > 0:
-        params_joined = "\n".join(params)
-        blocks.append(Stripped(params_joined))
+    result_items.extend(param_nodes)
 
-    if returns is not None:
-        blocks.append(
-            Stripped(
-                f"""\
-<returns>
-{returns}
-</returns>"""
-            )
-        )
+    if returns_node is not None:
+        result_items.append(returns_node)
 
-    commented_lines = [
-        _slash_slash_slash_line(line) for block in blocks for line in block.splitlines()
-    ]
+    return _List(items=result_items), None
+
+
+def generate_comment_for_signature(
+    description: intermediate.DescriptionOfSignature,
+) -> Tuple[Optional[Stripped], Optional[List[Error]]]:
+    """
+    Generate the documentation comment for the given signature.
+
+    A signature, in this context, means a function or a method signature.
+    """
+    node, errors = _render_description_of_signature(description=description)
+    if errors is not None:
+        return None, errors
+
+    assert node is not None
+
+    _compress_node_in_place(node=node)
+    text = _to_text(node)
+
+    commented_lines = [_slash_slash_slash_line(line) for line in text.splitlines()]
 
     return Stripped("\n".join(commented_lines)), None

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/types.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/types.cs
@@ -61,13 +61,15 @@ namespace AasCore.Aas3_0_RC02
     /// definitions.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Constraints:
+    /// </para>
     /// <ul>
-    ///     <li>
+    ///   <li>
     ///     Constraint AASd-118:
     ///     If there are ID <see cref="Aas.IHasSemantics.SupplementalSemanticIds" /> defined
     ///     then there shall be also a main semantic ID <see cref="Aas.IHasSemantics.SemanticId" />.
-    ///     </li>
+    ///   </li>
     /// </ul>
     /// </remarks>
     public interface IHasSemantics : IClass
@@ -118,12 +120,14 @@ namespace AasCore.Aas3_0_RC02
         /// Name of the extension.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// Constraints:
+        /// </para>
         /// <ul>
-        ///     <li>
+        ///   <li>
         ///     Constraint AASd-077:
         ///     The name of an extension within <see cref="Aas.IHasExtensions" /> needs to be unique.
-        ///     </li>
+        ///   </li>
         /// </ul>
         /// </remarks>
         public string Name { get; set; }
@@ -341,19 +345,30 @@ namespace AasCore.Aas3_0_RC02
         /// Display name. Can be provided in several languages.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// If no display name is defined in the language requested by the application,
         /// then the display name is selected in the following order if available:
-        ///
+        /// </para>
         /// <ul>
-        /// <li>the preferred name in the requested language of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>If there is a default language list defined in the application,
-        /// then the corresponding preferred name in the language is chosen
-        /// according to this order.</li>
-        /// <li>the English preferred name of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>the short name of the concept description</li>
-        /// <li>the <see cref="Aas.IReferable.IdShort" /> of the element</li>
+        ///   <li>
+        ///     the preferred name in the requested language of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     If there is a default language list defined in the application,
+        ///     then the corresponding preferred name in the language is chosen
+        ///     according to this order.
+        ///   </li>
+        ///   <li>
+        ///     the English preferred name of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     the short name of the concept description
+        ///   </li>
+        ///   <li>
+        ///     the <see cref="Aas.IReferable.IdShort" /> of the element
+        ///   </li>
         /// </ul>
         /// </remarks>
         public LangStringSet? DisplayName { get; set; }
@@ -362,15 +377,19 @@ namespace AasCore.Aas3_0_RC02
         /// Description or comments on the element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// The description can be provided in several languages.
-        ///
+        /// </para>
+        /// <para>
         /// If no description is defined, then the definition of the concept
         /// description that defines the semantics of the element is used.
-        ///
+        /// </para>
+        /// <para>
         /// Additional information can be provided, e.g., if the element is
         /// qualified and which qualifier types can be expected in which
         /// context or which additional data specification templates are
         /// provided.
+        /// </para>
         /// </remarks>
         public LangStringSet? Description { get; set; }
 
@@ -426,13 +445,17 @@ namespace AasCore.Aas3_0_RC02
         /// Concrete, clearly identifiable component of a certain template.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// It becomes an individual entity of a  template,  for example a
         /// device model, by defining specific property values.
-        ///
+        /// </para>
+        /// <para>
         /// In an object oriented view,  an instance denotes an object of a
         /// template (class).
-        ///
+        /// </para>
+        /// <para>
         /// [SOURCE: IEC 62890:2016, 3.1.16 65/617/CDV]  modified
+        /// </para>
         /// </remarks>
         [EnumMember(Value = "Instance")]
         Instance
@@ -482,14 +505,16 @@ namespace AasCore.Aas3_0_RC02
     /// information.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Constraints:
+    /// </para>
     /// <ul>
-    ///     <li>
+    ///   <li>
     ///     Constraint AASd-005:
     ///     If <see cref="Aas.AdministrativeInformation.Version" /> is not specified then also <see cref="Aas.AdministrativeInformation.Revision" /> shall be
     ///     unspecified. This means, a revision requires a version. If there is no version
     ///     there is no revision neither. Revision is optional.
-    ///     </li>
+    ///   </li>
     /// </ul>
     /// </remarks>
     public class AdministrativeInformation : IHasDataSpecification
@@ -612,15 +637,17 @@ namespace AasCore.Aas3_0_RC02
     /// qualifiers.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Constraints:
+    /// </para>
     /// <ul>
-    ///     <li>
+    ///   <li>
     ///     Constraint AASd-119:
     ///     If any <see cref="Aas.Qualifier.Kind" /> value of <see cref="Aas.IQualifiable.Qualifiers" /> is
     ///     equal to <see cref="Aas.QualifierKind.TemplateQualifier" /> and the qualified element
     ///     inherits from <see cref="Aas.IHasKind" /> then the qualified element shell be of
     ///     kind Template (<see cref="Aas.IHasKind.Kind" /> = <see cref="Aas.ModelingKind.Template" />).
-    ///     </li>
+    ///   </li>
     /// </ul>
     /// </remarks>
     public interface IQualifiable : IClass
@@ -629,13 +656,15 @@ namespace AasCore.Aas3_0_RC02
         /// Additional qualification of a qualifiable element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// Constraints:
+        /// </para>
         /// <ul>
-        ///     <li>
+        ///   <li>
         ///     Constraint AASd-021:
         ///     Every qualifiable can only have one qualifier with the same
         ///     <see cref="Aas.Qualifier.Type" />.
-        ///     </li>
+        ///   </li>
         /// </ul>
         /// </remarks>
         public List<Qualifier>? Qualifiers { get; set; }
@@ -679,20 +708,22 @@ namespace AasCore.Aas3_0_RC02
     /// of the element.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Constraints:
+    /// </para>
     /// <ul>
-    ///     <li>
+    ///   <li>
     ///     Constraint AASd-006:
     ///     If both the <see cref="Aas.Qualifier.Value" /> and the <see cref="Aas.Qualifier.ValueId" /> of
     ///     a <see cref="Aas.Qualifier" /> are present then the <see cref="Aas.Qualifier.Value" /> needs
     ///     to be identical to the value of the referenced coded value
     ///     in <see cref="Aas.Qualifier.ValueId" />.
-    ///     </li>
-    ///     <li>
+    ///   </li>
+    ///   <li>
     ///     Constraint AASd-020:
     ///     The value of <see cref="Aas.Qualifier.Value" /> shall be consistent to the data type as
     ///     defined in <see cref="Aas.Qualifier.ValueType" />.
-    ///     </li>
+    ///   </li>
     /// </ul>
     /// </remarks>
     public class Qualifier : IHasSemantics
@@ -934,19 +965,30 @@ namespace AasCore.Aas3_0_RC02
         /// Display name. Can be provided in several languages.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// If no display name is defined in the language requested by the application,
         /// then the display name is selected in the following order if available:
-        ///
+        /// </para>
         /// <ul>
-        /// <li>the preferred name in the requested language of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>If there is a default language list defined in the application,
-        /// then the corresponding preferred name in the language is chosen
-        /// according to this order.</li>
-        /// <li>the English preferred name of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>the short name of the concept description</li>
-        /// <li>the <see cref="Aas.IReferable.IdShort" /> of the element</li>
+        ///   <li>
+        ///     the preferred name in the requested language of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     If there is a default language list defined in the application,
+        ///     then the corresponding preferred name in the language is chosen
+        ///     according to this order.
+        ///   </li>
+        ///   <li>
+        ///     the English preferred name of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     the short name of the concept description
+        ///   </li>
+        ///   <li>
+        ///     the <see cref="Aas.IReferable.IdShort" /> of the element
+        ///   </li>
         /// </ul>
         /// </remarks>
         public LangStringSet? DisplayName { get; set; }
@@ -955,15 +997,19 @@ namespace AasCore.Aas3_0_RC02
         /// Description or comments on the element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// The description can be provided in several languages.
-        ///
+        /// </para>
+        /// <para>
         /// If no description is defined, then the definition of the concept
         /// description that defines the semantics of the element is used.
-        ///
+        /// </para>
+        /// <para>
         /// Additional information can be provided, e.g., if the element is
         /// qualified and which qualifier types can be expected in which
         /// context or which additional data specification templates are
         /// provided.
+        /// </para>
         /// </remarks>
         public LangStringSet? Description { get; set; }
 
@@ -1015,11 +1061,15 @@ namespace AasCore.Aas3_0_RC02
         /// References to submodels of the AAS.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// A submodel is a description of an aspect of the asset the AAS is representing.
-        ///
+        /// </para>
+        /// <para>
         /// The asset of an AAS is typically described by one or more submodels.
-        ///
+        /// </para>
+        /// <para>
         /// Temporarily no submodel might be assigned to the AAS.
+        /// </para>
         /// </remarks>
         public List<Reference>? Submodels { get; set; }
 
@@ -1277,21 +1327,25 @@ namespace AasCore.Aas3_0_RC02
     /// represented by an AAS is defined.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The asset may either represent an asset type or an asset instance.
-    ///
+    /// </para>
+    /// <para>
     /// The asset has a globally unique identifier plus – if needed – additional domain
     /// specific (proprietary) identifiers. However, to support the corner case of very
     /// first phase of lifecycle where a stabilised/constant_set global asset identifier does
     /// not already exist, the corresponding attribute <see cref="Aas.AssetInformation.GlobalAssetId" /> is optional.
-    ///
+    /// </para>
+    /// <para>
     /// Constraints:
+    /// </para>
     /// <ul>
-    ///     <li>
+    ///   <li>
     ///     Constraint AASd-116:
     ///     <c>globalAssetId</c> (case-insensitive) is a reserved key. If used as value for
     ///     <see cref="Aas.SpecificAssetId.Name" /> then <see cref="Aas.SpecificAssetId.Value" /> shall be
     ///     identical to <see cref="Aas.AssetInformation.GlobalAssetId" />.
-    ///     </li>
+    ///   </li>
     /// </ul>
     /// </remarks>
     public class AssetInformation : IClass
@@ -1306,12 +1360,15 @@ namespace AasCore.Aas3_0_RC02
         /// Global identifier of the asset the AAS is representing.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This attribute is required as soon as the AAS is exchanged via partners in the life
         /// cycle of the asset. In a first phase of the life cycle the asset might not yet have
         /// a global ID but already an internal identifier. The internal identifier would be
         /// modelled via <see cref="Aas.AssetInformation.SpecificAssetIds" />.
-        ///
+        /// </para>
+        /// <para>
         /// This is a global reference.
+        /// </para>
         /// </remarks>
         public Reference? GlobalAssetId { get; set; }
 
@@ -1567,13 +1624,17 @@ namespace AasCore.Aas3_0_RC02
         /// concrete, clearly identifiable component of a certain type
         /// </summary>
         /// <remarks>
+        /// <para>
         /// It becomes an individual entity of a type, for example a device, by defining
         /// specific property values.
-        ///
+        /// </para>
+        /// <para>
         /// In an object oriented view, an instance denotes an object of a class
         /// (of a type).
-        ///
+        /// </para>
+        /// <para>
         /// [SOURCE: IEC 62890:2016, 3.1.16] 65/617/CDV
+        /// </para>
         /// </remarks>
         [EnumMember(Value = "Instance")]
         Instance
@@ -1800,19 +1861,30 @@ namespace AasCore.Aas3_0_RC02
         /// Display name. Can be provided in several languages.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// If no display name is defined in the language requested by the application,
         /// then the display name is selected in the following order if available:
-        ///
+        /// </para>
         /// <ul>
-        /// <li>the preferred name in the requested language of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>If there is a default language list defined in the application,
-        /// then the corresponding preferred name in the language is chosen
-        /// according to this order.</li>
-        /// <li>the English preferred name of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>the short name of the concept description</li>
-        /// <li>the <see cref="Aas.IReferable.IdShort" /> of the element</li>
+        ///   <li>
+        ///     the preferred name in the requested language of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     If there is a default language list defined in the application,
+        ///     then the corresponding preferred name in the language is chosen
+        ///     according to this order.
+        ///   </li>
+        ///   <li>
+        ///     the English preferred name of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     the short name of the concept description
+        ///   </li>
+        ///   <li>
+        ///     the <see cref="Aas.IReferable.IdShort" /> of the element
+        ///   </li>
         /// </ul>
         /// </remarks>
         public LangStringSet? DisplayName { get; set; }
@@ -1821,15 +1893,19 @@ namespace AasCore.Aas3_0_RC02
         /// Description or comments on the element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// The description can be provided in several languages.
-        ///
+        /// </para>
+        /// <para>
         /// If no description is defined, then the definition of the concept
         /// description that defines the semantics of the element is used.
-        ///
+        /// </para>
+        /// <para>
         /// Additional information can be provided, e.g., if the element is
         /// qualified and which qualifier types can be expected in which
         /// context or which additional data specification templates are
         /// provided.
+        /// </para>
         /// </remarks>
         public LangStringSet? Description { get; set; }
 
@@ -1889,13 +1965,15 @@ namespace AasCore.Aas3_0_RC02
         /// Additional qualification of a qualifiable element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// Constraints:
+        /// </para>
         /// <ul>
-        ///     <li>
+        ///   <li>
         ///     Constraint AASd-021:
         ///     Every qualifiable can only have one qualifier with the same
         ///     <see cref="Aas.Qualifier.Type" />.
-        ///     </li>
+        ///   </li>
         /// </ul>
         /// </remarks>
         public List<Qualifier>? Qualifiers { get; set; }
@@ -2302,19 +2380,30 @@ namespace AasCore.Aas3_0_RC02
         /// Display name. Can be provided in several languages.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// If no display name is defined in the language requested by the application,
         /// then the display name is selected in the following order if available:
-        ///
+        /// </para>
         /// <ul>
-        /// <li>the preferred name in the requested language of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>If there is a default language list defined in the application,
-        /// then the corresponding preferred name in the language is chosen
-        /// according to this order.</li>
-        /// <li>the English preferred name of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>the short name of the concept description</li>
-        /// <li>the <see cref="Aas.IReferable.IdShort" /> of the element</li>
+        ///   <li>
+        ///     the preferred name in the requested language of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     If there is a default language list defined in the application,
+        ///     then the corresponding preferred name in the language is chosen
+        ///     according to this order.
+        ///   </li>
+        ///   <li>
+        ///     the English preferred name of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     the short name of the concept description
+        ///   </li>
+        ///   <li>
+        ///     the <see cref="Aas.IReferable.IdShort" /> of the element
+        ///   </li>
         /// </ul>
         /// </remarks>
         public LangStringSet? DisplayName { get; set; }
@@ -2323,15 +2412,19 @@ namespace AasCore.Aas3_0_RC02
         /// Description or comments on the element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// The description can be provided in several languages.
-        ///
+        /// </para>
+        /// <para>
         /// If no description is defined, then the definition of the concept
         /// description that defines the semantics of the element is used.
-        ///
+        /// </para>
+        /// <para>
         /// Additional information can be provided, e.g., if the element is
         /// qualified and which qualifier types can be expected in which
         /// context or which additional data specification templates are
         /// provided.
+        /// </para>
         /// </remarks>
         public LangStringSet? Description { get; set; }
 
@@ -2377,13 +2470,15 @@ namespace AasCore.Aas3_0_RC02
         /// Additional qualification of a qualifiable element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// Constraints:
+        /// </para>
         /// <ul>
-        ///     <li>
+        ///   <li>
         ///     Constraint AASd-021:
         ///     Every qualifiable can only have one qualifier with the same
         ///     <see cref="Aas.Qualifier.Type" />.
-        ///     </li>
+        ///   </li>
         /// </ul>
         /// </remarks>
         public List<Qualifier>? Qualifiers { get; set; }
@@ -2752,33 +2847,36 @@ namespace AasCore.Aas3_0_RC02
     /// A submodel element list is an ordered list of submodel elements.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The numbering starts with zero (0).
-    ///
+    /// </para>
+    /// <para>
     /// Constraints:
+    /// </para>
     /// <ul>
-    ///     <li>
+    ///   <li>
     ///     Constraint AASd-107:
     ///     If a first level child element in a <see cref="Aas.SubmodelElementList" /> has
     ///     a <see cref="Aas.ISubmodelElement.SemanticId" /> it
     ///     shall be identical to <see cref="Aas.SubmodelElementList.SemanticIdListElement" />.
-    ///     </li>
-    ///     <li>
+    ///   </li>
+    ///   <li>
     ///     Constraint AASd-114:
     ///     If two first level child elements in a <see cref="Aas.SubmodelElementList" /> have
     ///     a <see cref="Aas.ISubmodelElement.SemanticId" /> then they shall be identical.
-    ///     </li>
-    ///     <li>
+    ///   </li>
+    ///   <li>
     ///     Constraint AASd-115:
     ///     If a first level child element in a <see cref="Aas.SubmodelElementList" /> does not
     ///     specify a <see cref="Aas.ISubmodelElement.SemanticId" /> then the value is assumed to be
     ///     identical to <see cref="Aas.SubmodelElementList.SemanticIdListElement" />.
-    ///     </li>
-    ///     <li>
+    ///   </li>
+    ///   <li>
     ///     Constraint AASd-108:
     ///     All first level child elements in a <see cref="Aas.SubmodelElementList" /> shall have
     ///     the same submodel element type as specified in <see cref="Aas.SubmodelElementList.TypeValueListElement" />.
-    ///     </li>
-    ///     <li>
+    ///   </li>
+    ///   <li>
     ///     Constraint AASd-109:
     ///     If <see cref="Aas.SubmodelElementList.TypeValueListElement" /> is equal to
     ///     <see cref="Aas.AasSubmodelElements.Property" /> or
@@ -2786,7 +2884,7 @@ namespace AasCore.Aas3_0_RC02
     ///     <see cref="Aas.SubmodelElementList.ValueTypeListElement" /> shall be set and all first
     ///     level child elements in the <see cref="Aas.SubmodelElementList" /> shall have
     ///     the value type as specified in <see cref="Aas.SubmodelElementList.ValueTypeListElement" />.
-    ///     </li>
+    ///   </li>
     /// </ul>
     /// </remarks>
     public class SubmodelElementList : ISubmodelElement
@@ -2826,19 +2924,30 @@ namespace AasCore.Aas3_0_RC02
         /// Display name. Can be provided in several languages.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// If no display name is defined in the language requested by the application,
         /// then the display name is selected in the following order if available:
-        ///
+        /// </para>
         /// <ul>
-        /// <li>the preferred name in the requested language of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>If there is a default language list defined in the application,
-        /// then the corresponding preferred name in the language is chosen
-        /// according to this order.</li>
-        /// <li>the English preferred name of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>the short name of the concept description</li>
-        /// <li>the <see cref="Aas.IReferable.IdShort" /> of the element</li>
+        ///   <li>
+        ///     the preferred name in the requested language of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     If there is a default language list defined in the application,
+        ///     then the corresponding preferred name in the language is chosen
+        ///     according to this order.
+        ///   </li>
+        ///   <li>
+        ///     the English preferred name of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     the short name of the concept description
+        ///   </li>
+        ///   <li>
+        ///     the <see cref="Aas.IReferable.IdShort" /> of the element
+        ///   </li>
         /// </ul>
         /// </remarks>
         public LangStringSet? DisplayName { get; set; }
@@ -2847,15 +2956,19 @@ namespace AasCore.Aas3_0_RC02
         /// Description or comments on the element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// The description can be provided in several languages.
-        ///
+        /// </para>
+        /// <para>
         /// If no description is defined, then the definition of the concept
         /// description that defines the semantics of the element is used.
-        ///
+        /// </para>
+        /// <para>
         /// Additional information can be provided, e.g., if the element is
         /// qualified and which qualifier types can be expected in which
         /// context or which additional data specification templates are
         /// provided.
+        /// </para>
         /// </remarks>
         public LangStringSet? Description { get; set; }
 
@@ -2901,13 +3014,15 @@ namespace AasCore.Aas3_0_RC02
         /// Additional qualification of a qualifiable element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// Constraints:
+        /// </para>
         /// <ul>
-        ///     <li>
+        ///   <li>
         ///     Constraint AASd-021:
         ///     Every qualifiable can only have one qualifier with the same
         ///     <see cref="Aas.Qualifier.Type" />.
-        ///     </li>
+        ///   </li>
         /// </ul>
         /// </remarks>
         public List<Qualifier>? Qualifiers { get; set; }
@@ -3323,19 +3438,30 @@ namespace AasCore.Aas3_0_RC02
         /// Display name. Can be provided in several languages.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// If no display name is defined in the language requested by the application,
         /// then the display name is selected in the following order if available:
-        ///
+        /// </para>
         /// <ul>
-        /// <li>the preferred name in the requested language of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>If there is a default language list defined in the application,
-        /// then the corresponding preferred name in the language is chosen
-        /// according to this order.</li>
-        /// <li>the English preferred name of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>the short name of the concept description</li>
-        /// <li>the <see cref="Aas.IReferable.IdShort" /> of the element</li>
+        ///   <li>
+        ///     the preferred name in the requested language of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     If there is a default language list defined in the application,
+        ///     then the corresponding preferred name in the language is chosen
+        ///     according to this order.
+        ///   </li>
+        ///   <li>
+        ///     the English preferred name of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     the short name of the concept description
+        ///   </li>
+        ///   <li>
+        ///     the <see cref="Aas.IReferable.IdShort" /> of the element
+        ///   </li>
         /// </ul>
         /// </remarks>
         public LangStringSet? DisplayName { get; set; }
@@ -3344,15 +3470,19 @@ namespace AasCore.Aas3_0_RC02
         /// Description or comments on the element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// The description can be provided in several languages.
-        ///
+        /// </para>
+        /// <para>
         /// If no description is defined, then the definition of the concept
         /// description that defines the semantics of the element is used.
-        ///
+        /// </para>
+        /// <para>
         /// Additional information can be provided, e.g., if the element is
         /// qualified and which qualifier types can be expected in which
         /// context or which additional data specification templates are
         /// provided.
+        /// </para>
         /// </remarks>
         public LangStringSet? Description { get; set; }
 
@@ -3398,13 +3528,15 @@ namespace AasCore.Aas3_0_RC02
         /// Additional qualification of a qualifiable element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// Constraints:
+        /// </para>
         /// <ul>
-        ///     <li>
+        ///   <li>
         ///     Constraint AASd-021:
         ///     Every qualifiable can only have one qualifier with the same
         ///     <see cref="Aas.Qualifier.Type" />.
-        ///     </li>
+        ///   </li>
         /// </ul>
         /// </remarks>
         public List<Qualifier>? Qualifiers { get; set; }
@@ -3721,18 +3853,24 @@ namespace AasCore.Aas3_0_RC02
     /// other submodel elements.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// A data element is a submodel element that has a value. The type of value differs
     /// for different subtypes of data elements.
-    ///
+    /// </para>
+    /// <para>
     /// Constraints:
+    /// </para>
     /// <ul>
-    ///     <li>
+    ///   <li>
+    ///     <para>
     ///     Constraint AASd-090:
     ///     For data elements <see cref="Aas.IDataElement.Category" /> (inherited by <see cref="Aas.IReferable" />) shall be
     ///     one of the following values: <c>CONSTANT</c>, <c>PARAMETER</c> or <c>VARIABLE</c>.
-    ///
+    ///     </para>
+    ///     <para>
     ///     Default: <c>VARIABLE</c>
-    ///     </li>
+    ///     </para>
+    ///   </li>
     /// </ul>
     /// </remarks>
     public interface IDataElement : ISubmodelElement
@@ -3760,14 +3898,16 @@ namespace AasCore.Aas3_0_RC02
     /// A property is a data element that has a single value.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Constraints:
+    /// </para>
     /// <ul>
-    ///     <li>
+    ///   <li>
     ///     Constraint AASd-007:
     ///     If both, the <see cref="Aas.Property.Value" /> and the <see cref="Aas.Property.ValueId" /> are
     ///     present then the value of <see cref="Aas.Property.Value" /> needs to be identical to
     ///     the value of the referenced coded value in <see cref="Aas.Property.ValueId" />.
-    ///     </li>
+    ///   </li>
     /// </ul>
     /// </remarks>
     public class Property : IDataElement
@@ -3807,19 +3947,30 @@ namespace AasCore.Aas3_0_RC02
         /// Display name. Can be provided in several languages.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// If no display name is defined in the language requested by the application,
         /// then the display name is selected in the following order if available:
-        ///
+        /// </para>
         /// <ul>
-        /// <li>the preferred name in the requested language of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>If there is a default language list defined in the application,
-        /// then the corresponding preferred name in the language is chosen
-        /// according to this order.</li>
-        /// <li>the English preferred name of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>the short name of the concept description</li>
-        /// <li>the <see cref="Aas.IReferable.IdShort" /> of the element</li>
+        ///   <li>
+        ///     the preferred name in the requested language of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     If there is a default language list defined in the application,
+        ///     then the corresponding preferred name in the language is chosen
+        ///     according to this order.
+        ///   </li>
+        ///   <li>
+        ///     the English preferred name of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     the short name of the concept description
+        ///   </li>
+        ///   <li>
+        ///     the <see cref="Aas.IReferable.IdShort" /> of the element
+        ///   </li>
         /// </ul>
         /// </remarks>
         public LangStringSet? DisplayName { get; set; }
@@ -3828,15 +3979,19 @@ namespace AasCore.Aas3_0_RC02
         /// Description or comments on the element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// The description can be provided in several languages.
-        ///
+        /// </para>
+        /// <para>
         /// If no description is defined, then the definition of the concept
         /// description that defines the semantics of the element is used.
-        ///
+        /// </para>
+        /// <para>
         /// Additional information can be provided, e.g., if the element is
         /// qualified and which qualifier types can be expected in which
         /// context or which additional data specification templates are
         /// provided.
+        /// </para>
         /// </remarks>
         public LangStringSet? Description { get; set; }
 
@@ -3882,13 +4037,15 @@ namespace AasCore.Aas3_0_RC02
         /// Additional qualification of a qualifiable element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// Constraints:
+        /// </para>
         /// <ul>
-        ///     <li>
+        ///   <li>
         ///     Constraint AASd-021:
         ///     Every qualifiable can only have one qualifier with the same
         ///     <see cref="Aas.Qualifier.Type" />.
-        ///     </li>
+        ///   </li>
         /// </ul>
         /// </remarks>
         public List<Qualifier>? Qualifiers { get; set; }
@@ -4227,14 +4384,16 @@ namespace AasCore.Aas3_0_RC02
     /// A property is a data element that has a multi-language value.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Constraints:
+    /// </para>
     /// <ul>
-    ///     <li>
+    ///   <li>
     ///     Constraint AASd-012:
     ///     If both the <see cref="Aas.MultiLanguageProperty.Value" /> and the <see cref="Aas.MultiLanguageProperty.ValueId" /> are present then for each
     ///     string in a specific language the meaning must be the same as specified in
     ///     <see cref="Aas.MultiLanguageProperty.ValueId" />.
-    ///     </li>
+    ///   </li>
     /// </ul>
     /// </remarks>
     public class MultiLanguageProperty : IDataElement
@@ -4274,19 +4433,30 @@ namespace AasCore.Aas3_0_RC02
         /// Display name. Can be provided in several languages.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// If no display name is defined in the language requested by the application,
         /// then the display name is selected in the following order if available:
-        ///
+        /// </para>
         /// <ul>
-        /// <li>the preferred name in the requested language of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>If there is a default language list defined in the application,
-        /// then the corresponding preferred name in the language is chosen
-        /// according to this order.</li>
-        /// <li>the English preferred name of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>the short name of the concept description</li>
-        /// <li>the <see cref="Aas.IReferable.IdShort" /> of the element</li>
+        ///   <li>
+        ///     the preferred name in the requested language of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     If there is a default language list defined in the application,
+        ///     then the corresponding preferred name in the language is chosen
+        ///     according to this order.
+        ///   </li>
+        ///   <li>
+        ///     the English preferred name of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     the short name of the concept description
+        ///   </li>
+        ///   <li>
+        ///     the <see cref="Aas.IReferable.IdShort" /> of the element
+        ///   </li>
         /// </ul>
         /// </remarks>
         public LangStringSet? DisplayName { get; set; }
@@ -4295,15 +4465,19 @@ namespace AasCore.Aas3_0_RC02
         /// Description or comments on the element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// The description can be provided in several languages.
-        ///
+        /// </para>
+        /// <para>
         /// If no description is defined, then the definition of the concept
         /// description that defines the semantics of the element is used.
-        ///
+        /// </para>
+        /// <para>
         /// Additional information can be provided, e.g., if the element is
         /// qualified and which qualifier types can be expected in which
         /// context or which additional data specification templates are
         /// provided.
+        /// </para>
         /// </remarks>
         public LangStringSet? Description { get; set; }
 
@@ -4349,13 +4523,15 @@ namespace AasCore.Aas3_0_RC02
         /// Additional qualification of a qualifiable element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// Constraints:
+        /// </para>
         /// <ul>
-        ///     <li>
+        ///   <li>
         ///     Constraint AASd-021:
         ///     Every qualifiable can only have one qualifier with the same
         ///     <see cref="Aas.Qualifier.Type" />.
-        ///     </li>
+        ///   </li>
         /// </ul>
         /// </remarks>
         public List<Qualifier>? Qualifiers { get; set; }
@@ -4739,19 +4915,30 @@ namespace AasCore.Aas3_0_RC02
         /// Display name. Can be provided in several languages.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// If no display name is defined in the language requested by the application,
         /// then the display name is selected in the following order if available:
-        ///
+        /// </para>
         /// <ul>
-        /// <li>the preferred name in the requested language of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>If there is a default language list defined in the application,
-        /// then the corresponding preferred name in the language is chosen
-        /// according to this order.</li>
-        /// <li>the English preferred name of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>the short name of the concept description</li>
-        /// <li>the <see cref="Aas.IReferable.IdShort" /> of the element</li>
+        ///   <li>
+        ///     the preferred name in the requested language of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     If there is a default language list defined in the application,
+        ///     then the corresponding preferred name in the language is chosen
+        ///     according to this order.
+        ///   </li>
+        ///   <li>
+        ///     the English preferred name of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     the short name of the concept description
+        ///   </li>
+        ///   <li>
+        ///     the <see cref="Aas.IReferable.IdShort" /> of the element
+        ///   </li>
         /// </ul>
         /// </remarks>
         public LangStringSet? DisplayName { get; set; }
@@ -4760,15 +4947,19 @@ namespace AasCore.Aas3_0_RC02
         /// Description or comments on the element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// The description can be provided in several languages.
-        ///
+        /// </para>
+        /// <para>
         /// If no description is defined, then the definition of the concept
         /// description that defines the semantics of the element is used.
-        ///
+        /// </para>
+        /// <para>
         /// Additional information can be provided, e.g., if the element is
         /// qualified and which qualifier types can be expected in which
         /// context or which additional data specification templates are
         /// provided.
+        /// </para>
         /// </remarks>
         public LangStringSet? Description { get; set; }
 
@@ -4814,13 +5005,15 @@ namespace AasCore.Aas3_0_RC02
         /// Additional qualification of a qualifiable element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// Constraints:
+        /// </para>
         /// <ul>
-        ///     <li>
+        ///   <li>
         ///     Constraint AASd-021:
         ///     Every qualifiable can only have one qualifier with the same
         ///     <see cref="Aas.Qualifier.Type" />.
-        ///     </li>
+        ///   </li>
         /// </ul>
         /// </remarks>
         public List<Qualifier>? Qualifiers { get; set; }
@@ -5184,19 +5377,30 @@ namespace AasCore.Aas3_0_RC02
         /// Display name. Can be provided in several languages.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// If no display name is defined in the language requested by the application,
         /// then the display name is selected in the following order if available:
-        ///
+        /// </para>
         /// <ul>
-        /// <li>the preferred name in the requested language of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>If there is a default language list defined in the application,
-        /// then the corresponding preferred name in the language is chosen
-        /// according to this order.</li>
-        /// <li>the English preferred name of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>the short name of the concept description</li>
-        /// <li>the <see cref="Aas.IReferable.IdShort" /> of the element</li>
+        ///   <li>
+        ///     the preferred name in the requested language of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     If there is a default language list defined in the application,
+        ///     then the corresponding preferred name in the language is chosen
+        ///     according to this order.
+        ///   </li>
+        ///   <li>
+        ///     the English preferred name of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     the short name of the concept description
+        ///   </li>
+        ///   <li>
+        ///     the <see cref="Aas.IReferable.IdShort" /> of the element
+        ///   </li>
         /// </ul>
         /// </remarks>
         public LangStringSet? DisplayName { get; set; }
@@ -5205,15 +5409,19 @@ namespace AasCore.Aas3_0_RC02
         /// Description or comments on the element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// The description can be provided in several languages.
-        ///
+        /// </para>
+        /// <para>
         /// If no description is defined, then the definition of the concept
         /// description that defines the semantics of the element is used.
-        ///
+        /// </para>
+        /// <para>
         /// Additional information can be provided, e.g., if the element is
         /// qualified and which qualifier types can be expected in which
         /// context or which additional data specification templates are
         /// provided.
+        /// </para>
         /// </remarks>
         public LangStringSet? Description { get; set; }
 
@@ -5259,13 +5467,15 @@ namespace AasCore.Aas3_0_RC02
         /// Additional qualification of a qualifiable element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// Constraints:
+        /// </para>
         /// <ul>
-        ///     <li>
+        ///   <li>
         ///     Constraint AASd-021:
         ///     Every qualifiable can only have one qualifier with the same
         ///     <see cref="Aas.Qualifier.Type" />.
-        ///     </li>
+        ///   </li>
         /// </ul>
         /// </remarks>
         public List<Qualifier>? Qualifiers { get; set; }
@@ -5626,19 +5836,30 @@ namespace AasCore.Aas3_0_RC02
         /// Display name. Can be provided in several languages.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// If no display name is defined in the language requested by the application,
         /// then the display name is selected in the following order if available:
-        ///
+        /// </para>
         /// <ul>
-        /// <li>the preferred name in the requested language of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>If there is a default language list defined in the application,
-        /// then the corresponding preferred name in the language is chosen
-        /// according to this order.</li>
-        /// <li>the English preferred name of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>the short name of the concept description</li>
-        /// <li>the <see cref="Aas.IReferable.IdShort" /> of the element</li>
+        ///   <li>
+        ///     the preferred name in the requested language of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     If there is a default language list defined in the application,
+        ///     then the corresponding preferred name in the language is chosen
+        ///     according to this order.
+        ///   </li>
+        ///   <li>
+        ///     the English preferred name of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     the short name of the concept description
+        ///   </li>
+        ///   <li>
+        ///     the <see cref="Aas.IReferable.IdShort" /> of the element
+        ///   </li>
         /// </ul>
         /// </remarks>
         public LangStringSet? DisplayName { get; set; }
@@ -5647,15 +5868,19 @@ namespace AasCore.Aas3_0_RC02
         /// Description or comments on the element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// The description can be provided in several languages.
-        ///
+        /// </para>
+        /// <para>
         /// If no description is defined, then the definition of the concept
         /// description that defines the semantics of the element is used.
-        ///
+        /// </para>
+        /// <para>
         /// Additional information can be provided, e.g., if the element is
         /// qualified and which qualifier types can be expected in which
         /// context or which additional data specification templates are
         /// provided.
+        /// </para>
         /// </remarks>
         public LangStringSet? Description { get; set; }
 
@@ -5701,13 +5926,15 @@ namespace AasCore.Aas3_0_RC02
         /// Additional qualification of a qualifiable element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// Constraints:
+        /// </para>
         /// <ul>
-        ///     <li>
+        ///   <li>
         ///     Constraint AASd-021:
         ///     Every qualifiable can only have one qualifier with the same
         ///     <see cref="Aas.Qualifier.Type" />.
-        ///     </li>
+        ///   </li>
         /// </ul>
         /// </remarks>
         public List<Qualifier>? Qualifiers { get; set; }
@@ -5733,12 +5960,16 @@ namespace AasCore.Aas3_0_RC02
         /// Content type of the content of the <see cref="Aas.Blob" />.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// The content type (MIME type) states which file extensions the file can have.
-        ///
+        /// </para>
+        /// <para>
         /// Valid values are content types like e.g. <c>application/json</c>, <c>application/xls</c>,
         /// <c>image/jpg</c>.
-        ///
+        /// </para>
+        /// <para>
         /// The allowed values are defined as in RFC2046.
+        /// </para>
         /// </remarks>
         public string ContentType { get; set; }
 
@@ -6071,19 +6302,30 @@ namespace AasCore.Aas3_0_RC02
         /// Display name. Can be provided in several languages.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// If no display name is defined in the language requested by the application,
         /// then the display name is selected in the following order if available:
-        ///
+        /// </para>
         /// <ul>
-        /// <li>the preferred name in the requested language of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>If there is a default language list defined in the application,
-        /// then the corresponding preferred name in the language is chosen
-        /// according to this order.</li>
-        /// <li>the English preferred name of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>the short name of the concept description</li>
-        /// <li>the <see cref="Aas.IReferable.IdShort" /> of the element</li>
+        ///   <li>
+        ///     the preferred name in the requested language of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     If there is a default language list defined in the application,
+        ///     then the corresponding preferred name in the language is chosen
+        ///     according to this order.
+        ///   </li>
+        ///   <li>
+        ///     the English preferred name of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     the short name of the concept description
+        ///   </li>
+        ///   <li>
+        ///     the <see cref="Aas.IReferable.IdShort" /> of the element
+        ///   </li>
         /// </ul>
         /// </remarks>
         public LangStringSet? DisplayName { get; set; }
@@ -6092,15 +6334,19 @@ namespace AasCore.Aas3_0_RC02
         /// Description or comments on the element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// The description can be provided in several languages.
-        ///
+        /// </para>
+        /// <para>
         /// If no description is defined, then the definition of the concept
         /// description that defines the semantics of the element is used.
-        ///
+        /// </para>
+        /// <para>
         /// Additional information can be provided, e.g., if the element is
         /// qualified and which qualifier types can be expected in which
         /// context or which additional data specification templates are
         /// provided.
+        /// </para>
         /// </remarks>
         public LangStringSet? Description { get; set; }
 
@@ -6146,13 +6392,15 @@ namespace AasCore.Aas3_0_RC02
         /// Additional qualification of a qualifiable element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// Constraints:
+        /// </para>
         /// <ul>
-        ///     <li>
+        ///   <li>
         ///     Constraint AASd-021:
         ///     Every qualifiable can only have one qualifier with the same
         ///     <see cref="Aas.Qualifier.Type" />.
-        ///     </li>
+        ///   </li>
         /// </ul>
         /// </remarks>
         public List<Qualifier>? Qualifiers { get; set; }
@@ -6508,19 +6756,30 @@ namespace AasCore.Aas3_0_RC02
         /// Display name. Can be provided in several languages.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// If no display name is defined in the language requested by the application,
         /// then the display name is selected in the following order if available:
-        ///
+        /// </para>
         /// <ul>
-        /// <li>the preferred name in the requested language of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>If there is a default language list defined in the application,
-        /// then the corresponding preferred name in the language is chosen
-        /// according to this order.</li>
-        /// <li>the English preferred name of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>the short name of the concept description</li>
-        /// <li>the <see cref="Aas.IReferable.IdShort" /> of the element</li>
+        ///   <li>
+        ///     the preferred name in the requested language of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     If there is a default language list defined in the application,
+        ///     then the corresponding preferred name in the language is chosen
+        ///     according to this order.
+        ///   </li>
+        ///   <li>
+        ///     the English preferred name of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     the short name of the concept description
+        ///   </li>
+        ///   <li>
+        ///     the <see cref="Aas.IReferable.IdShort" /> of the element
+        ///   </li>
         /// </ul>
         /// </remarks>
         public LangStringSet? DisplayName { get; set; }
@@ -6529,15 +6788,19 @@ namespace AasCore.Aas3_0_RC02
         /// Description or comments on the element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// The description can be provided in several languages.
-        ///
+        /// </para>
+        /// <para>
         /// If no description is defined, then the definition of the concept
         /// description that defines the semantics of the element is used.
-        ///
+        /// </para>
+        /// <para>
         /// Additional information can be provided, e.g., if the element is
         /// qualified and which qualifier types can be expected in which
         /// context or which additional data specification templates are
         /// provided.
+        /// </para>
         /// </remarks>
         public LangStringSet? Description { get; set; }
 
@@ -6583,13 +6846,15 @@ namespace AasCore.Aas3_0_RC02
         /// Additional qualification of a qualifiable element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// Constraints:
+        /// </para>
         /// <ul>
-        ///     <li>
+        ///   <li>
         ///     Constraint AASd-021:
         ///     Every qualifiable can only have one qualifier with the same
         ///     <see cref="Aas.Qualifier.Type" />.
-        ///     </li>
+        ///   </li>
         /// </ul>
         /// </remarks>
         public List<Qualifier>? Qualifiers { get; set; }
@@ -6964,14 +7229,16 @@ namespace AasCore.Aas3_0_RC02
     /// An entity is a submodel element that is used to model entities.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Constraints:
+    /// </para>
     /// <ul>
-    ///     <li>
+    ///   <li>
     ///     Constraint AASd-014:
     ///     Either the attribute <see cref="Aas.Entity.GlobalAssetId" /> or <see cref="Aas.Entity.SpecificAssetId" />
     ///     of an <see cref="Aas.Entity" /> must be set if <see cref="Aas.Entity.EntityType" /> is set to
     ///     <see cref="Aas.EntityType.SelfManagedEntity" />. They are not existing otherwise.
-    ///     </li>
+    ///   </li>
     /// </ul>
     /// </remarks>
     public class Entity : ISubmodelElement
@@ -7011,19 +7278,30 @@ namespace AasCore.Aas3_0_RC02
         /// Display name. Can be provided in several languages.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// If no display name is defined in the language requested by the application,
         /// then the display name is selected in the following order if available:
-        ///
+        /// </para>
         /// <ul>
-        /// <li>the preferred name in the requested language of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>If there is a default language list defined in the application,
-        /// then the corresponding preferred name in the language is chosen
-        /// according to this order.</li>
-        /// <li>the English preferred name of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>the short name of the concept description</li>
-        /// <li>the <see cref="Aas.IReferable.IdShort" /> of the element</li>
+        ///   <li>
+        ///     the preferred name in the requested language of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     If there is a default language list defined in the application,
+        ///     then the corresponding preferred name in the language is chosen
+        ///     according to this order.
+        ///   </li>
+        ///   <li>
+        ///     the English preferred name of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     the short name of the concept description
+        ///   </li>
+        ///   <li>
+        ///     the <see cref="Aas.IReferable.IdShort" /> of the element
+        ///   </li>
         /// </ul>
         /// </remarks>
         public LangStringSet? DisplayName { get; set; }
@@ -7032,15 +7310,19 @@ namespace AasCore.Aas3_0_RC02
         /// Description or comments on the element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// The description can be provided in several languages.
-        ///
+        /// </para>
+        /// <para>
         /// If no description is defined, then the definition of the concept
         /// description that defines the semantics of the element is used.
-        ///
+        /// </para>
+        /// <para>
         /// Additional information can be provided, e.g., if the element is
         /// qualified and which qualifier types can be expected in which
         /// context or which additional data specification templates are
         /// provided.
+        /// </para>
         /// </remarks>
         public LangStringSet? Description { get; set; }
 
@@ -7086,13 +7368,15 @@ namespace AasCore.Aas3_0_RC02
         /// Additional qualification of a qualifiable element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// Constraints:
+        /// </para>
         /// <ul>
-        ///     <li>
+        ///   <li>
         ///     Constraint AASd-021:
         ///     Every qualifiable can only have one qualifier with the same
         ///     <see cref="Aas.Qualifier.Type" />.
-        ///     </li>
+        ///   </li>
         /// </ul>
         /// </remarks>
         public List<Qualifier>? Qualifiers { get; set; }
@@ -7750,19 +8034,30 @@ namespace AasCore.Aas3_0_RC02
         /// Display name. Can be provided in several languages.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// If no display name is defined in the language requested by the application,
         /// then the display name is selected in the following order if available:
-        ///
+        /// </para>
         /// <ul>
-        /// <li>the preferred name in the requested language of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>If there is a default language list defined in the application,
-        /// then the corresponding preferred name in the language is chosen
-        /// according to this order.</li>
-        /// <li>the English preferred name of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>the short name of the concept description</li>
-        /// <li>the <see cref="Aas.IReferable.IdShort" /> of the element</li>
+        ///   <li>
+        ///     the preferred name in the requested language of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     If there is a default language list defined in the application,
+        ///     then the corresponding preferred name in the language is chosen
+        ///     according to this order.
+        ///   </li>
+        ///   <li>
+        ///     the English preferred name of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     the short name of the concept description
+        ///   </li>
+        ///   <li>
+        ///     the <see cref="Aas.IReferable.IdShort" /> of the element
+        ///   </li>
         /// </ul>
         /// </remarks>
         public LangStringSet? DisplayName { get; set; }
@@ -7771,15 +8066,19 @@ namespace AasCore.Aas3_0_RC02
         /// Description or comments on the element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// The description can be provided in several languages.
-        ///
+        /// </para>
+        /// <para>
         /// If no description is defined, then the definition of the concept
         /// description that defines the semantics of the element is used.
-        ///
+        /// </para>
+        /// <para>
         /// Additional information can be provided, e.g., if the element is
         /// qualified and which qualifier types can be expected in which
         /// context or which additional data specification templates are
         /// provided.
+        /// </para>
         /// </remarks>
         public LangStringSet? Description { get; set; }
 
@@ -7825,13 +8124,15 @@ namespace AasCore.Aas3_0_RC02
         /// Additional qualification of a qualifiable element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// Constraints:
+        /// </para>
         /// <ul>
-        ///     <li>
+        ///   <li>
         ///     Constraint AASd-021:
         ///     Every qualifiable can only have one qualifier with the same
         ///     <see cref="Aas.Qualifier.Type" />.
-        ///     </li>
+        ///   </li>
         /// </ul>
         /// </remarks>
         public List<Qualifier>? Qualifiers { get; set; }
@@ -7901,10 +8202,13 @@ namespace AasCore.Aas3_0_RC02
         /// the respective Referable can handle input events.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// For output events, specifies the maximum frequency of outputting this event to
         /// an outer infrastructure.
-        ///
+        /// </para>
+        /// <para>
         /// Might be not specified, that is, there is no minimum interval.
+        /// </para>
         /// </remarks>
         public string? MinInterval { get; set; }
 
@@ -7912,11 +8216,14 @@ namespace AasCore.Aas3_0_RC02
         /// For input direction: not applicable.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// For output direction: maximum interval in time, the respective Referable shall send
         /// an update of the status of the event, even if no other trigger condition for
         /// the event was not met.
-        ///
+        /// </para>
+        /// <para>
         /// Might be not specified, that is, there is no maximum interval
+        /// </para>
         /// </remarks>
         public string? MaxInterval { get; set; }
 
@@ -8263,19 +8570,30 @@ namespace AasCore.Aas3_0_RC02
         /// Display name. Can be provided in several languages.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// If no display name is defined in the language requested by the application,
         /// then the display name is selected in the following order if available:
-        ///
+        /// </para>
         /// <ul>
-        /// <li>the preferred name in the requested language of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>If there is a default language list defined in the application,
-        /// then the corresponding preferred name in the language is chosen
-        /// according to this order.</li>
-        /// <li>the English preferred name of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>the short name of the concept description</li>
-        /// <li>the <see cref="Aas.IReferable.IdShort" /> of the element</li>
+        ///   <li>
+        ///     the preferred name in the requested language of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     If there is a default language list defined in the application,
+        ///     then the corresponding preferred name in the language is chosen
+        ///     according to this order.
+        ///   </li>
+        ///   <li>
+        ///     the English preferred name of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     the short name of the concept description
+        ///   </li>
+        ///   <li>
+        ///     the <see cref="Aas.IReferable.IdShort" /> of the element
+        ///   </li>
         /// </ul>
         /// </remarks>
         public LangStringSet? DisplayName { get; set; }
@@ -8284,15 +8602,19 @@ namespace AasCore.Aas3_0_RC02
         /// Description or comments on the element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// The description can be provided in several languages.
-        ///
+        /// </para>
+        /// <para>
         /// If no description is defined, then the definition of the concept
         /// description that defines the semantics of the element is used.
-        ///
+        /// </para>
+        /// <para>
         /// Additional information can be provided, e.g., if the element is
         /// qualified and which qualifier types can be expected in which
         /// context or which additional data specification templates are
         /// provided.
+        /// </para>
         /// </remarks>
         public LangStringSet? Description { get; set; }
 
@@ -8338,13 +8660,15 @@ namespace AasCore.Aas3_0_RC02
         /// Additional qualification of a qualifiable element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// Constraints:
+        /// </para>
         /// <ul>
-        ///     <li>
+        ///   <li>
         ///     Constraint AASd-021:
         ///     Every qualifiable can only have one qualifier with the same
         ///     <see cref="Aas.Qualifier.Type" />.
-        ///     </li>
+        ///   </li>
         /// </ul>
         /// </remarks>
         public List<Qualifier>? Qualifiers { get; set; }
@@ -8857,19 +9181,30 @@ namespace AasCore.Aas3_0_RC02
         /// Display name. Can be provided in several languages.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// If no display name is defined in the language requested by the application,
         /// then the display name is selected in the following order if available:
-        ///
+        /// </para>
         /// <ul>
-        /// <li>the preferred name in the requested language of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>If there is a default language list defined in the application,
-        /// then the corresponding preferred name in the language is chosen
-        /// according to this order.</li>
-        /// <li>the English preferred name of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>the short name of the concept description</li>
-        /// <li>the <see cref="Aas.IReferable.IdShort" /> of the element</li>
+        ///   <li>
+        ///     the preferred name in the requested language of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     If there is a default language list defined in the application,
+        ///     then the corresponding preferred name in the language is chosen
+        ///     according to this order.
+        ///   </li>
+        ///   <li>
+        ///     the English preferred name of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     the short name of the concept description
+        ///   </li>
+        ///   <li>
+        ///     the <see cref="Aas.IReferable.IdShort" /> of the element
+        ///   </li>
         /// </ul>
         /// </remarks>
         public LangStringSet? DisplayName { get; set; }
@@ -8878,15 +9213,19 @@ namespace AasCore.Aas3_0_RC02
         /// Description or comments on the element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// The description can be provided in several languages.
-        ///
+        /// </para>
+        /// <para>
         /// If no description is defined, then the definition of the concept
         /// description that defines the semantics of the element is used.
-        ///
+        /// </para>
+        /// <para>
         /// Additional information can be provided, e.g., if the element is
         /// qualified and which qualifier types can be expected in which
         /// context or which additional data specification templates are
         /// provided.
+        /// </para>
         /// </remarks>
         public LangStringSet? Description { get; set; }
 
@@ -8932,13 +9271,15 @@ namespace AasCore.Aas3_0_RC02
         /// Additional qualification of a qualifiable element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// Constraints:
+        /// </para>
         /// <ul>
-        ///     <li>
+        ///   <li>
         ///     Constraint AASd-021:
         ///     Every qualifiable can only have one qualifier with the same
         ///     <see cref="Aas.Qualifier.Type" />.
-        ///     </li>
+        ///   </li>
         /// </ul>
         /// </remarks>
         public List<Qualifier>? Qualifiers { get; set; }
@@ -9217,20 +9558,26 @@ namespace AasCore.Aas3_0_RC02
     /// is defined by a concept description.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The description of the concept should follow a standardized schema (realized as
     /// data specification template).
-    ///
+    /// </para>
+    /// <para>
     /// Constraints:
+    /// </para>
     /// <ul>
-    ///     <li>
+    ///   <li>
+    ///     <para>
     ///     Constraint AASd-051:
     ///     A <see cref="Aas.ConceptDescription" /> shall have one of the following categories
     ///     <c>VALUE</c>, <c>PROPERTY</c>, <c>REFERENCE</c>, <c>DOCUMENT</c>, <c>CAPABILITY</c>,
     ///     <c>RELATIONSHIP</c>, <c>COLLECTION</c>, <c>FUNCTION</c>, <c>EVENT</c>, <c>ENTITY</c>,
     ///     <c>APPLICATION_CLASS</c>, <c>QUALIFIER</c>, <c>VIEW</c>.
-    ///
+    ///     </para>
+    ///     <para>
     ///     Default: <c>PROPERTY</c>.
-    ///     </li>
+    ///     </para>
+    ///   </li>
     /// </ul>
     /// </remarks>
     public class ConceptDescription :
@@ -9272,19 +9619,30 @@ namespace AasCore.Aas3_0_RC02
         /// Display name. Can be provided in several languages.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// If no display name is defined in the language requested by the application,
         /// then the display name is selected in the following order if available:
-        ///
+        /// </para>
         /// <ul>
-        /// <li>the preferred name in the requested language of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>If there is a default language list defined in the application,
-        /// then the corresponding preferred name in the language is chosen
-        /// according to this order.</li>
-        /// <li>the English preferred name of the concept description defining
-        /// the semantics of the element</li>
-        /// <li>the short name of the concept description</li>
-        /// <li>the <see cref="Aas.IReferable.IdShort" /> of the element</li>
+        ///   <li>
+        ///     the preferred name in the requested language of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     If there is a default language list defined in the application,
+        ///     then the corresponding preferred name in the language is chosen
+        ///     according to this order.
+        ///   </li>
+        ///   <li>
+        ///     the English preferred name of the concept description defining
+        ///     the semantics of the element
+        ///   </li>
+        ///   <li>
+        ///     the short name of the concept description
+        ///   </li>
+        ///   <li>
+        ///     the <see cref="Aas.IReferable.IdShort" /> of the element
+        ///   </li>
         /// </ul>
         /// </remarks>
         public LangStringSet? DisplayName { get; set; }
@@ -9293,15 +9651,19 @@ namespace AasCore.Aas3_0_RC02
         /// Description or comments on the element.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// The description can be provided in several languages.
-        ///
+        /// </para>
+        /// <para>
         /// If no description is defined, then the definition of the concept
         /// description that defines the semantics of the element is used.
-        ///
+        /// </para>
+        /// <para>
         /// Additional information can be provided, e.g., if the element is
         /// qualified and which qualifier types can be expected in which
         /// context or which additional data specification templates are
         /// provided.
+        /// </para>
         /// </remarks>
         public LangStringSet? Description { get; set; }
 
@@ -9344,9 +9706,12 @@ namespace AasCore.Aas3_0_RC02
         /// from.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// It is recommended to use a global reference.
-        ///
+        /// </para>
+        /// <para>
         /// Compare to is-case-of relationship in ISO 13584-32 &amp; IEC EN 61360"
+        /// </para>
         /// </remarks>
         public List<Reference>? IsCaseOf { get; set; }
 
@@ -9613,61 +9978,70 @@ namespace AasCore.Aas3_0_RC02
     /// entity.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// A reference is an ordered list of keys.
-    ///
+    /// </para>
+    /// <para>
     /// A model reference is an ordered list of keys, each key referencing an element. The
     /// complete list of keys may for example be concatenated to a path that then gives
     /// unique access to an element.
-    ///
+    /// </para>
+    /// <para>
     /// A global reference is a reference to an external entity.
-    ///
+    /// </para>
+    /// <para>
     /// Constraints:
+    /// </para>
     /// <ul>
-    ///     <li>
+    ///   <li>
     ///     Constraint AASd-121:
     ///     For <see cref="Aas.Reference" />'s the <see cref="Aas.Key.Type" /> of the first key of
     ///     <see cref="Aas.Reference.Keys" /> shall be one of <see cref="Aas.Constants.GloballyIdentifiables" />.
-    ///     </li>
-    ///     <li>
+    ///   </li>
+    ///   <li>
     ///     Constraint AASd-122:
     ///     For global references, i.e. <see cref="Aas.Reference" />'s with
     ///     <see cref="Aas.Reference.Type" /> = <see cref="Aas.ReferenceTypes.GlobalReference" />, the type
     ///     of the first key of <see cref="Aas.Reference.Keys" /> shall be one of
     ///     <see cref="Aas.Constants.GenericGloballyIdentifiables" />.
-    ///     </li>
-    ///     <li>
+    ///   </li>
+    ///   <li>
     ///     Constraint AASd-123:
     ///     For model references, i.e. <see cref="Aas.Reference" />'s with
     ///     <see cref="Aas.Reference.Type" /> = <see cref="Aas.ReferenceTypes.ModelReference" />, the type
     ///     of the first key of <see cref="Aas.Reference.Keys" /> shall be one of
     ///     <see cref="Aas.Constants.AasIdentifiables" />.
-    ///     </li>
-    ///     <li>
+    ///   </li>
+    ///   <li>
     ///     Constraint AASd-124:
     ///     For global references, i.e. <see cref="Aas.Reference" />'s with
     ///     <see cref="Aas.Reference.Type" /> = <see cref="Aas.ReferenceTypes.GlobalReference" />, the last
     ///     key of <see cref="Aas.Reference.Keys" /> shall be either one of
     ///     <see cref="Aas.Constants.GenericGloballyIdentifiables" /> or one of
     ///     <see cref="Aas.Constants.GenericFragmentKeys" />.
-    ///     </li>
-    ///     <li>
+    ///   </li>
+    ///   <li>
+    ///     <para>
     ///     Constraint AASd-125:
     ///     For model references, i.e. <see cref="Aas.Reference" />'s with
     ///     <see cref="Aas.Reference.Type" /> = <see cref="Aas.ReferenceTypes.ModelReference" />, with more
     ///     than one key in <see cref="Aas.Reference.Keys" /> the type of the keys following the first
     ///     key of  <see cref="Aas.Reference.Keys" /> shall be one of <see cref="Aas.Constants.FragmentKeys" />.
-    ///
+    ///     </para>
+    ///     <para>
     ///     Constraint AASd-125 ensures that the shortest path is used.
-    ///     </li>
-    ///     <li>
+    ///     </para>
+    ///   </li>
+    ///   <li>
     ///     Constraint AASd-126:
     ///     For model references, i.e. <see cref="Aas.Reference" />'s with
     ///     <see cref="Aas.Reference.Type" /> = <see cref="Aas.ReferenceTypes.ModelReference" />, with more
     ///     than one key in <see cref="Aas.Reference.Keys" /> the type of the last key in the
     ///     reference key chain may be one of <see cref="Aas.Constants.GenericFragmentKeys" /> or no key
     ///     at all shall have a value out of <see cref="Aas.Constants.GenericFragmentKeys" />.
-    ///     </li>
-    ///     <li>
+    ///   </li>
+    ///   <li>
+    ///     <para>
     ///     Constraint AASd-127:
     ///     For model references, i.e. <see cref="Aas.Reference" />'s with
     ///     <see cref="Aas.Reference.Type" /> = <see cref="Aas.ReferenceTypes.ModelReference" />, with more
@@ -9676,19 +10050,21 @@ namespace AasCore.Aas3_0_RC02
     ///     <see cref="Aas.Key.Type" /> <see cref="Aas.KeyTypes.File" /> or <see cref="Aas.KeyTypes.Blob" />. All other
     ///     AAS fragments, i.e. type values out of <see cref="Aas.Constants.AasSubmodelElementsAsKeys" />,
     ///     do not support fragments.
-    ///
+    ///     </para>
+    ///     <para>
     ///     Which kind of fragments are supported depends on the content type and the
     ///     specification of allowed fragment identifiers for the corresponding resource
     ///     being referenced via the reference.
-    ///     </li>
-    ///     <li>
+    ///     </para>
+    ///   </li>
+    ///   <li>
     ///     Constraint AASd-128:
     ///     For model references, i.e. <see cref="Aas.Reference" />'s with
     ///     <see cref="Aas.Reference.Type" /> = <see cref="Aas.ReferenceTypes.ModelReference" />, the
     ///     <see cref="Aas.Key.Value" /> of a <see cref="Aas.Key" /> preceded by a <see cref="Aas.Key" /> with
     ///     <see cref="Aas.Key.Type" /> = <see cref="Aas.KeyTypes.SubmodelElementList" /> is an integer
     ///     number denoting the position in the array of the submodel element list.
-    ///     </li>
+    ///   </li>
     /// </ul>
     /// </remarks>
     public class Reference : IClass
@@ -9706,9 +10082,12 @@ namespace AasCore.Aas3_0_RC02
         /// (<see cref="Aas.Reference.Type" /> = <see cref="Aas.ReferenceTypes.ModelReference" />).
         /// </summary>
         /// <remarks>
+        /// <para>
         /// For global references there typically is no semantic ID.
-        ///
+        /// </para>
+        /// <para>
         /// It is recommended to use a global reference.
+        /// </para>
         /// </remarks>
         public Reference? ReferredSemanticId { get; set; }
 
@@ -9822,12 +10201,15 @@ namespace AasCore.Aas3_0_RC02
         /// Denotes which kind of entity is referenced.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// In case <see cref="Aas.Key.Type" /> = <see cref="Aas.KeyTypes.FragmentReference" /> the key represents
         /// a bookmark or a similar local identifier within its parent element as specified
         /// by the key that precedes this key.
-        ///
+        /// </para>
+        /// <para>
         /// In all other cases the key references a model element of the same or of another AAS.
         /// The name of the model element is explicitly listed.
+        /// </para>
         /// </remarks>
         public KeyTypes Type { get; set; }
 
@@ -10223,11 +10605,14 @@ namespace AasCore.Aas3_0_RC02
     /// Array of elements of type langString
     /// </summary>
     /// <remarks>
+    /// <para>
     /// langString is a RDF data type.
-    ///
+    /// </para>
+    /// <para>
     /// A langString is a string value tagged with a language code.
     /// It depends on the serialization rules for a technology how
     /// this is realized.
+    /// </para>
     /// </remarks>
     public class LangStringSet : IClass
     {

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/verification.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/verification.cs
@@ -77,11 +77,14 @@ namespace AasCore.Aas3_0_RC02
         /// Check that <paramref name="text" /> conforms to the pattern of an <c>xs:dateTimeStamp</c>.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// The time zone must be fixed to UTC. We verify only that the <c>text</c> matches
         /// a pre-defined pattern. We <em>do not</em> verify that the day of month is
         /// correct nor do we check for leap seconds.
-        ///
+        /// </para>
+        /// <para>
         /// See: https://www.w3.org/TR/xmlschema11-2/#dateTimeStamp
+        /// </para>
         /// </remarks>
         /// <param name="text">
         /// Text to be checked


### PR DESCRIPTION
The paragraph breaks are hard to get correct, and we actually got them
completely wrong in the first iteration. This patch implements a much
more complex rendering of docutils nodes to C# HTML-like documentation
comments.