### PR TITLE
Fix usings in C# for opinionated-usings

### DIFF
--- a/aas_core_codegen/csharp/common.py
+++ b/aas_core_codegen/csharp/common.py
@@ -161,7 +161,7 @@ NAMESPACE_IDENTIFIER_RE = re.compile(
 )
 
 
-class NamespaceIdentifier:
+class NamespaceIdentifier(str):
     """Capture a namespace identifier."""
 
     @require(lambda identifier: NAMESPACE_IDENTIFIER_RE.fullmatch(identifier))
@@ -202,3 +202,29 @@ def over_enumerations_classes_and_interfaces(
             yield our_type
         else:
             assert_never(our_type)
+
+
+# fmt: off
+@ensure(
+    lambda namespace, result:
+    not (namespace != "Aas") or len(result) == 1,
+    "Exactly one block of stripped text to be appended to the list of using directives "
+    "if this using directive is necessary"
+)
+@ensure(
+    lambda namespace, result:
+    not (namespace == "Aas") or len(result) == 0,
+    "Empty list if no directive is necessary"
+)
+# fmt: on
+def generate_using_aas_directive_if_necessary(
+    namespace: NamespaceIdentifier,
+) -> List[Stripped]:
+    """Generate the using directive if the namespace does not equal ``Aas``."""
+    if namespace == "Aas":
+        return []
+
+    if namespace.endswith(".Aas"):
+        return [Stripped(f"using Aas = {namespace};")]
+
+    return [Stripped(f"using Aas = {namespace};  // renamed")]

--- a/aas_core_codegen/csharp/jsonization/_generate.py
+++ b/aas_core_codegen/csharp/jsonization/_generate.py
@@ -1521,16 +1521,25 @@ namespace {namespace}
     jsonization_writer.write(f"\n{I}}}  // public static class Jsonization")
     jsonization_writer.write(f"\n}}  // namespace {namespace}")
 
-    # pylint: disable=line-too-long
-    blocks = [
-        csharp_common.WARNING,
+    using_directives = []  # type: List[Stripped]
+    using_directives.extend(
+        csharp_common.generate_using_aas_directive_if_necessary(namespace)
+    )
+
+    using_directives.append(
         Stripped(
             """\
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Nodes = System.Text.Json.Nodes;
+
 using System.Collections.Generic;  // can't alias"""
-        ),
-        Stripped(f"using Aas = {namespace};"),
+        )
+    )
+
+    # pylint: disable=line-too-long
+    blocks = [
+        csharp_common.WARNING,
+        Stripped("\n".join(using_directives)),
         Stripped(jsonization_writer.getvalue()),
         csharp_common.WARNING,
     ]

--- a/aas_core_codegen/csharp/reporting/_generate.py
+++ b/aas_core_codegen/csharp/reporting/_generate.py
@@ -2,6 +2,7 @@
 
 import io
 import textwrap
+from typing import List
 
 from icontract import ensure
 
@@ -226,15 +227,24 @@ namespace {namespace}
     writer.write(f"\n{I}}}  // public static class Reporting")
     writer.write(f"\n}}  // namespace {namespace}")
 
-    # pylint: disable=line-too-long
-    blocks = [
-        csharp_common.WARNING,
+    using_directives = []  # type: List[Stripped]
+    using_directives.extend(
+        csharp_common.generate_using_aas_directive_if_necessary(namespace)
+    )
+
+    using_directives.append(
         Stripped(
             """\
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
+
 using System.Collections.Generic;  // can't alias"""
-        ),
-        Stripped(f"using Aas = {namespace};"),
+        )
+    )
+
+    # pylint: disable=line-too-long
+    blocks = [
+        csharp_common.WARNING,
+        Stripped("\n".join(using_directives)),
         Stripped(writer.getvalue()),
         csharp_common.WARNING,
     ]

--- a/aas_core_codegen/csharp/stringification/_generate.py
+++ b/aas_core_codegen/csharp/stringification/_generate.py
@@ -180,15 +180,23 @@ def generate(
 
     The ``namespace`` defines the AAS C# namespace.
     """
+    using_directives = []  # type: List[Stripped]
+    using_directives.extend(
+        csharp_common.generate_using_aas_directive_if_necessary(namespace)
+    )
+
+    using_directives.append(
+        Stripped(
+            """\
+using CodeAnalysis = System.Diagnostics.CodeAnalysis;
+
+using System.Collections.Generic;  // can't alias"""
+        )
+    )
+
     blocks = [
         csharp_common.WARNING,
-        Stripped(
-            f"""\
-using CodeAnalysis = System.Diagnostics.CodeAnalysis;
-using System.Collections.Generic;  // can't alias
-
-using Aas = {namespace};"""
-        ),
+        Stripped("\n".join(using_directives)),
     ]
 
     stringification_blocks = []  # type: List[Stripped]

--- a/aas_core_codegen/csharp/structure/_generate.py
+++ b/aas_core_codegen/csharp/structure/_generate.py
@@ -1121,22 +1121,24 @@ def generate(
 
     The ``namespace`` defines the AAS C# namespace.
     """
-    blocks = [csharp_common.WARNING]  # type: List[Rstripped]
+    using_directives = []  # type: List[Stripped]
+    using_directives.extend(
+        csharp_common.generate_using_aas_directive_if_necessary(namespace)
+    )
 
-    using_directives = [
-        "using EnumMemberAttribute = System.Runtime.Serialization.EnumMemberAttribute;",
-        "using System.Collections.Generic;  // can't alias",
-    ]  # type: List[str]
+    using_directives.append(
+        Stripped(
+            """\
+using EnumMemberAttribute = System.Runtime.Serialization.EnumMemberAttribute;
 
-    if len(using_directives) > 0:
-        blocks.append(Stripped("\n".join(using_directives)))
+using System.Collections.Generic;  // can't alias"""
+        )
+    )
 
-    if namespace != csharp_common.NamespaceIdentifier("Aas"):
-        blocks.append(Stripped(f"using Aas = {namespace};"))
-
-    blocks.append(Stripped(f"namespace {namespace}\n{{"))
-
-    blocks.append(
+    blocks = [
+        csharp_common.WARNING,
+        Stripped("\n".join(using_directives)),
+        Stripped(f"namespace {namespace}\n{{"),
         Rstripped(
             textwrap.indent(
                 f"""\
@@ -1186,8 +1188,8 @@ public interface IClass
 }}""",
                 I,
             )
-        )
-    )
+        ),
+    ]  # type: List[Rstripped]
 
     errors = []  # type: List[Error]
 

--- a/aas_core_codegen/csharp/verification/_generate.py
+++ b/aas_core_codegen/csharp/verification/_generate.py
@@ -1763,18 +1763,25 @@ def generate(
 
     The ``namespace`` defines the AAS C# namespace.
     """
-    blocks = [
-        csharp_common.WARNING,
-        # Don't use textwrap.dedent since we add a newline in-between.
+    using_directives = []  # type: List[Stripped]
+    using_directives.extend(
+        csharp_common.generate_using_aas_directive_if_necessary(namespace)
+    )
+
+    using_directives.append(
         Stripped(
-            f"""\
+            """\
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
-using System.Collections.Generic;  // can't alias
-using System.Linq;  // can't alias
 
-using Aas = {namespace};"""
-        ),
+using System.Collections.Generic;  // can't alias
+using System.Linq;  // can't alias"""
+        )
+    )
+
+    blocks = [
+        csharp_common.WARNING,
+        Stripped("\n".join(using_directives)),
     ]  # type: List[Stripped]
 
     verification_blocks = []  # type: List[Stripped]

--- a/aas_core_codegen/csharp/xmlization/_generate.py
+++ b/aas_core_codegen/csharp/xmlization/_generate.py
@@ -2030,16 +2030,25 @@ namespace {namespace}
     xmlization_writer.write(f"\n{I}}}  // public static class Xmlization")
     xmlization_writer.write(f"\n}}  // namespace {namespace}")
 
-    # pylint: disable=line-too-long
-    blocks = [
-        csharp_common.WARNING,
+    using_directives = []  # type: List[Stripped]
+    using_directives.extend(
+        csharp_common.generate_using_aas_directive_if_necessary(namespace)
+    )
+
+    using_directives.append(
         Stripped(
             """\
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Xml = System.Xml;
+
 using System.Collections.Generic;  // can't alias"""
-        ),
-        Stripped(f"using Aas = {namespace};"),
+        )
+    )
+
+    # pylint: disable=line-too-long
+    blocks = [
+        csharp_common.WARNING,
+        Stripped("\n".join(using_directives)),
         Stripped(xmlization_writer.getvalue()),
         csharp_common.WARNING,
     ]

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/jsonization.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/jsonization.cs
@@ -3,11 +3,11 @@
  * Do NOT edit or append.
  */
 
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Nodes = System.Text.Json.Nodes;
-using System.Collections.Generic;  // can't alias
 
-using Aas = AasCore.Aas3_0_RC02;
+using System.Collections.Generic;  // can't alias
 
 namespace AasCore.Aas3_0_RC02
 {

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/reporting.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/reporting.cs
@@ -3,10 +3,10 @@
  * Do NOT edit or append.
  */
 
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
-using System.Collections.Generic;  // can't alias
 
-using Aas = AasCore.Aas3_0_RC02;
+using System.Collections.Generic;  // can't alias
 
 namespace AasCore.Aas3_0_RC02
 {

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/stringification.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/stringification.cs
@@ -3,10 +3,10 @@
  * Do NOT edit or append.
  */
 
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
-using System.Collections.Generic;  // can't alias
 
-using Aas = AasCore.Aas3_0_RC02;
+using System.Collections.Generic;  // can't alias
 
 namespace AasCore.Aas3_0_RC02
 {

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/types.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/types.cs
@@ -3,10 +3,10 @@
  * Do NOT edit or append.
  */
 
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 using EnumMemberAttribute = System.Runtime.Serialization.EnumMemberAttribute;
-using System.Collections.Generic;  // can't alias
 
-using Aas = AasCore.Aas3_0_RC02;
+using System.Collections.Generic;  // can't alias
 
 namespace AasCore.Aas3_0_RC02
 {

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/verification.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/verification.cs
@@ -3,12 +3,12 @@
  * Do NOT edit or append.
  */
 
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
+
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
-
-using Aas = AasCore.Aas3_0_RC02;
 
 namespace AasCore.Aas3_0_RC02
 {

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/xmlization.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/xmlization.cs
@@ -3,11 +3,11 @@
  * Do NOT edit or append.
  */
 
+using Aas = AasCore.Aas3_0_RC02;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Xml = System.Xml;
-using System.Collections.Generic;  // can't alias
 
-using Aas = AasCore.Aas3_0_RC02;
+using System.Collections.Generic;  // can't alias
 
 namespace AasCore.Aas3_0_RC02
 {

--- a/test_data/csharp/test_structure/concrete_class_with_descendants/expected_types.cs
+++ b/test_data/csharp/test_structure/concrete_class_with_descendants/expected_types.cs
@@ -3,10 +3,10 @@
  * Do NOT edit or append.
  */
 
+using Aas = dummyNamespace;  // renamed
 using EnumMemberAttribute = System.Runtime.Serialization.EnumMemberAttribute;
-using System.Collections.Generic;  // can't alias
 
-using Aas = dummyNamespace;
+using System.Collections.Generic;  // can't alias
 
 namespace dummyNamespace
 {

--- a/test_data/csharp/test_structure/constructor_without_arguments/all_properties_optional/expected_types.cs
+++ b/test_data/csharp/test_structure/constructor_without_arguments/all_properties_optional/expected_types.cs
@@ -3,10 +3,10 @@
  * Do NOT edit or append.
  */
 
+using Aas = dummyNamespace;  // renamed
 using EnumMemberAttribute = System.Runtime.Serialization.EnumMemberAttribute;
-using System.Collections.Generic;  // can't alias
 
-using Aas = dummyNamespace;
+using System.Collections.Generic;  // can't alias
 
 namespace dummyNamespace
 {

--- a/test_data/csharp/test_structure/constructor_without_arguments/no_properties/expected_types.cs
+++ b/test_data/csharp/test_structure/constructor_without_arguments/no_properties/expected_types.cs
@@ -3,10 +3,10 @@
  * Do NOT edit or append.
  */
 
+using Aas = dummyNamespace;  // renamed
 using EnumMemberAttribute = System.Runtime.Serialization.EnumMemberAttribute;
-using System.Collections.Generic;  // can't alias
 
-using Aas = dummyNamespace;
+using System.Collections.Generic;  // can't alias
 
 namespace dummyNamespace
 {

--- a/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/as_prefix/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/as_prefix/expected_verification.cs
@@ -3,12 +3,12 @@
  * Do NOT edit or append.
  */
 
+using Aas = dummyNamespace;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
+
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
-
-using Aas = dummyNamespace;
 
 namespace dummyNamespace
 {

--- a/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/as_suffix/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/as_suffix/expected_verification.cs
@@ -3,12 +3,12 @@
  * Do NOT edit or append.
  */
 
+using Aas = dummyNamespace;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
+
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
-
-using Aas = dummyNamespace;
 
 namespace dummyNamespace
 {

--- a/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/in_group_with_quantifier/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/in_group_with_quantifier/expected_verification.cs
@@ -3,12 +3,12 @@
  * Do NOT edit or append.
  */
 
+using Aas = dummyNamespace;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
+
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
-
-using Aas = dummyNamespace;
 
 namespace dummyNamespace
 {

--- a/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/in_the_middle/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/in_the_middle/expected_verification.cs
@@ -3,12 +3,12 @@
  * Do NOT edit or append.
  */
 
+using Aas = dummyNamespace;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
+
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
-
-using Aas = dummyNamespace;
 
 namespace dummyNamespace
 {

--- a/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/in_union/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/in_union/expected_verification.cs
@@ -3,12 +3,12 @@
  * Do NOT edit or append.
  */
 
+using Aas = dummyNamespace;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
+
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
-
-using Aas = dummyNamespace;
 
 namespace dummyNamespace
 {

--- a/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/single_utf32_literal/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/single_utf32_literal/expected_verification.cs
@@ -3,12 +3,12 @@
  * Do NOT edit or append.
  */
 
+using Aas = dummyNamespace;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
+
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
-
-using Aas = dummyNamespace;
 
 namespace dummyNamespace
 {

--- a/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/with_quantifier_within_group/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/with_quantifier_within_group/expected_verification.cs
@@ -3,12 +3,12 @@
  * Do NOT edit or append.
  */
 
+using Aas = dummyNamespace;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
+
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
-
-using Aas = dummyNamespace;
 
 namespace dummyNamespace
 {

--- a/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/with_quantifier_without_group/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/with_quantifier_without_group/expected_verification.cs
@@ -3,12 +3,12 @@
  * Do NOT edit or append.
  */
 
+using Aas = dummyNamespace;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
+
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
-
-using Aas = dummyNamespace;
 
 namespace dummyNamespace
 {

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/at_the_beginning/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/at_the_beginning/expected_verification.cs
@@ -3,12 +3,12 @@
  * Do NOT edit or append.
  */
 
+using Aas = dummyNamespace;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
+
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
-
-using Aas = dummyNamespace;
 
 namespace dummyNamespace
 {

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/at_the_end/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/at_the_end/expected_verification.cs
@@ -3,12 +3,12 @@
  * Do NOT edit or append.
  */
 
+using Aas = dummyNamespace;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
+
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
-
-using Aas = dummyNamespace;
 
 namespace dummyNamespace
 {

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/in_the_middle/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/in_the_middle/expected_verification.cs
@@ -3,12 +3,12 @@
  * Do NOT edit or append.
  */
 
+using Aas = dummyNamespace;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
+
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
-
-using Aas = dummyNamespace;
 
 namespace dummyNamespace
 {

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/multiple/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/multiple/expected_verification.cs
@@ -3,12 +3,12 @@
  * Do NOT edit or append.
  */
 
+using Aas = dummyNamespace;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
+
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
-
-using Aas = dummyNamespace;
 
 namespace dummyNamespace
 {

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/single/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/single/expected_verification.cs
@@ -3,12 +3,12 @@
  * Do NOT edit or append.
  */
 
+using Aas = dummyNamespace;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
+
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
-
-using Aas = dummyNamespace;
 
 namespace dummyNamespace
 {

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/single_with_quantifier/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/single_with_quantifier/expected_verification.cs
@@ -3,12 +3,12 @@
  * Do NOT edit or append.
  */
 
+using Aas = dummyNamespace;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
+
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
-
-using Aas = dummyNamespace;
 
 namespace dummyNamespace
 {

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/mixed_with_non_utf32/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/mixed_with_non_utf32/expected_verification.cs
@@ -3,12 +3,12 @@
  * Do NOT edit or append.
  */
 
+using Aas = dummyNamespace;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
+
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
-
-using Aas = dummyNamespace;
 
 namespace dummyNamespace
 {

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/more_than_two_high_surrogates/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/more_than_two_high_surrogates/expected_verification.cs
@@ -3,12 +3,12 @@
  * Do NOT edit or append.
  */
 
+using Aas = dummyNamespace;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
+
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
-
-using Aas = dummyNamespace;
 
 namespace dummyNamespace
 {

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/multiple_utf32_ranges/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/multiple_utf32_ranges/expected_verification.cs
@@ -3,12 +3,12 @@
  * Do NOT edit or append.
  */
 
+using Aas = dummyNamespace;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
+
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
-
-using Aas = dummyNamespace;
 
 namespace dummyNamespace
 {

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/multiple_utf32_ranges_mixed_with_non_utf32/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/multiple_utf32_ranges_mixed_with_non_utf32/expected_verification.cs
@@ -3,12 +3,12 @@
  * Do NOT edit or append.
  */
 
+using Aas = dummyNamespace;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
+
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
-
-using Aas = dummyNamespace;
 
 namespace dummyNamespace
 {

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/same_high_surrogate/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/same_high_surrogate/expected_verification.cs
@@ -3,12 +3,12 @@
  * Do NOT edit or append.
  */
 
+using Aas = dummyNamespace;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
+
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
-
-using Aas = dummyNamespace;
 
 namespace dummyNamespace
 {

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/same_high_surrogate_with_quantifier/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/same_high_surrogate_with_quantifier/expected_verification.cs
@@ -3,12 +3,12 @@
  * Do NOT edit or append.
  */
 
+using Aas = dummyNamespace;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
+
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
-
-using Aas = dummyNamespace;
 
 namespace dummyNamespace
 {

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/two_high_surrogates/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/two_high_surrogates/expected_verification.cs
@@ -3,12 +3,12 @@
  * Do NOT edit or append.
  */
 
+using Aas = dummyNamespace;  // renamed
 using CodeAnalysis = System.Diagnostics.CodeAnalysis;
 using Regex = System.Text.RegularExpressions.Regex;
+
 using System.Collections.Generic;  // can't alias
 using System.Linq;  // can't alias
-
-using Aas = dummyNamespace;
 
 namespace dummyNamespace
 {


### PR DESCRIPTION
We add [opinionated-usings] as a check on C# code for consistent and
readable using directives. This change makes sure the generated C# code
passes the tests.

[opinionated-usings]: https://github.com/mristin/opinionated-usings-csharp/