### PR TITLE
Fix mypy errors due to asttokens 2.0.8

### DIFF
--- a/aas_core_codegen/main.py
+++ b/aas_core_codegen/main.py
@@ -122,6 +122,8 @@ def execute(params: Parameters, stdout: TextIO, stderr: TextIO) -> int:
 
         return 1
 
+    assert atok is not None
+
     import_errors = parse.check_expected_imports(atok=atok)
     if import_errors:
         run.write_error_report(

--- a/aas_core_codegen/parse/_translate.py
+++ b/aas_core_codegen/parse/_translate.py
@@ -171,6 +171,7 @@ def check_expected_imports(atok: asttokens.ASTTokens) -> List[str]:
     Return errors, if any.
     """
     visitor = _ExpectedImportsVisitor()
+    assert atok.tree is not None
     visitor.visit(atok.tree)
 
     if len(visitor.errors) == 0:
@@ -3004,6 +3005,8 @@ def _atok_to_symbol_table(
     constants = []  # type: List[ConstantUnion]
 
     # region Parse
+
+    assert atok.tree is not None
 
     for node in atok.tree.body:
         # NOTE (mristin, 2021-12-27):

--- a/aas_core_codegen/smoke/main.py
+++ b/aas_core_codegen/smoke/main.py
@@ -78,6 +78,8 @@ def execute(model_path: pathlib.Path, stderr: TextIO) -> int:
 
         return 1
 
+    assert atok is not None
+
     import_errors = parse.check_expected_imports(atok=atok)
     if import_errors:
         run.write_error_report(

--- a/continuous_integration/mypy.ini
+++ b/continuous_integration/mypy.ini
@@ -6,9 +6,6 @@ ignore_missing_imports = True
 [mypy-sortedcontainers]
 ignore_missing_imports = True
 
-[mypy-asttokens]
-ignore_missing_imports = True
-
 [mypy-docutils]
 ignore_missing_imports = True
 

--- a/continuous_integration/precommit.py
+++ b/continuous_integration/precommit.py
@@ -37,10 +37,16 @@ def call_and_report(
 
     Return 1 if there is an error and 0 otherwise.
     """
+    cmd_str = " ".join(shlex.quote(part) for part in cmd)
+
+    if cwd is not None:
+        print(f"Executing from {cwd}: {cmd_str}")
+    else:
+        print(f"Executing: {cmd_str}")
+
     exit_code = subprocess.call(cmd, cwd=str(cwd) if cwd is not None else None, env=env)
 
     if exit_code != 0:
-        cmd_str = " ".join(shlex.quote(part) for part in cmd)
         print(
             f"Failed to {verb} with exit code {exit_code}: {cmd_str}", file=sys.stderr
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
+asttokens>=2.0.8,<3
 icontract>=2.5.2,<3
-asttokens>=2.0.5,<3
 sortedcontainers>=2.4.0,<3
 docutils>=0.18.1,<1
 more-itertools>=8,<9

--- a/tests/parse/test_retree.py
+++ b/tests/parse/test_retree.py
@@ -76,6 +76,7 @@ class Test_cursor(unittest.TestCase):
     def test_empty_string(self) -> None:
         source = '""'
         atok = asttokens.ASTTokens(source_text=source, parse=True)
+        assert atok.tree is not None
         values = parse_values_from_source(root_node=atok.tree)
 
         cursor = parse_retree.Cursor(values=values)
@@ -92,6 +93,7 @@ class Test_cursor(unittest.TestCase):
 
         for source, expected_tokens in table:
             atok = asttokens.ASTTokens(source_text=source, parse=True)
+            assert atok.tree is not None
             values = parse_values_from_source(root_node=atok.tree)
 
             cursor = parse_retree.Cursor(values=values)
@@ -111,6 +113,7 @@ class Test_cursor(unittest.TestCase):
     def test_try_string_in_formatted_value(self) -> None:
         source = 'f"{x}"'
         atok = asttokens.ASTTokens(source_text=source, parse=True)
+        assert atok.tree is not None
         values = parse_values_from_source(root_node=atok.tree)
 
         cursor = parse_retree.Cursor(values=values)
@@ -126,6 +129,7 @@ class Test_cursor(unittest.TestCase):
     def test_try_jump_over_to_formatted_value(self) -> None:
         source = 'f"abc{x}"'
         atok = asttokens.ASTTokens(source_text=source, parse=True)
+        assert atok.tree is not None
         values = parse_values_from_source(root_node=atok.tree)
 
         cursor = parse_retree.Cursor(values=values)
@@ -163,6 +167,8 @@ class Test_against_recorded(unittest.TestCase):
                 atok = asttokens.ASTTokens(
                     source_text=source, parse=True, filename=str(source_pth)
                 )
+
+                assert atok.tree is not None
 
                 values = parse_values_from_source(root_node=atok.tree)
 


### PR DESCRIPTION
The dependency asttokens introduced type annotations in the version
2.0.8. This revealed a couple of typing errors in our code, which this
patch fixes.