### PR TITLE
Handle XML namespace from the meta-model

### DIFF
--- a/.idea/dictionaries/rist.xml
+++ b/.idea/dictionaries/rist.xml
@@ -116,6 +116,7 @@
       <w>unroller</w>
       <w>unrollings</w>
       <w>uxxxxxxxx</w>
+      <w>vann</w>
       <w>versioning</w>
       <w>verwaltungsschale</w>
       <w>vistitation</w>

--- a/aas_core_codegen/common.py
+++ b/aas_core_codegen/common.py
@@ -195,6 +195,17 @@ class Rstripped(str):
         return cast(Rstripped, block)
 
 
+def is_stripped(text: str) -> bool:
+    """Check that the ``text`` does not have leading and trailing whitespace."""
+    return (
+        not text.startswith("\n")
+        and not text.startswith(" ")
+        and not text.startswith("\t")
+    ) and (
+        not text.endswith("\n") and not text.endswith(" ") and not text.endswith("\t")
+    )
+
+
 class Stripped(Rstripped):
     """
     Represent a block of text without leading and trailing whitespace.
@@ -202,20 +213,7 @@ class Stripped(Rstripped):
     The block of text can be both single-line and multi-line.
     """
 
-    # fmt: off
-    @require(
-        lambda block:
-        not block.startswith('\n')
-        and not block.startswith(' ')
-        and not block.startswith('\t')
-    )
-    @require(
-        lambda block:
-        not block.endswith('\n')
-        and not block.endswith(' ')
-        and not block.endswith('\t')
-    )
-    # fmt: on
+    @require(lambda block: is_stripped(block))
     def __new__(cls, block: str) -> "Stripped":
         return cast(Stripped, block)
 

--- a/aas_core_codegen/intermediate/_stringify.py
+++ b/aas_core_codegen/intermediate/_stringify.py
@@ -812,6 +812,7 @@ def _stringify_meta_model(
             stringify_mod.Property("description", stringify(that.description)),
             stringify_mod.Property("book_url", that.book_url),
             stringify_mod.Property("book_version", that.book_version),
+            stringify_mod.Property("xml_namespace", that.xml_namespace),
         ],
     )
 

--- a/aas_core_codegen/intermediate/_translate.py
+++ b/aas_core_codegen/intermediate/_translate.py
@@ -1895,6 +1895,7 @@ def _to_meta_model(
         MetaModel(
             book_url=parsed.book_url,
             book_version=parsed.book_version,
+            xml_namespace=parsed.xml_namespace,
             description=description,
         ),
         None,

--- a/aas_core_codegen/intermediate/_types.py
+++ b/aas_core_codegen/intermediate/_types.py
@@ -27,6 +27,7 @@ from aas_core_codegen.common import (
     assert_never,
     assert_union_of_descendants_exhaustive,
     assert_union_without_excluded,
+    Stripped,
 )
 from aas_core_codegen.intermediate import construction
 from aas_core_codegen.parse import tree as parse_tree
@@ -2182,14 +2183,20 @@ class MetaModel:
     #: Specify the version of the book that the meta-model is based on
     book_version: Final[str]
 
+    #: Specify the XML namespace that is used both for de/serialization and for schema
+    #: definitions
+    xml_namespace: Final[Stripped]
+
     def __init__(
         self,
         book_url: str,
         book_version: str,
+        xml_namespace: Stripped,
         description: Optional[DescriptionOfMetaModel],
     ) -> None:
         self.book_url = book_url
         self.book_version = book_version
+        self.xml_namespace = xml_namespace
         self.description = description
 
 

--- a/aas_core_codegen/parse/_stringify.py
+++ b/aas_core_codegen/parse/_stringify.py
@@ -427,6 +427,7 @@ def _stringify_meta_model(
             stringify.Property("description", _stringify(that.description)),
             stringify.Property("book_url", that.book_url),
             stringify.Property("book_version", that.book_version),
+            stringify.Property("xml_namespace", that.xml_namespace),
         ],
     )
 

--- a/aas_core_codegen/parse/_types.py
+++ b/aas_core_codegen/parse/_types.py
@@ -8,7 +8,11 @@ from typing import Sequence, Optional, Union, Final, Mapping, Tuple, cast
 import docutils.nodes
 from icontract import require, DBC, ensure, invariant
 
-from aas_core_codegen.common import Identifier, assert_union_of_descendants_exhaustive
+from aas_core_codegen.common import (
+    Identifier,
+    assert_union_of_descendants_exhaustive,
+    Stripped,
+)
 from aas_core_codegen.parse import tree
 
 _MODULE_NAME = pathlib.Path(os.path.realpath(__file__)).parent.name
@@ -811,11 +815,23 @@ class MetaModel:
     #: Specify the version of the book that the meta-model is based on
     book_version: Final[str]
 
+    #: Specify the XML namespace that is used both for de/serialization and for schema
+    #: definitions
+    xml_namespace: Final[Stripped]
+
+    @require(lambda xml_namespace: not xml_namespace.endswith("/"))
+    @require(lambda xml_namespace: '"' not in xml_namespace)
+    @require(lambda xml_namespace: "'" not in xml_namespace)
     def __init__(
-        self, book_url: str, book_version: str, description: Optional[Description]
+        self,
+        book_url: str,
+        book_version: str,
+        xml_namespace: Stripped,
+        description: Optional[Description],
     ) -> None:
         self.book_url = book_url
         self.book_version = book_version
+        self.xml_namespace = xml_namespace
         self.description = description
 
 

--- a/aas_core_codegen/xsd/main.py
+++ b/aas_core_codegen/xsd/main.py
@@ -777,7 +777,51 @@ def _generate(
     # it.
     # noinspection PyUnresolvedReferences
     minidom_doc = xml.dom.minidom.parseString(root_element_as_text)
+
+    if not minidom_doc.documentElement.hasAttribute("xmlns"):
+        return None, [
+            Error(
+                None,
+                f"The implementation snippet for the root element "
+                f"is missing the 'xmlns' attribute: {root_element_key}",
+            )
+        ]
+
     xmlns = minidom_doc.documentElement.getAttribute("xmlns")
+
+    if xmlns != symbol_table.meta_model.xml_namespace:
+        return None, [
+            Error(
+                None,
+                f"The 'xmlns' attribute of the implementation snippet "
+                f"{root_element_key} for the root element "
+                f"and the '__xml_namespace__' of the meta-model "
+                f"do not coincide: "
+                f"{xmlns!r} != {symbol_table.meta_model.xml_namespace!r}",
+            )
+        ]
+
+    if not minidom_doc.documentElement.hasAttribute("targetNamespace"):
+        return None, [
+            Error(
+                None,
+                f"The implementation snippet for the root element "
+                f"is missing the 'targetNamespace' attribute: {root_element_key}",
+            )
+        ]
+
+    target_namespace = minidom_doc.documentElement.getAttribute("targetNamespace")
+    if target_namespace != symbol_table.meta_model.xml_namespace:
+        return None, [
+            Error(
+                None,
+                f"The 'targetNamespace' attribute of the implementation snippet "
+                f"{root_element_key} for the root element "
+                f"and the '__xml_namespace__' of the meta-model "
+                f"do not coincide: "
+                f"{target_namespace!r} != {symbol_table.meta_model.xml_namespace!r}",
+            )
+        ]
 
     assert root is not None
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
             "twine",
             "jsonschema==3.2.0",
             "xmlschema==1.10.0",
-            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@e808e37#egg=aas-core-meta",
+            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@c913cb4#egg=aas-core-meta",
         ]
     },
     # fmt: on

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/jsonization.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/jsonization.cs
@@ -1066,7 +1066,7 @@ namespace AasCore.Aas3_0_RC02
                     return null;
                 }
 
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 string? theVersion = null;
                 string? theRevision = null;
 
@@ -1074,27 +1074,27 @@ namespace AasCore.Aas3_0_RC02
                 {
                     switch (keyValue.Key)
                     {
-                        case "dataSpecifications":
+                        case "embeddedDataSpecifications":
                         {
                             if (keyValue.Value == null)
                             {
                                 continue;
                             }
 
-                            Nodes.JsonArray? arrayDataSpecifications = keyValue.Value as Nodes.JsonArray;
-                            if (arrayDataSpecifications == null)
+                            Nodes.JsonArray? arrayEmbeddedDataSpecifications = keyValue.Value as Nodes.JsonArray;
+                            if (arrayEmbeddedDataSpecifications == null)
                             {
                                 error = new Reporting.Error(
                                     $"Expected a JsonArray, but got {keyValue.Value.GetType()}");
                                 error.PrependSegment(
                                     new Reporting.NameSegment(
-                                        "dataSpecifications"));
+                                        "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theDataSpecifications = new List<Reference>(
-                                arrayDataSpecifications.Count);
-                            int indexDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                            theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications.Count);
+                            int indexEmbeddedDataSpecifications = 0;
+                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
                             {
                                 if (item == null)
                                 {
@@ -1102,30 +1102,30 @@ namespace AasCore.Aas3_0_RC02
                                         "Expected a non-null item, but got a null");
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
+                                EmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
                                     item ?? throw new System.InvalidOperationException(),
                                     out error);
                                 if (error != null)
                                 {
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                theDataSpecifications.Add(
+                                theEmbeddedDataSpecifications.Add(
                                     parsedItem
                                         ?? throw new System.InvalidOperationException(
                                             "Unexpected result null when error is null"));
-                                indexDataSpecifications++;
+                                indexEmbeddedDataSpecifications++;
                             }
                             break;
                         }
@@ -1187,7 +1187,7 @@ namespace AasCore.Aas3_0_RC02
 
 
                 return new Aas.AdministrativeInformation(
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theVersion,
                     theRevision);
             }  // internal static AdministrativeInformationFrom
@@ -1614,7 +1614,7 @@ namespace AasCore.Aas3_0_RC02
                 LangStringSet? theDescription = null;
                 string? theChecksum = null;
                 AdministrativeInformation? theAdministration = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 Reference? theDerivedFrom = null;
                 List<Reference>? theSubmodels = null;
 
@@ -1869,27 +1869,27 @@ namespace AasCore.Aas3_0_RC02
                             }
                             break;
                         }
-                        case "dataSpecifications":
+                        case "embeddedDataSpecifications":
                         {
                             if (keyValue.Value == null)
                             {
                                 continue;
                             }
 
-                            Nodes.JsonArray? arrayDataSpecifications = keyValue.Value as Nodes.JsonArray;
-                            if (arrayDataSpecifications == null)
+                            Nodes.JsonArray? arrayEmbeddedDataSpecifications = keyValue.Value as Nodes.JsonArray;
+                            if (arrayEmbeddedDataSpecifications == null)
                             {
                                 error = new Reporting.Error(
                                     $"Expected a JsonArray, but got {keyValue.Value.GetType()}");
                                 error.PrependSegment(
                                     new Reporting.NameSegment(
-                                        "dataSpecifications"));
+                                        "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theDataSpecifications = new List<Reference>(
-                                arrayDataSpecifications.Count);
-                            int indexDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                            theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications.Count);
+                            int indexEmbeddedDataSpecifications = 0;
+                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
                             {
                                 if (item == null)
                                 {
@@ -1897,30 +1897,30 @@ namespace AasCore.Aas3_0_RC02
                                         "Expected a non-null item, but got a null");
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
+                                EmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
                                     item ?? throw new System.InvalidOperationException(),
                                     out error);
                                 if (error != null)
                                 {
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                theDataSpecifications.Add(
+                                theEmbeddedDataSpecifications.Add(
                                     parsedItem
                                         ?? throw new System.InvalidOperationException(
                                             "Unexpected result null when error is null"));
-                                indexDataSpecifications++;
+                                indexEmbeddedDataSpecifications++;
                             }
                             break;
                         }
@@ -2040,7 +2040,7 @@ namespace AasCore.Aas3_0_RC02
                     theDescription,
                     theChecksum,
                     theAdministration,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theDerivedFrom,
                     theSubmodels);
             }  // internal static AssetAdministrationShellFrom
@@ -2601,7 +2601,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 List<ISubmodelElement>? theSubmodelElements = null;
 
                 foreach (var keyValue in obj)
@@ -2989,27 +2989,27 @@ namespace AasCore.Aas3_0_RC02
                             }
                             break;
                         }
-                        case "dataSpecifications":
+                        case "embeddedDataSpecifications":
                         {
                             if (keyValue.Value == null)
                             {
                                 continue;
                             }
 
-                            Nodes.JsonArray? arrayDataSpecifications = keyValue.Value as Nodes.JsonArray;
-                            if (arrayDataSpecifications == null)
+                            Nodes.JsonArray? arrayEmbeddedDataSpecifications = keyValue.Value as Nodes.JsonArray;
+                            if (arrayEmbeddedDataSpecifications == null)
                             {
                                 error = new Reporting.Error(
                                     $"Expected a JsonArray, but got {keyValue.Value.GetType()}");
                                 error.PrependSegment(
                                     new Reporting.NameSegment(
-                                        "dataSpecifications"));
+                                        "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theDataSpecifications = new List<Reference>(
-                                arrayDataSpecifications.Count);
-                            int indexDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                            theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications.Count);
+                            int indexEmbeddedDataSpecifications = 0;
+                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
                             {
                                 if (item == null)
                                 {
@@ -3017,30 +3017,30 @@ namespace AasCore.Aas3_0_RC02
                                         "Expected a non-null item, but got a null");
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
+                                EmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
                                     item ?? throw new System.InvalidOperationException(),
                                     out error);
                                 if (error != null)
                                 {
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                theDataSpecifications.Add(
+                                theEmbeddedDataSpecifications.Add(
                                     parsedItem
                                         ?? throw new System.InvalidOperationException(
                                             "Unexpected result null when error is null"));
-                                indexDataSpecifications++;
+                                indexEmbeddedDataSpecifications++;
                             }
                             break;
                         }
@@ -3130,7 +3130,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theSubmodelElements);
             }  // internal static SubmodelFrom
 
@@ -3321,7 +3321,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
 
                 foreach (var keyValue in obj)
                 {
@@ -3708,27 +3708,27 @@ namespace AasCore.Aas3_0_RC02
                             }
                             break;
                         }
-                        case "dataSpecifications":
+                        case "embeddedDataSpecifications":
                         {
                             if (keyValue.Value == null)
                             {
                                 continue;
                             }
 
-                            Nodes.JsonArray? arrayDataSpecifications = keyValue.Value as Nodes.JsonArray;
-                            if (arrayDataSpecifications == null)
+                            Nodes.JsonArray? arrayEmbeddedDataSpecifications = keyValue.Value as Nodes.JsonArray;
+                            if (arrayEmbeddedDataSpecifications == null)
                             {
                                 error = new Reporting.Error(
                                     $"Expected a JsonArray, but got {keyValue.Value.GetType()}");
                                 error.PrependSegment(
                                     new Reporting.NameSegment(
-                                        "dataSpecifications"));
+                                        "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theDataSpecifications = new List<Reference>(
-                                arrayDataSpecifications.Count);
-                            int indexDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                            theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications.Count);
+                            int indexEmbeddedDataSpecifications = 0;
+                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
                             {
                                 if (item == null)
                                 {
@@ -3736,30 +3736,30 @@ namespace AasCore.Aas3_0_RC02
                                         "Expected a non-null item, but got a null");
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
+                                EmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
                                     item ?? throw new System.InvalidOperationException(),
                                     out error);
                                 if (error != null)
                                 {
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                theDataSpecifications.Add(
+                                theEmbeddedDataSpecifications.Add(
                                     parsedItem
                                         ?? throw new System.InvalidOperationException(
                                             "Unexpected result null when error is null"));
-                                indexDataSpecifications++;
+                                indexEmbeddedDataSpecifications++;
                             }
                             break;
                         }
@@ -3803,7 +3803,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications);
+                    theEmbeddedDataSpecifications);
             }  // internal static RelationshipElementFrom
 
             /// <summary>
@@ -3866,7 +3866,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 bool? theOrderRelevant = null;
                 List<ISubmodelElement>? theValue = null;
                 Reference? theSemanticIdListElement = null;
@@ -4233,27 +4233,27 @@ namespace AasCore.Aas3_0_RC02
                             }
                             break;
                         }
-                        case "dataSpecifications":
+                        case "embeddedDataSpecifications":
                         {
                             if (keyValue.Value == null)
                             {
                                 continue;
                             }
 
-                            Nodes.JsonArray? arrayDataSpecifications = keyValue.Value as Nodes.JsonArray;
-                            if (arrayDataSpecifications == null)
+                            Nodes.JsonArray? arrayEmbeddedDataSpecifications = keyValue.Value as Nodes.JsonArray;
+                            if (arrayEmbeddedDataSpecifications == null)
                             {
                                 error = new Reporting.Error(
                                     $"Expected a JsonArray, but got {keyValue.Value.GetType()}");
                                 error.PrependSegment(
                                     new Reporting.NameSegment(
-                                        "dataSpecifications"));
+                                        "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theDataSpecifications = new List<Reference>(
-                                arrayDataSpecifications.Count);
-                            int indexDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                            theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications.Count);
+                            int indexEmbeddedDataSpecifications = 0;
+                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
                             {
                                 if (item == null)
                                 {
@@ -4261,30 +4261,30 @@ namespace AasCore.Aas3_0_RC02
                                         "Expected a non-null item, but got a null");
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
+                                EmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
                                     item ?? throw new System.InvalidOperationException(),
                                     out error);
                                 if (error != null)
                                 {
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                theDataSpecifications.Add(
+                                theEmbeddedDataSpecifications.Add(
                                     parsedItem
                                         ?? throw new System.InvalidOperationException(
                                             "Unexpected result null when error is null"));
-                                indexDataSpecifications++;
+                                indexEmbeddedDataSpecifications++;
                             }
                             break;
                         }
@@ -4445,7 +4445,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theOrderRelevant,
                     theValue,
                     theSemanticIdListElement,
@@ -4481,7 +4481,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 List<ISubmodelElement>? theValue = null;
 
                 foreach (var keyValue in obj)
@@ -4821,27 +4821,27 @@ namespace AasCore.Aas3_0_RC02
                             }
                             break;
                         }
-                        case "dataSpecifications":
+                        case "embeddedDataSpecifications":
                         {
                             if (keyValue.Value == null)
                             {
                                 continue;
                             }
 
-                            Nodes.JsonArray? arrayDataSpecifications = keyValue.Value as Nodes.JsonArray;
-                            if (arrayDataSpecifications == null)
+                            Nodes.JsonArray? arrayEmbeddedDataSpecifications = keyValue.Value as Nodes.JsonArray;
+                            if (arrayEmbeddedDataSpecifications == null)
                             {
                                 error = new Reporting.Error(
                                     $"Expected a JsonArray, but got {keyValue.Value.GetType()}");
                                 error.PrependSegment(
                                     new Reporting.NameSegment(
-                                        "dataSpecifications"));
+                                        "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theDataSpecifications = new List<Reference>(
-                                arrayDataSpecifications.Count);
-                            int indexDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                            theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications.Count);
+                            int indexEmbeddedDataSpecifications = 0;
+                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
                             {
                                 if (item == null)
                                 {
@@ -4849,30 +4849,30 @@ namespace AasCore.Aas3_0_RC02
                                         "Expected a non-null item, but got a null");
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
+                                EmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
                                     item ?? throw new System.InvalidOperationException(),
                                     out error);
                                 if (error != null)
                                 {
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                theDataSpecifications.Add(
+                                theEmbeddedDataSpecifications.Add(
                                     parsedItem
                                         ?? throw new System.InvalidOperationException(
                                             "Unexpected result null when error is null"));
-                                indexDataSpecifications++;
+                                indexEmbeddedDataSpecifications++;
                             }
                             break;
                         }
@@ -4953,7 +4953,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theValue);
             }  // internal static SubmodelElementCollectionFrom
 
@@ -5059,7 +5059,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 string? theValue = null;
                 Reference? theValueId = null;
 
@@ -5424,27 +5424,27 @@ namespace AasCore.Aas3_0_RC02
                             }
                             break;
                         }
-                        case "dataSpecifications":
+                        case "embeddedDataSpecifications":
                         {
                             if (keyValue.Value == null)
                             {
                                 continue;
                             }
 
-                            Nodes.JsonArray? arrayDataSpecifications = keyValue.Value as Nodes.JsonArray;
-                            if (arrayDataSpecifications == null)
+                            Nodes.JsonArray? arrayEmbeddedDataSpecifications = keyValue.Value as Nodes.JsonArray;
+                            if (arrayEmbeddedDataSpecifications == null)
                             {
                                 error = new Reporting.Error(
                                     $"Expected a JsonArray, but got {keyValue.Value.GetType()}");
                                 error.PrependSegment(
                                     new Reporting.NameSegment(
-                                        "dataSpecifications"));
+                                        "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theDataSpecifications = new List<Reference>(
-                                arrayDataSpecifications.Count);
-                            int indexDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                            theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications.Count);
+                            int indexEmbeddedDataSpecifications = 0;
+                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
                             {
                                 if (item == null)
                                 {
@@ -5452,30 +5452,30 @@ namespace AasCore.Aas3_0_RC02
                                         "Expected a non-null item, but got a null");
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
+                                EmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
                                     item ?? throw new System.InvalidOperationException(),
                                     out error);
                                 if (error != null)
                                 {
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                theDataSpecifications.Add(
+                                theEmbeddedDataSpecifications.Add(
                                     parsedItem
                                         ?? throw new System.InvalidOperationException(
                                             "Unexpected result null when error is null"));
-                                indexDataSpecifications++;
+                                indexEmbeddedDataSpecifications++;
                             }
                             break;
                         }
@@ -5557,7 +5557,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theValue,
                     theValueId);
             }  // internal static PropertyFrom
@@ -5591,7 +5591,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 LangStringSet? theValue = null;
                 Reference? theValueId = null;
 
@@ -5932,27 +5932,27 @@ namespace AasCore.Aas3_0_RC02
                             }
                             break;
                         }
-                        case "dataSpecifications":
+                        case "embeddedDataSpecifications":
                         {
                             if (keyValue.Value == null)
                             {
                                 continue;
                             }
 
-                            Nodes.JsonArray? arrayDataSpecifications = keyValue.Value as Nodes.JsonArray;
-                            if (arrayDataSpecifications == null)
+                            Nodes.JsonArray? arrayEmbeddedDataSpecifications = keyValue.Value as Nodes.JsonArray;
+                            if (arrayEmbeddedDataSpecifications == null)
                             {
                                 error = new Reporting.Error(
                                     $"Expected a JsonArray, but got {keyValue.Value.GetType()}");
                                 error.PrependSegment(
                                     new Reporting.NameSegment(
-                                        "dataSpecifications"));
+                                        "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theDataSpecifications = new List<Reference>(
-                                arrayDataSpecifications.Count);
-                            int indexDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                            theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications.Count);
+                            int indexEmbeddedDataSpecifications = 0;
+                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
                             {
                                 if (item == null)
                                 {
@@ -5960,30 +5960,30 @@ namespace AasCore.Aas3_0_RC02
                                         "Expected a non-null item, but got a null");
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
+                                EmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
                                     item ?? throw new System.InvalidOperationException(),
                                     out error);
                                 if (error != null)
                                 {
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                theDataSpecifications.Add(
+                                theEmbeddedDataSpecifications.Add(
                                     parsedItem
                                         ?? throw new System.InvalidOperationException(
                                             "Unexpected result null when error is null"));
-                                indexDataSpecifications++;
+                                indexEmbeddedDataSpecifications++;
                             }
                             break;
                         }
@@ -6057,7 +6057,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theValue,
                     theValueId);
             }  // internal static MultiLanguagePropertyFrom
@@ -6092,7 +6092,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 string? theMin = null;
                 string? theMax = null;
 
@@ -6457,27 +6457,27 @@ namespace AasCore.Aas3_0_RC02
                             }
                             break;
                         }
-                        case "dataSpecifications":
+                        case "embeddedDataSpecifications":
                         {
                             if (keyValue.Value == null)
                             {
                                 continue;
                             }
 
-                            Nodes.JsonArray? arrayDataSpecifications = keyValue.Value as Nodes.JsonArray;
-                            if (arrayDataSpecifications == null)
+                            Nodes.JsonArray? arrayEmbeddedDataSpecifications = keyValue.Value as Nodes.JsonArray;
+                            if (arrayEmbeddedDataSpecifications == null)
                             {
                                 error = new Reporting.Error(
                                     $"Expected a JsonArray, but got {keyValue.Value.GetType()}");
                                 error.PrependSegment(
                                     new Reporting.NameSegment(
-                                        "dataSpecifications"));
+                                        "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theDataSpecifications = new List<Reference>(
-                                arrayDataSpecifications.Count);
-                            int indexDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                            theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications.Count);
+                            int indexEmbeddedDataSpecifications = 0;
+                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
                             {
                                 if (item == null)
                                 {
@@ -6485,30 +6485,30 @@ namespace AasCore.Aas3_0_RC02
                                         "Expected a non-null item, but got a null");
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
+                                EmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
                                     item ?? throw new System.InvalidOperationException(),
                                     out error);
                                 if (error != null)
                                 {
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                theDataSpecifications.Add(
+                                theEmbeddedDataSpecifications.Add(
                                     parsedItem
                                         ?? throw new System.InvalidOperationException(
                                             "Unexpected result null when error is null"));
-                                indexDataSpecifications++;
+                                indexEmbeddedDataSpecifications++;
                             }
                             break;
                         }
@@ -6590,7 +6590,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theMin,
                     theMax);
             }  // internal static RangeFrom
@@ -6624,7 +6624,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 Reference? theValue = null;
 
                 foreach (var keyValue in obj)
@@ -6964,27 +6964,27 @@ namespace AasCore.Aas3_0_RC02
                             }
                             break;
                         }
-                        case "dataSpecifications":
+                        case "embeddedDataSpecifications":
                         {
                             if (keyValue.Value == null)
                             {
                                 continue;
                             }
 
-                            Nodes.JsonArray? arrayDataSpecifications = keyValue.Value as Nodes.JsonArray;
-                            if (arrayDataSpecifications == null)
+                            Nodes.JsonArray? arrayEmbeddedDataSpecifications = keyValue.Value as Nodes.JsonArray;
+                            if (arrayEmbeddedDataSpecifications == null)
                             {
                                 error = new Reporting.Error(
                                     $"Expected a JsonArray, but got {keyValue.Value.GetType()}");
                                 error.PrependSegment(
                                     new Reporting.NameSegment(
-                                        "dataSpecifications"));
+                                        "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theDataSpecifications = new List<Reference>(
-                                arrayDataSpecifications.Count);
-                            int indexDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                            theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications.Count);
+                            int indexEmbeddedDataSpecifications = 0;
+                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
                             {
                                 if (item == null)
                                 {
@@ -6992,30 +6992,30 @@ namespace AasCore.Aas3_0_RC02
                                         "Expected a non-null item, but got a null");
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
+                                EmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
                                     item ?? throw new System.InvalidOperationException(),
                                     out error);
                                 if (error != null)
                                 {
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                theDataSpecifications.Add(
+                                theEmbeddedDataSpecifications.Add(
                                     parsedItem
                                         ?? throw new System.InvalidOperationException(
                                             "Unexpected result null when error is null"));
-                                indexDataSpecifications++;
+                                indexEmbeddedDataSpecifications++;
                             }
                             break;
                         }
@@ -7065,7 +7065,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theValue);
             }  // internal static ReferenceElementFrom
 
@@ -7099,7 +7099,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 byte[]? theValue = null;
 
                 foreach (var keyValue in obj)
@@ -7463,27 +7463,27 @@ namespace AasCore.Aas3_0_RC02
                             }
                             break;
                         }
-                        case "dataSpecifications":
+                        case "embeddedDataSpecifications":
                         {
                             if (keyValue.Value == null)
                             {
                                 continue;
                             }
 
-                            Nodes.JsonArray? arrayDataSpecifications = keyValue.Value as Nodes.JsonArray;
-                            if (arrayDataSpecifications == null)
+                            Nodes.JsonArray? arrayEmbeddedDataSpecifications = keyValue.Value as Nodes.JsonArray;
+                            if (arrayEmbeddedDataSpecifications == null)
                             {
                                 error = new Reporting.Error(
                                     $"Expected a JsonArray, but got {keyValue.Value.GetType()}");
                                 error.PrependSegment(
                                     new Reporting.NameSegment(
-                                        "dataSpecifications"));
+                                        "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theDataSpecifications = new List<Reference>(
-                                arrayDataSpecifications.Count);
-                            int indexDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                            theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications.Count);
+                            int indexEmbeddedDataSpecifications = 0;
+                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
                             {
                                 if (item == null)
                                 {
@@ -7491,30 +7491,30 @@ namespace AasCore.Aas3_0_RC02
                                         "Expected a non-null item, but got a null");
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
+                                EmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
                                     item ?? throw new System.InvalidOperationException(),
                                     out error);
                                 if (error != null)
                                 {
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                theDataSpecifications.Add(
+                                theEmbeddedDataSpecifications.Add(
                                     parsedItem
                                         ?? throw new System.InvalidOperationException(
                                             "Unexpected result null when error is null"));
-                                indexDataSpecifications++;
+                                indexEmbeddedDataSpecifications++;
                             }
                             break;
                         }
@@ -7572,7 +7572,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theValue);
             }  // internal static BlobFrom
 
@@ -7606,7 +7606,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 string? theValue = null;
 
                 foreach (var keyValue in obj)
@@ -7970,27 +7970,27 @@ namespace AasCore.Aas3_0_RC02
                             }
                             break;
                         }
-                        case "dataSpecifications":
+                        case "embeddedDataSpecifications":
                         {
                             if (keyValue.Value == null)
                             {
                                 continue;
                             }
 
-                            Nodes.JsonArray? arrayDataSpecifications = keyValue.Value as Nodes.JsonArray;
-                            if (arrayDataSpecifications == null)
+                            Nodes.JsonArray? arrayEmbeddedDataSpecifications = keyValue.Value as Nodes.JsonArray;
+                            if (arrayEmbeddedDataSpecifications == null)
                             {
                                 error = new Reporting.Error(
                                     $"Expected a JsonArray, but got {keyValue.Value.GetType()}");
                                 error.PrependSegment(
                                     new Reporting.NameSegment(
-                                        "dataSpecifications"));
+                                        "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theDataSpecifications = new List<Reference>(
-                                arrayDataSpecifications.Count);
-                            int indexDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                            theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications.Count);
+                            int indexEmbeddedDataSpecifications = 0;
+                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
                             {
                                 if (item == null)
                                 {
@@ -7998,30 +7998,30 @@ namespace AasCore.Aas3_0_RC02
                                         "Expected a non-null item, but got a null");
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
+                                EmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
                                     item ?? throw new System.InvalidOperationException(),
                                     out error);
                                 if (error != null)
                                 {
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                theDataSpecifications.Add(
+                                theEmbeddedDataSpecifications.Add(
                                     parsedItem
                                         ?? throw new System.InvalidOperationException(
                                             "Unexpected result null when error is null"));
-                                indexDataSpecifications++;
+                                indexEmbeddedDataSpecifications++;
                             }
                             break;
                         }
@@ -8079,7 +8079,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theValue);
             }  // internal static FileFrom
 
@@ -8114,7 +8114,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 List<IDataElement>? theAnnotations = null;
 
                 foreach (var keyValue in obj)
@@ -8502,27 +8502,27 @@ namespace AasCore.Aas3_0_RC02
                             }
                             break;
                         }
-                        case "dataSpecifications":
+                        case "embeddedDataSpecifications":
                         {
                             if (keyValue.Value == null)
                             {
                                 continue;
                             }
 
-                            Nodes.JsonArray? arrayDataSpecifications = keyValue.Value as Nodes.JsonArray;
-                            if (arrayDataSpecifications == null)
+                            Nodes.JsonArray? arrayEmbeddedDataSpecifications = keyValue.Value as Nodes.JsonArray;
+                            if (arrayEmbeddedDataSpecifications == null)
                             {
                                 error = new Reporting.Error(
                                     $"Expected a JsonArray, but got {keyValue.Value.GetType()}");
                                 error.PrependSegment(
                                     new Reporting.NameSegment(
-                                        "dataSpecifications"));
+                                        "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theDataSpecifications = new List<Reference>(
-                                arrayDataSpecifications.Count);
-                            int indexDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                            theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications.Count);
+                            int indexEmbeddedDataSpecifications = 0;
+                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
                             {
                                 if (item == null)
                                 {
@@ -8530,30 +8530,30 @@ namespace AasCore.Aas3_0_RC02
                                         "Expected a non-null item, but got a null");
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
+                                EmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
                                     item ?? throw new System.InvalidOperationException(),
                                     out error);
                                 if (error != null)
                                 {
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                theDataSpecifications.Add(
+                                theEmbeddedDataSpecifications.Add(
                                     parsedItem
                                         ?? throw new System.InvalidOperationException(
                                             "Unexpected result null when error is null"));
-                                indexDataSpecifications++;
+                                indexEmbeddedDataSpecifications++;
                             }
                             break;
                         }
@@ -8652,7 +8652,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theAnnotations);
             }  // internal static AnnotatedRelationshipElementFrom
 
@@ -8716,7 +8716,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 List<ISubmodelElement>? theStatements = null;
                 Reference? theGlobalAssetId = null;
                 SpecificAssetId? theSpecificAssetId = null;
@@ -9082,27 +9082,27 @@ namespace AasCore.Aas3_0_RC02
                             }
                             break;
                         }
-                        case "dataSpecifications":
+                        case "embeddedDataSpecifications":
                         {
                             if (keyValue.Value == null)
                             {
                                 continue;
                             }
 
-                            Nodes.JsonArray? arrayDataSpecifications = keyValue.Value as Nodes.JsonArray;
-                            if (arrayDataSpecifications == null)
+                            Nodes.JsonArray? arrayEmbeddedDataSpecifications = keyValue.Value as Nodes.JsonArray;
+                            if (arrayEmbeddedDataSpecifications == null)
                             {
                                 error = new Reporting.Error(
                                     $"Expected a JsonArray, but got {keyValue.Value.GetType()}");
                                 error.PrependSegment(
                                     new Reporting.NameSegment(
-                                        "dataSpecifications"));
+                                        "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theDataSpecifications = new List<Reference>(
-                                arrayDataSpecifications.Count);
-                            int indexDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                            theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications.Count);
+                            int indexEmbeddedDataSpecifications = 0;
+                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
                             {
                                 if (item == null)
                                 {
@@ -9110,30 +9110,30 @@ namespace AasCore.Aas3_0_RC02
                                         "Expected a non-null item, but got a null");
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
+                                EmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
                                     item ?? throw new System.InvalidOperationException(),
                                     out error);
                                 if (error != null)
                                 {
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                theDataSpecifications.Add(
+                                theEmbeddedDataSpecifications.Add(
                                     parsedItem
                                         ?? throw new System.InvalidOperationException(
                                             "Unexpected result null when error is null"));
-                                indexDataSpecifications++;
+                                indexEmbeddedDataSpecifications++;
                             }
                             break;
                         }
@@ -9270,7 +9270,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theStatements,
                     theGlobalAssetId,
                     theSpecificAssetId);
@@ -9694,7 +9694,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 string? theMessageTopic = null;
                 Reference? theMessageBroker = null;
                 string? theLastUpdate = null;
@@ -10110,27 +10110,27 @@ namespace AasCore.Aas3_0_RC02
                             }
                             break;
                         }
-                        case "dataSpecifications":
+                        case "embeddedDataSpecifications":
                         {
                             if (keyValue.Value == null)
                             {
                                 continue;
                             }
 
-                            Nodes.JsonArray? arrayDataSpecifications = keyValue.Value as Nodes.JsonArray;
-                            if (arrayDataSpecifications == null)
+                            Nodes.JsonArray? arrayEmbeddedDataSpecifications = keyValue.Value as Nodes.JsonArray;
+                            if (arrayEmbeddedDataSpecifications == null)
                             {
                                 error = new Reporting.Error(
                                     $"Expected a JsonArray, but got {keyValue.Value.GetType()}");
                                 error.PrependSegment(
                                     new Reporting.NameSegment(
-                                        "dataSpecifications"));
+                                        "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theDataSpecifications = new List<Reference>(
-                                arrayDataSpecifications.Count);
-                            int indexDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                            theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications.Count);
+                            int indexEmbeddedDataSpecifications = 0;
+                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
                             {
                                 if (item == null)
                                 {
@@ -10138,30 +10138,30 @@ namespace AasCore.Aas3_0_RC02
                                         "Expected a non-null item, but got a null");
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
+                                EmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
                                     item ?? throw new System.InvalidOperationException(),
                                     out error);
                                 if (error != null)
                                 {
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                theDataSpecifications.Add(
+                                theEmbeddedDataSpecifications.Add(
                                     parsedItem
                                         ?? throw new System.InvalidOperationException(
                                             "Unexpected result null when error is null"));
-                                indexDataSpecifications++;
+                                indexEmbeddedDataSpecifications++;
                             }
                             break;
                         }
@@ -10335,7 +10335,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theMessageTopic,
                     theMessageBroker,
                     theLastUpdate,
@@ -10372,7 +10372,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 List<OperationVariable>? theInputVariables = null;
                 List<OperationVariable>? theOutputVariables = null;
                 List<OperationVariable>? theInoutputVariables = null;
@@ -10714,27 +10714,27 @@ namespace AasCore.Aas3_0_RC02
                             }
                             break;
                         }
-                        case "dataSpecifications":
+                        case "embeddedDataSpecifications":
                         {
                             if (keyValue.Value == null)
                             {
                                 continue;
                             }
 
-                            Nodes.JsonArray? arrayDataSpecifications = keyValue.Value as Nodes.JsonArray;
-                            if (arrayDataSpecifications == null)
+                            Nodes.JsonArray? arrayEmbeddedDataSpecifications = keyValue.Value as Nodes.JsonArray;
+                            if (arrayEmbeddedDataSpecifications == null)
                             {
                                 error = new Reporting.Error(
                                     $"Expected a JsonArray, but got {keyValue.Value.GetType()}");
                                 error.PrependSegment(
                                     new Reporting.NameSegment(
-                                        "dataSpecifications"));
+                                        "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theDataSpecifications = new List<Reference>(
-                                arrayDataSpecifications.Count);
-                            int indexDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                            theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications.Count);
+                            int indexEmbeddedDataSpecifications = 0;
+                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
                             {
                                 if (item == null)
                                 {
@@ -10742,30 +10742,30 @@ namespace AasCore.Aas3_0_RC02
                                         "Expected a non-null item, but got a null");
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
+                                EmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
                                     item ?? throw new System.InvalidOperationException(),
                                     out error);
                                 if (error != null)
                                 {
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                theDataSpecifications.Add(
+                                theEmbeddedDataSpecifications.Add(
                                     parsedItem
                                         ?? throw new System.InvalidOperationException(
                                             "Unexpected result null when error is null"));
-                                indexDataSpecifications++;
+                                indexEmbeddedDataSpecifications++;
                             }
                             break;
                         }
@@ -10956,7 +10956,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theInputVariables,
                     theOutputVariables,
                     theInoutputVariables);
@@ -11060,7 +11060,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
 
                 foreach (var keyValue in obj)
                 {
@@ -11399,27 +11399,27 @@ namespace AasCore.Aas3_0_RC02
                             }
                             break;
                         }
-                        case "dataSpecifications":
+                        case "embeddedDataSpecifications":
                         {
                             if (keyValue.Value == null)
                             {
                                 continue;
                             }
 
-                            Nodes.JsonArray? arrayDataSpecifications = keyValue.Value as Nodes.JsonArray;
-                            if (arrayDataSpecifications == null)
+                            Nodes.JsonArray? arrayEmbeddedDataSpecifications = keyValue.Value as Nodes.JsonArray;
+                            if (arrayEmbeddedDataSpecifications == null)
                             {
                                 error = new Reporting.Error(
                                     $"Expected a JsonArray, but got {keyValue.Value.GetType()}");
                                 error.PrependSegment(
                                     new Reporting.NameSegment(
-                                        "dataSpecifications"));
+                                        "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theDataSpecifications = new List<Reference>(
-                                arrayDataSpecifications.Count);
-                            int indexDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                            theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications.Count);
+                            int indexEmbeddedDataSpecifications = 0;
+                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
                             {
                                 if (item == null)
                                 {
@@ -11427,30 +11427,30 @@ namespace AasCore.Aas3_0_RC02
                                         "Expected a non-null item, but got a null");
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
+                                EmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
                                     item ?? throw new System.InvalidOperationException(),
                                     out error);
                                 if (error != null)
                                 {
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                theDataSpecifications.Add(
+                                theEmbeddedDataSpecifications.Add(
                                     parsedItem
                                         ?? throw new System.InvalidOperationException(
                                             "Unexpected result null when error is null"));
-                                indexDataSpecifications++;
+                                indexEmbeddedDataSpecifications++;
                             }
                             break;
                         }
@@ -11476,7 +11476,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications);
+                    theEmbeddedDataSpecifications);
             }  // internal static CapabilityFrom
 
             /// <summary>
@@ -11506,7 +11506,7 @@ namespace AasCore.Aas3_0_RC02
                 LangStringSet? theDescription = null;
                 string? theChecksum = null;
                 AdministrativeInformation? theAdministration = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 List<Reference>? theIsCaseOf = null;
 
                 foreach (var keyValue in obj)
@@ -11736,27 +11736,27 @@ namespace AasCore.Aas3_0_RC02
                             }
                             break;
                         }
-                        case "dataSpecifications":
+                        case "embeddedDataSpecifications":
                         {
                             if (keyValue.Value == null)
                             {
                                 continue;
                             }
 
-                            Nodes.JsonArray? arrayDataSpecifications = keyValue.Value as Nodes.JsonArray;
-                            if (arrayDataSpecifications == null)
+                            Nodes.JsonArray? arrayEmbeddedDataSpecifications = keyValue.Value as Nodes.JsonArray;
+                            if (arrayEmbeddedDataSpecifications == null)
                             {
                                 error = new Reporting.Error(
                                     $"Expected a JsonArray, but got {keyValue.Value.GetType()}");
                                 error.PrependSegment(
                                     new Reporting.NameSegment(
-                                        "dataSpecifications"));
+                                        "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theDataSpecifications = new List<Reference>(
-                                arrayDataSpecifications.Count);
-                            int indexDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayDataSpecifications)
+                            theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications.Count);
+                            int indexEmbeddedDataSpecifications = 0;
+                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
                             {
                                 if (item == null)
                                 {
@@ -11764,30 +11764,30 @@ namespace AasCore.Aas3_0_RC02
                                         "Expected a non-null item, but got a null");
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                Reference? parsedItem = DeserializeImplementation.ReferenceFrom(
+                                EmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
                                     item ?? throw new System.InvalidOperationException(),
                                     out error);
                                 if (error != null)
                                 {
                                     error.PrependSegment(
                                         new Reporting.IndexSegment(
-                                            indexDataSpecifications));
+                                            indexEmbeddedDataSpecifications));
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
-                                            "dataSpecifications"));
+                                            "embeddedDataSpecifications"));
                                     return null;
                                 }
-                                theDataSpecifications.Add(
+                                theEmbeddedDataSpecifications.Add(
                                     parsedItem
                                         ?? throw new System.InvalidOperationException(
                                             "Unexpected result null when error is null"));
-                                indexDataSpecifications++;
+                                indexEmbeddedDataSpecifications++;
                             }
                             break;
                         }
@@ -11873,7 +11873,7 @@ namespace AasCore.Aas3_0_RC02
                     theDescription,
                     theChecksum,
                     theAdministration,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theIsCaseOf);
             }  // internal static ConceptDescriptionFrom
 
@@ -12437,199 +12437,6 @@ namespace AasCore.Aas3_0_RC02
             }  // internal static LangStringSetFrom
 
             /// <summary>
-            /// Deserialize an instance of DataSpecificationContent from <paramref name="node" />.
-            /// </summary>
-            /// <param name="node">JSON node to be parsed</param>
-            /// <param name="error">Error, if any, during the deserialization</param>
-            internal static Aas.DataSpecificationContent? DataSpecificationContentFrom(
-                Nodes.JsonNode node,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                Nodes.JsonObject? obj = node as Nodes.JsonObject;
-                if (obj == null)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a JsonObject, but got {node.GetType()}");
-                    return null;
-                }
-
-
-
-                foreach (var keyValue in obj)
-                {
-                    switch (keyValue.Key)
-                    {
-                        default:
-                            error = new Reporting.Error(
-                                $"Unexpected property: {keyValue.Key}");
-                            return null;
-                    }
-                }
-
-
-
-                return new Aas.DataSpecificationContent();
-            }  // internal static DataSpecificationContentFrom
-
-            /// <summary>
-            /// Deserialize an instance of DataSpecification from <paramref name="node" />.
-            /// </summary>
-            /// <param name="node">JSON node to be parsed</param>
-            /// <param name="error">Error, if any, during the deserialization</param>
-            internal static Aas.DataSpecification? DataSpecificationFrom(
-                Nodes.JsonNode node,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                Nodes.JsonObject? obj = node as Nodes.JsonObject;
-                if (obj == null)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a JsonObject, but got {node.GetType()}");
-                    return null;
-                }
-
-                string? theId = null;
-                DataSpecificationContent? theDataSpecificationContent = null;
-                AdministrativeInformation? theAdministration = null;
-                LangStringSet? theDescription = null;
-
-                foreach (var keyValue in obj)
-                {
-                    switch (keyValue.Key)
-                    {
-                        case "id":
-                        {
-                            if (keyValue.Value == null)
-                            {
-                                continue;
-                            }
-
-                            theId = DeserializeImplementation.StringFrom(
-                                keyValue.Value,
-                                out error);
-                            if (error != null)
-                            {
-                                error.PrependSegment(
-                                    new Reporting.NameSegment(
-                                        "id"));
-                                return null;
-                            }
-                            if (theId == null)
-                            {
-                                throw new System.InvalidOperationException(
-                                    "Unexpected theId null when error is also null");
-                            }
-                            break;
-                        }
-                        case "dataSpecificationContent":
-                        {
-                            if (keyValue.Value == null)
-                            {
-                                continue;
-                            }
-
-                            theDataSpecificationContent = DeserializeImplementation.DataSpecificationContentFrom(
-                                keyValue.Value,
-                                out error);
-                            if (error != null)
-                            {
-                                error.PrependSegment(
-                                    new Reporting.NameSegment(
-                                        "dataSpecificationContent"));
-                                return null;
-                            }
-                            if (theDataSpecificationContent == null)
-                            {
-                                throw new System.InvalidOperationException(
-                                    "Unexpected theDataSpecificationContent null when error is also null");
-                            }
-                            break;
-                        }
-                        case "administration":
-                        {
-                            if (keyValue.Value == null)
-                            {
-                                continue;
-                            }
-
-                            theAdministration = DeserializeImplementation.AdministrativeInformationFrom(
-                                keyValue.Value,
-                                out error);
-                            if (error != null)
-                            {
-                                error.PrependSegment(
-                                    new Reporting.NameSegment(
-                                        "administration"));
-                                return null;
-                            }
-                            if (theAdministration == null)
-                            {
-                                throw new System.InvalidOperationException(
-                                    "Unexpected theAdministration null when error is also null");
-                            }
-                            break;
-                        }
-                        case "description":
-                        {
-                            if (keyValue.Value == null)
-                            {
-                                continue;
-                            }
-
-                            theDescription = DeserializeImplementation.LangStringSetFrom(
-                                keyValue.Value,
-                                out error);
-                            if (error != null)
-                            {
-                                error.PrependSegment(
-                                    new Reporting.NameSegment(
-                                        "description"));
-                                return null;
-                            }
-                            if (theDescription == null)
-                            {
-                                throw new System.InvalidOperationException(
-                                    "Unexpected theDescription null when error is also null");
-                            }
-                            break;
-                        }
-                        default:
-                            error = new Reporting.Error(
-                                $"Unexpected property: {keyValue.Key}");
-                            return null;
-                    }
-                }
-
-                if (theId == null)
-                {
-                    error = new Reporting.Error(
-                        "Required property \"id\" is missing");
-                    return null;
-                }
-
-                if (theDataSpecificationContent == null)
-                {
-                    error = new Reporting.Error(
-                        "Required property \"dataSpecificationContent\" is missing");
-                    return null;
-                }
-
-                return new Aas.DataSpecification(
-                    theId
-                         ?? throw new System.InvalidOperationException(
-                            "Unexpected null, had to be handled before"),
-                    theDataSpecificationContent
-                         ?? throw new System.InvalidOperationException(
-                            "Unexpected null, had to be handled before"),
-                    theAdministration,
-                    theDescription);
-            }  // internal static DataSpecificationFrom
-
-            /// <summary>
             /// Deserialize an instance of Environment from <paramref name="node" />.
             /// </summary>
             /// <param name="node">JSON node to be parsed</param>
@@ -12835,6 +12642,1222 @@ namespace AasCore.Aas3_0_RC02
                     theSubmodels,
                     theConceptDescriptions);
             }  // internal static EnvironmentFrom
+
+            /// <summary>
+            /// Deserialize an instance of IDataSpecificationContent by dispatching
+            /// based on <c>modelType</c> property of the <paramref name="node" />.
+            /// </summary>
+            /// <param name="node">JSON node to be parsed</param>
+            /// <param name="error">Error, if any, during the deserialization</param>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+            public static Aas.IDataSpecificationContent? IDataSpecificationContentFrom(
+                Nodes.JsonNode node,
+                out Reporting.Error? error)
+            {
+                error = null;
+
+                var obj = node as Nodes.JsonObject;
+                if (obj == null)
+                {
+                    error = new Reporting.Error(
+                        "Expected Nodes.JsonObject, but got {node.GetType()}");
+                    return null;
+                }
+
+                Nodes.JsonNode? modelTypeNode = obj["modelType"];
+                if (modelTypeNode == null)
+                {
+                    error = new Reporting.Error(
+                        "Expected a model type, but none is present");
+                    return null;
+                }
+                Nodes.JsonValue? modelTypeValue = modelTypeNode as Nodes.JsonValue;
+                if (modelTypeValue == null)
+                {
+                    error = new Reporting.Error(
+                        "Expected JsonValue, " +
+                        $"but got {modelTypeNode.GetType()}");
+                    return null;
+                }
+                modelTypeValue.TryGetValue<string>(out string? modelType);
+                if (modelType == null)
+                {
+                    error = new Reporting.Error(
+                        "Expected a string, " +
+                        $"but the conversion failed from {modelTypeValue}");
+                    return null;
+                }
+
+                switch (modelType)
+                {
+                    case "DataSpecificationIEC61360":
+                        return DataSpecificationIec61360From(
+                            node, out error);
+                    case "DataSpecificationPhysicalUnit":
+                        return DataSpecificationPhysicalUnitFrom(
+                            node, out error);
+                    default:
+                        error = new Reporting.Error(
+                            $"Unexpected model type for IDataSpecificationContent: {modelType}");
+                        return null;
+                }
+            }  // public static Aas.IDataSpecificationContent IDataSpecificationContentFrom
+
+            /// <summary>
+            /// Deserialize an instance of EmbeddedDataSpecification from <paramref name="node" />.
+            /// </summary>
+            /// <param name="node">JSON node to be parsed</param>
+            /// <param name="error">Error, if any, during the deserialization</param>
+            internal static Aas.EmbeddedDataSpecification? EmbeddedDataSpecificationFrom(
+                Nodes.JsonNode node,
+                out Reporting.Error? error)
+            {
+                error = null;
+
+                Nodes.JsonObject? obj = node as Nodes.JsonObject;
+                if (obj == null)
+                {
+                    error = new Reporting.Error(
+                        $"Expected a JsonObject, but got {node.GetType()}");
+                    return null;
+                }
+
+                Reference? theDataSpecification = null;
+                IDataSpecificationContent? theDataSpecificationContent = null;
+
+                foreach (var keyValue in obj)
+                {
+                    switch (keyValue.Key)
+                    {
+                        case "dataSpecification":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            theDataSpecification = DeserializeImplementation.ReferenceFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "dataSpecification"));
+                                return null;
+                            }
+                            if (theDataSpecification == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theDataSpecification null when error is also null");
+                            }
+                            break;
+                        }
+                        case "dataSpecificationContent":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            theDataSpecificationContent = DeserializeImplementation.IDataSpecificationContentFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "dataSpecificationContent"));
+                                return null;
+                            }
+                            if (theDataSpecificationContent == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theDataSpecificationContent null when error is also null");
+                            }
+                            break;
+                        }
+                        default:
+                            error = new Reporting.Error(
+                                $"Unexpected property: {keyValue.Key}");
+                            return null;
+                    }
+                }
+
+                if (theDataSpecification == null)
+                {
+                    error = new Reporting.Error(
+                        "Required property \"dataSpecification\" is missing");
+                    return null;
+                }
+
+                if (theDataSpecificationContent == null)
+                {
+                    error = new Reporting.Error(
+                        "Required property \"dataSpecificationContent\" is missing");
+                    return null;
+                }
+
+                return new Aas.EmbeddedDataSpecification(
+                    theDataSpecification
+                         ?? throw new System.InvalidOperationException(
+                            "Unexpected null, had to be handled before"),
+                    theDataSpecificationContent
+                         ?? throw new System.InvalidOperationException(
+                            "Unexpected null, had to be handled before"));
+            }  // internal static EmbeddedDataSpecificationFrom
+
+            /// <summary>
+            /// Deserialize the enumeration DataTypeIec61360 from the <paramref name="node" />.
+            /// </summary>
+            /// <param name="node">JSON node to be parsed</param>
+            /// <param name="error">Error, if any, during the deserialization</param>
+            internal static Aas.DataTypeIec61360? DataTypeIec61360From(
+                Nodes.JsonNode node,
+                out Reporting.Error? error)
+            {
+                error = null;
+                string? text = DeserializeImplementation.StringFrom(
+                    node, out error);
+                if (error != null)
+                {
+                    return null;
+                }
+                if (text == null)
+                {
+                    throw new System.InvalidOperationException(
+                        "Unexpected text null if error null");
+                }
+                Aas.DataTypeIec61360? result = Stringification.DataTypeIec61360FromString(text);
+                if (result == null)
+                {
+                    error = new Reporting.Error(
+                        "Not a valid JSON representation of DataTypeIec61360");
+                }
+                return result;
+            }  // internal static DataTypeIec61360From
+
+            /// <summary>
+            /// Deserialize the enumeration ConceptDescriptionsCategories from the <paramref name="node" />.
+            /// </summary>
+            /// <param name="node">JSON node to be parsed</param>
+            /// <param name="error">Error, if any, during the deserialization</param>
+            internal static Aas.ConceptDescriptionsCategories? ConceptDescriptionsCategoriesFrom(
+                Nodes.JsonNode node,
+                out Reporting.Error? error)
+            {
+                error = null;
+                string? text = DeserializeImplementation.StringFrom(
+                    node, out error);
+                if (error != null)
+                {
+                    return null;
+                }
+                if (text == null)
+                {
+                    throw new System.InvalidOperationException(
+                        "Unexpected text null if error null");
+                }
+                Aas.ConceptDescriptionsCategories? result = Stringification.ConceptDescriptionsCategoriesFromString(text);
+                if (result == null)
+                {
+                    error = new Reporting.Error(
+                        "Not a valid JSON representation of ConceptDescriptionsCategories");
+                }
+                return result;
+            }  // internal static ConceptDescriptionsCategoriesFrom
+
+            /// <summary>
+            /// Deserialize the enumeration LevelType from the <paramref name="node" />.
+            /// </summary>
+            /// <param name="node">JSON node to be parsed</param>
+            /// <param name="error">Error, if any, during the deserialization</param>
+            internal static Aas.LevelType? LevelTypeFrom(
+                Nodes.JsonNode node,
+                out Reporting.Error? error)
+            {
+                error = null;
+                string? text = DeserializeImplementation.StringFrom(
+                    node, out error);
+                if (error != null)
+                {
+                    return null;
+                }
+                if (text == null)
+                {
+                    throw new System.InvalidOperationException(
+                        "Unexpected text null if error null");
+                }
+                Aas.LevelType? result = Stringification.LevelTypeFromString(text);
+                if (result == null)
+                {
+                    error = new Reporting.Error(
+                        "Not a valid JSON representation of LevelType");
+                }
+                return result;
+            }  // internal static LevelTypeFrom
+
+            /// <summary>
+            /// Deserialize an instance of ValueReferencePair from <paramref name="node" />.
+            /// </summary>
+            /// <param name="node">JSON node to be parsed</param>
+            /// <param name="error">Error, if any, during the deserialization</param>
+            internal static Aas.ValueReferencePair? ValueReferencePairFrom(
+                Nodes.JsonNode node,
+                out Reporting.Error? error)
+            {
+                error = null;
+
+                Nodes.JsonObject? obj = node as Nodes.JsonObject;
+                if (obj == null)
+                {
+                    error = new Reporting.Error(
+                        $"Expected a JsonObject, but got {node.GetType()}");
+                    return null;
+                }
+
+                string? theValue = null;
+                Reference? theValueId = null;
+
+                foreach (var keyValue in obj)
+                {
+                    switch (keyValue.Key)
+                    {
+                        case "value":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            theValue = DeserializeImplementation.StringFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "value"));
+                                return null;
+                            }
+                            if (theValue == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theValue null when error is also null");
+                            }
+                            break;
+                        }
+                        case "valueId":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            theValueId = DeserializeImplementation.ReferenceFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "valueId"));
+                                return null;
+                            }
+                            if (theValueId == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theValueId null when error is also null");
+                            }
+                            break;
+                        }
+                        default:
+                            error = new Reporting.Error(
+                                $"Unexpected property: {keyValue.Key}");
+                            return null;
+                    }
+                }
+
+                if (theValue == null)
+                {
+                    error = new Reporting.Error(
+                        "Required property \"value\" is missing");
+                    return null;
+                }
+
+                if (theValueId == null)
+                {
+                    error = new Reporting.Error(
+                        "Required property \"valueId\" is missing");
+                    return null;
+                }
+
+                return new Aas.ValueReferencePair(
+                    theValue
+                         ?? throw new System.InvalidOperationException(
+                            "Unexpected null, had to be handled before"),
+                    theValueId
+                         ?? throw new System.InvalidOperationException(
+                            "Unexpected null, had to be handled before"));
+            }  // internal static ValueReferencePairFrom
+
+            /// <summary>
+            /// Deserialize an instance of ValueList from <paramref name="node" />.
+            /// </summary>
+            /// <param name="node">JSON node to be parsed</param>
+            /// <param name="error">Error, if any, during the deserialization</param>
+            internal static Aas.ValueList? ValueListFrom(
+                Nodes.JsonNode node,
+                out Reporting.Error? error)
+            {
+                error = null;
+
+                Nodes.JsonObject? obj = node as Nodes.JsonObject;
+                if (obj == null)
+                {
+                    error = new Reporting.Error(
+                        $"Expected a JsonObject, but got {node.GetType()}");
+                    return null;
+                }
+
+                List<ValueReferencePair>? theValueReferencePairTypes = null;
+
+                foreach (var keyValue in obj)
+                {
+                    switch (keyValue.Key)
+                    {
+                        case "valueReferencePairTypes":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            Nodes.JsonArray? arrayValueReferencePairTypes = keyValue.Value as Nodes.JsonArray;
+                            if (arrayValueReferencePairTypes == null)
+                            {
+                                error = new Reporting.Error(
+                                    $"Expected a JsonArray, but got {keyValue.Value.GetType()}");
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "valueReferencePairTypes"));
+                                return null;
+                            }
+                            theValueReferencePairTypes = new List<ValueReferencePair>(
+                                arrayValueReferencePairTypes.Count);
+                            int indexValueReferencePairTypes = 0;
+                            foreach (Nodes.JsonNode? item in arrayValueReferencePairTypes)
+                            {
+                                if (item == null)
+                                {
+                                    error = new Reporting.Error(
+                                        "Expected a non-null item, but got a null");
+                                    error.PrependSegment(
+                                        new Reporting.IndexSegment(
+                                            indexValueReferencePairTypes));
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "valueReferencePairTypes"));
+                                    return null;
+                                }
+                                ValueReferencePair? parsedItem = DeserializeImplementation.ValueReferencePairFrom(
+                                    item ?? throw new System.InvalidOperationException(),
+                                    out error);
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.IndexSegment(
+                                            indexValueReferencePairTypes));
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "valueReferencePairTypes"));
+                                    return null;
+                                }
+                                theValueReferencePairTypes.Add(
+                                    parsedItem
+                                        ?? throw new System.InvalidOperationException(
+                                            "Unexpected result null when error is null"));
+                                indexValueReferencePairTypes++;
+                            }
+                            break;
+                        }
+                        default:
+                            error = new Reporting.Error(
+                                $"Unexpected property: {keyValue.Key}");
+                            return null;
+                    }
+                }
+
+                if (theValueReferencePairTypes == null)
+                {
+                    error = new Reporting.Error(
+                        "Required property \"valueReferencePairTypes\" is missing");
+                    return null;
+                }
+
+                return new Aas.ValueList(
+                    theValueReferencePairTypes
+                         ?? throw new System.InvalidOperationException(
+                            "Unexpected null, had to be handled before"));
+            }  // internal static ValueListFrom
+
+            /// <summary>
+            /// Deserialize an instance of DataSpecificationIec61360 from <paramref name="node" />.
+            /// </summary>
+            /// <param name="node">JSON node to be parsed</param>
+            /// <param name="error">Error, if any, during the deserialization</param>
+            internal static Aas.DataSpecificationIec61360? DataSpecificationIec61360From(
+                Nodes.JsonNode node,
+                out Reporting.Error? error)
+            {
+                error = null;
+
+                Nodes.JsonObject? obj = node as Nodes.JsonObject;
+                if (obj == null)
+                {
+                    error = new Reporting.Error(
+                        $"Expected a JsonObject, but got {node.GetType()}");
+                    return null;
+                }
+
+                LangStringSet? thePreferredName = null;
+                LangStringSet? theShortName = null;
+                string? theUnit = null;
+                Reference? theUnitId = null;
+                string? theSourceOfDefinition = null;
+                string? theSymbol = null;
+                DataTypeIec61360? theDataType = null;
+                LangStringSet? theDefinition = null;
+                string? theValueFormat = null;
+                ValueList? theValueList = null;
+                string? theValue = null;
+                LevelType? theLevelType = null;
+
+                foreach (var keyValue in obj)
+                {
+                    switch (keyValue.Key)
+                    {
+                        case "preferredName":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            thePreferredName = DeserializeImplementation.LangStringSetFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "preferredName"));
+                                return null;
+                            }
+                            if (thePreferredName == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected thePreferredName null when error is also null");
+                            }
+                            break;
+                        }
+                        case "shortName":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            theShortName = DeserializeImplementation.LangStringSetFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "shortName"));
+                                return null;
+                            }
+                            if (theShortName == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theShortName null when error is also null");
+                            }
+                            break;
+                        }
+                        case "unit":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            theUnit = DeserializeImplementation.StringFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "unit"));
+                                return null;
+                            }
+                            if (theUnit == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theUnit null when error is also null");
+                            }
+                            break;
+                        }
+                        case "unitId":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            theUnitId = DeserializeImplementation.ReferenceFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "unitId"));
+                                return null;
+                            }
+                            if (theUnitId == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theUnitId null when error is also null");
+                            }
+                            break;
+                        }
+                        case "sourceOfDefinition":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            theSourceOfDefinition = DeserializeImplementation.StringFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "sourceOfDefinition"));
+                                return null;
+                            }
+                            if (theSourceOfDefinition == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theSourceOfDefinition null when error is also null");
+                            }
+                            break;
+                        }
+                        case "symbol":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            theSymbol = DeserializeImplementation.StringFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "symbol"));
+                                return null;
+                            }
+                            if (theSymbol == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theSymbol null when error is also null");
+                            }
+                            break;
+                        }
+                        case "dataType":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            theDataType = DeserializeImplementation.DataTypeIec61360From(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "dataType"));
+                                return null;
+                            }
+                            if (theDataType == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theDataType null when error is also null");
+                            }
+                            break;
+                        }
+                        case "definition":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            theDefinition = DeserializeImplementation.LangStringSetFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "definition"));
+                                return null;
+                            }
+                            if (theDefinition == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theDefinition null when error is also null");
+                            }
+                            break;
+                        }
+                        case "valueFormat":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            theValueFormat = DeserializeImplementation.StringFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "valueFormat"));
+                                return null;
+                            }
+                            if (theValueFormat == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theValueFormat null when error is also null");
+                            }
+                            break;
+                        }
+                        case "valueList":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            theValueList = DeserializeImplementation.ValueListFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "valueList"));
+                                return null;
+                            }
+                            if (theValueList == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theValueList null when error is also null");
+                            }
+                            break;
+                        }
+                        case "value":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            theValue = DeserializeImplementation.StringFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "value"));
+                                return null;
+                            }
+                            if (theValue == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theValue null when error is also null");
+                            }
+                            break;
+                        }
+                        case "levelType":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            theLevelType = DeserializeImplementation.LevelTypeFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "levelType"));
+                                return null;
+                            }
+                            if (theLevelType == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theLevelType null when error is also null");
+                            }
+                            break;
+                        }
+                        case "modelType":
+                            continue;
+                        default:
+                            error = new Reporting.Error(
+                                $"Unexpected property: {keyValue.Key}");
+                            return null;
+                    }
+                }
+
+                if (thePreferredName == null)
+                {
+                    error = new Reporting.Error(
+                        "Required property \"preferredName\" is missing");
+                    return null;
+                }
+
+                return new Aas.DataSpecificationIec61360(
+                    thePreferredName
+                         ?? throw new System.InvalidOperationException(
+                            "Unexpected null, had to be handled before"),
+                    theShortName,
+                    theUnit,
+                    theUnitId,
+                    theSourceOfDefinition,
+                    theSymbol,
+                    theDataType,
+                    theDefinition,
+                    theValueFormat,
+                    theValueList,
+                    theValue,
+                    theLevelType);
+            }  // internal static DataSpecificationIec61360From
+
+            /// <summary>
+            /// Deserialize an instance of DataSpecificationPhysicalUnit from <paramref name="node" />.
+            /// </summary>
+            /// <param name="node">JSON node to be parsed</param>
+            /// <param name="error">Error, if any, during the deserialization</param>
+            internal static Aas.DataSpecificationPhysicalUnit? DataSpecificationPhysicalUnitFrom(
+                Nodes.JsonNode node,
+                out Reporting.Error? error)
+            {
+                error = null;
+
+                Nodes.JsonObject? obj = node as Nodes.JsonObject;
+                if (obj == null)
+                {
+                    error = new Reporting.Error(
+                        $"Expected a JsonObject, but got {node.GetType()}");
+                    return null;
+                }
+
+                string? theUnitName = null;
+                string? theUnitSymbol = null;
+                LangStringSet? theDefinition = null;
+                string? theSiNotation = null;
+                string? theSiName = null;
+                string? theDinNotation = null;
+                string? theEceName = null;
+                string? theEceCode = null;
+                string? theNistName = null;
+                string? theSourceOfDefinition = null;
+                string? theConversionFactor = null;
+                string? theRegistrationAuthorityId = null;
+                string? theSupplier = null;
+
+                foreach (var keyValue in obj)
+                {
+                    switch (keyValue.Key)
+                    {
+                        case "unitName":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            theUnitName = DeserializeImplementation.StringFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "unitName"));
+                                return null;
+                            }
+                            if (theUnitName == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theUnitName null when error is also null");
+                            }
+                            break;
+                        }
+                        case "unitSymbol":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            theUnitSymbol = DeserializeImplementation.StringFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "unitSymbol"));
+                                return null;
+                            }
+                            if (theUnitSymbol == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theUnitSymbol null when error is also null");
+                            }
+                            break;
+                        }
+                        case "definition":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            theDefinition = DeserializeImplementation.LangStringSetFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "definition"));
+                                return null;
+                            }
+                            if (theDefinition == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theDefinition null when error is also null");
+                            }
+                            break;
+                        }
+                        case "siNotation":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            theSiNotation = DeserializeImplementation.StringFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "siNotation"));
+                                return null;
+                            }
+                            if (theSiNotation == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theSiNotation null when error is also null");
+                            }
+                            break;
+                        }
+                        case "siName":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            theSiName = DeserializeImplementation.StringFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "siName"));
+                                return null;
+                            }
+                            if (theSiName == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theSiName null when error is also null");
+                            }
+                            break;
+                        }
+                        case "dinNotation":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            theDinNotation = DeserializeImplementation.StringFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "dinNotation"));
+                                return null;
+                            }
+                            if (theDinNotation == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theDinNotation null when error is also null");
+                            }
+                            break;
+                        }
+                        case "eceName":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            theEceName = DeserializeImplementation.StringFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "eceName"));
+                                return null;
+                            }
+                            if (theEceName == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theEceName null when error is also null");
+                            }
+                            break;
+                        }
+                        case "eceCode":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            theEceCode = DeserializeImplementation.StringFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "eceCode"));
+                                return null;
+                            }
+                            if (theEceCode == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theEceCode null when error is also null");
+                            }
+                            break;
+                        }
+                        case "nistName":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            theNistName = DeserializeImplementation.StringFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "nistName"));
+                                return null;
+                            }
+                            if (theNistName == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theNistName null when error is also null");
+                            }
+                            break;
+                        }
+                        case "sourceOfDefinition":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            theSourceOfDefinition = DeserializeImplementation.StringFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "sourceOfDefinition"));
+                                return null;
+                            }
+                            if (theSourceOfDefinition == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theSourceOfDefinition null when error is also null");
+                            }
+                            break;
+                        }
+                        case "conversionFactor":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            theConversionFactor = DeserializeImplementation.StringFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "conversionFactor"));
+                                return null;
+                            }
+                            if (theConversionFactor == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theConversionFactor null when error is also null");
+                            }
+                            break;
+                        }
+                        case "registrationAuthorityId":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            theRegistrationAuthorityId = DeserializeImplementation.StringFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "registrationAuthorityId"));
+                                return null;
+                            }
+                            if (theRegistrationAuthorityId == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theRegistrationAuthorityId null when error is also null");
+                            }
+                            break;
+                        }
+                        case "supplier":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            theSupplier = DeserializeImplementation.StringFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "supplier"));
+                                return null;
+                            }
+                            if (theSupplier == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theSupplier null when error is also null");
+                            }
+                            break;
+                        }
+                        case "modelType":
+                            continue;
+                        default:
+                            error = new Reporting.Error(
+                                $"Unexpected property: {keyValue.Key}");
+                            return null;
+                    }
+                }
+
+                if (theUnitName == null)
+                {
+                    error = new Reporting.Error(
+                        "Required property \"unitName\" is missing");
+                    return null;
+                }
+
+                if (theUnitSymbol == null)
+                {
+                    error = new Reporting.Error(
+                        "Required property \"unitSymbol\" is missing");
+                    return null;
+                }
+
+                if (theDefinition == null)
+                {
+                    error = new Reporting.Error(
+                        "Required property \"definition\" is missing");
+                    return null;
+                }
+
+                return new Aas.DataSpecificationPhysicalUnit(
+                    theUnitName
+                         ?? throw new System.InvalidOperationException(
+                            "Unexpected null, had to be handled before"),
+                    theUnitSymbol
+                         ?? throw new System.InvalidOperationException(
+                            "Unexpected null, had to be handled before"),
+                    theDefinition
+                         ?? throw new System.InvalidOperationException(
+                            "Unexpected null, had to be handled before"),
+                    theSiNotation,
+                    theSiName,
+                    theDinNotation,
+                    theEceName,
+                    theEceCode,
+                    theNistName,
+                    theSourceOfDefinition,
+                    theConversionFactor,
+                    theRegistrationAuthorityId,
+                    theSupplier);
+            }  // internal static DataSpecificationPhysicalUnitFrom
         }  // public static class DeserializeImplementation
 
         /// <summary>
@@ -14128,56 +15151,6 @@ namespace AasCore.Aas3_0_RC02
             }
 
             /// <summary>
-            /// Deserialize an instance of DataSpecificationContent from <paramref name="node" />.
-            /// </summary>
-            /// <param name="node">JSON node to be parsed</param>
-            /// <exception cref="Jsonization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid JSON
-            /// representation of DataSpecificationContent.
-            /// </exception>
-            public static Aas.DataSpecificationContent DataSpecificationContentFrom(
-                Nodes.JsonNode node)
-            {
-                Aas.DataSpecificationContent? result = DeserializeImplementation.DataSpecificationContentFrom(
-                    node,
-                    out Reporting.Error? error);
-                if (error != null)
-                {
-                    throw new Jsonization.Exception(
-                        Reporting.GenerateJsonPath(error.PathSegments),
-                        error.Cause);
-                }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
-            }
-
-            /// <summary>
-            /// Deserialize an instance of DataSpecification from <paramref name="node" />.
-            /// </summary>
-            /// <param name="node">JSON node to be parsed</param>
-            /// <exception cref="Jsonization.Exception">
-            /// Thrown when <paramref name="node" /> is not a valid JSON
-            /// representation of DataSpecification.
-            /// </exception>
-            public static Aas.DataSpecification DataSpecificationFrom(
-                Nodes.JsonNode node)
-            {
-                Aas.DataSpecification? result = DeserializeImplementation.DataSpecificationFrom(
-                    node,
-                    out Reporting.Error? error);
-                if (error != null)
-                {
-                    throw new Jsonization.Exception(
-                        Reporting.GenerateJsonPath(error.PathSegments),
-                        error.Cause);
-                }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
-            }
-
-            /// <summary>
             /// Deserialize an instance of Environment from <paramref name="node" />.
             /// </summary>
             /// <param name="node">JSON node to be parsed</param>
@@ -14189,6 +15162,232 @@ namespace AasCore.Aas3_0_RC02
                 Nodes.JsonNode node)
             {
                 Aas.Environment? result = DeserializeImplementation.EnvironmentFrom(
+                    node,
+                    out Reporting.Error? error);
+                if (error != null)
+                {
+                    throw new Jsonization.Exception(
+                        Reporting.GenerateJsonPath(error.PathSegments),
+                        error.Cause);
+                }
+                return result
+                    ?? throw new System.InvalidOperationException(
+                        "Unexpected output null when error is null");
+            }
+
+            /// <summary>
+            /// Deserialize an instance of IDataSpecificationContent from <paramref name="node" />.
+            /// </summary>
+            /// <param name="node">JSON node to be parsed</param>
+            /// <exception cref="Jsonization.Exception">
+            /// Thrown when <paramref name="node" /> is not a valid JSON
+            /// representation of IDataSpecificationContent.
+            /// </exception>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+            public static Aas.IDataSpecificationContent IDataSpecificationContentFrom(
+                Nodes.JsonNode node)
+            {
+                Aas.IDataSpecificationContent? result = DeserializeImplementation.IDataSpecificationContentFrom(
+                    node,
+                    out Reporting.Error? error);
+                if (error != null)
+                {
+                    throw new Jsonization.Exception(
+                        Reporting.GenerateJsonPath(error.PathSegments),
+                        error.Cause);
+                }
+                return result
+                    ?? throw new System.InvalidOperationException(
+                        "Unexpected output null when error is null");
+            }
+
+            /// <summary>
+            /// Deserialize an instance of EmbeddedDataSpecification from <paramref name="node" />.
+            /// </summary>
+            /// <param name="node">JSON node to be parsed</param>
+            /// <exception cref="Jsonization.Exception">
+            /// Thrown when <paramref name="node" /> is not a valid JSON
+            /// representation of EmbeddedDataSpecification.
+            /// </exception>
+            public static Aas.EmbeddedDataSpecification EmbeddedDataSpecificationFrom(
+                Nodes.JsonNode node)
+            {
+                Aas.EmbeddedDataSpecification? result = DeserializeImplementation.EmbeddedDataSpecificationFrom(
+                    node,
+                    out Reporting.Error? error);
+                if (error != null)
+                {
+                    throw new Jsonization.Exception(
+                        Reporting.GenerateJsonPath(error.PathSegments),
+                        error.Cause);
+                }
+                return result
+                    ?? throw new System.InvalidOperationException(
+                        "Unexpected output null when error is null");
+            }
+
+            /// <summary>
+            /// Deserialize an instance of DataTypeIec61360 from <paramref name="node" />.
+            /// </summary>
+            /// <param name="node">JSON node to be parsed</param>
+            /// <exception cref="Jsonization.Exception">
+            /// Thrown when <paramref name="node" /> is not a valid JSON
+            /// representation of DataTypeIec61360.
+            /// </exception>
+            public static Aas.DataTypeIec61360 DataTypeIec61360From(
+                Nodes.JsonNode node)
+            {
+                Aas.DataTypeIec61360? result = DeserializeImplementation.DataTypeIec61360From(
+                    node,
+                    out Reporting.Error? error);
+                if (error != null)
+                {
+                    throw new Jsonization.Exception(
+                        Reporting.GenerateJsonPath(error.PathSegments),
+                        error.Cause);
+                }
+                return result
+                    ?? throw new System.InvalidOperationException(
+                        "Unexpected output null when error is null");
+            }
+
+            /// <summary>
+            /// Deserialize an instance of ConceptDescriptionsCategories from <paramref name="node" />.
+            /// </summary>
+            /// <param name="node">JSON node to be parsed</param>
+            /// <exception cref="Jsonization.Exception">
+            /// Thrown when <paramref name="node" /> is not a valid JSON
+            /// representation of ConceptDescriptionsCategories.
+            /// </exception>
+            public static Aas.ConceptDescriptionsCategories ConceptDescriptionsCategoriesFrom(
+                Nodes.JsonNode node)
+            {
+                Aas.ConceptDescriptionsCategories? result = DeserializeImplementation.ConceptDescriptionsCategoriesFrom(
+                    node,
+                    out Reporting.Error? error);
+                if (error != null)
+                {
+                    throw new Jsonization.Exception(
+                        Reporting.GenerateJsonPath(error.PathSegments),
+                        error.Cause);
+                }
+                return result
+                    ?? throw new System.InvalidOperationException(
+                        "Unexpected output null when error is null");
+            }
+
+            /// <summary>
+            /// Deserialize an instance of LevelType from <paramref name="node" />.
+            /// </summary>
+            /// <param name="node">JSON node to be parsed</param>
+            /// <exception cref="Jsonization.Exception">
+            /// Thrown when <paramref name="node" /> is not a valid JSON
+            /// representation of LevelType.
+            /// </exception>
+            public static Aas.LevelType LevelTypeFrom(
+                Nodes.JsonNode node)
+            {
+                Aas.LevelType? result = DeserializeImplementation.LevelTypeFrom(
+                    node,
+                    out Reporting.Error? error);
+                if (error != null)
+                {
+                    throw new Jsonization.Exception(
+                        Reporting.GenerateJsonPath(error.PathSegments),
+                        error.Cause);
+                }
+                return result
+                    ?? throw new System.InvalidOperationException(
+                        "Unexpected output null when error is null");
+            }
+
+            /// <summary>
+            /// Deserialize an instance of ValueReferencePair from <paramref name="node" />.
+            /// </summary>
+            /// <param name="node">JSON node to be parsed</param>
+            /// <exception cref="Jsonization.Exception">
+            /// Thrown when <paramref name="node" /> is not a valid JSON
+            /// representation of ValueReferencePair.
+            /// </exception>
+            public static Aas.ValueReferencePair ValueReferencePairFrom(
+                Nodes.JsonNode node)
+            {
+                Aas.ValueReferencePair? result = DeserializeImplementation.ValueReferencePairFrom(
+                    node,
+                    out Reporting.Error? error);
+                if (error != null)
+                {
+                    throw new Jsonization.Exception(
+                        Reporting.GenerateJsonPath(error.PathSegments),
+                        error.Cause);
+                }
+                return result
+                    ?? throw new System.InvalidOperationException(
+                        "Unexpected output null when error is null");
+            }
+
+            /// <summary>
+            /// Deserialize an instance of ValueList from <paramref name="node" />.
+            /// </summary>
+            /// <param name="node">JSON node to be parsed</param>
+            /// <exception cref="Jsonization.Exception">
+            /// Thrown when <paramref name="node" /> is not a valid JSON
+            /// representation of ValueList.
+            /// </exception>
+            public static Aas.ValueList ValueListFrom(
+                Nodes.JsonNode node)
+            {
+                Aas.ValueList? result = DeserializeImplementation.ValueListFrom(
+                    node,
+                    out Reporting.Error? error);
+                if (error != null)
+                {
+                    throw new Jsonization.Exception(
+                        Reporting.GenerateJsonPath(error.PathSegments),
+                        error.Cause);
+                }
+                return result
+                    ?? throw new System.InvalidOperationException(
+                        "Unexpected output null when error is null");
+            }
+
+            /// <summary>
+            /// Deserialize an instance of DataSpecificationIec61360 from <paramref name="node" />.
+            /// </summary>
+            /// <param name="node">JSON node to be parsed</param>
+            /// <exception cref="Jsonization.Exception">
+            /// Thrown when <paramref name="node" /> is not a valid JSON
+            /// representation of DataSpecificationIec61360.
+            /// </exception>
+            public static Aas.DataSpecificationIec61360 DataSpecificationIec61360From(
+                Nodes.JsonNode node)
+            {
+                Aas.DataSpecificationIec61360? result = DeserializeImplementation.DataSpecificationIec61360From(
+                    node,
+                    out Reporting.Error? error);
+                if (error != null)
+                {
+                    throw new Jsonization.Exception(
+                        Reporting.GenerateJsonPath(error.PathSegments),
+                        error.Cause);
+                }
+                return result
+                    ?? throw new System.InvalidOperationException(
+                        "Unexpected output null when error is null");
+            }
+
+            /// <summary>
+            /// Deserialize an instance of DataSpecificationPhysicalUnit from <paramref name="node" />.
+            /// </summary>
+            /// <param name="node">JSON node to be parsed</param>
+            /// <exception cref="Jsonization.Exception">
+            /// Thrown when <paramref name="node" /> is not a valid JSON
+            /// representation of DataSpecificationPhysicalUnit.
+            /// </exception>
+            public static Aas.DataSpecificationPhysicalUnit DataSpecificationPhysicalUnitFrom(
+                Nodes.JsonNode node)
+            {
+                Aas.DataSpecificationPhysicalUnit? result = DeserializeImplementation.DataSpecificationPhysicalUnitFrom(
                     node,
                     out Reporting.Error? error);
                 if (error != null)
@@ -14279,16 +15478,16 @@ namespace AasCore.Aas3_0_RC02
             {
                 var result = new Nodes.JsonObject();
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (Reference item in that.DataSpecifications)
+                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
+                    foreach (EmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
                     {
-                        arrayDataSpecifications.Add(
+                        arrayEmbeddedDataSpecifications.Add(
                             Transform(
                                 item));
                     }
-                    result["dataSpecifications"] = arrayDataSpecifications;
+                    result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
                 if (that.Version != null)
@@ -14413,16 +15612,16 @@ namespace AasCore.Aas3_0_RC02
                 result["id"] = Nodes.JsonValue.Create(
                     that.Id);
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (Reference item in that.DataSpecifications)
+                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
+                    foreach (EmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
                     {
-                        arrayDataSpecifications.Add(
+                        arrayEmbeddedDataSpecifications.Add(
                             Transform(
                                 item));
                     }
-                    result["dataSpecifications"] = arrayDataSpecifications;
+                    result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
                 if (that.DerivedFrom != null)
@@ -14629,16 +15828,16 @@ namespace AasCore.Aas3_0_RC02
                     result["qualifiers"] = arrayQualifiers;
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (Reference item in that.DataSpecifications)
+                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
+                    foreach (EmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
                     {
-                        arrayDataSpecifications.Add(
+                        arrayEmbeddedDataSpecifications.Add(
                             Transform(
                                 item));
                     }
-                    result["dataSpecifications"] = arrayDataSpecifications;
+                    result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
                 if (that.SubmodelElements != null)
@@ -14743,16 +15942,16 @@ namespace AasCore.Aas3_0_RC02
                     result["qualifiers"] = arrayQualifiers;
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (Reference item in that.DataSpecifications)
+                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
+                    foreach (EmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
                     {
-                        arrayDataSpecifications.Add(
+                        arrayEmbeddedDataSpecifications.Add(
                             Transform(
                                 item));
                     }
-                    result["dataSpecifications"] = arrayDataSpecifications;
+                    result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
                 result["first"] = Transform(
@@ -14851,16 +16050,16 @@ namespace AasCore.Aas3_0_RC02
                     result["qualifiers"] = arrayQualifiers;
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (Reference item in that.DataSpecifications)
+                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
+                    foreach (EmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
                     {
-                        arrayDataSpecifications.Add(
+                        arrayEmbeddedDataSpecifications.Add(
                             Transform(
                                 item));
                     }
-                    result["dataSpecifications"] = arrayDataSpecifications;
+                    result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
                 if (that.OrderRelevant != null)
@@ -14989,16 +16188,16 @@ namespace AasCore.Aas3_0_RC02
                     result["qualifiers"] = arrayQualifiers;
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (Reference item in that.DataSpecifications)
+                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
+                    foreach (EmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
                     {
-                        arrayDataSpecifications.Add(
+                        arrayEmbeddedDataSpecifications.Add(
                             Transform(
                                 item));
                     }
-                    result["dataSpecifications"] = arrayDataSpecifications;
+                    result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
                 if (that.Value != null)
@@ -15103,16 +16302,16 @@ namespace AasCore.Aas3_0_RC02
                     result["qualifiers"] = arrayQualifiers;
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (Reference item in that.DataSpecifications)
+                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
+                    foreach (EmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
                     {
-                        arrayDataSpecifications.Add(
+                        arrayEmbeddedDataSpecifications.Add(
                             Transform(
                                 item));
                     }
-                    result["dataSpecifications"] = arrayDataSpecifications;
+                    result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
                 result["valueType"] = Serialize.DataTypeDefXsdToJsonValue(
@@ -15220,16 +16419,16 @@ namespace AasCore.Aas3_0_RC02
                     result["qualifiers"] = arrayQualifiers;
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (Reference item in that.DataSpecifications)
+                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
+                    foreach (EmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
                     {
-                        arrayDataSpecifications.Add(
+                        arrayEmbeddedDataSpecifications.Add(
                             Transform(
                                 item));
                     }
-                    result["dataSpecifications"] = arrayDataSpecifications;
+                    result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
                 if (that.Value != null)
@@ -15334,16 +16533,16 @@ namespace AasCore.Aas3_0_RC02
                     result["qualifiers"] = arrayQualifiers;
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (Reference item in that.DataSpecifications)
+                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
+                    foreach (EmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
                     {
-                        arrayDataSpecifications.Add(
+                        arrayEmbeddedDataSpecifications.Add(
                             Transform(
                                 item));
                     }
-                    result["dataSpecifications"] = arrayDataSpecifications;
+                    result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
                 result["valueType"] = Serialize.DataTypeDefXsdToJsonValue(
@@ -15451,16 +16650,16 @@ namespace AasCore.Aas3_0_RC02
                     result["qualifiers"] = arrayQualifiers;
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (Reference item in that.DataSpecifications)
+                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
+                    foreach (EmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
                     {
-                        arrayDataSpecifications.Add(
+                        arrayEmbeddedDataSpecifications.Add(
                             Transform(
                                 item));
                     }
-                    result["dataSpecifications"] = arrayDataSpecifications;
+                    result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
                 if (that.Value != null)
@@ -15559,16 +16758,16 @@ namespace AasCore.Aas3_0_RC02
                     result["qualifiers"] = arrayQualifiers;
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (Reference item in that.DataSpecifications)
+                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
+                    foreach (EmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
                     {
-                        arrayDataSpecifications.Add(
+                        arrayEmbeddedDataSpecifications.Add(
                             Transform(
                                 item));
                     }
-                    result["dataSpecifications"] = arrayDataSpecifications;
+                    result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
                 if (that.Value != null)
@@ -15671,16 +16870,16 @@ namespace AasCore.Aas3_0_RC02
                     result["qualifiers"] = arrayQualifiers;
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (Reference item in that.DataSpecifications)
+                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
+                    foreach (EmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
                     {
-                        arrayDataSpecifications.Add(
+                        arrayEmbeddedDataSpecifications.Add(
                             Transform(
                                 item));
                     }
-                    result["dataSpecifications"] = arrayDataSpecifications;
+                    result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
                 if (that.Value != null)
@@ -15782,16 +16981,16 @@ namespace AasCore.Aas3_0_RC02
                     result["qualifiers"] = arrayQualifiers;
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (Reference item in that.DataSpecifications)
+                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
+                    foreach (EmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
                     {
-                        arrayDataSpecifications.Add(
+                        arrayEmbeddedDataSpecifications.Add(
                             Transform(
                                 item));
                     }
-                    result["dataSpecifications"] = arrayDataSpecifications;
+                    result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
                 result["first"] = Transform(
@@ -15902,16 +17101,16 @@ namespace AasCore.Aas3_0_RC02
                     result["qualifiers"] = arrayQualifiers;
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (Reference item in that.DataSpecifications)
+                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
+                    foreach (EmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
                     {
-                        arrayDataSpecifications.Add(
+                        arrayEmbeddedDataSpecifications.Add(
                             Transform(
                                 item));
                     }
-                    result["dataSpecifications"] = arrayDataSpecifications;
+                    result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
                 if (that.Statements != null)
@@ -16077,16 +17276,16 @@ namespace AasCore.Aas3_0_RC02
                     result["qualifiers"] = arrayQualifiers;
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (Reference item in that.DataSpecifications)
+                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
+                    foreach (EmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
                     {
-                        arrayDataSpecifications.Add(
+                        arrayEmbeddedDataSpecifications.Add(
                             Transform(
                                 item));
                     }
-                    result["dataSpecifications"] = arrayDataSpecifications;
+                    result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
                 result["observed"] = Transform(
@@ -16218,16 +17417,16 @@ namespace AasCore.Aas3_0_RC02
                     result["qualifiers"] = arrayQualifiers;
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (Reference item in that.DataSpecifications)
+                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
+                    foreach (EmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
                     {
-                        arrayDataSpecifications.Add(
+                        arrayEmbeddedDataSpecifications.Add(
                             Transform(
                                 item));
                     }
-                    result["dataSpecifications"] = arrayDataSpecifications;
+                    result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
                 if (that.InputVariables != null)
@@ -16366,16 +17565,16 @@ namespace AasCore.Aas3_0_RC02
                     result["qualifiers"] = arrayQualifiers;
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (Reference item in that.DataSpecifications)
+                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
+                    foreach (EmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
                     {
-                        arrayDataSpecifications.Add(
+                        arrayEmbeddedDataSpecifications.Add(
                             Transform(
                                 item));
                     }
-                    result["dataSpecifications"] = arrayDataSpecifications;
+                    result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
                 result["modelType"] = "Capability";
@@ -16438,16 +17637,16 @@ namespace AasCore.Aas3_0_RC02
                 result["id"] = Nodes.JsonValue.Create(
                     that.Id);
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayDataSpecifications = new Nodes.JsonArray();
-                    foreach (Reference item in that.DataSpecifications)
+                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
+                    foreach (EmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
                     {
-                        arrayDataSpecifications.Add(
+                        arrayEmbeddedDataSpecifications.Add(
                             Transform(
                                 item));
                     }
-                    result["dataSpecifications"] = arrayDataSpecifications;
+                    result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
                 if (that.IsCaseOf != null)
@@ -16534,38 +17733,6 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.DataSpecificationContent that)
-            {
-                var result = new Nodes.JsonObject();
-
-                return result;
-            }
-
-            public override Nodes.JsonObject Transform(Aas.DataSpecification that)
-            {
-                var result = new Nodes.JsonObject();
-
-                result["id"] = Nodes.JsonValue.Create(
-                    that.Id);
-
-                result["dataSpecificationContent"] = Transform(
-                    that.DataSpecificationContent);
-
-                if (that.Administration != null)
-                {
-                    result["administration"] = Transform(
-                        that.Administration);
-                }
-
-                if (that.Description != null)
-                {
-                    result["description"] = Transform(
-                        that.Description);
-                }
-
-                return result;
-            }
-
             public override Nodes.JsonObject Transform(Aas.Environment that)
             {
                 var result = new Nodes.JsonObject();
@@ -16605,6 +17772,210 @@ namespace AasCore.Aas3_0_RC02
                     }
                     result["conceptDescriptions"] = arrayConceptDescriptions;
                 }
+
+                return result;
+            }
+
+            public override Nodes.JsonObject Transform(Aas.EmbeddedDataSpecification that)
+            {
+                var result = new Nodes.JsonObject();
+
+                result["dataSpecification"] = Transform(
+                    that.DataSpecification);
+
+                result["dataSpecificationContent"] = Transform(
+                    that.DataSpecificationContent);
+
+                return result;
+            }
+
+            public override Nodes.JsonObject Transform(Aas.ValueReferencePair that)
+            {
+                var result = new Nodes.JsonObject();
+
+                result["value"] = Nodes.JsonValue.Create(
+                    that.Value);
+
+                result["valueId"] = Transform(
+                    that.ValueId);
+
+                return result;
+            }
+
+            public override Nodes.JsonObject Transform(Aas.ValueList that)
+            {
+                var result = new Nodes.JsonObject();
+
+                var arrayValueReferencePairTypes = new Nodes.JsonArray();
+                foreach (ValueReferencePair item in that.ValueReferencePairTypes)
+                {
+                    arrayValueReferencePairTypes.Add(
+                        Transform(
+                            item));
+                }
+                result["valueReferencePairTypes"] = arrayValueReferencePairTypes;
+
+                return result;
+            }
+
+            public override Nodes.JsonObject Transform(Aas.DataSpecificationIec61360 that)
+            {
+                var result = new Nodes.JsonObject();
+
+                result["preferredName"] = Transform(
+                    that.PreferredName);
+
+                if (that.ShortName != null)
+                {
+                    result["shortName"] = Transform(
+                        that.ShortName);
+                }
+
+                if (that.Unit != null)
+                {
+                    result["unit"] = Nodes.JsonValue.Create(
+                        that.Unit);
+                }
+
+                if (that.UnitId != null)
+                {
+                    result["unitId"] = Transform(
+                        that.UnitId);
+                }
+
+                if (that.SourceOfDefinition != null)
+                {
+                    result["sourceOfDefinition"] = Nodes.JsonValue.Create(
+                        that.SourceOfDefinition);
+                }
+
+                if (that.Symbol != null)
+                {
+                    result["symbol"] = Nodes.JsonValue.Create(
+                        that.Symbol);
+                }
+
+                if (that.DataType != null)
+                {
+                    // We need to help the static analyzer with a null coalescing.
+                    Aas.DataTypeIec61360 value = that.DataType
+                        ?? throw new System.InvalidOperationException();
+                    result["dataType"] = Serialize.DataTypeIec61360ToJsonValue(
+                        value);
+                }
+
+                if (that.Definition != null)
+                {
+                    result["definition"] = Transform(
+                        that.Definition);
+                }
+
+                if (that.ValueFormat != null)
+                {
+                    result["valueFormat"] = Nodes.JsonValue.Create(
+                        that.ValueFormat);
+                }
+
+                if (that.ValueList != null)
+                {
+                    result["valueList"] = Transform(
+                        that.ValueList);
+                }
+
+                if (that.Value != null)
+                {
+                    result["value"] = Nodes.JsonValue.Create(
+                        that.Value);
+                }
+
+                if (that.LevelType != null)
+                {
+                    // We need to help the static analyzer with a null coalescing.
+                    Aas.LevelType value = that.LevelType
+                        ?? throw new System.InvalidOperationException();
+                    result["levelType"] = Serialize.LevelTypeToJsonValue(
+                        value);
+                }
+
+                result["modelType"] = "DataSpecificationIEC61360";
+
+                return result;
+            }
+
+            public override Nodes.JsonObject Transform(Aas.DataSpecificationPhysicalUnit that)
+            {
+                var result = new Nodes.JsonObject();
+
+                result["unitName"] = Nodes.JsonValue.Create(
+                    that.UnitName);
+
+                result["unitSymbol"] = Nodes.JsonValue.Create(
+                    that.UnitSymbol);
+
+                result["definition"] = Transform(
+                    that.Definition);
+
+                if (that.SiNotation != null)
+                {
+                    result["siNotation"] = Nodes.JsonValue.Create(
+                        that.SiNotation);
+                }
+
+                if (that.SiName != null)
+                {
+                    result["siName"] = Nodes.JsonValue.Create(
+                        that.SiName);
+                }
+
+                if (that.DinNotation != null)
+                {
+                    result["dinNotation"] = Nodes.JsonValue.Create(
+                        that.DinNotation);
+                }
+
+                if (that.EceName != null)
+                {
+                    result["eceName"] = Nodes.JsonValue.Create(
+                        that.EceName);
+                }
+
+                if (that.EceCode != null)
+                {
+                    result["eceCode"] = Nodes.JsonValue.Create(
+                        that.EceCode);
+                }
+
+                if (that.NistName != null)
+                {
+                    result["nistName"] = Nodes.JsonValue.Create(
+                        that.NistName);
+                }
+
+                if (that.SourceOfDefinition != null)
+                {
+                    result["sourceOfDefinition"] = Nodes.JsonValue.Create(
+                        that.SourceOfDefinition);
+                }
+
+                if (that.ConversionFactor != null)
+                {
+                    result["conversionFactor"] = Nodes.JsonValue.Create(
+                        that.ConversionFactor);
+                }
+
+                if (that.RegistrationAuthorityId != null)
+                {
+                    result["registrationAuthorityId"] = Nodes.JsonValue.Create(
+                        that.RegistrationAuthorityId);
+                }
+
+                if (that.Supplier != null)
+                {
+                    result["supplier"] = Nodes.JsonValue.Create(
+                        that.Supplier);
+                }
+
+                result["modelType"] = "DataSpecificationPhysicalUnit";
 
                 return result;
             }
@@ -16744,6 +18115,39 @@ namespace AasCore.Aas3_0_RC02
                 return Nodes.JsonValue.Create(text)
                     ?? throw new System.ArgumentException(
                         $"Invalid DataTypeDefXsd: {that}");
+            }
+
+            /// <summary>
+            /// Serialize a literal of DataTypeIec61360 into a JSON string.
+            /// </summary>
+            public static Nodes.JsonValue DataTypeIec61360ToJsonValue(Aas.DataTypeIec61360 that)
+            {
+                string? text = Stringification.ToString(that);
+                return Nodes.JsonValue.Create(text)
+                    ?? throw new System.ArgumentException(
+                        $"Invalid DataTypeIec61360: {that}");
+            }
+
+            /// <summary>
+            /// Serialize a literal of ConceptDescriptionsCategories into a JSON string.
+            /// </summary>
+            public static Nodes.JsonValue ConceptDescriptionsCategoriesToJsonValue(Aas.ConceptDescriptionsCategories that)
+            {
+                string? text = Stringification.ToString(that);
+                return Nodes.JsonValue.Create(text)
+                    ?? throw new System.ArgumentException(
+                        $"Invalid ConceptDescriptionsCategories: {that}");
+            }
+
+            /// <summary>
+            /// Serialize a literal of LevelType into a JSON string.
+            /// </summary>
+            public static Nodes.JsonValue LevelTypeToJsonValue(Aas.LevelType that)
+            {
+                string? text = Stringification.ToString(that);
+                return Nodes.JsonValue.Create(text)
+                    ?? throw new System.ArgumentException(
+                        $"Invalid LevelType: {that}");
             }
         }  // public static class Serialize
     }  // public static class Jsonization

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/stringification.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/stringification.cs
@@ -749,6 +749,246 @@ namespace AasCore.Aas3_0_RC02
                 return null;
             }
         }
+
+        private static readonly Dictionary<Aas.DataTypeIec61360, string> DataTypeIec61360ToString = (
+            new Dictionary<Aas.DataTypeIec61360, string>()
+            {
+                { Aas.DataTypeIec61360.Date, "DATE" },
+                { Aas.DataTypeIec61360.String, "STRING" },
+                { Aas.DataTypeIec61360.StringTranslatable, "STRING_TRANSLATABLE" },
+                { Aas.DataTypeIec61360.IntegerMeasure, "INTEGER_MEASURE" },
+                { Aas.DataTypeIec61360.IntegerCount, "INTEGER_COUNT" },
+                { Aas.DataTypeIec61360.IntegerCurrency, "INTEGER_CURRENCY" },
+                { Aas.DataTypeIec61360.RealMeasure, "REAL_MEASURE" },
+                { Aas.DataTypeIec61360.RealCount, "REAL_COUNT" },
+                { Aas.DataTypeIec61360.RealCurrency, "REAL_CURRENCY" },
+                { Aas.DataTypeIec61360.Boolean, "BOOLEAN" },
+                { Aas.DataTypeIec61360.Iri, "IRI" },
+                { Aas.DataTypeIec61360.Irdi, "IRDI" },
+                { Aas.DataTypeIec61360.Rational, "RATIONAL" },
+                { Aas.DataTypeIec61360.RationalMeasure, "RATIONAL_MEASURE" },
+                { Aas.DataTypeIec61360.Time, "TIME" },
+                { Aas.DataTypeIec61360.Timestamp, "TIMESTAMP" },
+                { Aas.DataTypeIec61360.File, "FILE" },
+                { Aas.DataTypeIec61360.Html, "HTML" },
+                { Aas.DataTypeIec61360.Blob, "BLOB" }
+            });
+
+        /// <summary>
+        /// Retrieve the string representation of <paramref name="that" />.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="that" /> is not a valid literal, return <c>null</c>.
+        /// </remarks>
+        public static string? ToString(Aas.DataTypeIec61360? that)
+        {
+            if (!that.HasValue)
+            {
+                return null;
+            }
+            else
+            {
+                if (DataTypeIec61360ToString.TryGetValue(that.Value, out string? value))
+                {
+                    return value;
+                }
+                else
+                {
+                    return null;
+                }
+            }
+        }
+
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        private static readonly Dictionary<string, Aas.DataTypeIec61360> _dataTypeIec61360FromString = (
+            new Dictionary<string, Aas.DataTypeIec61360>()
+            {
+                { "DATE", Aas.DataTypeIec61360.Date },
+                { "STRING", Aas.DataTypeIec61360.String },
+                { "STRING_TRANSLATABLE", Aas.DataTypeIec61360.StringTranslatable },
+                { "INTEGER_MEASURE", Aas.DataTypeIec61360.IntegerMeasure },
+                { "INTEGER_COUNT", Aas.DataTypeIec61360.IntegerCount },
+                { "INTEGER_CURRENCY", Aas.DataTypeIec61360.IntegerCurrency },
+                { "REAL_MEASURE", Aas.DataTypeIec61360.RealMeasure },
+                { "REAL_COUNT", Aas.DataTypeIec61360.RealCount },
+                { "REAL_CURRENCY", Aas.DataTypeIec61360.RealCurrency },
+                { "BOOLEAN", Aas.DataTypeIec61360.Boolean },
+                { "IRI", Aas.DataTypeIec61360.Iri },
+                { "IRDI", Aas.DataTypeIec61360.Irdi },
+                { "RATIONAL", Aas.DataTypeIec61360.Rational },
+                { "RATIONAL_MEASURE", Aas.DataTypeIec61360.RationalMeasure },
+                { "TIME", Aas.DataTypeIec61360.Time },
+                { "TIMESTAMP", Aas.DataTypeIec61360.Timestamp },
+                { "FILE", Aas.DataTypeIec61360.File },
+                { "HTML", Aas.DataTypeIec61360.Html },
+                { "BLOB", Aas.DataTypeIec61360.Blob }
+            });
+
+        /// <summary>
+        /// Parse the string representation of <see cref="DataTypeIec61360" />.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="text" /> is not a valid string representation
+        /// of a literal of <see cref="DataTypeIec61360" />,
+        /// return <c>null</c>.
+        /// </remarks>
+        public static Aas.DataTypeIec61360? DataTypeIec61360FromString(string text)
+        {
+            if (_dataTypeIec61360FromString.TryGetValue(text, out DataTypeIec61360 value))
+            {
+                return value;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        private static readonly Dictionary<Aas.ConceptDescriptionsCategories, string> ConceptDescriptionsCategoriesToString = (
+            new Dictionary<Aas.ConceptDescriptionsCategories, string>()
+            {
+                { Aas.ConceptDescriptionsCategories.ApplicationClass, "APPLICATION_CLASS" },
+                { Aas.ConceptDescriptionsCategories.Capability, "CAPABILITY" },
+                { Aas.ConceptDescriptionsCategories.Collections, "COLLECTIONS" },
+                { Aas.ConceptDescriptionsCategories.Documentation, "DOCUMENTATION" },
+                { Aas.ConceptDescriptionsCategories.Entity, "ENTITY" },
+                { Aas.ConceptDescriptionsCategories.Event, "EVENT" },
+                { Aas.ConceptDescriptionsCategories.Function, "FUNCTION" },
+                { Aas.ConceptDescriptionsCategories.Property, "PROPERTY" },
+                { Aas.ConceptDescriptionsCategories.Value, "VALUE" },
+                { Aas.ConceptDescriptionsCategories.Range, "RANGE" },
+                { Aas.ConceptDescriptionsCategories.QualifierType, "QUALIFIER_TYPE" },
+                { Aas.ConceptDescriptionsCategories.Referencing, "REFERENCING" },
+                { Aas.ConceptDescriptionsCategories.Relationship, "RELATIONSHIP" }
+            });
+
+        /// <summary>
+        /// Retrieve the string representation of <paramref name="that" />.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="that" /> is not a valid literal, return <c>null</c>.
+        /// </remarks>
+        public static string? ToString(Aas.ConceptDescriptionsCategories? that)
+        {
+            if (!that.HasValue)
+            {
+                return null;
+            }
+            else
+            {
+                if (ConceptDescriptionsCategoriesToString.TryGetValue(that.Value, out string? value))
+                {
+                    return value;
+                }
+                else
+                {
+                    return null;
+                }
+            }
+        }
+
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        private static readonly Dictionary<string, Aas.ConceptDescriptionsCategories> _conceptDescriptionsCategoriesFromString = (
+            new Dictionary<string, Aas.ConceptDescriptionsCategories>()
+            {
+                { "APPLICATION_CLASS", Aas.ConceptDescriptionsCategories.ApplicationClass },
+                { "CAPABILITY", Aas.ConceptDescriptionsCategories.Capability },
+                { "COLLECTIONS", Aas.ConceptDescriptionsCategories.Collections },
+                { "DOCUMENTATION", Aas.ConceptDescriptionsCategories.Documentation },
+                { "ENTITY", Aas.ConceptDescriptionsCategories.Entity },
+                { "EVENT", Aas.ConceptDescriptionsCategories.Event },
+                { "FUNCTION", Aas.ConceptDescriptionsCategories.Function },
+                { "PROPERTY", Aas.ConceptDescriptionsCategories.Property },
+                { "VALUE", Aas.ConceptDescriptionsCategories.Value },
+                { "RANGE", Aas.ConceptDescriptionsCategories.Range },
+                { "QUALIFIER_TYPE", Aas.ConceptDescriptionsCategories.QualifierType },
+                { "REFERENCING", Aas.ConceptDescriptionsCategories.Referencing },
+                { "RELATIONSHIP", Aas.ConceptDescriptionsCategories.Relationship }
+            });
+
+        /// <summary>
+        /// Parse the string representation of <see cref="ConceptDescriptionsCategories" />.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="text" /> is not a valid string representation
+        /// of a literal of <see cref="ConceptDescriptionsCategories" />,
+        /// return <c>null</c>.
+        /// </remarks>
+        public static Aas.ConceptDescriptionsCategories? ConceptDescriptionsCategoriesFromString(string text)
+        {
+            if (_conceptDescriptionsCategoriesFromString.TryGetValue(text, out ConceptDescriptionsCategories value))
+            {
+                return value;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        private static readonly Dictionary<Aas.LevelType, string> LevelTypeToString = (
+            new Dictionary<Aas.LevelType, string>()
+            {
+                { Aas.LevelType.Min, "Min" },
+                { Aas.LevelType.Max, "Max" },
+                { Aas.LevelType.Nom, "Nom" },
+                { Aas.LevelType.Typ, "Typ" }
+            });
+
+        /// <summary>
+        /// Retrieve the string representation of <paramref name="that" />.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="that" /> is not a valid literal, return <c>null</c>.
+        /// </remarks>
+        public static string? ToString(Aas.LevelType? that)
+        {
+            if (!that.HasValue)
+            {
+                return null;
+            }
+            else
+            {
+                if (LevelTypeToString.TryGetValue(that.Value, out string? value))
+                {
+                    return value;
+                }
+                else
+                {
+                    return null;
+                }
+            }
+        }
+
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        private static readonly Dictionary<string, Aas.LevelType> _levelTypeFromString = (
+            new Dictionary<string, Aas.LevelType>()
+            {
+                { "Min", Aas.LevelType.Min },
+                { "Max", Aas.LevelType.Max },
+                { "Nom", Aas.LevelType.Nom },
+                { "Typ", Aas.LevelType.Typ }
+            });
+
+        /// <summary>
+        /// Parse the string representation of <see cref="LevelType" />.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="text" /> is not a valid string representation
+        /// of a literal of <see cref="LevelType" />,
+        /// return <c>null</c>.
+        /// </remarks>
+        public static Aas.LevelType? LevelTypeFromString(string text)
+        {
+            if (_levelTypeFromString.TryGetValue(text, out LevelType value))
+            {
+                return value;
+            }
+            else
+            {
+                return null;
+            }
+        }
     }  // public static class Stringification
 }  // namespace AasCore.Aas3_0_RC02
 

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/types.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/types.cs
@@ -492,12 +492,9 @@ namespace AasCore.Aas3_0_RC02
     public interface IHasDataSpecification : IClass
     {
         /// <summary>
-        /// Global reference to the data specification template used by the element.
+        /// Embedded data specification.
         /// </summary>
-        /// <remarks>
-        /// This is a global reference.
-        /// </remarks>
-        public List<Reference>? DataSpecifications { get; set; }
+        public List<EmbeddedDataSpecification>? EmbeddedDataSpecifications { get; set; }
     }
 
     /// <summary>
@@ -520,12 +517,9 @@ namespace AasCore.Aas3_0_RC02
     public class AdministrativeInformation : IHasDataSpecification
     {
         /// <summary>
-        /// Global reference to the data specification template used by the element.
+        /// Embedded data specification.
         /// </summary>
-        /// <remarks>
-        /// This is a global reference.
-        /// </remarks>
-        public List<Reference>? DataSpecifications { get; set; }
+        public List<EmbeddedDataSpecification>? EmbeddedDataSpecifications { get; set; }
 
         /// <summary>
         /// Version of the element.
@@ -538,12 +532,12 @@ namespace AasCore.Aas3_0_RC02
         public string? Revision { get; set; }
 
         /// <summary>
-        /// Iterate over DataSpecifications, if set, and otherwise return an empty enumerable.
+        /// Iterate over EmbeddedDataSpecifications, if set, and otherwise return an empty enumerable.
         /// </summary>
-        public IEnumerable<Reference> OverDataSpecificationsOrEmpty()
+        public IEnumerable<EmbeddedDataSpecification> OverEmbeddedDataSpecificationsOrEmpty()
         {
-            return DataSpecifications
-                ?? System.Linq.Enumerable.Empty<Reference>();
+            return EmbeddedDataSpecifications
+                ?? System.Linq.Enumerable.Empty<EmbeddedDataSpecification>();
         }
 
         /// <summary>
@@ -552,9 +546,9 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public IEnumerable<IClass> DescendOnce()
         {
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
                 }
@@ -566,9 +560,9 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public IEnumerable<IClass> Descend()
         {
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
 
@@ -622,11 +616,11 @@ namespace AasCore.Aas3_0_RC02
         }
 
         public AdministrativeInformation(
-            List<Reference>? dataSpecifications = null,
+            List<EmbeddedDataSpecification>? embeddedDataSpecifications = null,
             string? version = null,
             string? revision = null)
         {
-            DataSpecifications = dataSpecifications;
+            EmbeddedDataSpecifications = embeddedDataSpecifications;
             Version = version;
             Revision = revision;
         }
@@ -1040,12 +1034,9 @@ namespace AasCore.Aas3_0_RC02
         public string Id { get; set; }
 
         /// <summary>
-        /// Global reference to the data specification template used by the element.
+        /// Embedded data specification.
         /// </summary>
-        /// <remarks>
-        /// This is a global reference.
-        /// </remarks>
-        public List<Reference>? DataSpecifications { get; set; }
+        public List<EmbeddedDataSpecification>? EmbeddedDataSpecifications { get; set; }
 
         /// <summary>
         /// The reference to the AAS the AAS was derived from.
@@ -1083,12 +1074,12 @@ namespace AasCore.Aas3_0_RC02
         }
 
         /// <summary>
-        /// Iterate over DataSpecifications, if set, and otherwise return an empty enumerable.
+        /// Iterate over EmbeddedDataSpecifications, if set, and otherwise return an empty enumerable.
         /// </summary>
-        public IEnumerable<Reference> OverDataSpecificationsOrEmpty()
+        public IEnumerable<EmbeddedDataSpecification> OverEmbeddedDataSpecificationsOrEmpty()
         {
-            return DataSpecifications
-                ?? System.Linq.Enumerable.Empty<Reference>();
+            return EmbeddedDataSpecifications
+                ?? System.Linq.Enumerable.Empty<EmbeddedDataSpecification>();
         }
 
         /// <summary>
@@ -1129,9 +1120,9 @@ namespace AasCore.Aas3_0_RC02
                 yield return Administration;
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
                 }
@@ -1205,9 +1196,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
 
@@ -1303,7 +1294,7 @@ namespace AasCore.Aas3_0_RC02
             LangStringSet? description = null,
             string? checksum = null,
             AdministrativeInformation? administration = null,
-            List<Reference>? dataSpecifications = null,
+            List<EmbeddedDataSpecification>? embeddedDataSpecifications = null,
             Reference? derivedFrom = null,
             List<Reference>? submodels = null)
         {
@@ -1315,7 +1306,7 @@ namespace AasCore.Aas3_0_RC02
             Checksum = checksum;
             Id = id;
             Administration = administration;
-            DataSpecifications = dataSpecifications;
+            EmbeddedDataSpecifications = embeddedDataSpecifications;
             DerivedFrom = derivedFrom;
             AssetInformation = assetInformation;
             Submodels = submodels;
@@ -1979,12 +1970,9 @@ namespace AasCore.Aas3_0_RC02
         public List<Qualifier>? Qualifiers { get; set; }
 
         /// <summary>
-        /// Global reference to the data specification template used by the element.
+        /// Embedded data specification.
         /// </summary>
-        /// <remarks>
-        /// This is a global reference.
-        /// </remarks>
-        public List<Reference>? DataSpecifications { get; set; }
+        public List<EmbeddedDataSpecification>? EmbeddedDataSpecifications { get; set; }
 
         /// <summary>
         /// A submodel consists of zero or more submodel elements.
@@ -2019,12 +2007,12 @@ namespace AasCore.Aas3_0_RC02
         }
 
         /// <summary>
-        /// Iterate over DataSpecifications, if set, and otherwise return an empty enumerable.
+        /// Iterate over EmbeddedDataSpecifications, if set, and otherwise return an empty enumerable.
         /// </summary>
-        public IEnumerable<Reference> OverDataSpecificationsOrEmpty()
+        public IEnumerable<EmbeddedDataSpecification> OverEmbeddedDataSpecificationsOrEmpty()
         {
-            return DataSpecifications
-                ?? System.Linq.Enumerable.Empty<Reference>();
+            return EmbeddedDataSpecifications
+                ?? System.Linq.Enumerable.Empty<EmbeddedDataSpecification>();
         }
 
         /// <summary>
@@ -2095,9 +2083,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
                 }
@@ -2203,9 +2191,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
 
@@ -2285,7 +2273,7 @@ namespace AasCore.Aas3_0_RC02
             Reference? semanticId = null,
             List<Reference>? supplementalSemanticIds = null,
             List<Qualifier>? qualifiers = null,
-            List<Reference>? dataSpecifications = null,
+            List<EmbeddedDataSpecification>? embeddedDataSpecifications = null,
             List<ISubmodelElement>? submodelElements = null)
         {
             Extensions = extensions;
@@ -2300,7 +2288,7 @@ namespace AasCore.Aas3_0_RC02
             SemanticId = semanticId;
             SupplementalSemanticIds = supplementalSemanticIds;
             Qualifiers = qualifiers;
-            DataSpecifications = dataSpecifications;
+            EmbeddedDataSpecifications = embeddedDataSpecifications;
             SubmodelElements = submodelElements;
         }
     }
@@ -2484,12 +2472,9 @@ namespace AasCore.Aas3_0_RC02
         public List<Qualifier>? Qualifiers { get; set; }
 
         /// <summary>
-        /// Global reference to the data specification template used by the element.
+        /// Embedded data specification.
         /// </summary>
-        /// <remarks>
-        /// This is a global reference.
-        /// </remarks>
-        public List<Reference>? DataSpecifications { get; set; }
+        public List<EmbeddedDataSpecification>? EmbeddedDataSpecifications { get; set; }
 
         /// <summary>
         /// Reference to the first element in the relationship taking the role of the subject.
@@ -2529,12 +2514,12 @@ namespace AasCore.Aas3_0_RC02
         }
 
         /// <summary>
-        /// Iterate over DataSpecifications, if set, and otherwise return an empty enumerable.
+        /// Iterate over EmbeddedDataSpecifications, if set, and otherwise return an empty enumerable.
         /// </summary>
-        public IEnumerable<Reference> OverDataSpecificationsOrEmpty()
+        public IEnumerable<EmbeddedDataSpecification> OverEmbeddedDataSpecificationsOrEmpty()
         {
-            return DataSpecifications
-                ?? System.Linq.Enumerable.Empty<Reference>();
+            return EmbeddedDataSpecifications
+                ?? System.Linq.Enumerable.Empty<EmbeddedDataSpecification>();
         }
 
         /// <summary>
@@ -2591,9 +2576,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
                 }
@@ -2684,9 +2669,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
 
@@ -2768,7 +2753,7 @@ namespace AasCore.Aas3_0_RC02
             Reference? semanticId = null,
             List<Reference>? supplementalSemanticIds = null,
             List<Qualifier>? qualifiers = null,
-            List<Reference>? dataSpecifications = null)
+            List<EmbeddedDataSpecification>? embeddedDataSpecifications = null)
         {
             Extensions = extensions;
             IdShort = idShort;
@@ -2780,7 +2765,7 @@ namespace AasCore.Aas3_0_RC02
             SemanticId = semanticId;
             SupplementalSemanticIds = supplementalSemanticIds;
             Qualifiers = qualifiers;
-            DataSpecifications = dataSpecifications;
+            EmbeddedDataSpecifications = embeddedDataSpecifications;
             First = first;
             Second = second;
         }
@@ -3028,12 +3013,9 @@ namespace AasCore.Aas3_0_RC02
         public List<Qualifier>? Qualifiers { get; set; }
 
         /// <summary>
-        /// Global reference to the data specification template used by the element.
+        /// Embedded data specification.
         /// </summary>
-        /// <remarks>
-        /// This is a global reference.
-        /// </remarks>
-        public List<Reference>? DataSpecifications { get; set; }
+        public List<EmbeddedDataSpecification>? EmbeddedDataSpecifications { get; set; }
 
         /// <summary>
         /// Defines whether order in list is relevant. If <see cref="Aas.SubmodelElementList.OrderRelevant" /> = <c>False</c>
@@ -3098,12 +3080,12 @@ namespace AasCore.Aas3_0_RC02
         }
 
         /// <summary>
-        /// Iterate over DataSpecifications, if set, and otherwise return an empty enumerable.
+        /// Iterate over EmbeddedDataSpecifications, if set, and otherwise return an empty enumerable.
         /// </summary>
-        public IEnumerable<Reference> OverDataSpecificationsOrEmpty()
+        public IEnumerable<EmbeddedDataSpecification> OverEmbeddedDataSpecificationsOrEmpty()
         {
-            return DataSpecifications
-                ?? System.Linq.Enumerable.Empty<Reference>();
+            return EmbeddedDataSpecifications
+                ?? System.Linq.Enumerable.Empty<EmbeddedDataSpecification>();
         }
 
         /// <summary>
@@ -3178,9 +3160,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
                 }
@@ -3280,9 +3262,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
 
@@ -3372,7 +3354,7 @@ namespace AasCore.Aas3_0_RC02
             Reference? semanticId = null,
             List<Reference>? supplementalSemanticIds = null,
             List<Qualifier>? qualifiers = null,
-            List<Reference>? dataSpecifications = null,
+            List<EmbeddedDataSpecification>? embeddedDataSpecifications = null,
             bool? orderRelevant = null,
             List<ISubmodelElement>? value = null,
             Reference? semanticIdListElement = null,
@@ -3388,7 +3370,7 @@ namespace AasCore.Aas3_0_RC02
             SemanticId = semanticId;
             SupplementalSemanticIds = supplementalSemanticIds;
             Qualifiers = qualifiers;
-            DataSpecifications = dataSpecifications;
+            EmbeddedDataSpecifications = embeddedDataSpecifications;
             TypeValueListElement = typeValueListElement;
             OrderRelevant = orderRelevant;
             Value = value;
@@ -3542,12 +3524,9 @@ namespace AasCore.Aas3_0_RC02
         public List<Qualifier>? Qualifiers { get; set; }
 
         /// <summary>
-        /// Global reference to the data specification template used by the element.
+        /// Embedded data specification.
         /// </summary>
-        /// <remarks>
-        /// This is a global reference.
-        /// </remarks>
-        public List<Reference>? DataSpecifications { get; set; }
+        public List<EmbeddedDataSpecification>? EmbeddedDataSpecifications { get; set; }
 
         /// <summary>
         /// Submodel element contained in the collection.
@@ -3582,12 +3561,12 @@ namespace AasCore.Aas3_0_RC02
         }
 
         /// <summary>
-        /// Iterate over DataSpecifications, if set, and otherwise return an empty enumerable.
+        /// Iterate over EmbeddedDataSpecifications, if set, and otherwise return an empty enumerable.
         /// </summary>
-        public IEnumerable<Reference> OverDataSpecificationsOrEmpty()
+        public IEnumerable<EmbeddedDataSpecification> OverEmbeddedDataSpecificationsOrEmpty()
         {
-            return DataSpecifications
-                ?? System.Linq.Enumerable.Empty<Reference>();
+            return EmbeddedDataSpecifications
+                ?? System.Linq.Enumerable.Empty<EmbeddedDataSpecification>();
         }
 
         /// <summary>
@@ -3653,9 +3632,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
                 }
@@ -3750,9 +3729,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
 
@@ -3830,7 +3809,7 @@ namespace AasCore.Aas3_0_RC02
             Reference? semanticId = null,
             List<Reference>? supplementalSemanticIds = null,
             List<Qualifier>? qualifiers = null,
-            List<Reference>? dataSpecifications = null,
+            List<EmbeddedDataSpecification>? embeddedDataSpecifications = null,
             List<ISubmodelElement>? value = null)
         {
             Extensions = extensions;
@@ -3843,7 +3822,7 @@ namespace AasCore.Aas3_0_RC02
             SemanticId = semanticId;
             SupplementalSemanticIds = supplementalSemanticIds;
             Qualifiers = qualifiers;
-            DataSpecifications = dataSpecifications;
+            EmbeddedDataSpecifications = embeddedDataSpecifications;
             Value = value;
         }
     }
@@ -3889,9 +3868,9 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public IEnumerable<Qualifier> OverQualifiersOrEmpty();
         /// <summary>
-        /// Iterate over DataSpecifications, if set, and otherwise return an empty enumerable.
+        /// Iterate over EmbeddedDataSpecifications, if set, and otherwise return an empty enumerable.
         /// </summary>
-        public IEnumerable<Reference> OverDataSpecificationsOrEmpty();
+        public IEnumerable<EmbeddedDataSpecification> OverEmbeddedDataSpecificationsOrEmpty();
     }
 
     /// <summary>
@@ -4051,12 +4030,9 @@ namespace AasCore.Aas3_0_RC02
         public List<Qualifier>? Qualifiers { get; set; }
 
         /// <summary>
-        /// Global reference to the data specification template used by the element.
+        /// Embedded data specification.
         /// </summary>
-        /// <remarks>
-        /// This is a global reference.
-        /// </remarks>
-        public List<Reference>? DataSpecifications { get; set; }
+        public List<EmbeddedDataSpecification>? EmbeddedDataSpecifications { get; set; }
 
         /// <summary>
         /// Data type of the value
@@ -4104,12 +4080,12 @@ namespace AasCore.Aas3_0_RC02
         }
 
         /// <summary>
-        /// Iterate over DataSpecifications, if set, and otherwise return an empty enumerable.
+        /// Iterate over EmbeddedDataSpecifications, if set, and otherwise return an empty enumerable.
         /// </summary>
-        public IEnumerable<Reference> OverDataSpecificationsOrEmpty()
+        public IEnumerable<EmbeddedDataSpecification> OverEmbeddedDataSpecificationsOrEmpty()
         {
-            return DataSpecifications
-                ?? System.Linq.Enumerable.Empty<Reference>();
+            return EmbeddedDataSpecifications
+                ?? System.Linq.Enumerable.Empty<EmbeddedDataSpecification>();
         }
 
         /// <summary>
@@ -4187,9 +4163,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
                 }
@@ -4281,9 +4257,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
 
@@ -4359,7 +4335,7 @@ namespace AasCore.Aas3_0_RC02
             Reference? semanticId = null,
             List<Reference>? supplementalSemanticIds = null,
             List<Qualifier>? qualifiers = null,
-            List<Reference>? dataSpecifications = null,
+            List<EmbeddedDataSpecification>? embeddedDataSpecifications = null,
             string? value = null,
             Reference? valueId = null)
         {
@@ -4373,7 +4349,7 @@ namespace AasCore.Aas3_0_RC02
             SemanticId = semanticId;
             SupplementalSemanticIds = supplementalSemanticIds;
             Qualifiers = qualifiers;
-            DataSpecifications = dataSpecifications;
+            EmbeddedDataSpecifications = embeddedDataSpecifications;
             ValueType = valueType;
             Value = value;
             ValueId = valueId;
@@ -4537,12 +4513,9 @@ namespace AasCore.Aas3_0_RC02
         public List<Qualifier>? Qualifiers { get; set; }
 
         /// <summary>
-        /// Global reference to the data specification template used by the element.
+        /// Embedded data specification.
         /// </summary>
-        /// <remarks>
-        /// This is a global reference.
-        /// </remarks>
-        public List<Reference>? DataSpecifications { get; set; }
+        public List<EmbeddedDataSpecification>? EmbeddedDataSpecifications { get; set; }
 
         /// <summary>
         /// The value of the property instance.
@@ -4585,12 +4558,12 @@ namespace AasCore.Aas3_0_RC02
         }
 
         /// <summary>
-        /// Iterate over DataSpecifications, if set, and otherwise return an empty enumerable.
+        /// Iterate over EmbeddedDataSpecifications, if set, and otherwise return an empty enumerable.
         /// </summary>
-        public IEnumerable<Reference> OverDataSpecificationsOrEmpty()
+        public IEnumerable<EmbeddedDataSpecification> OverEmbeddedDataSpecificationsOrEmpty()
         {
-            return DataSpecifications
-                ?? System.Linq.Enumerable.Empty<Reference>();
+            return EmbeddedDataSpecifications
+                ?? System.Linq.Enumerable.Empty<EmbeddedDataSpecification>();
         }
 
         /// <summary>
@@ -4668,9 +4641,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
                 }
@@ -4767,9 +4740,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
 
@@ -4855,7 +4828,7 @@ namespace AasCore.Aas3_0_RC02
             Reference? semanticId = null,
             List<Reference>? supplementalSemanticIds = null,
             List<Qualifier>? qualifiers = null,
-            List<Reference>? dataSpecifications = null,
+            List<EmbeddedDataSpecification>? embeddedDataSpecifications = null,
             LangStringSet? value = null,
             Reference? valueId = null)
         {
@@ -4869,7 +4842,7 @@ namespace AasCore.Aas3_0_RC02
             SemanticId = semanticId;
             SupplementalSemanticIds = supplementalSemanticIds;
             Qualifiers = qualifiers;
-            DataSpecifications = dataSpecifications;
+            EmbeddedDataSpecifications = embeddedDataSpecifications;
             Value = value;
             ValueId = valueId;
         }
@@ -5019,12 +4992,9 @@ namespace AasCore.Aas3_0_RC02
         public List<Qualifier>? Qualifiers { get; set; }
 
         /// <summary>
-        /// Global reference to the data specification template used by the element.
+        /// Embedded data specification.
         /// </summary>
-        /// <remarks>
-        /// This is a global reference.
-        /// </remarks>
-        public List<Reference>? DataSpecifications { get; set; }
+        public List<EmbeddedDataSpecification>? EmbeddedDataSpecifications { get; set; }
 
         /// <summary>
         /// Data type of the min und max
@@ -5075,12 +5045,12 @@ namespace AasCore.Aas3_0_RC02
         }
 
         /// <summary>
-        /// Iterate over DataSpecifications, if set, and otherwise return an empty enumerable.
+        /// Iterate over EmbeddedDataSpecifications, if set, and otherwise return an empty enumerable.
         /// </summary>
-        public IEnumerable<Reference> OverDataSpecificationsOrEmpty()
+        public IEnumerable<EmbeddedDataSpecification> OverEmbeddedDataSpecificationsOrEmpty()
         {
-            return DataSpecifications
-                ?? System.Linq.Enumerable.Empty<Reference>();
+            return EmbeddedDataSpecifications
+                ?? System.Linq.Enumerable.Empty<EmbeddedDataSpecification>();
         }
 
         /// <summary>
@@ -5158,9 +5128,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
                 }
@@ -5247,9 +5217,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
 
@@ -5314,7 +5284,7 @@ namespace AasCore.Aas3_0_RC02
             Reference? semanticId = null,
             List<Reference>? supplementalSemanticIds = null,
             List<Qualifier>? qualifiers = null,
-            List<Reference>? dataSpecifications = null,
+            List<EmbeddedDataSpecification>? embeddedDataSpecifications = null,
             string? min = null,
             string? max = null)
         {
@@ -5328,7 +5298,7 @@ namespace AasCore.Aas3_0_RC02
             SemanticId = semanticId;
             SupplementalSemanticIds = supplementalSemanticIds;
             Qualifiers = qualifiers;
-            DataSpecifications = dataSpecifications;
+            EmbeddedDataSpecifications = embeddedDataSpecifications;
             ValueType = valueType;
             Min = min;
             Max = max;
@@ -5481,12 +5451,9 @@ namespace AasCore.Aas3_0_RC02
         public List<Qualifier>? Qualifiers { get; set; }
 
         /// <summary>
-        /// Global reference to the data specification template used by the element.
+        /// Embedded data specification.
         /// </summary>
-        /// <remarks>
-        /// This is a global reference.
-        /// </remarks>
-        public List<Reference>? DataSpecifications { get; set; }
+        public List<EmbeddedDataSpecification>? EmbeddedDataSpecifications { get; set; }
 
         /// <summary>
         /// Global reference to an external object or entity or a logical reference to
@@ -5523,12 +5490,12 @@ namespace AasCore.Aas3_0_RC02
         }
 
         /// <summary>
-        /// Iterate over DataSpecifications, if set, and otherwise return an empty enumerable.
+        /// Iterate over EmbeddedDataSpecifications, if set, and otherwise return an empty enumerable.
         /// </summary>
-        public IEnumerable<Reference> OverDataSpecificationsOrEmpty()
+        public IEnumerable<EmbeddedDataSpecification> OverEmbeddedDataSpecificationsOrEmpty()
         {
-            return DataSpecifications
-                ?? System.Linq.Enumerable.Empty<Reference>();
+            return EmbeddedDataSpecifications
+                ?? System.Linq.Enumerable.Empty<EmbeddedDataSpecification>();
         }
 
         /// <summary>
@@ -5606,9 +5573,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
                 }
@@ -5700,9 +5667,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
 
@@ -5777,7 +5744,7 @@ namespace AasCore.Aas3_0_RC02
             Reference? semanticId = null,
             List<Reference>? supplementalSemanticIds = null,
             List<Qualifier>? qualifiers = null,
-            List<Reference>? dataSpecifications = null,
+            List<EmbeddedDataSpecification>? embeddedDataSpecifications = null,
             Reference? value = null)
         {
             Extensions = extensions;
@@ -5790,7 +5757,7 @@ namespace AasCore.Aas3_0_RC02
             SemanticId = semanticId;
             SupplementalSemanticIds = supplementalSemanticIds;
             Qualifiers = qualifiers;
-            DataSpecifications = dataSpecifications;
+            EmbeddedDataSpecifications = embeddedDataSpecifications;
             Value = value;
         }
     }
@@ -5940,12 +5907,9 @@ namespace AasCore.Aas3_0_RC02
         public List<Qualifier>? Qualifiers { get; set; }
 
         /// <summary>
-        /// Global reference to the data specification template used by the element.
+        /// Embedded data specification.
         /// </summary>
-        /// <remarks>
-        /// This is a global reference.
-        /// </remarks>
-        public List<Reference>? DataSpecifications { get; set; }
+        public List<EmbeddedDataSpecification>? EmbeddedDataSpecifications { get; set; }
 
         /// <summary>
         /// The value of the <see cref="Aas.Blob" /> instance of a blob data element.
@@ -6001,12 +5965,12 @@ namespace AasCore.Aas3_0_RC02
         }
 
         /// <summary>
-        /// Iterate over DataSpecifications, if set, and otherwise return an empty enumerable.
+        /// Iterate over EmbeddedDataSpecifications, if set, and otherwise return an empty enumerable.
         /// </summary>
-        public IEnumerable<Reference> OverDataSpecificationsOrEmpty()
+        public IEnumerable<EmbeddedDataSpecification> OverEmbeddedDataSpecificationsOrEmpty()
         {
-            return DataSpecifications
-                ?? System.Linq.Enumerable.Empty<Reference>();
+            return EmbeddedDataSpecifications
+                ?? System.Linq.Enumerable.Empty<EmbeddedDataSpecification>();
         }
 
         /// <summary>
@@ -6084,9 +6048,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
                 }
@@ -6173,9 +6137,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
 
@@ -6240,7 +6204,7 @@ namespace AasCore.Aas3_0_RC02
             Reference? semanticId = null,
             List<Reference>? supplementalSemanticIds = null,
             List<Qualifier>? qualifiers = null,
-            List<Reference>? dataSpecifications = null,
+            List<EmbeddedDataSpecification>? embeddedDataSpecifications = null,
             byte[]? value = null)
         {
             Extensions = extensions;
@@ -6253,7 +6217,7 @@ namespace AasCore.Aas3_0_RC02
             SemanticId = semanticId;
             SupplementalSemanticIds = supplementalSemanticIds;
             Qualifiers = qualifiers;
-            DataSpecifications = dataSpecifications;
+            EmbeddedDataSpecifications = embeddedDataSpecifications;
             ContentType = contentType;
             Value = value;
         }
@@ -6406,12 +6370,9 @@ namespace AasCore.Aas3_0_RC02
         public List<Qualifier>? Qualifiers { get; set; }
 
         /// <summary>
-        /// Global reference to the data specification template used by the element.
+        /// Embedded data specification.
         /// </summary>
-        /// <remarks>
-        /// This is a global reference.
-        /// </remarks>
-        public List<Reference>? DataSpecifications { get; set; }
+        public List<EmbeddedDataSpecification>? EmbeddedDataSpecifications { get; set; }
 
         /// <summary>
         /// Path and name of the referenced file (with file extension).
@@ -6457,12 +6418,12 @@ namespace AasCore.Aas3_0_RC02
         }
 
         /// <summary>
-        /// Iterate over DataSpecifications, if set, and otherwise return an empty enumerable.
+        /// Iterate over EmbeddedDataSpecifications, if set, and otherwise return an empty enumerable.
         /// </summary>
-        public IEnumerable<Reference> OverDataSpecificationsOrEmpty()
+        public IEnumerable<EmbeddedDataSpecification> OverEmbeddedDataSpecificationsOrEmpty()
         {
-            return DataSpecifications
-                ?? System.Linq.Enumerable.Empty<Reference>();
+            return EmbeddedDataSpecifications
+                ?? System.Linq.Enumerable.Empty<EmbeddedDataSpecification>();
         }
 
         /// <summary>
@@ -6540,9 +6501,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
                 }
@@ -6629,9 +6590,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
 
@@ -6696,7 +6657,7 @@ namespace AasCore.Aas3_0_RC02
             Reference? semanticId = null,
             List<Reference>? supplementalSemanticIds = null,
             List<Qualifier>? qualifiers = null,
-            List<Reference>? dataSpecifications = null,
+            List<EmbeddedDataSpecification>? embeddedDataSpecifications = null,
             string? value = null)
         {
             Extensions = extensions;
@@ -6709,7 +6670,7 @@ namespace AasCore.Aas3_0_RC02
             SemanticId = semanticId;
             SupplementalSemanticIds = supplementalSemanticIds;
             Qualifiers = qualifiers;
-            DataSpecifications = dataSpecifications;
+            EmbeddedDataSpecifications = embeddedDataSpecifications;
             ContentType = contentType;
             Value = value;
         }
@@ -6860,12 +6821,9 @@ namespace AasCore.Aas3_0_RC02
         public List<Qualifier>? Qualifiers { get; set; }
 
         /// <summary>
-        /// Global reference to the data specification template used by the element.
+        /// Embedded data specification.
         /// </summary>
-        /// <remarks>
-        /// This is a global reference.
-        /// </remarks>
-        public List<Reference>? DataSpecifications { get; set; }
+        public List<EmbeddedDataSpecification>? EmbeddedDataSpecifications { get; set; }
 
         /// <summary>
         /// Reference to the first element in the relationship taking the role of the subject.
@@ -6911,12 +6869,12 @@ namespace AasCore.Aas3_0_RC02
         }
 
         /// <summary>
-        /// Iterate over DataSpecifications, if set, and otherwise return an empty enumerable.
+        /// Iterate over EmbeddedDataSpecifications, if set, and otherwise return an empty enumerable.
         /// </summary>
-        public IEnumerable<Reference> OverDataSpecificationsOrEmpty()
+        public IEnumerable<EmbeddedDataSpecification> OverEmbeddedDataSpecificationsOrEmpty()
         {
-            return DataSpecifications
-                ?? System.Linq.Enumerable.Empty<Reference>();
+            return EmbeddedDataSpecifications
+                ?? System.Linq.Enumerable.Empty<EmbeddedDataSpecification>();
         }
 
         /// <summary>
@@ -6982,9 +6940,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
                 }
@@ -7083,9 +7041,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
 
@@ -7181,7 +7139,7 @@ namespace AasCore.Aas3_0_RC02
             Reference? semanticId = null,
             List<Reference>? supplementalSemanticIds = null,
             List<Qualifier>? qualifiers = null,
-            List<Reference>? dataSpecifications = null,
+            List<EmbeddedDataSpecification>? embeddedDataSpecifications = null,
             List<IDataElement>? annotations = null)
         {
             Extensions = extensions;
@@ -7194,7 +7152,7 @@ namespace AasCore.Aas3_0_RC02
             SemanticId = semanticId;
             SupplementalSemanticIds = supplementalSemanticIds;
             Qualifiers = qualifiers;
-            DataSpecifications = dataSpecifications;
+            EmbeddedDataSpecifications = embeddedDataSpecifications;
             First = first;
             Second = second;
             Annotations = annotations;
@@ -7382,12 +7340,9 @@ namespace AasCore.Aas3_0_RC02
         public List<Qualifier>? Qualifiers { get; set; }
 
         /// <summary>
-        /// Global reference to the data specification template used by the element.
+        /// Embedded data specification.
         /// </summary>
-        /// <remarks>
-        /// This is a global reference.
-        /// </remarks>
-        public List<Reference>? DataSpecifications { get; set; }
+        public List<EmbeddedDataSpecification>? EmbeddedDataSpecifications { get; set; }
 
         /// <summary>
         /// Describes statements applicable to the entity by a set of submodel elements,
@@ -7442,12 +7397,12 @@ namespace AasCore.Aas3_0_RC02
         }
 
         /// <summary>
-        /// Iterate over DataSpecifications, if set, and otherwise return an empty enumerable.
+        /// Iterate over EmbeddedDataSpecifications, if set, and otherwise return an empty enumerable.
         /// </summary>
-        public IEnumerable<Reference> OverDataSpecificationsOrEmpty()
+        public IEnumerable<EmbeddedDataSpecification> OverEmbeddedDataSpecificationsOrEmpty()
         {
-            return DataSpecifications
-                ?? System.Linq.Enumerable.Empty<Reference>();
+            return EmbeddedDataSpecifications
+                ?? System.Linq.Enumerable.Empty<EmbeddedDataSpecification>();
         }
 
         /// <summary>
@@ -7513,9 +7468,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
                 }
@@ -7620,9 +7575,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
 
@@ -7723,7 +7678,7 @@ namespace AasCore.Aas3_0_RC02
             Reference? semanticId = null,
             List<Reference>? supplementalSemanticIds = null,
             List<Qualifier>? qualifiers = null,
-            List<Reference>? dataSpecifications = null,
+            List<EmbeddedDataSpecification>? embeddedDataSpecifications = null,
             List<ISubmodelElement>? statements = null,
             Reference? globalAssetId = null,
             SpecificAssetId? specificAssetId = null)
@@ -7738,7 +7693,7 @@ namespace AasCore.Aas3_0_RC02
             SemanticId = semanticId;
             SupplementalSemanticIds = supplementalSemanticIds;
             Qualifiers = qualifiers;
-            DataSpecifications = dataSpecifications;
+            EmbeddedDataSpecifications = embeddedDataSpecifications;
             Statements = statements;
             EntityType = entityType;
             GlobalAssetId = globalAssetId;
@@ -8138,12 +8093,9 @@ namespace AasCore.Aas3_0_RC02
         public List<Qualifier>? Qualifiers { get; set; }
 
         /// <summary>
-        /// Global reference to the data specification template used by the element.
+        /// Embedded data specification.
         /// </summary>
-        /// <remarks>
-        /// This is a global reference.
-        /// </remarks>
-        public List<Reference>? DataSpecifications { get; set; }
+        public List<EmbeddedDataSpecification>? EmbeddedDataSpecifications { get; set; }
 
         /// <summary>
         /// Reference to the <see cref="Aas.IReferable" />, which defines the scope of the event.
@@ -8255,12 +8207,12 @@ namespace AasCore.Aas3_0_RC02
         }
 
         /// <summary>
-        /// Iterate over DataSpecifications, if set, and otherwise return an empty enumerable.
+        /// Iterate over EmbeddedDataSpecifications, if set, and otherwise return an empty enumerable.
         /// </summary>
-        public IEnumerable<Reference> OverDataSpecificationsOrEmpty()
+        public IEnumerable<EmbeddedDataSpecification> OverEmbeddedDataSpecificationsOrEmpty()
         {
-            return DataSpecifications
-                ?? System.Linq.Enumerable.Empty<Reference>();
+            return EmbeddedDataSpecifications
+                ?? System.Linq.Enumerable.Empty<EmbeddedDataSpecification>();
         }
 
         /// <summary>
@@ -8317,9 +8269,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
                 }
@@ -8413,9 +8365,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
 
@@ -8501,7 +8453,7 @@ namespace AasCore.Aas3_0_RC02
             Reference? semanticId = null,
             List<Reference>? supplementalSemanticIds = null,
             List<Qualifier>? qualifiers = null,
-            List<Reference>? dataSpecifications = null,
+            List<EmbeddedDataSpecification>? embeddedDataSpecifications = null,
             string? messageTopic = null,
             Reference? messageBroker = null,
             string? lastUpdate = null,
@@ -8518,7 +8470,7 @@ namespace AasCore.Aas3_0_RC02
             SemanticId = semanticId;
             SupplementalSemanticIds = supplementalSemanticIds;
             Qualifiers = qualifiers;
-            DataSpecifications = dataSpecifications;
+            EmbeddedDataSpecifications = embeddedDataSpecifications;
             Observed = observed;
             Direction = direction;
             State = state;
@@ -8674,12 +8626,9 @@ namespace AasCore.Aas3_0_RC02
         public List<Qualifier>? Qualifiers { get; set; }
 
         /// <summary>
-        /// Global reference to the data specification template used by the element.
+        /// Embedded data specification.
         /// </summary>
-        /// <remarks>
-        /// This is a global reference.
-        /// </remarks>
-        public List<Reference>? DataSpecifications { get; set; }
+        public List<EmbeddedDataSpecification>? EmbeddedDataSpecifications { get; set; }
 
         /// <summary>
         /// Input parameter of the operation.
@@ -8724,12 +8673,12 @@ namespace AasCore.Aas3_0_RC02
         }
 
         /// <summary>
-        /// Iterate over DataSpecifications, if set, and otherwise return an empty enumerable.
+        /// Iterate over EmbeddedDataSpecifications, if set, and otherwise return an empty enumerable.
         /// </summary>
-        public IEnumerable<Reference> OverDataSpecificationsOrEmpty()
+        public IEnumerable<EmbeddedDataSpecification> OverEmbeddedDataSpecificationsOrEmpty()
         {
-            return DataSpecifications
-                ?? System.Linq.Enumerable.Empty<Reference>();
+            return EmbeddedDataSpecifications
+                ?? System.Linq.Enumerable.Empty<EmbeddedDataSpecification>();
         }
 
         /// <summary>
@@ -8813,9 +8762,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
                 }
@@ -8926,9 +8875,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
 
@@ -9034,7 +8983,7 @@ namespace AasCore.Aas3_0_RC02
             Reference? semanticId = null,
             List<Reference>? supplementalSemanticIds = null,
             List<Qualifier>? qualifiers = null,
-            List<Reference>? dataSpecifications = null,
+            List<EmbeddedDataSpecification>? embeddedDataSpecifications = null,
             List<OperationVariable>? inputVariables = null,
             List<OperationVariable>? outputVariables = null,
             List<OperationVariable>? inoutputVariables = null)
@@ -9049,7 +8998,7 @@ namespace AasCore.Aas3_0_RC02
             SemanticId = semanticId;
             SupplementalSemanticIds = supplementalSemanticIds;
             Qualifiers = qualifiers;
-            DataSpecifications = dataSpecifications;
+            EmbeddedDataSpecifications = embeddedDataSpecifications;
             InputVariables = inputVariables;
             OutputVariables = outputVariables;
             InoutputVariables = inoutputVariables;
@@ -9285,12 +9234,9 @@ namespace AasCore.Aas3_0_RC02
         public List<Qualifier>? Qualifiers { get; set; }
 
         /// <summary>
-        /// Global reference to the data specification template used by the element.
+        /// Embedded data specification.
         /// </summary>
-        /// <remarks>
-        /// This is a global reference.
-        /// </remarks>
-        public List<Reference>? DataSpecifications { get; set; }
+        public List<EmbeddedDataSpecification>? EmbeddedDataSpecifications { get; set; }
 
         /// <summary>
         /// Iterate over Extensions, if set, and otherwise return an empty enumerable.
@@ -9320,12 +9266,12 @@ namespace AasCore.Aas3_0_RC02
         }
 
         /// <summary>
-        /// Iterate over DataSpecifications, if set, and otherwise return an empty enumerable.
+        /// Iterate over EmbeddedDataSpecifications, if set, and otherwise return an empty enumerable.
         /// </summary>
-        public IEnumerable<Reference> OverDataSpecificationsOrEmpty()
+        public IEnumerable<EmbeddedDataSpecification> OverEmbeddedDataSpecificationsOrEmpty()
         {
-            return DataSpecifications
-                ?? System.Linq.Enumerable.Empty<Reference>();
+            return EmbeddedDataSpecifications
+                ?? System.Linq.Enumerable.Empty<EmbeddedDataSpecification>();
         }
 
         /// <summary>
@@ -9382,9 +9328,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
                 }
@@ -9471,9 +9417,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
 
@@ -9537,7 +9483,7 @@ namespace AasCore.Aas3_0_RC02
             Reference? semanticId = null,
             List<Reference>? supplementalSemanticIds = null,
             List<Qualifier>? qualifiers = null,
-            List<Reference>? dataSpecifications = null)
+            List<EmbeddedDataSpecification>? embeddedDataSpecifications = null)
         {
             Extensions = extensions;
             IdShort = idShort;
@@ -9549,7 +9495,7 @@ namespace AasCore.Aas3_0_RC02
             SemanticId = semanticId;
             SupplementalSemanticIds = supplementalSemanticIds;
             Qualifiers = qualifiers;
-            DataSpecifications = dataSpecifications;
+            EmbeddedDataSpecifications = embeddedDataSpecifications;
         }
     }
 
@@ -9694,12 +9640,9 @@ namespace AasCore.Aas3_0_RC02
         public string Id { get; set; }
 
         /// <summary>
-        /// Global reference to the data specification template used by the element.
+        /// Embedded data specification.
         /// </summary>
-        /// <remarks>
-        /// This is a global reference.
-        /// </remarks>
-        public List<Reference>? DataSpecifications { get; set; }
+        public List<EmbeddedDataSpecification>? EmbeddedDataSpecifications { get; set; }
 
         /// <summary>
         /// Reference to an external definition the concept is compatible to or was derived
@@ -9725,12 +9668,12 @@ namespace AasCore.Aas3_0_RC02
         }
 
         /// <summary>
-        /// Iterate over DataSpecifications, if set, and otherwise return an empty enumerable.
+        /// Iterate over EmbeddedDataSpecifications, if set, and otherwise return an empty enumerable.
         /// </summary>
-        public IEnumerable<Reference> OverDataSpecificationsOrEmpty()
+        public IEnumerable<EmbeddedDataSpecification> OverEmbeddedDataSpecificationsOrEmpty()
         {
-            return DataSpecifications
-                ?? System.Linq.Enumerable.Empty<Reference>();
+            return EmbeddedDataSpecifications
+                ?? System.Linq.Enumerable.Empty<EmbeddedDataSpecification>();
         }
 
         /// <summary>
@@ -9792,9 +9735,9 @@ namespace AasCore.Aas3_0_RC02
                 yield return Administration;
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
                 }
@@ -9861,9 +9804,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            if (DataSpecifications != null)
+            if (EmbeddedDataSpecifications != null)
             {
-                foreach (var anItem in DataSpecifications)
+                foreach (var anItem in EmbeddedDataSpecifications)
                 {
                     yield return anItem;
 
@@ -9939,7 +9882,7 @@ namespace AasCore.Aas3_0_RC02
             LangStringSet? description = null,
             string? checksum = null,
             AdministrativeInformation? administration = null,
-            List<Reference>? dataSpecifications = null,
+            List<EmbeddedDataSpecification>? embeddedDataSpecifications = null,
             List<Reference>? isCaseOf = null)
         {
             Extensions = extensions;
@@ -9950,7 +9893,7 @@ namespace AasCore.Aas3_0_RC02
             Checksum = checksum;
             Id = id;
             Administration = administration;
-            DataSpecifications = dataSpecifications;
+            EmbeddedDataSpecifications = embeddedDataSpecifications;
             IsCaseOf = isCaseOf;
         }
     }
@@ -10697,211 +10640,6 @@ namespace AasCore.Aas3_0_RC02
     }
 
     /// <summary>
-    /// Data specification content is part of a data specification template and defines
-    /// which additional attributes shall be added to the element instance that references
-    /// the data specification template and meta information about the template itself.
-    /// </summary>
-    public class DataSpecificationContent : IClass
-    {
-        /// <summary>
-        /// Iterate over all the class instances referenced from this instance
-        /// without further recursion.
-        /// </summary>
-        public IEnumerable<IClass> DescendOnce()
-        {
-            // No descendable properties
-            yield break;
-        }
-
-        /// <summary>
-        /// Iterate recursively over all the class instances referenced from this instance.
-        /// </summary>
-        public IEnumerable<IClass> Descend()
-        {
-            // No descendable properties
-            yield break;
-        }
-
-        /// <summary>
-        /// Accept the <paramref name="visitor" /> to visit this instance
-        /// for double dispatch.
-        /// </summary>
-        public void Accept(Visitation.IVisitor visitor)
-        {
-            visitor.Visit(this);
-        }
-
-        /// <summary>
-        /// Accept the visitor to visit this instance for double dispatch
-        /// with the <paramref name="context" />.
-        /// </summary>
-        public void Accept<TContext>(
-            Visitation.IVisitorWithContext<TContext> visitor,
-            TContext context)
-        {
-            visitor.Visit(this, context);
-        }
-
-        /// <summary>
-        /// Accept the <paramref name="transformer" /> to transform this instance
-        /// for double dispatch.
-        /// </summary>
-        public T Transform<T>(Visitation.ITransformer<T> transformer)
-        {
-            return transformer.Transform(this);
-        }
-
-        /// <summary>
-        /// Accept the <paramref name="transformer" /> to visit this instance
-        /// for double dispatch with the <paramref name="context" />.
-        /// </summary>
-        public T Transform<TContext, T>(
-            Visitation.ITransformerWithContext<TContext, T> transformer,
-            TContext context)
-        {
-            return transformer.Transform(this, context);
-        }
-    }
-
-    /// <summary>
-    /// Data Specification Template
-    /// </summary>
-    public class DataSpecification : IClass
-    {
-        /// <summary>
-        /// The globally unique identification of the element.
-        /// </summary>
-        public string Id { get; set; }
-
-        /// <summary>
-        /// The content of the template without meta data
-        /// </summary>
-        public DataSpecificationContent DataSpecificationContent { get; set; }
-
-        /// <summary>
-        /// Administrative information of an identifiable element.
-        /// </summary>
-        /// <remarks>
-        /// Some of the administrative information like the version number might need to
-        /// be part of the identification.
-        /// </remarks>
-        public AdministrativeInformation? Administration { get; set; }
-
-        /// <summary>
-        /// Description how and in which context the data specification template is applicable.
-        /// The description can be provided in several languages.
-        /// </summary>
-        public LangStringSet? Description { get; set; }
-
-        /// <summary>
-        /// Iterate over all the class instances referenced from this instance
-        /// without further recursion.
-        /// </summary>
-        public IEnumerable<IClass> DescendOnce()
-        {
-            yield return DataSpecificationContent;
-
-            if (Administration != null)
-            {
-                yield return Administration;
-            }
-
-            if (Description != null)
-            {
-                yield return Description;
-            }
-        }
-
-        /// <summary>
-        /// Iterate recursively over all the class instances referenced from this instance.
-        /// </summary>
-        public IEnumerable<IClass> Descend()
-        {
-            yield return DataSpecificationContent;
-
-            // Recurse
-            foreach (var anItem in DataSpecificationContent.Descend())
-            {
-                yield return anItem;
-            }
-
-            if (Administration != null)
-            {
-                yield return Administration;
-
-                // Recurse
-                foreach (var anItem in Administration.Descend())
-                {
-                    yield return anItem;
-                }
-            }
-
-            if (Description != null)
-            {
-                yield return Description;
-
-                // Recurse
-                foreach (var anItem in Description.Descend())
-                {
-                    yield return anItem;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Accept the <paramref name="visitor" /> to visit this instance
-        /// for double dispatch.
-        /// </summary>
-        public void Accept(Visitation.IVisitor visitor)
-        {
-            visitor.Visit(this);
-        }
-
-        /// <summary>
-        /// Accept the visitor to visit this instance for double dispatch
-        /// with the <paramref name="context" />.
-        /// </summary>
-        public void Accept<TContext>(
-            Visitation.IVisitorWithContext<TContext> visitor,
-            TContext context)
-        {
-            visitor.Visit(this, context);
-        }
-
-        /// <summary>
-        /// Accept the <paramref name="transformer" /> to transform this instance
-        /// for double dispatch.
-        /// </summary>
-        public T Transform<T>(Visitation.ITransformer<T> transformer)
-        {
-            return transformer.Transform(this);
-        }
-
-        /// <summary>
-        /// Accept the <paramref name="transformer" /> to visit this instance
-        /// for double dispatch with the <paramref name="context" />.
-        /// </summary>
-        public T Transform<TContext, T>(
-            Visitation.ITransformerWithContext<TContext, T> transformer,
-            TContext context)
-        {
-            return transformer.Transform(this, context);
-        }
-
-        public DataSpecification(
-            string id,
-            DataSpecificationContent dataSpecificationContent,
-            AdministrativeInformation? administration,
-            LangStringSet? description)
-        {
-            Id = id;
-            DataSpecificationContent = dataSpecificationContent;
-            Administration = administration;
-            Description = description;
-        }
-    }
-
-    /// <summary>
     /// Container for the sets of different identifiables.
     /// </summary>
     /// <remarks>
@@ -11080,6 +10818,962 @@ namespace AasCore.Aas3_0_RC02
             AssetAdministrationShells = assetAdministrationShells;
             Submodels = submodels;
             ConceptDescriptions = conceptDescriptions;
+        }
+    }
+
+    /// <summary>
+    /// Data specification content is part of a data specification template and defines
+    /// which additional attributes shall be added to the element instance that references
+    /// the data specification template and meta information about the template itself.
+    /// </summary>
+    public interface IDataSpecificationContent : IClass
+    {
+        // Intentionally empty.
+    }
+
+    /// <summary>
+    /// Embed the content of a data specification.
+    /// </summary>
+    public class EmbeddedDataSpecification : IClass
+    {
+        /// <summary>
+        /// Reference to the data specification
+        /// </summary>
+        public Reference DataSpecification { get; set; }
+
+        /// <summary>
+        /// Actual content of the data specification
+        /// </summary>
+        public IDataSpecificationContent DataSpecificationContent { get; set; }
+
+        /// <summary>
+        /// Iterate over all the class instances referenced from this instance
+        /// without further recursion.
+        /// </summary>
+        public IEnumerable<IClass> DescendOnce()
+        {
+            yield return DataSpecification;
+
+            yield return DataSpecificationContent;
+        }
+
+        /// <summary>
+        /// Iterate recursively over all the class instances referenced from this instance.
+        /// </summary>
+        public IEnumerable<IClass> Descend()
+        {
+            yield return DataSpecification;
+
+            // Recurse
+            foreach (var anItem in DataSpecification.Descend())
+            {
+                yield return anItem;
+            }
+
+            yield return DataSpecificationContent;
+
+            // Recurse
+            foreach (var anItem in DataSpecificationContent.Descend())
+            {
+                yield return anItem;
+            }
+        }
+
+        /// <summary>
+        /// Accept the <paramref name="visitor" /> to visit this instance
+        /// for double dispatch.
+        /// </summary>
+        public void Accept(Visitation.IVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+
+        /// <summary>
+        /// Accept the visitor to visit this instance for double dispatch
+        /// with the <paramref name="context" />.
+        /// </summary>
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
+        {
+            visitor.Visit(this, context);
+        }
+
+        /// <summary>
+        /// Accept the <paramref name="transformer" /> to transform this instance
+        /// for double dispatch.
+        /// </summary>
+        public T Transform<T>(Visitation.ITransformer<T> transformer)
+        {
+            return transformer.Transform(this);
+        }
+
+        /// <summary>
+        /// Accept the <paramref name="transformer" /> to visit this instance
+        /// for double dispatch with the <paramref name="context" />.
+        /// </summary>
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
+        {
+            return transformer.Transform(this, context);
+        }
+
+        public EmbeddedDataSpecification(
+            Reference dataSpecification,
+            IDataSpecificationContent dataSpecificationContent)
+        {
+            DataSpecification = dataSpecification;
+            DataSpecificationContent = dataSpecificationContent;
+        }
+    }
+
+    public enum DataTypeIec61360
+    {
+        /// <summary>
+        /// values containing a calendar date, conformant to ISO 8601:2004 Format yyyy-mm-dd
+        /// Example from IEC 61360-1:2017: "1999-05-31" is the [DATE] representation of:
+        /// "31 May 1999".
+        /// </summary>
+        [EnumMember(Value = "DATE")]
+        Date,
+
+        /// <summary>
+        /// values consisting of sequence of characters but cannot be translated into other
+        /// languages
+        /// </summary>
+        [EnumMember(Value = "STRING")]
+        String,
+
+        /// <summary>
+        /// values containing string but shall be represented as different string in different
+        /// languages
+        /// </summary>
+        [EnumMember(Value = "STRING_TRANSLATABLE")]
+        StringTranslatable,
+
+        /// <summary>
+        /// values containing values that are measure of type INTEGER. In addition such a value
+        /// comes with a physical unit.
+        /// </summary>
+        [EnumMember(Value = "INTEGER_MEASURE")]
+        IntegerMeasure,
+
+        /// <summary>
+        /// values containing values of type INTEGER but are no currencies or measures
+        /// </summary>
+        [EnumMember(Value = "INTEGER_COUNT")]
+        IntegerCount,
+
+        /// <summary>
+        /// values containing values of type INTEGER that are currencies
+        /// </summary>
+        [EnumMember(Value = "INTEGER_CURRENCY")]
+        IntegerCurrency,
+
+        /// <summary>
+        /// values containing values that are measures of type REAL. In addition such a value
+        /// comes with a physical unit.
+        /// </summary>
+        [EnumMember(Value = "REAL_MEASURE")]
+        RealMeasure,
+
+        /// <summary>
+        /// values containing numbers that can be written as a terminating or non-terminating
+        /// decimal; a rational or irrational number but are no currencies or measures
+        /// </summary>
+        [EnumMember(Value = "REAL_COUNT")]
+        RealCount,
+
+        /// <summary>
+        /// values containing values of type REAL that are currencies
+        /// </summary>
+        [EnumMember(Value = "REAL_CURRENCY")]
+        RealCurrency,
+
+        /// <summary>
+        /// values representing truth of logic or Boolean algebra (TRUE, FALSE)
+        /// </summary>
+        [EnumMember(Value = "BOOLEAN")]
+        Boolean,
+
+        /// <summary>
+        /// values containing values of type STRING conformant to Rfc 3987
+        /// </summary>
+        /// <remarks>
+        /// In IEC61360-1 (2017) only URI is supported.
+        /// An IRI type allows in particular to express an URL or an URI.
+        /// </remarks>
+        [EnumMember(Value = "IRI")]
+        Iri,
+
+        /// <summary>
+        /// values conforming to ISO/IEC 11179 series global identifier sequences
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// IRDI can be used instead of the more specific data types ICID or ISO29002_IRDI.
+        /// </para>
+        /// <para>
+        /// ICID values are value conformant to an IRDI, where the delimiter between RAI and ID
+        /// is “#” while the delimiter between DI and VI is confined to “##”
+        /// </para>
+        /// <para>
+        /// ISO29002_IRDI values are values containing a global identifier that identifies an
+        /// administrated item in a registry. The structure of this identifier complies with
+        /// identifier syntax defined in ISO/TS 29002-5. The identifier shall fulfil the
+        /// requirements specified in ISO/TS 29002-5 for an "international registration data
+        /// identifier" (IRDI).
+        /// </para>
+        /// </remarks>
+        [EnumMember(Value = "IRDI")]
+        Irdi,
+
+        /// <summary>
+        /// values containing values of type rational
+        /// </summary>
+        [EnumMember(Value = "RATIONAL")]
+        Rational,
+
+        /// <summary>
+        /// values containing values of type rational. In addition such a value comes with a
+        /// physical unit.
+        /// </summary>
+        [EnumMember(Value = "RATIONAL_MEASURE")]
+        RationalMeasure,
+
+        /// <summary>
+        /// values containing a time, conformant to ISO 8601:2004 but restricted to what is
+        /// allowed in the corresponding type in xml.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Format hh:mm (ECLASS)
+        /// </para>
+        /// <para>
+        /// Example from IEC 61360-1:2017: "13:20:00-05:00" is the [TIME] representation of:
+        /// 1.20 p.m. for Eastern Standard Time, which is 5 hours behind Coordinated
+        /// Universal Time (UTC).
+        /// </para>
+        /// </remarks>
+        [EnumMember(Value = "TIME")]
+        Time,
+
+        /// <summary>
+        /// values containing a time, conformant to ISO 8601:2004 but restricted to what is
+        /// allowed in the corresponding type in xml.
+        /// </summary>
+        /// <remarks>
+        /// Format yyyy-mm-dd hh:mm (ECLASS)
+        /// </remarks>
+        [EnumMember(Value = "TIMESTAMP")]
+        Timestamp,
+
+        /// <summary>
+        /// values containing an address to a file. The values are of type URI and can represent
+        /// an absolute or relative path.
+        /// </summary>
+        /// <remarks>
+        /// IEC61360 does not support the file type.
+        /// </remarks>
+        [EnumMember(Value = "FILE")]
+        File,
+
+        /// <summary>
+        /// Values containing string with any sequence of characters, using the syntax of HTML5
+        /// (see W3C Recommendation 28:2014)
+        /// </summary>
+        [EnumMember(Value = "HTML")]
+        Html,
+
+        /// <summary>
+        /// values containing the content of a file. Values may be binaries.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// HTML conformant to HTML5 is a special blob.
+        /// </para>
+        /// <para>
+        /// In IEC61360 binary is for a sequence of bits, each bit being represented by “0” and
+        /// “1” only. A binary is a blob but a blob may also contain other source code.
+        /// </para>
+        /// </remarks>
+        [EnumMember(Value = "BLOB")]
+        Blob
+    }
+
+    public enum ConceptDescriptionsCategories
+    {
+        [EnumMember(Value = "APPLICATION_CLASS")]
+        ApplicationClass,
+
+        [EnumMember(Value = "CAPABILITY")]
+        Capability,
+
+        [EnumMember(Value = "COLLECTIONS")]
+        Collections,
+
+        [EnumMember(Value = "DOCUMENTATION")]
+        Documentation,
+
+        [EnumMember(Value = "ENTITY")]
+        Entity,
+
+        [EnumMember(Value = "EVENT")]
+        Event,
+
+        [EnumMember(Value = "FUNCTION")]
+        Function,
+
+        [EnumMember(Value = "PROPERTY")]
+        Property,
+
+        [EnumMember(Value = "VALUE")]
+        Value,
+
+        [EnumMember(Value = "RANGE")]
+        Range,
+
+        [EnumMember(Value = "QUALIFIER_TYPE")]
+        QualifierType,
+
+        [EnumMember(Value = "REFERENCING")]
+        Referencing,
+
+        [EnumMember(Value = "RELATIONSHIP")]
+        Relationship
+    }
+
+    public enum LevelType
+    {
+        [EnumMember(Value = "Min")]
+        Min,
+
+        [EnumMember(Value = "Max")]
+        Max,
+
+        [EnumMember(Value = "Nom")]
+        Nom,
+
+        [EnumMember(Value = "Typ")]
+        Typ
+    }
+
+    /// <summary>
+    /// A value reference pair within a value list. Each value has a global unique id
+    /// defining its semantic.
+    /// </summary>
+    public class ValueReferencePair : IClass
+    {
+        /// <summary>
+        /// The value of the referenced concept definition of the value in valueId.
+        /// </summary>
+        public string Value { get; set; }
+
+        /// <summary>
+        /// Global unique id of the value.
+        /// </summary>
+        /// <remarks>
+        /// It is recommended to use a global reference.
+        /// </remarks>
+        public Reference ValueId { get; set; }
+
+        /// <summary>
+        /// Iterate over all the class instances referenced from this instance
+        /// without further recursion.
+        /// </summary>
+        public IEnumerable<IClass> DescendOnce()
+        {
+            yield return ValueId;
+        }
+
+        /// <summary>
+        /// Iterate recursively over all the class instances referenced from this instance.
+        /// </summary>
+        public IEnumerable<IClass> Descend()
+        {
+            yield return ValueId;
+
+            // Recurse
+            foreach (var anItem in ValueId.Descend())
+            {
+                yield return anItem;
+            }
+        }
+
+        /// <summary>
+        /// Accept the <paramref name="visitor" /> to visit this instance
+        /// for double dispatch.
+        /// </summary>
+        public void Accept(Visitation.IVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+
+        /// <summary>
+        /// Accept the visitor to visit this instance for double dispatch
+        /// with the <paramref name="context" />.
+        /// </summary>
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
+        {
+            visitor.Visit(this, context);
+        }
+
+        /// <summary>
+        /// Accept the <paramref name="transformer" /> to transform this instance
+        /// for double dispatch.
+        /// </summary>
+        public T Transform<T>(Visitation.ITransformer<T> transformer)
+        {
+            return transformer.Transform(this);
+        }
+
+        /// <summary>
+        /// Accept the <paramref name="transformer" /> to visit this instance
+        /// for double dispatch with the <paramref name="context" />.
+        /// </summary>
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
+        {
+            return transformer.Transform(this, context);
+        }
+
+        public ValueReferencePair(
+            string value,
+            Reference valueId)
+        {
+            Value = value;
+            ValueId = valueId;
+        }
+    }
+
+    /// <summary>
+    /// A set of value reference pairs.
+    /// </summary>
+    public class ValueList : IClass
+    {
+        /// <summary>
+        /// A pair of a value together with its global unique id.
+        /// </summary>
+        public List<ValueReferencePair> ValueReferencePairTypes { get; set; }
+
+        /// <summary>
+        /// Iterate over all the class instances referenced from this instance
+        /// without further recursion.
+        /// </summary>
+        public IEnumerable<IClass> DescendOnce()
+        {
+            foreach (var anItem in ValueReferencePairTypes)
+            {
+                yield return anItem;
+            }
+        }
+
+        /// <summary>
+        /// Iterate recursively over all the class instances referenced from this instance.
+        /// </summary>
+        public IEnumerable<IClass> Descend()
+        {
+            foreach (var anItem in ValueReferencePairTypes)
+            {
+                yield return anItem;
+
+                // Recurse
+                foreach (var anotherItem in anItem.Descend())
+                {
+                    yield return anotherItem;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Accept the <paramref name="visitor" /> to visit this instance
+        /// for double dispatch.
+        /// </summary>
+        public void Accept(Visitation.IVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+
+        /// <summary>
+        /// Accept the visitor to visit this instance for double dispatch
+        /// with the <paramref name="context" />.
+        /// </summary>
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
+        {
+            visitor.Visit(this, context);
+        }
+
+        /// <summary>
+        /// Accept the <paramref name="transformer" /> to transform this instance
+        /// for double dispatch.
+        /// </summary>
+        public T Transform<T>(Visitation.ITransformer<T> transformer)
+        {
+            return transformer.Transform(this);
+        }
+
+        /// <summary>
+        /// Accept the <paramref name="transformer" /> to visit this instance
+        /// for double dispatch with the <paramref name="context" />.
+        /// </summary>
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
+        {
+            return transformer.Transform(this, context);
+        }
+
+        public ValueList(List<ValueReferencePair> valueReferencePairTypes)
+        {
+            ValueReferencePairTypes = valueReferencePairTypes;
+        }
+    }
+
+    /// <summary>
+    /// Content of data specification template for concept descriptions for properties,
+    /// values and value lists conformant to IEC 61360.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// IEC61360 requires also a globally unique identifier for a concept
+    /// description. This ID is not part of the data specification template.
+    /// Instead the <see cref="Aas.ConceptDescription.Id" /> as inherited via
+    /// <see cref="Aas.IIdentifiable" /> is used. Same holds for administrative
+    /// information like the version and revision.
+    /// </para>
+    /// <para>
+    /// <see cref="Aas.ConceptDescription.IdShort" /> and <see cref="Aas.DataSpecificationIec61360.ShortName" /> are very
+    /// similar. However, in this case the decision was to add
+    /// <see cref="Aas.DataSpecificationIec61360.ShortName" /> explicitly to the data specification. Same holds for
+    /// <see cref="Aas.ConceptDescription.DisplayName" /> and
+    /// <see cref="Aas.DataSpecificationIec61360.PreferredName" />. Same holds for
+    /// <see cref="Aas.ConceptDescription.Description" /> and <see cref="Aas.DataSpecificationIec61360.Definition" />.
+    /// </para>
+    /// <para>
+    /// Constraints:
+    /// </para>
+    /// <ul>
+    ///   <li>
+    ///     Constraint AASd-010:
+    ///     If <see cref="Aas.DataSpecificationIec61360.Value" /> is not empty then <see cref="Aas.DataSpecificationIec61360.ValueList" /> shall be empty
+    ///     and vice versa.
+    ///   </li>
+    ///   <li>
+    ///     Constraint AASd-009:
+    ///     If <see cref="Aas.DataSpecificationIec61360.DataType" /> one of: <c>INTEGER_MEASURE</c>, <c>REAL_MEASURE</c>,
+    ///     <c>RATIONAL_MEASURE</c>, <c>INTEGER_CURRENCY</c>, <c>REAL_CURRENCY</c>, then
+    ///     <see cref="Aas.DataSpecificationIec61360.Unit" /> or <see cref="Aas.DataSpecificationIec61360.UnitId" /> shall be defined.
+    ///   </li>
+    /// </ul>
+    /// </remarks>
+    public class DataSpecificationIec61360 : IDataSpecificationContent
+    {
+        /// <summary>
+        /// Preferred name
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Constraints:
+        /// </para>
+        /// <ul>
+        ///   <li>
+        ///     Constraint AASc-002:
+        ///     <see cref="Aas.DataSpecificationIec61360.PreferredName" /> shall be provided at least in English.
+        ///   </li>
+        /// </ul>
+        /// </remarks>
+        public LangStringSet PreferredName { get; set; }
+
+        /// <summary>
+        /// Short name
+        /// </summary>
+        public LangStringSet? ShortName { get; set; }
+
+        /// <summary>
+        /// Unit
+        /// </summary>
+        public string? Unit { get; set; }
+
+        /// <summary>
+        /// Unique unit id
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <see cref="Aas.DataSpecificationIec61360.Unit" /> and <see cref="Aas.DataSpecificationIec61360.UnitId" /> need to be consistent if both attributes
+        /// are set
+        /// </para>
+        /// <para>
+        /// It is recommended to use a global reference.
+        /// </para>
+        /// <para>
+        /// Although the <see cref="Aas.DataSpecificationIec61360.UnitId" /> is a global reference there might exist a
+        /// <see cref="Aas.ConceptDescription" />
+        /// with data specification <see cref="Aas.DataSpecificationPhysicalUnit" /> with
+        /// the same ID.
+        /// </para>
+        /// </remarks>
+        public Reference? UnitId { get; set; }
+
+        /// <summary>
+        /// Source of definition
+        /// </summary>
+        public string? SourceOfDefinition { get; set; }
+
+        /// <summary>
+        /// Symbol
+        /// </summary>
+        public string? Symbol { get; set; }
+
+        /// <summary>
+        /// Data Type
+        /// </summary>
+        public DataTypeIec61360? DataType { get; set; }
+
+        /// <summary>
+        /// Definition in different languages
+        /// </summary>
+        public LangStringSet? Definition { get; set; }
+
+        /// <summary>
+        /// Value Format
+        /// </summary>
+        public string? ValueFormat { get; set; }
+
+        /// <summary>
+        /// List of allowed values
+        /// </summary>
+        public ValueList? ValueList { get; set; }
+
+        /// <summary>
+        /// Value
+        /// </summary>
+        public string? Value { get; set; }
+
+        /// <summary>
+        /// Set of levels.
+        /// </summary>
+        public LevelType? LevelType { get; set; }
+
+        /// <summary>
+        /// Iterate over all the class instances referenced from this instance
+        /// without further recursion.
+        /// </summary>
+        public IEnumerable<IClass> DescendOnce()
+        {
+            yield return PreferredName;
+
+            if (ShortName != null)
+            {
+                yield return ShortName;
+            }
+
+            if (UnitId != null)
+            {
+                yield return UnitId;
+            }
+
+            if (Definition != null)
+            {
+                yield return Definition;
+            }
+
+            if (ValueList != null)
+            {
+                yield return ValueList;
+            }
+        }
+
+        /// <summary>
+        /// Iterate recursively over all the class instances referenced from this instance.
+        /// </summary>
+        public IEnumerable<IClass> Descend()
+        {
+            yield return PreferredName;
+
+            // Recurse
+            foreach (var anItem in PreferredName.Descend())
+            {
+                yield return anItem;
+            }
+
+            if (ShortName != null)
+            {
+                yield return ShortName;
+
+                // Recurse
+                foreach (var anItem in ShortName.Descend())
+                {
+                    yield return anItem;
+                }
+            }
+
+            if (UnitId != null)
+            {
+                yield return UnitId;
+
+                // Recurse
+                foreach (var anItem in UnitId.Descend())
+                {
+                    yield return anItem;
+                }
+            }
+
+            if (Definition != null)
+            {
+                yield return Definition;
+
+                // Recurse
+                foreach (var anItem in Definition.Descend())
+                {
+                    yield return anItem;
+                }
+            }
+
+            if (ValueList != null)
+            {
+                yield return ValueList;
+
+                // Recurse
+                foreach (var anItem in ValueList.Descend())
+                {
+                    yield return anItem;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Accept the <paramref name="visitor" /> to visit this instance
+        /// for double dispatch.
+        /// </summary>
+        public void Accept(Visitation.IVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+
+        /// <summary>
+        /// Accept the visitor to visit this instance for double dispatch
+        /// with the <paramref name="context" />.
+        /// </summary>
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
+        {
+            visitor.Visit(this, context);
+        }
+
+        /// <summary>
+        /// Accept the <paramref name="transformer" /> to transform this instance
+        /// for double dispatch.
+        /// </summary>
+        public T Transform<T>(Visitation.ITransformer<T> transformer)
+        {
+            return transformer.Transform(this);
+        }
+
+        /// <summary>
+        /// Accept the <paramref name="transformer" /> to visit this instance
+        /// for double dispatch with the <paramref name="context" />.
+        /// </summary>
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
+        {
+            return transformer.Transform(this, context);
+        }
+
+        public DataSpecificationIec61360(
+            LangStringSet preferredName,
+            LangStringSet? shortName = null,
+            string? unit = null,
+            Reference? unitId = null,
+            string? sourceOfDefinition = null,
+            string? symbol = null,
+            DataTypeIec61360? dataType = null,
+            LangStringSet? definition = null,
+            string? valueFormat = null,
+            ValueList? valueList = null,
+            string? value = null,
+            LevelType? levelType = null)
+        {
+            PreferredName = preferredName;
+            ShortName = shortName;
+            Unit = unit;
+            UnitId = unitId;
+            SourceOfDefinition = sourceOfDefinition;
+            Symbol = symbol;
+            DataType = dataType;
+            Definition = definition;
+            ValueFormat = valueFormat;
+            ValueList = valueList;
+            Value = value;
+            LevelType = levelType;
+        }
+    }
+
+    public class DataSpecificationPhysicalUnit : IDataSpecificationContent
+    {
+        /// <summary>
+        /// Name of the physical unit
+        /// </summary>
+        public string UnitName { get; set; }
+
+        /// <summary>
+        /// Symbol for the physical unit
+        /// </summary>
+        public string UnitSymbol { get; set; }
+
+        /// <summary>
+        /// Definition in different languages
+        /// </summary>
+        public LangStringSet Definition { get; set; }
+
+        /// <summary>
+        /// Notation of SI physical unit
+        /// </summary>
+        public string? SiNotation { get; set; }
+
+        /// <summary>
+        /// Name of SI physical unit
+        /// </summary>
+        public string? SiName { get; set; }
+
+        /// <summary>
+        /// Notation of physical unit conformant to DIN
+        /// </summary>
+        public string? DinNotation { get; set; }
+
+        /// <summary>
+        /// Name of physical unit conformant to ECE
+        /// </summary>
+        public string? EceName { get; set; }
+
+        /// <summary>
+        /// Code of physical unit conformant to ECE
+        /// </summary>
+        public string? EceCode { get; set; }
+
+        /// <summary>
+        /// Name of NIST physical unit
+        /// </summary>
+        public string? NistName { get; set; }
+
+        /// <summary>
+        /// Source of definition
+        /// </summary>
+        public string? SourceOfDefinition { get; set; }
+
+        /// <summary>
+        /// Conversion factor
+        /// </summary>
+        public string? ConversionFactor { get; set; }
+
+        /// <summary>
+        /// Registration authority ID
+        /// </summary>
+        public string? RegistrationAuthorityId { get; set; }
+
+        /// <summary>
+        /// Supplier
+        /// </summary>
+        public string? Supplier { get; set; }
+
+        /// <summary>
+        /// Iterate over all the class instances referenced from this instance
+        /// without further recursion.
+        /// </summary>
+        public IEnumerable<IClass> DescendOnce()
+        {
+            yield return Definition;
+        }
+
+        /// <summary>
+        /// Iterate recursively over all the class instances referenced from this instance.
+        /// </summary>
+        public IEnumerable<IClass> Descend()
+        {
+            yield return Definition;
+
+            // Recurse
+            foreach (var anItem in Definition.Descend())
+            {
+                yield return anItem;
+            }
+        }
+
+        /// <summary>
+        /// Accept the <paramref name="visitor" /> to visit this instance
+        /// for double dispatch.
+        /// </summary>
+        public void Accept(Visitation.IVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+
+        /// <summary>
+        /// Accept the visitor to visit this instance for double dispatch
+        /// with the <paramref name="context" />.
+        /// </summary>
+        public void Accept<TContext>(
+            Visitation.IVisitorWithContext<TContext> visitor,
+            TContext context)
+        {
+            visitor.Visit(this, context);
+        }
+
+        /// <summary>
+        /// Accept the <paramref name="transformer" /> to transform this instance
+        /// for double dispatch.
+        /// </summary>
+        public T Transform<T>(Visitation.ITransformer<T> transformer)
+        {
+            return transformer.Transform(this);
+        }
+
+        /// <summary>
+        /// Accept the <paramref name="transformer" /> to visit this instance
+        /// for double dispatch with the <paramref name="context" />.
+        /// </summary>
+        public T Transform<TContext, T>(
+            Visitation.ITransformerWithContext<TContext, T> transformer,
+            TContext context)
+        {
+            return transformer.Transform(this, context);
+        }
+
+        public DataSpecificationPhysicalUnit(
+            string unitName,
+            string unitSymbol,
+            LangStringSet definition,
+            string? siNotation = null,
+            string? siName = null,
+            string? dinNotation = null,
+            string? eceName = null,
+            string? eceCode = null,
+            string? nistName = null,
+            string? sourceOfDefinition = null,
+            string? conversionFactor = null,
+            string? registrationAuthorityId = null,
+            string? supplier = null)
+        {
+            UnitName = unitName;
+            UnitSymbol = unitSymbol;
+            Definition = definition;
+            SiNotation = siNotation;
+            SiName = siName;
+            DinNotation = dinNotation;
+            EceName = eceName;
+            EceCode = eceCode;
+            NistName = nistName;
+            SourceOfDefinition = sourceOfDefinition;
+            ConversionFactor = conversionFactor;
+            RegistrationAuthorityId = registrationAuthorityId;
+            Supplier = supplier;
         }
     }
 

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/verification.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/verification.cs
@@ -2340,6 +2340,57 @@ namespace AasCore.Aas3_0_RC02
                 (int)Aas.DataTypeDefXsd.NonPositiveInteger,
                 (int)Aas.DataTypeDefXsd.NegativeInteger
             };
+
+            internal static readonly HashSet<int> ForDataTypeIec61360 = new HashSet<int>
+            {
+
+                (int)Aas.DataTypeIec61360.Date,
+                (int)Aas.DataTypeIec61360.String,
+                (int)Aas.DataTypeIec61360.StringTranslatable,
+                (int)Aas.DataTypeIec61360.IntegerMeasure,
+                (int)Aas.DataTypeIec61360.IntegerCount,
+                (int)Aas.DataTypeIec61360.IntegerCurrency,
+                (int)Aas.DataTypeIec61360.RealMeasure,
+                (int)Aas.DataTypeIec61360.RealCount,
+                (int)Aas.DataTypeIec61360.RealCurrency,
+                (int)Aas.DataTypeIec61360.Boolean,
+                (int)Aas.DataTypeIec61360.Iri,
+                (int)Aas.DataTypeIec61360.Irdi,
+                (int)Aas.DataTypeIec61360.Rational,
+                (int)Aas.DataTypeIec61360.RationalMeasure,
+                (int)Aas.DataTypeIec61360.Time,
+                (int)Aas.DataTypeIec61360.Timestamp,
+                (int)Aas.DataTypeIec61360.File,
+                (int)Aas.DataTypeIec61360.Html,
+                (int)Aas.DataTypeIec61360.Blob
+            };
+
+            internal static readonly HashSet<int> ForConceptDescriptionsCategories = new HashSet<int>
+            {
+
+                (int)Aas.ConceptDescriptionsCategories.ApplicationClass,
+                (int)Aas.ConceptDescriptionsCategories.Capability,
+                (int)Aas.ConceptDescriptionsCategories.Collections,
+                (int)Aas.ConceptDescriptionsCategories.Documentation,
+                (int)Aas.ConceptDescriptionsCategories.Entity,
+                (int)Aas.ConceptDescriptionsCategories.Event,
+                (int)Aas.ConceptDescriptionsCategories.Function,
+                (int)Aas.ConceptDescriptionsCategories.Property,
+                (int)Aas.ConceptDescriptionsCategories.Value,
+                (int)Aas.ConceptDescriptionsCategories.Range,
+                (int)Aas.ConceptDescriptionsCategories.QualifierType,
+                (int)Aas.ConceptDescriptionsCategories.Referencing,
+                (int)Aas.ConceptDescriptionsCategories.Relationship
+            };
+
+            internal static readonly HashSet<int> ForLevelType = new HashSet<int>
+            {
+
+                (int)Aas.LevelType.Min,
+                (int)Aas.LevelType.Max,
+                (int)Aas.LevelType.Nom,
+                (int)Aas.LevelType.Typ
+            };
         }  // internal static class EnumValueSet
 
         [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
@@ -2455,23 +2506,6 @@ namespace AasCore.Aas3_0_RC02
                 Aas.AdministrativeInformation that)
             {
                 if (!(
-                    !(that.DataSpecifications != null)
-                    || (
-                        that.DataSpecifications.All(
-                            dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)
-                    )))
-                {
-                    yield return new Reporting.Error(
-                        "Invariant violated:\n" +
-                        "References to data specifications are global references.\n" +
-                        "!(that.DataSpecifications != null)\n" +
-                        "|| (\n" +
-                        "    that.DataSpecifications.All(\n" +
-                        "        dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)\n" +
-                        ")");
-                }
-
-                if (!(
                     !(that.Revision != null)
                     || (that.Version != null)))
                 {
@@ -2485,22 +2519,22 @@ namespace AasCore.Aas3_0_RC02
                         "|| (that.Version != null)");
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
+                    int indexEmbeddedDataSpecifications = 0;
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         foreach (var error in Verification.Verify(item))
                         {
                             error.PrependSegment(
                                 new Reporting.IndexSegment(
-                                    indexDataSpecifications));
+                                    indexEmbeddedDataSpecifications));
                             error.PrependSegment(
                                 new Reporting.NameSegment(
-                                    "dataSpecifications"));
+                                    "embeddedDataSpecifications"));
                             yield return error;
                         }
-                        indexDataSpecifications++;
+                        indexEmbeddedDataSpecifications++;
                     }
                 }
 
@@ -2655,23 +2689,6 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 if (!(
-                    !(that.DataSpecifications != null)
-                    || (
-                        that.DataSpecifications.All(
-                            dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)
-                    )))
-                {
-                    yield return new Reporting.Error(
-                        "Invariant violated:\n" +
-                        "References to data specifications are global references.\n" +
-                        "!(that.DataSpecifications != null)\n" +
-                        "|| (\n" +
-                        "    that.DataSpecifications.All(\n" +
-                        "        dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)\n" +
-                        ")");
-                }
-
-                if (!(
                     !(that.DerivedFrom != null)
                     || Verification.IsModelReferenceTo(
                         that.DerivedFrom,
@@ -2794,22 +2811,22 @@ namespace AasCore.Aas3_0_RC02
                     yield return error;
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
+                    int indexEmbeddedDataSpecifications = 0;
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         foreach (var error in Verification.Verify(item))
                         {
                             error.PrependSegment(
                                 new Reporting.IndexSegment(
-                                    indexDataSpecifications));
+                                    indexEmbeddedDataSpecifications));
                             error.PrependSegment(
                                 new Reporting.NameSegment(
-                                    "dataSpecifications"));
+                                    "embeddedDataSpecifications"));
                             yield return error;
                         }
-                        indexDataSpecifications++;
+                        indexEmbeddedDataSpecifications++;
                     }
                 }
 
@@ -3042,23 +3059,6 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 if (!(
-                    !(that.DataSpecifications != null)
-                    || (
-                        that.DataSpecifications.All(
-                            dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)
-                    )))
-                {
-                    yield return new Reporting.Error(
-                        "Invariant violated:\n" +
-                        "References to data specifications are global references.\n" +
-                        "!(that.DataSpecifications != null)\n" +
-                        "|| (\n" +
-                        "    that.DataSpecifications.All(\n" +
-                        "        dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)\n" +
-                        ")");
-                }
-
-                if (!(
                     !(that.SubmodelElements != null)
                     || (
                         that.SubmodelElements.All(
@@ -3269,22 +3269,22 @@ namespace AasCore.Aas3_0_RC02
                     }
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
+                    int indexEmbeddedDataSpecifications = 0;
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         foreach (var error in Verification.Verify(item))
                         {
                             error.PrependSegment(
                                 new Reporting.IndexSegment(
-                                    indexDataSpecifications));
+                                    indexEmbeddedDataSpecifications));
                             error.PrependSegment(
                                 new Reporting.NameSegment(
-                                    "dataSpecifications"));
+                                    "embeddedDataSpecifications"));
                             yield return error;
                         }
-                        indexDataSpecifications++;
+                        indexEmbeddedDataSpecifications++;
                     }
                 }
 
@@ -3346,23 +3346,6 @@ namespace AasCore.Aas3_0_RC02
                         "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
-                }
-
-                if (!(
-                    !(that.DataSpecifications != null)
-                    || (
-                        that.DataSpecifications.All(
-                            dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)
-                    )))
-                {
-                    yield return new Reporting.Error(
-                        "Invariant violated:\n" +
-                        "References to data specifications are global references.\n" +
-                        "!(that.DataSpecifications != null)\n" +
-                        "|| (\n" +
-                        "    that.DataSpecifications.All(\n" +
-                        "        dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)\n" +
-                        ")");
                 }
 
                 if (!(
@@ -3528,22 +3511,22 @@ namespace AasCore.Aas3_0_RC02
                     }
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
+                    int indexEmbeddedDataSpecifications = 0;
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         foreach (var error in Verification.Verify(item))
                         {
                             error.PrependSegment(
                                 new Reporting.IndexSegment(
-                                    indexDataSpecifications));
+                                    indexEmbeddedDataSpecifications));
                             error.PrependSegment(
                                 new Reporting.NameSegment(
-                                    "dataSpecifications"));
+                                    "embeddedDataSpecifications"));
                             yield return error;
                         }
-                        indexDataSpecifications++;
+                        indexEmbeddedDataSpecifications++;
                     }
                 }
 
@@ -3602,23 +3585,6 @@ namespace AasCore.Aas3_0_RC02
                         "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
-                }
-
-                if (!(
-                    !(that.DataSpecifications != null)
-                    || (
-                        that.DataSpecifications.All(
-                            dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)
-                    )))
-                {
-                    yield return new Reporting.Error(
-                        "Invariant violated:\n" +
-                        "References to data specifications are global references.\n" +
-                        "!(that.DataSpecifications != null)\n" +
-                        "|| (\n" +
-                        "    that.DataSpecifications.All(\n" +
-                        "        dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)\n" +
-                        ")");
                 }
 
                 if (!(
@@ -3892,22 +3858,22 @@ namespace AasCore.Aas3_0_RC02
                     }
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
+                    int indexEmbeddedDataSpecifications = 0;
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         foreach (var error in Verification.Verify(item))
                         {
                             error.PrependSegment(
                                 new Reporting.IndexSegment(
-                                    indexDataSpecifications));
+                                    indexEmbeddedDataSpecifications));
                             error.PrependSegment(
                                 new Reporting.NameSegment(
-                                    "dataSpecifications"));
+                                    "embeddedDataSpecifications"));
                             yield return error;
                         }
-                        indexDataSpecifications++;
+                        indexEmbeddedDataSpecifications++;
                     }
                 }
 
@@ -4004,23 +3970,6 @@ namespace AasCore.Aas3_0_RC02
                         "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
-                }
-
-                if (!(
-                    !(that.DataSpecifications != null)
-                    || (
-                        that.DataSpecifications.All(
-                            dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)
-                    )))
-                {
-                    yield return new Reporting.Error(
-                        "Invariant violated:\n" +
-                        "References to data specifications are global references.\n" +
-                        "!(that.DataSpecifications != null)\n" +
-                        "|| (\n" +
-                        "    that.DataSpecifications.All(\n" +
-                        "        dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)\n" +
-                        ")");
                 }
 
                 if (!(
@@ -4213,22 +4162,22 @@ namespace AasCore.Aas3_0_RC02
                     }
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
+                    int indexEmbeddedDataSpecifications = 0;
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         foreach (var error in Verification.Verify(item))
                         {
                             error.PrependSegment(
                                 new Reporting.IndexSegment(
-                                    indexDataSpecifications));
+                                    indexEmbeddedDataSpecifications));
                             error.PrependSegment(
                                 new Reporting.NameSegment(
-                                    "dataSpecifications"));
+                                    "embeddedDataSpecifications"));
                             yield return error;
                         }
-                        indexDataSpecifications++;
+                        indexEmbeddedDataSpecifications++;
                     }
                 }
 
@@ -4290,23 +4239,6 @@ namespace AasCore.Aas3_0_RC02
                         "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
-                }
-
-                if (!(
-                    !(that.DataSpecifications != null)
-                    || (
-                        that.DataSpecifications.All(
-                            dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)
-                    )))
-                {
-                    yield return new Reporting.Error(
-                        "Invariant violated:\n" +
-                        "References to data specifications are global references.\n" +
-                        "!(that.DataSpecifications != null)\n" +
-                        "|| (\n" +
-                        "    that.DataSpecifications.All(\n" +
-                        "        dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)\n" +
-                        ")");
                 }
 
                 if (!(
@@ -4494,22 +4426,22 @@ namespace AasCore.Aas3_0_RC02
                     }
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
+                    int indexEmbeddedDataSpecifications = 0;
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         foreach (var error in Verification.Verify(item))
                         {
                             error.PrependSegment(
                                 new Reporting.IndexSegment(
-                                    indexDataSpecifications));
+                                    indexEmbeddedDataSpecifications));
                             error.PrependSegment(
                                 new Reporting.NameSegment(
-                                    "dataSpecifications"));
+                                    "embeddedDataSpecifications"));
                             yield return error;
                         }
-                        indexDataSpecifications++;
+                        indexEmbeddedDataSpecifications++;
                     }
                 }
 
@@ -4582,23 +4514,6 @@ namespace AasCore.Aas3_0_RC02
                         "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
-                }
-
-                if (!(
-                    !(that.DataSpecifications != null)
-                    || (
-                        that.DataSpecifications.All(
-                            dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)
-                    )))
-                {
-                    yield return new Reporting.Error(
-                        "Invariant violated:\n" +
-                        "References to data specifications are global references.\n" +
-                        "!(that.DataSpecifications != null)\n" +
-                        "|| (\n" +
-                        "    that.DataSpecifications.All(\n" +
-                        "        dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)\n" +
-                        ")");
                 }
 
                 if (!(
@@ -4776,22 +4691,22 @@ namespace AasCore.Aas3_0_RC02
                     }
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
+                    int indexEmbeddedDataSpecifications = 0;
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         foreach (var error in Verification.Verify(item))
                         {
                             error.PrependSegment(
                                 new Reporting.IndexSegment(
-                                    indexDataSpecifications));
+                                    indexEmbeddedDataSpecifications));
                             error.PrependSegment(
                                 new Reporting.NameSegment(
-                                    "dataSpecifications"));
+                                    "embeddedDataSpecifications"));
                             yield return error;
                         }
-                        indexDataSpecifications++;
+                        indexEmbeddedDataSpecifications++;
                     }
                 }
 
@@ -4856,23 +4771,6 @@ namespace AasCore.Aas3_0_RC02
                         "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
-                }
-
-                if (!(
-                    !(that.DataSpecifications != null)
-                    || (
-                        that.DataSpecifications.All(
-                            dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)
-                    )))
-                {
-                    yield return new Reporting.Error(
-                        "Invariant violated:\n" +
-                        "References to data specifications are global references.\n" +
-                        "!(that.DataSpecifications != null)\n" +
-                        "|| (\n" +
-                        "    that.DataSpecifications.All(\n" +
-                        "        dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)\n" +
-                        ")");
                 }
 
                 if (!(
@@ -5070,22 +4968,22 @@ namespace AasCore.Aas3_0_RC02
                     }
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
+                    int indexEmbeddedDataSpecifications = 0;
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         foreach (var error in Verification.Verify(item))
                         {
                             error.PrependSegment(
                                 new Reporting.IndexSegment(
-                                    indexDataSpecifications));
+                                    indexEmbeddedDataSpecifications));
                             error.PrependSegment(
                                 new Reporting.NameSegment(
-                                    "dataSpecifications"));
+                                    "embeddedDataSpecifications"));
                             yield return error;
                         }
-                        indexDataSpecifications++;
+                        indexEmbeddedDataSpecifications++;
                     }
                 }
 
@@ -5161,23 +5059,6 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 if (!(
-                    !(that.DataSpecifications != null)
-                    || (
-                        that.DataSpecifications.All(
-                            dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)
-                    )))
-                {
-                    yield return new Reporting.Error(
-                        "Invariant violated:\n" +
-                        "References to data specifications are global references.\n" +
-                        "!(that.DataSpecifications != null)\n" +
-                        "|| (\n" +
-                        "    that.DataSpecifications.All(\n" +
-                        "        dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)\n" +
-                        ")");
-                }
-
-                if (!(
                     !(that.Qualifiers != null)
                     || (
                         !(
@@ -5352,22 +5233,22 @@ namespace AasCore.Aas3_0_RC02
                     }
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
+                    int indexEmbeddedDataSpecifications = 0;
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         foreach (var error in Verification.Verify(item))
                         {
                             error.PrependSegment(
                                 new Reporting.IndexSegment(
-                                    indexDataSpecifications));
+                                    indexEmbeddedDataSpecifications));
                             error.PrependSegment(
                                 new Reporting.NameSegment(
-                                    "dataSpecifications"));
+                                    "embeddedDataSpecifications"));
                             yield return error;
                         }
-                        indexDataSpecifications++;
+                        indexEmbeddedDataSpecifications++;
                     }
                 }
 
@@ -5424,23 +5305,6 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 if (!(
-                    !(that.DataSpecifications != null)
-                    || (
-                        that.DataSpecifications.All(
-                            dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)
-                    )))
-                {
-                    yield return new Reporting.Error(
-                        "Invariant violated:\n" +
-                        "References to data specifications are global references.\n" +
-                        "!(that.DataSpecifications != null)\n" +
-                        "|| (\n" +
-                        "    that.DataSpecifications.All(\n" +
-                        "        dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)\n" +
-                        ")");
-                }
-
-                if (!(
                     !(that.Qualifiers != null)
                     || (
                         !(
@@ -5615,22 +5479,22 @@ namespace AasCore.Aas3_0_RC02
                     }
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
+                    int indexEmbeddedDataSpecifications = 0;
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         foreach (var error in Verification.Verify(item))
                         {
                             error.PrependSegment(
                                 new Reporting.IndexSegment(
-                                    indexDataSpecifications));
+                                    indexEmbeddedDataSpecifications));
                             error.PrependSegment(
                                 new Reporting.NameSegment(
-                                    "dataSpecifications"));
+                                    "embeddedDataSpecifications"));
                             yield return error;
                         }
-                        indexDataSpecifications++;
+                        indexEmbeddedDataSpecifications++;
                     }
                 }
 
@@ -5695,23 +5559,6 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 if (!(
-                    !(that.DataSpecifications != null)
-                    || (
-                        that.DataSpecifications.All(
-                            dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)
-                    )))
-                {
-                    yield return new Reporting.Error(
-                        "Invariant violated:\n" +
-                        "References to data specifications are global references.\n" +
-                        "!(that.DataSpecifications != null)\n" +
-                        "|| (\n" +
-                        "    that.DataSpecifications.All(\n" +
-                        "        dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)\n" +
-                        ")");
-                }
-
-                if (!(
                     !(that.Qualifiers != null)
                     || (
                         !(
@@ -5886,22 +5733,22 @@ namespace AasCore.Aas3_0_RC02
                     }
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
+                    int indexEmbeddedDataSpecifications = 0;
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         foreach (var error in Verification.Verify(item))
                         {
                             error.PrependSegment(
                                 new Reporting.IndexSegment(
-                                    indexDataSpecifications));
+                                    indexEmbeddedDataSpecifications));
                             error.PrependSegment(
                                 new Reporting.NameSegment(
-                                    "dataSpecifications"));
+                                    "embeddedDataSpecifications"));
                             yield return error;
                         }
-                        indexDataSpecifications++;
+                        indexEmbeddedDataSpecifications++;
                     }
                 }
 
@@ -5963,23 +5810,6 @@ namespace AasCore.Aas3_0_RC02
                         "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
-                }
-
-                if (!(
-                    !(that.DataSpecifications != null)
-                    || (
-                        that.DataSpecifications.All(
-                            dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)
-                    )))
-                {
-                    yield return new Reporting.Error(
-                        "Invariant violated:\n" +
-                        "References to data specifications are global references.\n" +
-                        "!(that.DataSpecifications != null)\n" +
-                        "|| (\n" +
-                        "    that.DataSpecifications.All(\n" +
-                        "        dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)\n" +
-                        ")");
                 }
 
                 if (!(
@@ -6145,22 +5975,22 @@ namespace AasCore.Aas3_0_RC02
                     }
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
+                    int indexEmbeddedDataSpecifications = 0;
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         foreach (var error in Verification.Verify(item))
                         {
                             error.PrependSegment(
                                 new Reporting.IndexSegment(
-                                    indexDataSpecifications));
+                                    indexEmbeddedDataSpecifications));
                             error.PrependSegment(
                                 new Reporting.NameSegment(
-                                    "dataSpecifications"));
+                                    "embeddedDataSpecifications"));
                             yield return error;
                         }
-                        indexDataSpecifications++;
+                        indexEmbeddedDataSpecifications++;
                     }
                 }
 
@@ -6238,23 +6068,6 @@ namespace AasCore.Aas3_0_RC02
                         "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
-                }
-
-                if (!(
-                    !(that.DataSpecifications != null)
-                    || (
-                        that.DataSpecifications.All(
-                            dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)
-                    )))
-                {
-                    yield return new Reporting.Error(
-                        "Invariant violated:\n" +
-                        "References to data specifications are global references.\n" +
-                        "!(that.DataSpecifications != null)\n" +
-                        "|| (\n" +
-                        "    that.DataSpecifications.All(\n" +
-                        "        dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)\n" +
-                        ")");
                 }
 
                 if (!(
@@ -6463,22 +6276,22 @@ namespace AasCore.Aas3_0_RC02
                     }
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
+                    int indexEmbeddedDataSpecifications = 0;
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         foreach (var error in Verification.Verify(item))
                         {
                             error.PrependSegment(
                                 new Reporting.IndexSegment(
-                                    indexDataSpecifications));
+                                    indexEmbeddedDataSpecifications));
                             error.PrependSegment(
                                 new Reporting.NameSegment(
-                                    "dataSpecifications"));
+                                    "embeddedDataSpecifications"));
                             yield return error;
                         }
-                        indexDataSpecifications++;
+                        indexEmbeddedDataSpecifications++;
                     }
                 }
 
@@ -6673,23 +6486,6 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 if (!(
-                    !(that.DataSpecifications != null)
-                    || (
-                        that.DataSpecifications.All(
-                            dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)
-                    )))
-                {
-                    yield return new Reporting.Error(
-                        "Invariant violated:\n" +
-                        "References to data specifications are global references.\n" +
-                        "!(that.DataSpecifications != null)\n" +
-                        "|| (\n" +
-                        "    that.DataSpecifications.All(\n" +
-                        "        dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)\n" +
-                        ")");
-                }
-
-                if (!(
                     !(that.Qualifiers != null)
                     || (
                         !(
@@ -6881,22 +6677,22 @@ namespace AasCore.Aas3_0_RC02
                     }
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
+                    int indexEmbeddedDataSpecifications = 0;
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         foreach (var error in Verification.Verify(item))
                         {
                             error.PrependSegment(
                                 new Reporting.IndexSegment(
-                                    indexDataSpecifications));
+                                    indexEmbeddedDataSpecifications));
                             error.PrependSegment(
                                 new Reporting.NameSegment(
-                                    "dataSpecifications"));
+                                    "embeddedDataSpecifications"));
                             yield return error;
                         }
-                        indexDataSpecifications++;
+                        indexEmbeddedDataSpecifications++;
                     }
                 }
 
@@ -7021,23 +6817,6 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 if (!(
-                    !(that.DataSpecifications != null)
-                    || (
-                        that.DataSpecifications.All(
-                            dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)
-                    )))
-                {
-                    yield return new Reporting.Error(
-                        "Invariant violated:\n" +
-                        "References to data specifications are global references.\n" +
-                        "!(that.DataSpecifications != null)\n" +
-                        "|| (\n" +
-                        "    that.DataSpecifications.All(\n" +
-                        "        dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)\n" +
-                        ")");
-                }
-
-                if (!(
                     !(that.Qualifiers != null)
                     || (
                         !(
@@ -7200,22 +6979,22 @@ namespace AasCore.Aas3_0_RC02
                     }
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
+                    int indexEmbeddedDataSpecifications = 0;
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         foreach (var error in Verification.Verify(item))
                         {
                             error.PrependSegment(
                                 new Reporting.IndexSegment(
-                                    indexDataSpecifications));
+                                    indexEmbeddedDataSpecifications));
                             error.PrependSegment(
                                 new Reporting.NameSegment(
-                                    "dataSpecifications"));
+                                    "embeddedDataSpecifications"));
                             yield return error;
                         }
-                        indexDataSpecifications++;
+                        indexEmbeddedDataSpecifications++;
                     }
                 }
 
@@ -7331,23 +7110,6 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 if (!(
-                    !(that.DataSpecifications != null)
-                    || (
-                        that.DataSpecifications.All(
-                            dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)
-                    )))
-                {
-                    yield return new Reporting.Error(
-                        "Invariant violated:\n" +
-                        "References to data specifications are global references.\n" +
-                        "!(that.DataSpecifications != null)\n" +
-                        "|| (\n" +
-                        "    that.DataSpecifications.All(\n" +
-                        "        dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)\n" +
-                        ")");
-                }
-
-                if (!(
                     !(that.Qualifiers != null)
                     || (
                         !(
@@ -7510,22 +7272,22 @@ namespace AasCore.Aas3_0_RC02
                     }
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
+                    int indexEmbeddedDataSpecifications = 0;
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         foreach (var error in Verification.Verify(item))
                         {
                             error.PrependSegment(
                                 new Reporting.IndexSegment(
-                                    indexDataSpecifications));
+                                    indexEmbeddedDataSpecifications));
                             error.PrependSegment(
                                 new Reporting.NameSegment(
-                                    "dataSpecifications"));
+                                    "embeddedDataSpecifications"));
                             yield return error;
                         }
-                        indexDataSpecifications++;
+                        indexEmbeddedDataSpecifications++;
                     }
                 }
             }
@@ -7544,23 +7306,6 @@ namespace AasCore.Aas3_0_RC02
                         "Has-Extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
-                }
-
-                if (!(
-                    !(that.DataSpecifications != null)
-                    || (
-                        that.DataSpecifications.All(
-                            dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)
-                    )))
-                {
-                    yield return new Reporting.Error(
-                        "Invariant violated:\n" +
-                        "References to data specifications are global references.\n" +
-                        "!(that.DataSpecifications != null)\n" +
-                        "|| (\n" +
-                        "    that.DataSpecifications.All(\n" +
-                        "        dataSpecification => dataSpecification.Type == ReferenceTypes.GlobalReference)\n" +
-                        ")");
                 }
 
                 if (!(
@@ -7671,22 +7416,22 @@ namespace AasCore.Aas3_0_RC02
                     yield return error;
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
-                    int indexDataSpecifications = 0;
-                    foreach (var item in that.DataSpecifications)
+                    int indexEmbeddedDataSpecifications = 0;
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         foreach (var error in Verification.Verify(item))
                         {
                             error.PrependSegment(
                                 new Reporting.IndexSegment(
-                                    indexDataSpecifications));
+                                    indexEmbeddedDataSpecifications));
                             error.PrependSegment(
                                 new Reporting.NameSegment(
-                                    "dataSpecifications"));
+                                    "embeddedDataSpecifications"));
                             yield return error;
                         }
-                        indexDataSpecifications++;
+                        indexEmbeddedDataSpecifications++;
                     }
                 }
 
@@ -8027,57 +7772,6 @@ namespace AasCore.Aas3_0_RC02
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
             public override IEnumerable<Reporting.Error> Transform(
-                Aas.DataSpecificationContent that)
-            {
-                // No verification has been defined for DataSpecificationContent.
-                yield break;
-            }
-
-            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.DataSpecification that)
-            {
-                foreach (var error in Verification.VerifyIdentifier(that.Id))
-                {
-                    error.PrependSegment(
-                        new Reporting.NameSegment(
-                            "id"));
-                    yield return error;
-                }
-
-                foreach (var error in Verification.Verify(that.DataSpecificationContent))
-                {
-                    error.PrependSegment(
-                        new Reporting.NameSegment(
-                            "dataSpecificationContent"));
-                    yield return error;
-                }
-
-                if (that.Administration != null)
-                {
-                    foreach (var error in Verification.Verify(that.Administration))
-                    {
-                        error.PrependSegment(
-                            new Reporting.NameSegment(
-                                "administration"));
-                        yield return error;
-                    }
-                }
-
-                if (that.Description != null)
-                {
-                    foreach (var error in Verification.Verify(that.Description))
-                    {
-                        error.PrependSegment(
-                            new Reporting.NameSegment(
-                                "description"));
-                        yield return error;
-                    }
-                }
-            }
-
-            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
                 Aas.Environment that)
             {
                 if (that.AssetAdministrationShells != null)
@@ -8134,6 +7828,342 @@ namespace AasCore.Aas3_0_RC02
                             yield return error;
                         }
                         indexConceptDescriptions++;
+                    }
+                }
+            }
+
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
+            public override IEnumerable<Reporting.Error> Transform(
+                Aas.EmbeddedDataSpecification that)
+            {
+                foreach (var error in Verification.Verify(that.DataSpecification))
+                {
+                    error.PrependSegment(
+                        new Reporting.NameSegment(
+                            "dataSpecification"));
+                    yield return error;
+                }
+
+                foreach (var error in Verification.Verify(that.DataSpecificationContent))
+                {
+                    error.PrependSegment(
+                        new Reporting.NameSegment(
+                            "dataSpecificationContent"));
+                    yield return error;
+                }
+            }
+
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
+            public override IEnumerable<Reporting.Error> Transform(
+                Aas.ValueReferencePair that)
+            {
+                foreach (var error in Verification.Verify(that.ValueId))
+                {
+                    error.PrependSegment(
+                        new Reporting.NameSegment(
+                            "valueId"));
+                    yield return error;
+                }
+            }
+
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
+            public override IEnumerable<Reporting.Error> Transform(
+                Aas.ValueList that)
+            {
+                if (!(that.ValueReferencePairTypes.Count >= 1))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "that.ValueReferencePairTypes.Count >= 1");
+                }
+
+                int indexValueReferencePairTypes = 0;
+                foreach (var item in that.ValueReferencePairTypes)
+                {
+                    foreach (var error in Verification.Verify(item))
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                indexValueReferencePairTypes));
+                        error.PrependSegment(
+                            new Reporting.NameSegment(
+                                "valueReferencePairTypes"));
+                        yield return error;
+                    }
+                    indexValueReferencePairTypes++;
+                }
+            }
+
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
+            public override IEnumerable<Reporting.Error> Transform(
+                Aas.DataSpecificationIec61360 that)
+            {
+                foreach (var error in Verification.Verify(that.PreferredName))
+                {
+                    error.PrependSegment(
+                        new Reporting.NameSegment(
+                            "preferredName"));
+                    yield return error;
+                }
+
+                if (that.ShortName != null)
+                {
+                    foreach (var error in Verification.Verify(that.ShortName))
+                    {
+                        error.PrependSegment(
+                            new Reporting.NameSegment(
+                                "shortName"));
+                        yield return error;
+                    }
+                }
+
+                if (that.Unit != null)
+                {
+                    foreach (var error in Verification.VerifyNonEmptyString(that.Unit))
+                    {
+                        error.PrependSegment(
+                            new Reporting.NameSegment(
+                                "unit"));
+                        yield return error;
+                    }
+                }
+
+                if (that.UnitId != null)
+                {
+                    foreach (var error in Verification.Verify(that.UnitId))
+                    {
+                        error.PrependSegment(
+                            new Reporting.NameSegment(
+                                "unitId"));
+                        yield return error;
+                    }
+                }
+
+                if (that.SourceOfDefinition != null)
+                {
+                    foreach (
+                            var error in Verification.VerifyNonEmptyString(
+                                that.SourceOfDefinition))
+                    {
+                        error.PrependSegment(
+                            new Reporting.NameSegment(
+                                "sourceOfDefinition"));
+                        yield return error;
+                    }
+                }
+
+                if (that.Symbol != null)
+                {
+                    foreach (var error in Verification.VerifyNonEmptyString(that.Symbol))
+                    {
+                        error.PrependSegment(
+                            new Reporting.NameSegment(
+                                "symbol"));
+                        yield return error;
+                    }
+                }
+
+                if (that.DataType != null)
+                {
+                    // We need to help the static analyzer with a null coalescing.
+                    Aas.DataTypeIec61360 value = that.DataType
+                        ?? throw new System.InvalidOperationException();
+                    foreach (var error in Verification.VerifyDataTypeIec61360(value))
+                    {
+                        error.PrependSegment(
+                            new Reporting.NameSegment(
+                                "dataType"));
+                        yield return error;
+                    }
+                }
+
+                if (that.Definition != null)
+                {
+                    foreach (var error in Verification.Verify(that.Definition))
+                    {
+                        error.PrependSegment(
+                            new Reporting.NameSegment(
+                                "definition"));
+                        yield return error;
+                    }
+                }
+
+                if (that.ValueFormat != null)
+                {
+                    foreach (var error in Verification.VerifyNonEmptyString(that.ValueFormat))
+                    {
+                        error.PrependSegment(
+                            new Reporting.NameSegment(
+                                "valueFormat"));
+                        yield return error;
+                    }
+                }
+
+                if (that.ValueList != null)
+                {
+                    foreach (var error in Verification.Verify(that.ValueList))
+                    {
+                        error.PrependSegment(
+                            new Reporting.NameSegment(
+                                "valueList"));
+                        yield return error;
+                    }
+                }
+
+                if (that.LevelType != null)
+                {
+                    // We need to help the static analyzer with a null coalescing.
+                    Aas.LevelType value = that.LevelType
+                        ?? throw new System.InvalidOperationException();
+                    foreach (var error in Verification.VerifyLevelType(value))
+                    {
+                        error.PrependSegment(
+                            new Reporting.NameSegment(
+                                "levelType"));
+                        yield return error;
+                    }
+                }
+            }
+
+            [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
+            public override IEnumerable<Reporting.Error> Transform(
+                Aas.DataSpecificationPhysicalUnit that)
+            {
+                foreach (var error in Verification.VerifyNonEmptyString(that.UnitName))
+                {
+                    error.PrependSegment(
+                        new Reporting.NameSegment(
+                            "unitName"));
+                    yield return error;
+                }
+
+                foreach (var error in Verification.VerifyNonEmptyString(that.UnitSymbol))
+                {
+                    error.PrependSegment(
+                        new Reporting.NameSegment(
+                            "unitSymbol"));
+                    yield return error;
+                }
+
+                foreach (var error in Verification.Verify(that.Definition))
+                {
+                    error.PrependSegment(
+                        new Reporting.NameSegment(
+                            "definition"));
+                    yield return error;
+                }
+
+                if (that.SiNotation != null)
+                {
+                    foreach (var error in Verification.VerifyNonEmptyString(that.SiNotation))
+                    {
+                        error.PrependSegment(
+                            new Reporting.NameSegment(
+                                "siNotation"));
+                        yield return error;
+                    }
+                }
+
+                if (that.SiName != null)
+                {
+                    foreach (var error in Verification.VerifyNonEmptyString(that.SiName))
+                    {
+                        error.PrependSegment(
+                            new Reporting.NameSegment(
+                                "siName"));
+                        yield return error;
+                    }
+                }
+
+                if (that.DinNotation != null)
+                {
+                    foreach (var error in Verification.VerifyNonEmptyString(that.DinNotation))
+                    {
+                        error.PrependSegment(
+                            new Reporting.NameSegment(
+                                "dinNotation"));
+                        yield return error;
+                    }
+                }
+
+                if (that.EceName != null)
+                {
+                    foreach (var error in Verification.VerifyNonEmptyString(that.EceName))
+                    {
+                        error.PrependSegment(
+                            new Reporting.NameSegment(
+                                "eceName"));
+                        yield return error;
+                    }
+                }
+
+                if (that.EceCode != null)
+                {
+                    foreach (var error in Verification.VerifyNonEmptyString(that.EceCode))
+                    {
+                        error.PrependSegment(
+                            new Reporting.NameSegment(
+                                "eceCode"));
+                        yield return error;
+                    }
+                }
+
+                if (that.NistName != null)
+                {
+                    foreach (var error in Verification.VerifyNonEmptyString(that.NistName))
+                    {
+                        error.PrependSegment(
+                            new Reporting.NameSegment(
+                                "nistName"));
+                        yield return error;
+                    }
+                }
+
+                if (that.SourceOfDefinition != null)
+                {
+                    foreach (
+                            var error in Verification.VerifyNonEmptyString(
+                                that.SourceOfDefinition))
+                    {
+                        error.PrependSegment(
+                            new Reporting.NameSegment(
+                                "sourceOfDefinition"));
+                        yield return error;
+                    }
+                }
+
+                if (that.ConversionFactor != null)
+                {
+                    foreach (var error in Verification.VerifyNonEmptyString(that.ConversionFactor))
+                    {
+                        error.PrependSegment(
+                            new Reporting.NameSegment(
+                                "conversionFactor"));
+                        yield return error;
+                    }
+                }
+
+                if (that.RegistrationAuthorityId != null)
+                {
+                    foreach (
+                            var error in Verification.VerifyNonEmptyString(
+                                that.RegistrationAuthorityId))
+                    {
+                        error.PrependSegment(
+                            new Reporting.NameSegment(
+                                "registrationAuthorityId"));
+                        yield return error;
+                    }
+                }
+
+                if (that.Supplier != null)
+                {
+                    foreach (var error in Verification.VerifyNonEmptyString(that.Supplier))
+                    {
+                        error.PrependSegment(
+                            new Reporting.NameSegment(
+                                "supplier"));
+                        yield return error;
                     }
                 }
             }
@@ -8455,6 +8485,48 @@ namespace AasCore.Aas3_0_RC02
             {
                 yield return new Reporting.Error(
                     $"Invalid DataTypeDefXsd: {that}");
+            }
+        }
+
+        /// <summary>
+        /// Verify that <paramref name="that" /> is a valid enumeration value.
+        /// </summary>
+        public static IEnumerable<Reporting.Error> VerifyDataTypeIec61360(
+            Aas.DataTypeIec61360 that)
+        {
+            if (!EnumValueSet.ForDataTypeIec61360.Contains(
+                (int)that))
+            {
+                yield return new Reporting.Error(
+                    $"Invalid DataTypeIec61360: {that}");
+            }
+        }
+
+        /// <summary>
+        /// Verify that <paramref name="that" /> is a valid enumeration value.
+        /// </summary>
+        public static IEnumerable<Reporting.Error> VerifyConceptDescriptionsCategories(
+            Aas.ConceptDescriptionsCategories that)
+        {
+            if (!EnumValueSet.ForConceptDescriptionsCategories.Contains(
+                (int)that))
+            {
+                yield return new Reporting.Error(
+                    $"Invalid ConceptDescriptionsCategories: {that}");
+            }
+        }
+
+        /// <summary>
+        /// Verify that <paramref name="that" /> is a valid enumeration value.
+        /// </summary>
+        public static IEnumerable<Reporting.Error> VerifyLevelType(
+            Aas.LevelType that)
+        {
+            if (!EnumValueSet.ForLevelType.Contains(
+                (int)that))
+            {
+                yield return new Reporting.Error(
+                    $"Invalid LevelType: {that}");
             }
         }
     }  // public static class Verification

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/visitation.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/visitation.cs
@@ -42,9 +42,12 @@ namespace AasCore.Aas3_0_RC02
             public void Visit(Key that);
             public void Visit(LangString that);
             public void Visit(LangStringSet that);
-            public void Visit(DataSpecificationContent that);
-            public void Visit(DataSpecification that);
             public void Visit(Environment that);
+            public void Visit(EmbeddedDataSpecification that);
+            public void Visit(ValueReferencePair that);
+            public void Visit(ValueList that);
+            public void Visit(DataSpecificationIec61360 that);
+            public void Visit(DataSpecificationPhysicalUnit that);
         }  // public interface IVisitor
 
         /// <summary>
@@ -323,25 +326,52 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(DataSpecificationContent that)
-            {
-                // Just descend through, do nothing with <c>that</c>
-                foreach (var something in that.DescendOnce())
-                {
-                    Visit(something);
-                }
-            }
-
-            public virtual void Visit(DataSpecification that)
-            {
-                // Just descend through, do nothing with <c>that</c>
-                foreach (var something in that.DescendOnce())
-                {
-                    Visit(something);
-                }
-            }
-
             public virtual void Visit(Environment that)
+            {
+                // Just descend through, do nothing with <c>that</c>
+                foreach (var something in that.DescendOnce())
+                {
+                    Visit(something);
+                }
+            }
+
+            public virtual void Visit(EmbeddedDataSpecification that)
+            {
+                // Just descend through, do nothing with <c>that</c>
+                foreach (var something in that.DescendOnce())
+                {
+                    Visit(something);
+                }
+            }
+
+            public virtual void Visit(ValueReferencePair that)
+            {
+                // Just descend through, do nothing with <c>that</c>
+                foreach (var something in that.DescendOnce())
+                {
+                    Visit(something);
+                }
+            }
+
+            public virtual void Visit(ValueList that)
+            {
+                // Just descend through, do nothing with <c>that</c>
+                foreach (var something in that.DescendOnce())
+                {
+                    Visit(something);
+                }
+            }
+
+            public virtual void Visit(DataSpecificationIec61360 that)
+            {
+                // Just descend through, do nothing with <c>that</c>
+                foreach (var something in that.DescendOnce())
+                {
+                    Visit(something);
+                }
+            }
+
+            public virtual void Visit(DataSpecificationPhysicalUnit that)
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -389,9 +419,12 @@ namespace AasCore.Aas3_0_RC02
             public abstract void Visit(Key that);
             public abstract void Visit(LangString that);
             public abstract void Visit(LangStringSet that);
-            public abstract void Visit(DataSpecificationContent that);
-            public abstract void Visit(DataSpecification that);
             public abstract void Visit(Environment that);
+            public abstract void Visit(EmbeddedDataSpecification that);
+            public abstract void Visit(ValueReferencePair that);
+            public abstract void Visit(ValueList that);
+            public abstract void Visit(DataSpecificationIec61360 that);
+            public abstract void Visit(DataSpecificationPhysicalUnit that);
         }  // public abstract class AbstractVisitor
 
         /// <summary>
@@ -430,9 +463,12 @@ namespace AasCore.Aas3_0_RC02
             public void Visit(Key that, TContext context);
             public void Visit(LangString that, TContext context);
             public void Visit(LangStringSet that, TContext context);
-            public void Visit(DataSpecificationContent that, TContext context);
-            public void Visit(DataSpecification that, TContext context);
             public void Visit(Environment that, TContext context);
+            public void Visit(EmbeddedDataSpecification that, TContext context);
+            public void Visit(ValueReferencePair that, TContext context);
+            public void Visit(ValueList that, TContext context);
+            public void Visit(DataSpecificationIec61360 that, TContext context);
+            public void Visit(DataSpecificationPhysicalUnit that, TContext context);
         }  // public interface IVisitorWithContext
 
         /// <summary>
@@ -476,9 +512,12 @@ namespace AasCore.Aas3_0_RC02
             public abstract void Visit(Key that, TContext context);
             public abstract void Visit(LangString that, TContext context);
             public abstract void Visit(LangStringSet that, TContext context);
-            public abstract void Visit(DataSpecificationContent that, TContext context);
-            public abstract void Visit(DataSpecification that, TContext context);
             public abstract void Visit(Environment that, TContext context);
+            public abstract void Visit(EmbeddedDataSpecification that, TContext context);
+            public abstract void Visit(ValueReferencePair that, TContext context);
+            public abstract void Visit(ValueList that, TContext context);
+            public abstract void Visit(DataSpecificationIec61360 that, TContext context);
+            public abstract void Visit(DataSpecificationPhysicalUnit that, TContext context);
         }  // public abstract class AbstractVisitorWithContext
 
         /// <summary>
@@ -518,9 +557,12 @@ namespace AasCore.Aas3_0_RC02
             public T Transform(Key that);
             public T Transform(LangString that);
             public T Transform(LangStringSet that);
-            public T Transform(DataSpecificationContent that);
-            public T Transform(DataSpecification that);
             public T Transform(Environment that);
+            public T Transform(EmbeddedDataSpecification that);
+            public T Transform(ValueReferencePair that);
+            public T Transform(ValueList that);
+            public T Transform(DataSpecificationIec61360 that);
+            public T Transform(DataSpecificationPhysicalUnit that);
         }  // public interface ITransformer
 
         /// <summary>
@@ -593,11 +635,17 @@ namespace AasCore.Aas3_0_RC02
 
             public abstract T Transform(LangStringSet that);
 
-            public abstract T Transform(DataSpecificationContent that);
-
-            public abstract T Transform(DataSpecification that);
-
             public abstract T Transform(Environment that);
+
+            public abstract T Transform(EmbeddedDataSpecification that);
+
+            public abstract T Transform(ValueReferencePair that);
+
+            public abstract T Transform(ValueList that);
+
+            public abstract T Transform(DataSpecificationIec61360 that);
+
+            public abstract T Transform(DataSpecificationPhysicalUnit that);
         }  // public abstract class AbstractTransformer
 
         /// <summary>
@@ -638,9 +686,12 @@ namespace AasCore.Aas3_0_RC02
             public T Transform(Key that, TContext context);
             public T Transform(LangString that, TContext context);
             public T Transform(LangStringSet that, TContext context);
-            public T Transform(DataSpecificationContent that, TContext context);
-            public T Transform(DataSpecification that, TContext context);
             public T Transform(Environment that, TContext context);
+            public T Transform(EmbeddedDataSpecification that, TContext context);
+            public T Transform(ValueReferencePair that, TContext context);
+            public T Transform(ValueList that, TContext context);
+            public T Transform(DataSpecificationIec61360 that, TContext context);
+            public T Transform(DataSpecificationPhysicalUnit that, TContext context);
         }  // public interface ITransformerWithContext
 
         /// <summary>
@@ -715,11 +766,17 @@ namespace AasCore.Aas3_0_RC02
 
             public abstract T Transform(LangStringSet that, TContext context);
 
-            public abstract T Transform(DataSpecificationContent that, TContext context);
-
-            public abstract T Transform(DataSpecification that, TContext context);
-
             public abstract T Transform(Environment that, TContext context);
+
+            public abstract T Transform(EmbeddedDataSpecification that, TContext context);
+
+            public abstract T Transform(ValueReferencePair that, TContext context);
+
+            public abstract T Transform(ValueList that, TContext context);
+
+            public abstract T Transform(DataSpecificationIec61360 that, TContext context);
+
+            public abstract T Transform(DataSpecificationPhysicalUnit that, TContext context);
         }  // public abstract class AbstractTransformerWithContext
     }  // public static class Visitation
 }  // namespace AasCore.Aas3_0_RC02

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/xmlization.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/xmlization.cs
@@ -16,6 +16,11 @@ namespace AasCore.Aas3_0_RC02
     /// </summary>
     public static class Xmlization
     {
+        /// The XML namespace of the meta-model
+        [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+        public static readonly string NS = (
+            "http://www.admin-shell.io/aas/3/0/RC02");
+
         /// <summary>
         /// Implement the deserialization of meta-model classes from XML.
         /// </summary>
@@ -69,14 +74,8 @@ namespace AasCore.Aas3_0_RC02
             /// <summary>
             /// Check the namespace and extract the element's name.
             /// </summary>
-            /// <remarks>
-            /// If the namespace has been specified, the prefix is automatically
-            /// taken care of by <see cref="Xml.XmlReader" />, and we return the local
-            /// name stripped of the prefix. Otherwise, we return the element's name as-is.
-            /// </remarks>
             private static string TryElementName(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error
                 )
             {
@@ -91,21 +90,15 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 error = null;
-                if (ns == null)
+                if (reader.NamespaceURI != NS)
                 {
-                    return reader.Name;
+                    error = new Reporting.Error(
+                        $"Expected an element within a namespace {NS}, " +
+                        $"but got: {reader.NamespaceURI}");
+                        return "";
                 }
-                else
-                {
-                    if (ns != reader.NamespaceURI)
-                    {
-                        error = new Reporting.Error(
-                            $"Expected an element within a namespace {ns}, " +
-                            $"but got: {reader.NamespaceURI}");
-                            return "";
-                    }
-                    return reader.LocalName;
-                }
+
+                return reader.LocalName;
             }
 
             /// <summary>
@@ -114,7 +107,6 @@ namespace AasCore.Aas3_0_RC02
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             internal static Aas.IHasSemantics? IHasSemanticsFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -138,7 +130,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -148,58 +140,58 @@ namespace AasCore.Aas3_0_RC02
                 {
                     case "relationshipElement":
                         return RelationshipElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "annotatedRelationshipElement":
                         return AnnotatedRelationshipElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "basicEventElement":
                         return BasicEventElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "blob":
                         return BlobFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "capability":
                         return CapabilityFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "entity":
                         return EntityFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "extension":
                         return ExtensionFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "file":
                         return FileFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "multiLanguageProperty":
                         return MultiLanguagePropertyFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "operation":
                         return OperationFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "property":
                         return PropertyFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "qualifier":
                         return QualifierFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "range":
                         return RangeFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "referenceElement":
                         return ReferenceElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "specificAssetId":
                         return SpecificAssetIdFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "submodel":
                         return SubmodelFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "submodelElementCollection":
                         return SubmodelElementCollectionFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "submodelElementList":
                         return SubmodelElementListFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
@@ -218,7 +210,6 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.Extension? ExtensionFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -244,7 +235,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -260,7 +251,7 @@ namespace AasCore.Aas3_0_RC02
                             case "semanticId":
                             {
                                 theSemanticId = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -283,7 +274,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -442,7 +433,7 @@ namespace AasCore.Aas3_0_RC02
                             case "refersTo":
                             {
                                 theRefersTo = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -486,7 +477,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -537,7 +528,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.Extension? ExtensionFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -562,7 +552,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -583,7 +573,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.Extension? result = (
                     ExtensionFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -611,7 +601,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -638,7 +628,6 @@ namespace AasCore.Aas3_0_RC02
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             internal static Aas.IHasExtensions? IHasExtensionsFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -662,7 +651,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -672,55 +661,55 @@ namespace AasCore.Aas3_0_RC02
                 {
                     case "relationshipElement":
                         return RelationshipElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "annotatedRelationshipElement":
                         return AnnotatedRelationshipElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "assetAdministrationShell":
                         return AssetAdministrationShellFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "basicEventElement":
                         return BasicEventElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "blob":
                         return BlobFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "capability":
                         return CapabilityFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "conceptDescription":
                         return ConceptDescriptionFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "entity":
                         return EntityFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "file":
                         return FileFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "multiLanguageProperty":
                         return MultiLanguagePropertyFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "operation":
                         return OperationFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "property":
                         return PropertyFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "range":
                         return RangeFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "referenceElement":
                         return ReferenceElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "submodel":
                         return SubmodelFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "submodelElementCollection":
                         return SubmodelElementCollectionFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "submodelElementList":
                         return SubmodelElementListFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
@@ -734,7 +723,6 @@ namespace AasCore.Aas3_0_RC02
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             internal static Aas.IReferable? IReferableFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -758,7 +746,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -768,55 +756,55 @@ namespace AasCore.Aas3_0_RC02
                 {
                     case "relationshipElement":
                         return RelationshipElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "annotatedRelationshipElement":
                         return AnnotatedRelationshipElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "assetAdministrationShell":
                         return AssetAdministrationShellFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "basicEventElement":
                         return BasicEventElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "blob":
                         return BlobFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "capability":
                         return CapabilityFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "conceptDescription":
                         return ConceptDescriptionFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "entity":
                         return EntityFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "file":
                         return FileFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "multiLanguageProperty":
                         return MultiLanguagePropertyFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "operation":
                         return OperationFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "property":
                         return PropertyFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "range":
                         return RangeFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "referenceElement":
                         return ReferenceElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "submodel":
                         return SubmodelFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "submodelElementCollection":
                         return SubmodelElementCollectionFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "submodelElementList":
                         return SubmodelElementListFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
@@ -830,7 +818,6 @@ namespace AasCore.Aas3_0_RC02
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             internal static Aas.IIdentifiable? IIdentifiableFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -854,7 +841,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -864,13 +851,13 @@ namespace AasCore.Aas3_0_RC02
                 {
                     case "assetAdministrationShell":
                         return AssetAdministrationShellFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "conceptDescription":
                         return ConceptDescriptionFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "submodel":
                         return SubmodelFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
@@ -884,7 +871,6 @@ namespace AasCore.Aas3_0_RC02
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             internal static Aas.IHasKind? IHasKindFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -908,7 +894,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -918,49 +904,49 @@ namespace AasCore.Aas3_0_RC02
                 {
                     case "relationshipElement":
                         return RelationshipElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "annotatedRelationshipElement":
                         return AnnotatedRelationshipElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "basicEventElement":
                         return BasicEventElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "blob":
                         return BlobFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "capability":
                         return CapabilityFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "entity":
                         return EntityFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "file":
                         return FileFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "multiLanguageProperty":
                         return MultiLanguagePropertyFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "operation":
                         return OperationFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "property":
                         return PropertyFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "range":
                         return RangeFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "referenceElement":
                         return ReferenceElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "submodel":
                         return SubmodelFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "submodelElementCollection":
                         return SubmodelElementCollectionFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "submodelElementList":
                         return SubmodelElementListFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
@@ -974,7 +960,6 @@ namespace AasCore.Aas3_0_RC02
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             internal static Aas.IHasDataSpecification? IHasDataSpecificationFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -998,7 +983,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -1008,58 +993,58 @@ namespace AasCore.Aas3_0_RC02
                 {
                     case "administrativeInformation":
                         return AdministrativeInformationFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "relationshipElement":
                         return RelationshipElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "annotatedRelationshipElement":
                         return AnnotatedRelationshipElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "assetAdministrationShell":
                         return AssetAdministrationShellFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "basicEventElement":
                         return BasicEventElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "blob":
                         return BlobFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "capability":
                         return CapabilityFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "conceptDescription":
                         return ConceptDescriptionFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "entity":
                         return EntityFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "file":
                         return FileFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "multiLanguageProperty":
                         return MultiLanguagePropertyFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "operation":
                         return OperationFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "property":
                         return PropertyFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "range":
                         return RangeFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "referenceElement":
                         return ReferenceElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "submodel":
                         return SubmodelFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "submodelElementCollection":
                         return SubmodelElementCollectionFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "submodelElementList":
                         return SubmodelElementListFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
@@ -1078,12 +1063,11 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.AdministrativeInformation? AdministrativeInformationFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
 
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 string? theVersion = null;
                 string? theRevision = null;
 
@@ -1101,7 +1085,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -1114,34 +1098,34 @@ namespace AasCore.Aas3_0_RC02
 
                         switch (elementName)
                         {
-                            case "dataSpecifications":
+                            case "embeddedDataSpecifications":
                             {
-                                theDataSpecifications = new List<Reference>();
+                                theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>();
 
                                 if (!isEmptyProperty)
                                 {
                                     SkipNoneWhitespaceAndComments(reader);
 
-                                    int indexDataSpecifications = 0;
+                                    int indexEmbeddedDataSpecifications = 0;
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
-                                        Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                        EmbeddedDataSpecification? item = EmbeddedDataSpecificationFromElement(
+                                            reader, out error);
 
                                         if (error != null)
                                         {
                                             error.PrependSegment(
                                                 new Reporting.IndexSegment(
-                                                    indexDataSpecifications));
+                                                    indexEmbeddedDataSpecifications));
                                             return null;
                                         }
 
-                                        theDataSpecifications.Add(
+                                        theEmbeddedDataSpecifications.Add(
                                             item
                                                 ?? throw new System.InvalidOperationException(
                                                     "Unexpected item null when error null"));
 
-                                        indexDataSpecifications++;
+                                        indexEmbeddedDataSpecifications++;
                                         SkipNoneWhitespaceAndComments(reader);
                                     }
                                 }
@@ -1260,7 +1244,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -1288,7 +1272,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 return new Aas.AdministrativeInformation(
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theVersion,
                     theRevision);
             }  // internal static Aas.AdministrativeInformation? AdministrativeInformationFromSequence
@@ -1298,7 +1282,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.AdministrativeInformation? AdministrativeInformationFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -1323,7 +1306,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -1344,7 +1327,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.AdministrativeInformation? result = (
                     AdministrativeInformationFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -1372,7 +1355,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -1399,7 +1382,6 @@ namespace AasCore.Aas3_0_RC02
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             internal static Aas.IQualifiable? IQualifiableFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -1423,7 +1405,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -1433,49 +1415,49 @@ namespace AasCore.Aas3_0_RC02
                 {
                     case "relationshipElement":
                         return RelationshipElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "annotatedRelationshipElement":
                         return AnnotatedRelationshipElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "basicEventElement":
                         return BasicEventElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "blob":
                         return BlobFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "capability":
                         return CapabilityFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "entity":
                         return EntityFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "file":
                         return FileFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "multiLanguageProperty":
                         return MultiLanguagePropertyFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "operation":
                         return OperationFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "property":
                         return PropertyFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "range":
                         return RangeFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "referenceElement":
                         return ReferenceElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "submodel":
                         return SubmodelFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "submodelElementCollection":
                         return SubmodelElementCollectionFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "submodelElementList":
                         return SubmodelElementListFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
@@ -1494,7 +1476,6 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.Qualifier? QualifierFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -1521,7 +1502,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -1537,7 +1518,7 @@ namespace AasCore.Aas3_0_RC02
                             case "semanticId":
                             {
                                 theSemanticId = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -1560,7 +1541,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -1774,7 +1755,7 @@ namespace AasCore.Aas3_0_RC02
                             case "valueId":
                             {
                                 theValueId = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -1818,7 +1799,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -1880,7 +1861,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.Qualifier? QualifierFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -1905,7 +1885,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -1926,7 +1906,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.Qualifier? result = (
                     QualifierFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -1954,7 +1934,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -1986,7 +1966,6 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.AssetAdministrationShell? AssetAdministrationShellFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -1999,7 +1978,7 @@ namespace AasCore.Aas3_0_RC02
                 string? theChecksum = null;
                 AdministrativeInformation? theAdministration = null;
                 string? theId = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 Reference? theDerivedFrom = null;
                 AssetInformation? theAssetInformation = null;
                 List<Reference>? theSubmodels = null;
@@ -2018,7 +1997,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -2043,7 +2022,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Extension? item = ExtensionFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -2147,7 +2126,7 @@ namespace AasCore.Aas3_0_RC02
                             case "displayName":
                             {
                                 theDisplayName = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -2161,7 +2140,7 @@ namespace AasCore.Aas3_0_RC02
                             case "description":
                             {
                                 theDescription = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -2215,7 +2194,7 @@ namespace AasCore.Aas3_0_RC02
                             case "administration":
                             {
                                 theAdministration = AdministrativeInformationFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -2266,34 +2245,34 @@ namespace AasCore.Aas3_0_RC02
                                 }
                                 break;
                             }
-                            case "dataSpecifications":
+                            case "embeddedDataSpecifications":
                             {
-                                theDataSpecifications = new List<Reference>();
+                                theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>();
 
                                 if (!isEmptyProperty)
                                 {
                                     SkipNoneWhitespaceAndComments(reader);
 
-                                    int indexDataSpecifications = 0;
+                                    int indexEmbeddedDataSpecifications = 0;
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
-                                        Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                        EmbeddedDataSpecification? item = EmbeddedDataSpecificationFromElement(
+                                            reader, out error);
 
                                         if (error != null)
                                         {
                                             error.PrependSegment(
                                                 new Reporting.IndexSegment(
-                                                    indexDataSpecifications));
+                                                    indexEmbeddedDataSpecifications));
                                             return null;
                                         }
 
-                                        theDataSpecifications.Add(
+                                        theEmbeddedDataSpecifications.Add(
                                             item
                                                 ?? throw new System.InvalidOperationException(
                                                     "Unexpected item null when error null"));
 
-                                        indexDataSpecifications++;
+                                        indexEmbeddedDataSpecifications++;
                                         SkipNoneWhitespaceAndComments(reader);
                                     }
                                 }
@@ -2302,7 +2281,7 @@ namespace AasCore.Aas3_0_RC02
                             case "derivedFrom":
                             {
                                 theDerivedFrom = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -2316,7 +2295,7 @@ namespace AasCore.Aas3_0_RC02
                             case "assetInformation":
                             {
                                 theAssetInformation = AssetInformationFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -2339,7 +2318,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -2393,7 +2372,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -2450,7 +2429,7 @@ namespace AasCore.Aas3_0_RC02
                     theDescription,
                     theChecksum,
                     theAdministration,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theDerivedFrom,
                     theSubmodels);
             }  // internal static Aas.AssetAdministrationShell? AssetAdministrationShellFromSequence
@@ -2460,7 +2439,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.AssetAdministrationShell? AssetAdministrationShellFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -2485,7 +2463,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -2506,7 +2484,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.AssetAdministrationShell? result = (
                     AssetAdministrationShellFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -2534,7 +2512,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -2566,7 +2544,6 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.AssetInformation? AssetInformationFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -2590,7 +2567,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -2661,7 +2638,7 @@ namespace AasCore.Aas3_0_RC02
                             case "globalAssetId":
                             {
                                 theGlobalAssetId = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -2684,7 +2661,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         SpecificAssetId? item = SpecificAssetIdFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -2708,7 +2685,7 @@ namespace AasCore.Aas3_0_RC02
                             case "defaultThumbnail":
                             {
                                 theDefaultThumbnail = ResourceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -2752,7 +2729,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -2801,7 +2778,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.AssetInformation? AssetInformationFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -2826,7 +2802,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -2847,7 +2823,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.AssetInformation? result = (
                     AssetInformationFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -2875,7 +2851,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -2907,7 +2883,6 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.Resource? ResourceFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -2929,7 +2904,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -3055,7 +3030,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -3102,7 +3077,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.Resource? ResourceFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -3127,7 +3101,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -3148,7 +3122,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.Resource? result = (
                     ResourceFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -3176,7 +3150,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -3208,7 +3182,6 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.SpecificAssetId? SpecificAssetIdFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -3233,7 +3206,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -3249,7 +3222,7 @@ namespace AasCore.Aas3_0_RC02
                             case "semanticId":
                             {
                                 theSemanticId = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -3272,7 +3245,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -3376,7 +3349,7 @@ namespace AasCore.Aas3_0_RC02
                             case "externalSubjectId":
                             {
                                 theExternalSubjectId = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -3420,7 +3393,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -3490,7 +3463,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.SpecificAssetId? SpecificAssetIdFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -3515,7 +3487,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -3536,7 +3508,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.SpecificAssetId? result = (
                     SpecificAssetIdFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -3564,7 +3536,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -3596,7 +3568,6 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.Submodel? SubmodelFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -3613,7 +3584,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 List<ISubmodelElement>? theSubmodelElements = null;
 
                 if (!isEmptySequence)
@@ -3630,7 +3601,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -3655,7 +3626,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Extension? item = ExtensionFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -3759,7 +3730,7 @@ namespace AasCore.Aas3_0_RC02
                             case "displayName":
                             {
                                 theDisplayName = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -3773,7 +3744,7 @@ namespace AasCore.Aas3_0_RC02
                             case "description":
                             {
                                 theDescription = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -3827,7 +3798,7 @@ namespace AasCore.Aas3_0_RC02
                             case "administration":
                             {
                                 theAdministration = AdministrativeInformationFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -3936,7 +3907,7 @@ namespace AasCore.Aas3_0_RC02
                             case "semanticId":
                             {
                                 theSemanticId = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -3959,7 +3930,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -3992,7 +3963,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Qualifier? item = QualifierFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -4013,34 +3984,34 @@ namespace AasCore.Aas3_0_RC02
                                 }
                                 break;
                             }
-                            case "dataSpecifications":
+                            case "embeddedDataSpecifications":
                             {
-                                theDataSpecifications = new List<Reference>();
+                                theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>();
 
                                 if (!isEmptyProperty)
                                 {
                                     SkipNoneWhitespaceAndComments(reader);
 
-                                    int indexDataSpecifications = 0;
+                                    int indexEmbeddedDataSpecifications = 0;
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
-                                        Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                        EmbeddedDataSpecification? item = EmbeddedDataSpecificationFromElement(
+                                            reader, out error);
 
                                         if (error != null)
                                         {
                                             error.PrependSegment(
                                                 new Reporting.IndexSegment(
-                                                    indexDataSpecifications));
+                                                    indexEmbeddedDataSpecifications));
                                             return null;
                                         }
 
-                                        theDataSpecifications.Add(
+                                        theEmbeddedDataSpecifications.Add(
                                             item
                                                 ?? throw new System.InvalidOperationException(
                                                     "Unexpected item null when error null"));
 
-                                        indexDataSpecifications++;
+                                        indexEmbeddedDataSpecifications++;
                                         SkipNoneWhitespaceAndComments(reader);
                                     }
                                 }
@@ -4058,7 +4029,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         ISubmodelElement? item = ISubmodelElementFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -4112,7 +4083,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -4162,7 +4133,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theSubmodelElements);
             }  // internal static Aas.Submodel? SubmodelFromSequence
 
@@ -4171,7 +4142,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.Submodel? SubmodelFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -4196,7 +4166,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -4217,7 +4187,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.Submodel? result = (
                     SubmodelFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -4245,7 +4215,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -4272,7 +4242,6 @@ namespace AasCore.Aas3_0_RC02
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             internal static Aas.ISubmodelElement? ISubmodelElementFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -4296,7 +4265,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -4306,46 +4275,46 @@ namespace AasCore.Aas3_0_RC02
                 {
                     case "relationshipElement":
                         return RelationshipElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "annotatedRelationshipElement":
                         return AnnotatedRelationshipElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "basicEventElement":
                         return BasicEventElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "blob":
                         return BlobFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "capability":
                         return CapabilityFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "entity":
                         return EntityFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "file":
                         return FileFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "multiLanguageProperty":
                         return MultiLanguagePropertyFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "operation":
                         return OperationFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "property":
                         return PropertyFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "range":
                         return RangeFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "referenceElement":
                         return ReferenceElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "submodelElementCollection":
                         return SubmodelElementCollectionFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "submodelElementList":
                         return SubmodelElementListFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
@@ -4364,7 +4333,6 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.RelationshipElement? RelationshipElementFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -4379,7 +4347,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 Reference? theFirst = null;
                 Reference? theSecond = null;
 
@@ -4397,7 +4365,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -4422,7 +4390,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Extension? item = ExtensionFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -4526,7 +4494,7 @@ namespace AasCore.Aas3_0_RC02
                             case "displayName":
                             {
                                 theDisplayName = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -4540,7 +4508,7 @@ namespace AasCore.Aas3_0_RC02
                             case "description":
                             {
                                 theDescription = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -4649,7 +4617,7 @@ namespace AasCore.Aas3_0_RC02
                             case "semanticId":
                             {
                                 theSemanticId = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -4672,7 +4640,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -4705,7 +4673,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Qualifier? item = QualifierFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -4726,34 +4694,34 @@ namespace AasCore.Aas3_0_RC02
                                 }
                                 break;
                             }
-                            case "dataSpecifications":
+                            case "embeddedDataSpecifications":
                             {
-                                theDataSpecifications = new List<Reference>();
+                                theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>();
 
                                 if (!isEmptyProperty)
                                 {
                                     SkipNoneWhitespaceAndComments(reader);
 
-                                    int indexDataSpecifications = 0;
+                                    int indexEmbeddedDataSpecifications = 0;
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
-                                        Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                        EmbeddedDataSpecification? item = EmbeddedDataSpecificationFromElement(
+                                            reader, out error);
 
                                         if (error != null)
                                         {
                                             error.PrependSegment(
                                                 new Reporting.IndexSegment(
-                                                    indexDataSpecifications));
+                                                    indexEmbeddedDataSpecifications));
                                             return null;
                                         }
 
-                                        theDataSpecifications.Add(
+                                        theEmbeddedDataSpecifications.Add(
                                             item
                                                 ?? throw new System.InvalidOperationException(
                                                     "Unexpected item null when error null"));
 
-                                        indexDataSpecifications++;
+                                        indexEmbeddedDataSpecifications++;
                                         SkipNoneWhitespaceAndComments(reader);
                                     }
                                 }
@@ -4762,7 +4730,7 @@ namespace AasCore.Aas3_0_RC02
                             case "first":
                             {
                                 theFirst = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -4776,7 +4744,7 @@ namespace AasCore.Aas3_0_RC02
                             case "second":
                             {
                                 theSecond = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -4820,7 +4788,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -4880,7 +4848,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications);
+                    theEmbeddedDataSpecifications);
             }  // internal static Aas.RelationshipElement? RelationshipElementFromSequence
 
             /// <summary>
@@ -4889,7 +4857,6 @@ namespace AasCore.Aas3_0_RC02
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             internal static Aas.IRelationshipElement? IRelationshipElementFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -4913,7 +4880,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -4923,10 +4890,10 @@ namespace AasCore.Aas3_0_RC02
                 {
                     case "annotatedRelationshipElement":
                         return AnnotatedRelationshipElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "relationshipElement":
                         return RelationshipElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
@@ -4939,7 +4906,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.RelationshipElement? RelationshipElementFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -4964,7 +4930,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -4985,7 +4951,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.RelationshipElement? result = (
                     RelationshipElementFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -5013,7 +4979,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -5045,7 +5011,6 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.SubmodelElementList? SubmodelElementListFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -5060,7 +5025,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 bool? theOrderRelevant = null;
                 List<ISubmodelElement>? theValue = null;
                 Reference? theSemanticIdListElement = null;
@@ -5081,7 +5046,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -5106,7 +5071,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Extension? item = ExtensionFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -5210,7 +5175,7 @@ namespace AasCore.Aas3_0_RC02
                             case "displayName":
                             {
                                 theDisplayName = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -5224,7 +5189,7 @@ namespace AasCore.Aas3_0_RC02
                             case "description":
                             {
                                 theDescription = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -5333,7 +5298,7 @@ namespace AasCore.Aas3_0_RC02
                             case "semanticId":
                             {
                                 theSemanticId = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -5356,7 +5321,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -5389,7 +5354,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Qualifier? item = QualifierFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -5410,34 +5375,34 @@ namespace AasCore.Aas3_0_RC02
                                 }
                                 break;
                             }
-                            case "dataSpecifications":
+                            case "embeddedDataSpecifications":
                             {
-                                theDataSpecifications = new List<Reference>();
+                                theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>();
 
                                 if (!isEmptyProperty)
                                 {
                                     SkipNoneWhitespaceAndComments(reader);
 
-                                    int indexDataSpecifications = 0;
+                                    int indexEmbeddedDataSpecifications = 0;
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
-                                        Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                        EmbeddedDataSpecification? item = EmbeddedDataSpecificationFromElement(
+                                            reader, out error);
 
                                         if (error != null)
                                         {
                                             error.PrependSegment(
                                                 new Reporting.IndexSegment(
-                                                    indexDataSpecifications));
+                                                    indexEmbeddedDataSpecifications));
                                             return null;
                                         }
 
-                                        theDataSpecifications.Add(
+                                        theEmbeddedDataSpecifications.Add(
                                             item
                                                 ?? throw new System.InvalidOperationException(
                                                     "Unexpected item null when error null"));
 
-                                        indexDataSpecifications++;
+                                        indexEmbeddedDataSpecifications++;
                                         SkipNoneWhitespaceAndComments(reader);
                                     }
                                 }
@@ -5502,7 +5467,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         ISubmodelElement? item = ISubmodelElementFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -5526,7 +5491,7 @@ namespace AasCore.Aas3_0_RC02
                             case "semanticIdListElement":
                             {
                                 theSemanticIdListElement = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -5680,7 +5645,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -5729,7 +5694,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theOrderRelevant,
                     theValue,
                     theSemanticIdListElement,
@@ -5741,7 +5706,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.SubmodelElementList? SubmodelElementListFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -5766,7 +5730,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -5787,7 +5751,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.SubmodelElementList? result = (
                     SubmodelElementListFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -5815,7 +5779,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -5847,7 +5811,6 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.SubmodelElementCollection? SubmodelElementCollectionFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -5862,7 +5825,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 List<ISubmodelElement>? theValue = null;
 
                 if (!isEmptySequence)
@@ -5879,7 +5842,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -5904,7 +5867,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Extension? item = ExtensionFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -6008,7 +5971,7 @@ namespace AasCore.Aas3_0_RC02
                             case "displayName":
                             {
                                 theDisplayName = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -6022,7 +5985,7 @@ namespace AasCore.Aas3_0_RC02
                             case "description":
                             {
                                 theDescription = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -6131,7 +6094,7 @@ namespace AasCore.Aas3_0_RC02
                             case "semanticId":
                             {
                                 theSemanticId = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -6154,7 +6117,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -6187,7 +6150,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Qualifier? item = QualifierFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -6208,34 +6171,34 @@ namespace AasCore.Aas3_0_RC02
                                 }
                                 break;
                             }
-                            case "dataSpecifications":
+                            case "embeddedDataSpecifications":
                             {
-                                theDataSpecifications = new List<Reference>();
+                                theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>();
 
                                 if (!isEmptyProperty)
                                 {
                                     SkipNoneWhitespaceAndComments(reader);
 
-                                    int indexDataSpecifications = 0;
+                                    int indexEmbeddedDataSpecifications = 0;
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
-                                        Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                        EmbeddedDataSpecification? item = EmbeddedDataSpecificationFromElement(
+                                            reader, out error);
 
                                         if (error != null)
                                         {
                                             error.PrependSegment(
                                                 new Reporting.IndexSegment(
-                                                    indexDataSpecifications));
+                                                    indexEmbeddedDataSpecifications));
                                             return null;
                                         }
 
-                                        theDataSpecifications.Add(
+                                        theEmbeddedDataSpecifications.Add(
                                             item
                                                 ?? throw new System.InvalidOperationException(
                                                     "Unexpected item null when error null"));
 
-                                        indexDataSpecifications++;
+                                        indexEmbeddedDataSpecifications++;
                                         SkipNoneWhitespaceAndComments(reader);
                                     }
                                 }
@@ -6253,7 +6216,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         ISubmodelElement? item = ISubmodelElementFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -6307,7 +6270,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -6345,7 +6308,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theValue);
             }  // internal static Aas.SubmodelElementCollection? SubmodelElementCollectionFromSequence
 
@@ -6354,7 +6317,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.SubmodelElementCollection? SubmodelElementCollectionFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -6379,7 +6341,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -6400,7 +6362,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.SubmodelElementCollection? result = (
                     SubmodelElementCollectionFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -6428,7 +6390,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -6455,7 +6417,6 @@ namespace AasCore.Aas3_0_RC02
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             internal static Aas.IDataElement? IDataElementFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -6479,7 +6440,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -6489,22 +6450,22 @@ namespace AasCore.Aas3_0_RC02
                 {
                     case "blob":
                         return BlobFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "file":
                         return FileFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "multiLanguageProperty":
                         return MultiLanguagePropertyFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "property":
                         return PropertyFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "range":
                         return RangeFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     case "referenceElement":
                         return ReferenceElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
@@ -6523,7 +6484,6 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.Property? PropertyFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -6538,7 +6498,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 DataTypeDefXsd? theValueType = null;
                 string? theValue = null;
                 Reference? theValueId = null;
@@ -6557,7 +6517,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -6582,7 +6542,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Extension? item = ExtensionFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -6686,7 +6646,7 @@ namespace AasCore.Aas3_0_RC02
                             case "displayName":
                             {
                                 theDisplayName = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -6700,7 +6660,7 @@ namespace AasCore.Aas3_0_RC02
                             case "description":
                             {
                                 theDescription = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -6809,7 +6769,7 @@ namespace AasCore.Aas3_0_RC02
                             case "semanticId":
                             {
                                 theSemanticId = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -6832,7 +6792,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -6865,7 +6825,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Qualifier? item = QualifierFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -6886,34 +6846,34 @@ namespace AasCore.Aas3_0_RC02
                                 }
                                 break;
                             }
-                            case "dataSpecifications":
+                            case "embeddedDataSpecifications":
                             {
-                                theDataSpecifications = new List<Reference>();
+                                theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>();
 
                                 if (!isEmptyProperty)
                                 {
                                     SkipNoneWhitespaceAndComments(reader);
 
-                                    int indexDataSpecifications = 0;
+                                    int indexEmbeddedDataSpecifications = 0;
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
-                                        Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                        EmbeddedDataSpecification? item = EmbeddedDataSpecificationFromElement(
+                                            reader, out error);
 
                                         if (error != null)
                                         {
                                             error.PrependSegment(
                                                 new Reporting.IndexSegment(
-                                                    indexDataSpecifications));
+                                                    indexEmbeddedDataSpecifications));
                                             return null;
                                         }
 
-                                        theDataSpecifications.Add(
+                                        theEmbeddedDataSpecifications.Add(
                                             item
                                                 ?? throw new System.InvalidOperationException(
                                                     "Unexpected item null when error null"));
 
-                                        indexDataSpecifications++;
+                                        indexEmbeddedDataSpecifications++;
                                         SkipNoneWhitespaceAndComments(reader);
                                     }
                                 }
@@ -7017,7 +6977,7 @@ namespace AasCore.Aas3_0_RC02
                             case "valueId":
                             {
                                 theValueId = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -7061,7 +7021,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -7110,7 +7070,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theValue,
                     theValueId);
             }  // internal static Aas.Property? PropertyFromSequence
@@ -7120,7 +7080,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.Property? PropertyFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -7145,7 +7104,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -7166,7 +7125,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.Property? result = (
                     PropertyFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -7194,7 +7153,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -7226,7 +7185,6 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.MultiLanguageProperty? MultiLanguagePropertyFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -7241,7 +7199,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 LangStringSet? theValue = null;
                 Reference? theValueId = null;
 
@@ -7259,7 +7217,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -7284,7 +7242,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Extension? item = ExtensionFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -7388,7 +7346,7 @@ namespace AasCore.Aas3_0_RC02
                             case "displayName":
                             {
                                 theDisplayName = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -7402,7 +7360,7 @@ namespace AasCore.Aas3_0_RC02
                             case "description":
                             {
                                 theDescription = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -7511,7 +7469,7 @@ namespace AasCore.Aas3_0_RC02
                             case "semanticId":
                             {
                                 theSemanticId = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -7534,7 +7492,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -7567,7 +7525,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Qualifier? item = QualifierFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -7588,34 +7546,34 @@ namespace AasCore.Aas3_0_RC02
                                 }
                                 break;
                             }
-                            case "dataSpecifications":
+                            case "embeddedDataSpecifications":
                             {
-                                theDataSpecifications = new List<Reference>();
+                                theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>();
 
                                 if (!isEmptyProperty)
                                 {
                                     SkipNoneWhitespaceAndComments(reader);
 
-                                    int indexDataSpecifications = 0;
+                                    int indexEmbeddedDataSpecifications = 0;
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
-                                        Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                        EmbeddedDataSpecification? item = EmbeddedDataSpecificationFromElement(
+                                            reader, out error);
 
                                         if (error != null)
                                         {
                                             error.PrependSegment(
                                                 new Reporting.IndexSegment(
-                                                    indexDataSpecifications));
+                                                    indexEmbeddedDataSpecifications));
                                             return null;
                                         }
 
-                                        theDataSpecifications.Add(
+                                        theEmbeddedDataSpecifications.Add(
                                             item
                                                 ?? throw new System.InvalidOperationException(
                                                     "Unexpected item null when error null"));
 
-                                        indexDataSpecifications++;
+                                        indexEmbeddedDataSpecifications++;
                                         SkipNoneWhitespaceAndComments(reader);
                                     }
                                 }
@@ -7624,7 +7582,7 @@ namespace AasCore.Aas3_0_RC02
                             case "value":
                             {
                                 theValue = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -7638,7 +7596,7 @@ namespace AasCore.Aas3_0_RC02
                             case "valueId":
                             {
                                 theValueId = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -7682,7 +7640,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -7720,7 +7678,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theValue,
                     theValueId);
             }  // internal static Aas.MultiLanguageProperty? MultiLanguagePropertyFromSequence
@@ -7730,7 +7688,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.MultiLanguageProperty? MultiLanguagePropertyFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -7755,7 +7712,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -7776,7 +7733,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.MultiLanguageProperty? result = (
                     MultiLanguagePropertyFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -7804,7 +7761,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -7836,7 +7793,6 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.Range? RangeFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -7851,7 +7807,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 DataTypeDefXsd? theValueType = null;
                 string? theMin = null;
                 string? theMax = null;
@@ -7870,7 +7826,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -7895,7 +7851,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Extension? item = ExtensionFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -7999,7 +7955,7 @@ namespace AasCore.Aas3_0_RC02
                             case "displayName":
                             {
                                 theDisplayName = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -8013,7 +7969,7 @@ namespace AasCore.Aas3_0_RC02
                             case "description":
                             {
                                 theDescription = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -8122,7 +8078,7 @@ namespace AasCore.Aas3_0_RC02
                             case "semanticId":
                             {
                                 theSemanticId = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -8145,7 +8101,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -8178,7 +8134,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Qualifier? item = QualifierFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -8199,34 +8155,34 @@ namespace AasCore.Aas3_0_RC02
                                 }
                                 break;
                             }
-                            case "dataSpecifications":
+                            case "embeddedDataSpecifications":
                             {
-                                theDataSpecifications = new List<Reference>();
+                                theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>();
 
                                 if (!isEmptyProperty)
                                 {
                                     SkipNoneWhitespaceAndComments(reader);
 
-                                    int indexDataSpecifications = 0;
+                                    int indexEmbeddedDataSpecifications = 0;
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
-                                        Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                        EmbeddedDataSpecification? item = EmbeddedDataSpecificationFromElement(
+                                            reader, out error);
 
                                         if (error != null)
                                         {
                                             error.PrependSegment(
                                                 new Reporting.IndexSegment(
-                                                    indexDataSpecifications));
+                                                    indexEmbeddedDataSpecifications));
                                             return null;
                                         }
 
-                                        theDataSpecifications.Add(
+                                        theEmbeddedDataSpecifications.Add(
                                             item
                                                 ?? throw new System.InvalidOperationException(
                                                     "Unexpected item null when error null"));
 
-                                        indexDataSpecifications++;
+                                        indexEmbeddedDataSpecifications++;
                                         SkipNoneWhitespaceAndComments(reader);
                                     }
                                 }
@@ -8400,7 +8356,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -8449,7 +8405,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theMin,
                     theMax);
             }  // internal static Aas.Range? RangeFromSequence
@@ -8459,7 +8415,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.Range? RangeFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -8484,7 +8439,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -8505,7 +8460,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.Range? result = (
                     RangeFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -8533,7 +8488,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -8565,7 +8520,6 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.ReferenceElement? ReferenceElementFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -8580,7 +8534,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 Reference? theValue = null;
 
                 if (!isEmptySequence)
@@ -8597,7 +8551,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -8622,7 +8576,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Extension? item = ExtensionFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -8726,7 +8680,7 @@ namespace AasCore.Aas3_0_RC02
                             case "displayName":
                             {
                                 theDisplayName = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -8740,7 +8694,7 @@ namespace AasCore.Aas3_0_RC02
                             case "description":
                             {
                                 theDescription = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -8849,7 +8803,7 @@ namespace AasCore.Aas3_0_RC02
                             case "semanticId":
                             {
                                 theSemanticId = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -8872,7 +8826,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -8905,7 +8859,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Qualifier? item = QualifierFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -8926,34 +8880,34 @@ namespace AasCore.Aas3_0_RC02
                                 }
                                 break;
                             }
-                            case "dataSpecifications":
+                            case "embeddedDataSpecifications":
                             {
-                                theDataSpecifications = new List<Reference>();
+                                theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>();
 
                                 if (!isEmptyProperty)
                                 {
                                     SkipNoneWhitespaceAndComments(reader);
 
-                                    int indexDataSpecifications = 0;
+                                    int indexEmbeddedDataSpecifications = 0;
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
-                                        Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                        EmbeddedDataSpecification? item = EmbeddedDataSpecificationFromElement(
+                                            reader, out error);
 
                                         if (error != null)
                                         {
                                             error.PrependSegment(
                                                 new Reporting.IndexSegment(
-                                                    indexDataSpecifications));
+                                                    indexEmbeddedDataSpecifications));
                                             return null;
                                         }
 
-                                        theDataSpecifications.Add(
+                                        theEmbeddedDataSpecifications.Add(
                                             item
                                                 ?? throw new System.InvalidOperationException(
                                                     "Unexpected item null when error null"));
 
-                                        indexDataSpecifications++;
+                                        indexEmbeddedDataSpecifications++;
                                         SkipNoneWhitespaceAndComments(reader);
                                     }
                                 }
@@ -8962,7 +8916,7 @@ namespace AasCore.Aas3_0_RC02
                             case "value":
                             {
                                 theValue = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -9006,7 +8960,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -9044,7 +8998,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theValue);
             }  // internal static Aas.ReferenceElement? ReferenceElementFromSequence
 
@@ -9053,7 +9007,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.ReferenceElement? ReferenceElementFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -9078,7 +9031,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -9099,7 +9052,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.ReferenceElement? result = (
                     ReferenceElementFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -9127,7 +9080,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -9159,7 +9112,6 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.Blob? BlobFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -9174,7 +9126,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 byte[]? theValue = null;
                 string? theContentType = null;
 
@@ -9192,7 +9144,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -9217,7 +9169,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Extension? item = ExtensionFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -9321,7 +9273,7 @@ namespace AasCore.Aas3_0_RC02
                             case "displayName":
                             {
                                 theDisplayName = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -9335,7 +9287,7 @@ namespace AasCore.Aas3_0_RC02
                             case "description":
                             {
                                 theDescription = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -9444,7 +9396,7 @@ namespace AasCore.Aas3_0_RC02
                             case "semanticId":
                             {
                                 theSemanticId = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -9467,7 +9419,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -9500,7 +9452,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Qualifier? item = QualifierFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -9521,34 +9473,34 @@ namespace AasCore.Aas3_0_RC02
                                 }
                                 break;
                             }
-                            case "dataSpecifications":
+                            case "embeddedDataSpecifications":
                             {
-                                theDataSpecifications = new List<Reference>();
+                                theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>();
 
                                 if (!isEmptyProperty)
                                 {
                                     SkipNoneWhitespaceAndComments(reader);
 
-                                    int indexDataSpecifications = 0;
+                                    int indexEmbeddedDataSpecifications = 0;
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
-                                        Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                        EmbeddedDataSpecification? item = EmbeddedDataSpecificationFromElement(
+                                            reader, out error);
 
                                         if (error != null)
                                         {
                                             error.PrependSegment(
                                                 new Reporting.IndexSegment(
-                                                    indexDataSpecifications));
+                                                    indexEmbeddedDataSpecifications));
                                             return null;
                                         }
 
-                                        theDataSpecifications.Add(
+                                        theEmbeddedDataSpecifications.Add(
                                             item
                                                 ?? throw new System.InvalidOperationException(
                                                     "Unexpected item null when error null"));
 
-                                        indexDataSpecifications++;
+                                        indexEmbeddedDataSpecifications++;
                                         SkipNoneWhitespaceAndComments(reader);
                                     }
                                 }
@@ -9675,7 +9627,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -9724,7 +9676,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theValue);
             }  // internal static Aas.Blob? BlobFromSequence
 
@@ -9733,7 +9685,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.Blob? BlobFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -9758,7 +9709,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -9779,7 +9730,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.Blob? result = (
                     BlobFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -9807,7 +9758,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -9839,7 +9790,6 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.File? FileFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -9854,7 +9804,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 string? theValue = null;
                 string? theContentType = null;
 
@@ -9872,7 +9822,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -9897,7 +9847,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Extension? item = ExtensionFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -10001,7 +9951,7 @@ namespace AasCore.Aas3_0_RC02
                             case "displayName":
                             {
                                 theDisplayName = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -10015,7 +9965,7 @@ namespace AasCore.Aas3_0_RC02
                             case "description":
                             {
                                 theDescription = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -10124,7 +10074,7 @@ namespace AasCore.Aas3_0_RC02
                             case "semanticId":
                             {
                                 theSemanticId = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -10147,7 +10097,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -10180,7 +10130,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Qualifier? item = QualifierFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -10201,34 +10151,34 @@ namespace AasCore.Aas3_0_RC02
                                 }
                                 break;
                             }
-                            case "dataSpecifications":
+                            case "embeddedDataSpecifications":
                             {
-                                theDataSpecifications = new List<Reference>();
+                                theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>();
 
                                 if (!isEmptyProperty)
                                 {
                                     SkipNoneWhitespaceAndComments(reader);
 
-                                    int indexDataSpecifications = 0;
+                                    int indexEmbeddedDataSpecifications = 0;
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
-                                        Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                        EmbeddedDataSpecification? item = EmbeddedDataSpecificationFromElement(
+                                            reader, out error);
 
                                         if (error != null)
                                         {
                                             error.PrependSegment(
                                                 new Reporting.IndexSegment(
-                                                    indexDataSpecifications));
+                                                    indexEmbeddedDataSpecifications));
                                             return null;
                                         }
 
-                                        theDataSpecifications.Add(
+                                        theEmbeddedDataSpecifications.Add(
                                             item
                                                 ?? throw new System.InvalidOperationException(
                                                     "Unexpected item null when error null"));
 
-                                        indexDataSpecifications++;
+                                        indexEmbeddedDataSpecifications++;
                                         SkipNoneWhitespaceAndComments(reader);
                                     }
                                 }
@@ -10347,7 +10297,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -10396,7 +10346,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theValue);
             }  // internal static Aas.File? FileFromSequence
 
@@ -10405,7 +10355,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.File? FileFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -10430,7 +10379,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -10451,7 +10400,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.File? result = (
                     FileFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -10479,7 +10428,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -10511,7 +10460,6 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.AnnotatedRelationshipElement? AnnotatedRelationshipElementFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -10526,7 +10474,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 Reference? theFirst = null;
                 Reference? theSecond = null;
                 List<IDataElement>? theAnnotations = null;
@@ -10545,7 +10493,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -10570,7 +10518,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Extension? item = ExtensionFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -10674,7 +10622,7 @@ namespace AasCore.Aas3_0_RC02
                             case "displayName":
                             {
                                 theDisplayName = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -10688,7 +10636,7 @@ namespace AasCore.Aas3_0_RC02
                             case "description":
                             {
                                 theDescription = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -10797,7 +10745,7 @@ namespace AasCore.Aas3_0_RC02
                             case "semanticId":
                             {
                                 theSemanticId = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -10820,7 +10768,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -10853,7 +10801,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Qualifier? item = QualifierFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -10874,34 +10822,34 @@ namespace AasCore.Aas3_0_RC02
                                 }
                                 break;
                             }
-                            case "dataSpecifications":
+                            case "embeddedDataSpecifications":
                             {
-                                theDataSpecifications = new List<Reference>();
+                                theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>();
 
                                 if (!isEmptyProperty)
                                 {
                                     SkipNoneWhitespaceAndComments(reader);
 
-                                    int indexDataSpecifications = 0;
+                                    int indexEmbeddedDataSpecifications = 0;
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
-                                        Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                        EmbeddedDataSpecification? item = EmbeddedDataSpecificationFromElement(
+                                            reader, out error);
 
                                         if (error != null)
                                         {
                                             error.PrependSegment(
                                                 new Reporting.IndexSegment(
-                                                    indexDataSpecifications));
+                                                    indexEmbeddedDataSpecifications));
                                             return null;
                                         }
 
-                                        theDataSpecifications.Add(
+                                        theEmbeddedDataSpecifications.Add(
                                             item
                                                 ?? throw new System.InvalidOperationException(
                                                     "Unexpected item null when error null"));
 
-                                        indexDataSpecifications++;
+                                        indexEmbeddedDataSpecifications++;
                                         SkipNoneWhitespaceAndComments(reader);
                                     }
                                 }
@@ -10910,7 +10858,7 @@ namespace AasCore.Aas3_0_RC02
                             case "first":
                             {
                                 theFirst = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -10924,7 +10872,7 @@ namespace AasCore.Aas3_0_RC02
                             case "second":
                             {
                                 theSecond = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -10947,7 +10895,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         IDataElement? item = IDataElementFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -11001,7 +10949,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -11061,7 +11009,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theAnnotations);
             }  // internal static Aas.AnnotatedRelationshipElement? AnnotatedRelationshipElementFromSequence
 
@@ -11070,7 +11018,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.AnnotatedRelationshipElement? AnnotatedRelationshipElementFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -11095,7 +11042,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -11116,7 +11063,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.AnnotatedRelationshipElement? result = (
                     AnnotatedRelationshipElementFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -11144,7 +11091,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -11176,7 +11123,6 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.Entity? EntityFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -11191,7 +11137,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 List<ISubmodelElement>? theStatements = null;
                 EntityType? theEntityType = null;
                 Reference? theGlobalAssetId = null;
@@ -11211,7 +11157,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -11236,7 +11182,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Extension? item = ExtensionFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -11340,7 +11286,7 @@ namespace AasCore.Aas3_0_RC02
                             case "displayName":
                             {
                                 theDisplayName = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -11354,7 +11300,7 @@ namespace AasCore.Aas3_0_RC02
                             case "description":
                             {
                                 theDescription = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -11463,7 +11409,7 @@ namespace AasCore.Aas3_0_RC02
                             case "semanticId":
                             {
                                 theSemanticId = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -11486,7 +11432,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -11519,7 +11465,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Qualifier? item = QualifierFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -11540,34 +11486,34 @@ namespace AasCore.Aas3_0_RC02
                                 }
                                 break;
                             }
-                            case "dataSpecifications":
+                            case "embeddedDataSpecifications":
                             {
-                                theDataSpecifications = new List<Reference>();
+                                theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>();
 
                                 if (!isEmptyProperty)
                                 {
                                     SkipNoneWhitespaceAndComments(reader);
 
-                                    int indexDataSpecifications = 0;
+                                    int indexEmbeddedDataSpecifications = 0;
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
-                                        Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                        EmbeddedDataSpecification? item = EmbeddedDataSpecificationFromElement(
+                                            reader, out error);
 
                                         if (error != null)
                                         {
                                             error.PrependSegment(
                                                 new Reporting.IndexSegment(
-                                                    indexDataSpecifications));
+                                                    indexEmbeddedDataSpecifications));
                                             return null;
                                         }
 
-                                        theDataSpecifications.Add(
+                                        theEmbeddedDataSpecifications.Add(
                                             item
                                                 ?? throw new System.InvalidOperationException(
                                                     "Unexpected item null when error null"));
 
-                                        indexDataSpecifications++;
+                                        indexEmbeddedDataSpecifications++;
                                         SkipNoneWhitespaceAndComments(reader);
                                     }
                                 }
@@ -11585,7 +11531,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         ISubmodelElement? item = ISubmodelElementFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -11664,7 +11610,7 @@ namespace AasCore.Aas3_0_RC02
                             case "globalAssetId":
                             {
                                 theGlobalAssetId = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -11678,7 +11624,7 @@ namespace AasCore.Aas3_0_RC02
                             case "specificAssetId":
                             {
                                 theSpecificAssetId = SpecificAssetIdFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -11722,7 +11668,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -11771,7 +11717,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theStatements,
                     theGlobalAssetId,
                     theSpecificAssetId);
@@ -11782,7 +11728,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.Entity? EntityFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -11807,7 +11752,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -11828,7 +11773,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.Entity? result = (
                     EntityFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -11856,7 +11801,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -11888,7 +11833,6 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.EventPayload? EventPayloadFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -11916,7 +11860,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -11932,7 +11876,7 @@ namespace AasCore.Aas3_0_RC02
                             case "source":
                             {
                                 theSource = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -11946,7 +11890,7 @@ namespace AasCore.Aas3_0_RC02
                             case "sourceSemanticId":
                             {
                                 theSourceSemanticId = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -11960,7 +11904,7 @@ namespace AasCore.Aas3_0_RC02
                             case "observableReference":
                             {
                                 theObservableReference = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -11974,7 +11918,7 @@ namespace AasCore.Aas3_0_RC02
                             case "observableSemanticId":
                             {
                                 theObservableSemanticId = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -12028,7 +11972,7 @@ namespace AasCore.Aas3_0_RC02
                             case "subjectId":
                             {
                                 theSubjectId = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -12152,7 +12096,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -12225,7 +12169,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.EventPayload? EventPayloadFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -12250,7 +12193,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -12271,7 +12214,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.EventPayload? result = (
                     EventPayloadFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -12299,7 +12242,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -12326,7 +12269,6 @@ namespace AasCore.Aas3_0_RC02
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
             internal static Aas.IEventElement? IEventElementFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -12350,7 +12292,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -12360,7 +12302,7 @@ namespace AasCore.Aas3_0_RC02
                 {
                     case "basicEventElement":
                         return BasicEventElementFromElement(
-                            reader, ns, out error);
+                            reader, out error);
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
@@ -12379,7 +12321,6 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.BasicEventElement? BasicEventElementFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -12394,7 +12335,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 Reference? theObserved = null;
                 Direction? theDirection = null;
                 StateOfEvent? theState = null;
@@ -12418,7 +12359,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -12443,7 +12384,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Extension? item = ExtensionFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -12547,7 +12488,7 @@ namespace AasCore.Aas3_0_RC02
                             case "displayName":
                             {
                                 theDisplayName = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -12561,7 +12502,7 @@ namespace AasCore.Aas3_0_RC02
                             case "description":
                             {
                                 theDescription = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -12670,7 +12611,7 @@ namespace AasCore.Aas3_0_RC02
                             case "semanticId":
                             {
                                 theSemanticId = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -12693,7 +12634,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -12726,7 +12667,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Qualifier? item = QualifierFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -12747,34 +12688,34 @@ namespace AasCore.Aas3_0_RC02
                                 }
                                 break;
                             }
-                            case "dataSpecifications":
+                            case "embeddedDataSpecifications":
                             {
-                                theDataSpecifications = new List<Reference>();
+                                theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>();
 
                                 if (!isEmptyProperty)
                                 {
                                     SkipNoneWhitespaceAndComments(reader);
 
-                                    int indexDataSpecifications = 0;
+                                    int indexEmbeddedDataSpecifications = 0;
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
-                                        Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                        EmbeddedDataSpecification? item = EmbeddedDataSpecificationFromElement(
+                                            reader, out error);
 
                                         if (error != null)
                                         {
                                             error.PrependSegment(
                                                 new Reporting.IndexSegment(
-                                                    indexDataSpecifications));
+                                                    indexEmbeddedDataSpecifications));
                                             return null;
                                         }
 
-                                        theDataSpecifications.Add(
+                                        theEmbeddedDataSpecifications.Add(
                                             item
                                                 ?? throw new System.InvalidOperationException(
                                                     "Unexpected item null when error null"));
 
-                                        indexDataSpecifications++;
+                                        indexEmbeddedDataSpecifications++;
                                         SkipNoneWhitespaceAndComments(reader);
                                     }
                                 }
@@ -12783,7 +12724,7 @@ namespace AasCore.Aas3_0_RC02
                             case "observed":
                             {
                                 theObserved = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -12947,7 +12888,7 @@ namespace AasCore.Aas3_0_RC02
                             case "messageBroker":
                             {
                                 theMessageBroker = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -13111,7 +13052,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -13182,7 +13123,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theMessageTopic,
                     theMessageBroker,
                     theLastUpdate,
@@ -13195,7 +13136,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.BasicEventElement? BasicEventElementFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -13220,7 +13160,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -13241,7 +13181,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.BasicEventElement? result = (
                     BasicEventElementFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -13269,7 +13209,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -13301,7 +13241,6 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.Operation? OperationFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -13316,7 +13255,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 List<OperationVariable>? theInputVariables = null;
                 List<OperationVariable>? theOutputVariables = null;
                 List<OperationVariable>? theInoutputVariables = null;
@@ -13335,7 +13274,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -13360,7 +13299,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Extension? item = ExtensionFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -13464,7 +13403,7 @@ namespace AasCore.Aas3_0_RC02
                             case "displayName":
                             {
                                 theDisplayName = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -13478,7 +13417,7 @@ namespace AasCore.Aas3_0_RC02
                             case "description":
                             {
                                 theDescription = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -13587,7 +13526,7 @@ namespace AasCore.Aas3_0_RC02
                             case "semanticId":
                             {
                                 theSemanticId = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -13610,7 +13549,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -13643,7 +13582,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Qualifier? item = QualifierFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -13664,34 +13603,34 @@ namespace AasCore.Aas3_0_RC02
                                 }
                                 break;
                             }
-                            case "dataSpecifications":
+                            case "embeddedDataSpecifications":
                             {
-                                theDataSpecifications = new List<Reference>();
+                                theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>();
 
                                 if (!isEmptyProperty)
                                 {
                                     SkipNoneWhitespaceAndComments(reader);
 
-                                    int indexDataSpecifications = 0;
+                                    int indexEmbeddedDataSpecifications = 0;
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
-                                        Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                        EmbeddedDataSpecification? item = EmbeddedDataSpecificationFromElement(
+                                            reader, out error);
 
                                         if (error != null)
                                         {
                                             error.PrependSegment(
                                                 new Reporting.IndexSegment(
-                                                    indexDataSpecifications));
+                                                    indexEmbeddedDataSpecifications));
                                             return null;
                                         }
 
-                                        theDataSpecifications.Add(
+                                        theEmbeddedDataSpecifications.Add(
                                             item
                                                 ?? throw new System.InvalidOperationException(
                                                     "Unexpected item null when error null"));
 
-                                        indexDataSpecifications++;
+                                        indexEmbeddedDataSpecifications++;
                                         SkipNoneWhitespaceAndComments(reader);
                                     }
                                 }
@@ -13709,7 +13648,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         OperationVariable? item = OperationVariableFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -13742,7 +13681,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         OperationVariable? item = OperationVariableFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -13775,7 +13714,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         OperationVariable? item = OperationVariableFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -13829,7 +13768,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -13867,7 +13806,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theInputVariables,
                     theOutputVariables,
                     theInoutputVariables);
@@ -13878,7 +13817,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.Operation? OperationFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -13903,7 +13841,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -13924,7 +13862,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.Operation? result = (
                     OperationFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -13952,7 +13890,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -13984,7 +13922,6 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.OperationVariable? OperationVariableFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -14005,7 +13942,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -14039,7 +13976,7 @@ namespace AasCore.Aas3_0_RC02
                                 }
 
                                 theValue = ISubmodelElementFromElement(
-                                    reader, ns, out error);
+                                    reader, out error);
 
                                 if (error != null)
                                 {
@@ -14083,7 +14020,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -14129,7 +14066,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.OperationVariable? OperationVariableFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -14154,7 +14090,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -14175,7 +14111,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.OperationVariable? result = (
                     OperationVariableFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -14203,7 +14139,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -14235,7 +14171,6 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.Capability? CapabilityFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -14250,7 +14185,7 @@ namespace AasCore.Aas3_0_RC02
                 Reference? theSemanticId = null;
                 List<Reference>? theSupplementalSemanticIds = null;
                 List<Qualifier>? theQualifiers = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
 
                 if (!isEmptySequence)
                 {
@@ -14266,7 +14201,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -14291,7 +14226,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Extension? item = ExtensionFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -14395,7 +14330,7 @@ namespace AasCore.Aas3_0_RC02
                             case "displayName":
                             {
                                 theDisplayName = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -14409,7 +14344,7 @@ namespace AasCore.Aas3_0_RC02
                             case "description":
                             {
                                 theDescription = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -14518,7 +14453,7 @@ namespace AasCore.Aas3_0_RC02
                             case "semanticId":
                             {
                                 theSemanticId = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -14541,7 +14476,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -14574,7 +14509,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Qualifier? item = QualifierFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -14595,34 +14530,34 @@ namespace AasCore.Aas3_0_RC02
                                 }
                                 break;
                             }
-                            case "dataSpecifications":
+                            case "embeddedDataSpecifications":
                             {
-                                theDataSpecifications = new List<Reference>();
+                                theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>();
 
                                 if (!isEmptyProperty)
                                 {
                                     SkipNoneWhitespaceAndComments(reader);
 
-                                    int indexDataSpecifications = 0;
+                                    int indexEmbeddedDataSpecifications = 0;
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
-                                        Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                        EmbeddedDataSpecification? item = EmbeddedDataSpecificationFromElement(
+                                            reader, out error);
 
                                         if (error != null)
                                         {
                                             error.PrependSegment(
                                                 new Reporting.IndexSegment(
-                                                    indexDataSpecifications));
+                                                    indexEmbeddedDataSpecifications));
                                             return null;
                                         }
 
-                                        theDataSpecifications.Add(
+                                        theEmbeddedDataSpecifications.Add(
                                             item
                                                 ?? throw new System.InvalidOperationException(
                                                     "Unexpected item null when error null"));
 
-                                        indexDataSpecifications++;
+                                        indexEmbeddedDataSpecifications++;
                                         SkipNoneWhitespaceAndComments(reader);
                                     }
                                 }
@@ -14661,7 +14596,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -14699,7 +14634,7 @@ namespace AasCore.Aas3_0_RC02
                     theSemanticId,
                     theSupplementalSemanticIds,
                     theQualifiers,
-                    theDataSpecifications);
+                    theEmbeddedDataSpecifications);
             }  // internal static Aas.Capability? CapabilityFromSequence
 
             /// <summary>
@@ -14707,7 +14642,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.Capability? CapabilityFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -14732,7 +14666,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -14753,7 +14687,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.Capability? result = (
                     CapabilityFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -14781,7 +14715,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -14813,7 +14747,6 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.ConceptDescription? ConceptDescriptionFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -14826,7 +14759,7 @@ namespace AasCore.Aas3_0_RC02
                 string? theChecksum = null;
                 AdministrativeInformation? theAdministration = null;
                 string? theId = null;
-                List<Reference>? theDataSpecifications = null;
+                List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 List<Reference>? theIsCaseOf = null;
 
                 if (!isEmptySequence)
@@ -14843,7 +14776,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -14868,7 +14801,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Extension? item = ExtensionFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -14972,7 +14905,7 @@ namespace AasCore.Aas3_0_RC02
                             case "displayName":
                             {
                                 theDisplayName = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -14986,7 +14919,7 @@ namespace AasCore.Aas3_0_RC02
                             case "description":
                             {
                                 theDescription = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -15040,7 +14973,7 @@ namespace AasCore.Aas3_0_RC02
                             case "administration":
                             {
                                 theAdministration = AdministrativeInformationFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -15091,34 +15024,34 @@ namespace AasCore.Aas3_0_RC02
                                 }
                                 break;
                             }
-                            case "dataSpecifications":
+                            case "embeddedDataSpecifications":
                             {
-                                theDataSpecifications = new List<Reference>();
+                                theEmbeddedDataSpecifications = new List<EmbeddedDataSpecification>();
 
                                 if (!isEmptyProperty)
                                 {
                                     SkipNoneWhitespaceAndComments(reader);
 
-                                    int indexDataSpecifications = 0;
+                                    int indexEmbeddedDataSpecifications = 0;
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
-                                        Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                        EmbeddedDataSpecification? item = EmbeddedDataSpecificationFromElement(
+                                            reader, out error);
 
                                         if (error != null)
                                         {
                                             error.PrependSegment(
                                                 new Reporting.IndexSegment(
-                                                    indexDataSpecifications));
+                                                    indexEmbeddedDataSpecifications));
                                             return null;
                                         }
 
-                                        theDataSpecifications.Add(
+                                        theEmbeddedDataSpecifications.Add(
                                             item
                                                 ?? throw new System.InvalidOperationException(
                                                     "Unexpected item null when error null"));
 
-                                        indexDataSpecifications++;
+                                        indexEmbeddedDataSpecifications++;
                                         SkipNoneWhitespaceAndComments(reader);
                                     }
                                 }
@@ -15136,7 +15069,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Reference? item = ReferenceFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -15190,7 +15123,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -15236,7 +15169,7 @@ namespace AasCore.Aas3_0_RC02
                     theDescription,
                     theChecksum,
                     theAdministration,
-                    theDataSpecifications,
+                    theEmbeddedDataSpecifications,
                     theIsCaseOf);
             }  // internal static Aas.ConceptDescription? ConceptDescriptionFromSequence
 
@@ -15245,7 +15178,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.ConceptDescription? ConceptDescriptionFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -15270,7 +15202,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -15291,7 +15223,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.ConceptDescription? result = (
                     ConceptDescriptionFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -15319,7 +15251,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -15351,7 +15283,6 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.Reference? ReferenceFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -15374,7 +15305,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -15445,7 +15376,7 @@ namespace AasCore.Aas3_0_RC02
                             case "referredSemanticId":
                             {
                                 theReferredSemanticId = ReferenceFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
+                                    reader, isEmptyProperty, out error);
 
                                 if (error != null)
                                 {
@@ -15468,7 +15399,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Key? item = KeyFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -15522,7 +15453,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -15580,7 +15511,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.Reference? ReferenceFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -15605,7 +15535,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -15626,7 +15556,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.Reference? result = (
                     ReferenceFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -15654,7 +15584,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -15686,7 +15616,6 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.Key? KeyFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -15708,7 +15637,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -15849,7 +15778,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -15906,7 +15835,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.Key? KeyFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -15931,7 +15859,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -15952,7 +15880,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.Key? result = (
                     KeyFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -15980,7 +15908,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -16012,7 +15940,6 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.LangString? LangStringFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -16034,7 +15961,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -16160,7 +16087,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -16217,7 +16144,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.LangString? LangStringFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -16242,7 +16168,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -16263,7 +16189,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.LangString? result = (
                     LangStringFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -16291,7 +16217,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -16323,7 +16249,6 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.LangStringSet? LangStringSetFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -16344,7 +16269,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -16369,7 +16294,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         LangString? item = LangStringFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -16423,7 +16348,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -16469,7 +16394,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.LangStringSet? LangStringSetFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -16494,7 +16418,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -16515,7 +16439,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.LangStringSet? result = (
                     LangStringSetFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -16543,7 +16467,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -16565,441 +16489,6 @@ namespace AasCore.Aas3_0_RC02
             }  // internal static Aas.LangStringSet? LangStringSetFromElement
 
             /// <summary>
-            /// Deserialize an instance of class DataSpecificationContent from a sequence of XML elements.
-            /// </summary>
-            /// <remarks>
-            /// If <paramref name="isEmptySequence" /> is set, we should try to deserialize
-            /// the instance from an empty sequence. That is, the parent element
-            /// was a self-closing element.
-            /// </remarks>
-            internal static Aas.DataSpecificationContent DataSpecificationContentFromSequence(
-                Xml.XmlReader reader,
-                bool isEmptySequence,
-                string? ns,
-                out Reporting.Error? error)
-            {
-                error = null;
-                return new Aas.DataSpecificationContent();
-            }  // internal static Aas.DataSpecificationContent? DataSpecificationContentFromSequence
-
-            /// <summary>
-            /// Deserialize an instance of class DataSpecificationContent from an XML element.
-            /// </summary>
-            internal static Aas.DataSpecificationContent? DataSpecificationContentFromElement(
-                Xml.XmlReader reader,
-                string? ns,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                if (reader.EOF)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element representing an instance of class DataSpecificationContent, " +
-                        "but reached the end-of-file");
-                    return null;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element representing an instance of class DataSpecificationContent, " +
-                        $"but got a node of type {reader.NodeType} " +
-                        $"with value {reader.Value}");
-                    return null;
-                }
-
-                string elementName = TryElementName(
-                    reader, ns, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "dataSpecificationContent")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class DataSpecificationContent " +
-                        $"with element name dataSpecificationContent, but got: {elementName}");
-                    return null;
-                }
-
-                bool isEmptyElement = reader.IsEmptyElement;
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.DataSpecificationContent result = (
-                    DataSpecificationContentFromSequence(
-                        reader, isEmptyElement, ns, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                if (!isEmptyElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML end element concluding an instance of class DataSpecificationContent, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML end element concluding an instance of class DataSpecificationContent, " +
-                            $"but got a node of type {reader.NodeType} " +
-                            $"with value {reader.Value}");
-                        return null;
-                    }
-
-                    string endElementName = TryElementName(
-                        reader, ns, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-
-                    if (endElementName != elementName)
-                    {
-                        error = new Reporting.Error(
-                            $"Expected an XML end element with an name {elementName}, " +
-                            $"but got: {endElementName}");
-                        return null;
-                    }
-
-                    // Skip the end element
-                    reader.Read();
-                }
-
-                return result;
-            }  // internal static Aas.DataSpecificationContent? DataSpecificationContentFromElement
-
-            /// <summary>
-            /// Deserialize an instance of class DataSpecification from a sequence of XML elements.
-            /// </summary>
-            /// <remarks>
-            /// If <paramref name="isEmptySequence" /> is set, we should try to deserialize
-            /// the instance from an empty sequence. That is, the parent element
-            /// was a self-closing element.
-            /// </remarks>
-            internal static Aas.DataSpecification? DataSpecificationFromSequence(
-                Xml.XmlReader reader,
-                bool isEmptySequence,
-                string? ns,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string? theId = null;
-                DataSpecificationContent? theDataSpecificationContent = null;
-                AdministrativeInformation? theAdministration = null;
-                LangStringSet? theDescription = null;
-
-                if (!isEmptySequence)
-                {
-                    SkipNoneWhitespaceAndComments(reader);
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML element representing " +
-                            "a property of an instance of class DataSpecification, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
-                    {
-                        string elementName = TryElementName(
-                            reader, ns, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
-                        switch (elementName)
-                        {
-                            case "id":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theId = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Id of an instance of class DataSpecification, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theId = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                    {
-                                        if (exception is System.FormatException
-                                            || exception is System.Xml.XmlException)
-                                        {
-                                            error = new Reporting.Error(
-                                                "The property Id of an instance of class DataSpecification " +
-                                                $"could not be de-serialized: {exception.Message}");
-                                            error.PrependSegment(
-                                                new Reporting.NameSegment(
-                                                    "id"));
-                                            return null;
-                                        }
-
-                                        throw;
-                                    }
-                                }
-                                break;
-                            }
-                            case "dataSpecificationContent":
-                            {
-                                theDataSpecificationContent = DataSpecificationContentFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "dataSpecificationContent"));
-                                    return null;
-                                }
-                                break;
-                            }
-                            case "administration":
-                            {
-                                theAdministration = AdministrativeInformationFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "administration"));
-                                    return null;
-                                }
-                                break;
-                            }
-                            case "description":
-                            {
-                                theDescription = LangStringSetFromSequence(
-                                    reader, isEmptyProperty, ns, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                break;
-                            }
-                            default:
-                                error = new Reporting.Error(
-                                    "We expected properties of the class DataSpecification, " +
-                                    "but got an unexpected element " +
-                                    $"with the name {elementName}");
-                                return null;
-                        }
-
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
-                        {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class DataSpecification " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class DataSpecification " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, ns, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class DataSpecification " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
-                        }
-                    }
-                }
-
-                if (theId == null)
-                {
-                    error = new Reporting.Error(
-                        "The required property Id has not been given " +
-                        "in the XML representation of an instance of class DataSpecification");
-                    return null;
-                }
-
-                if (theDataSpecificationContent == null)
-                {
-                    error = new Reporting.Error(
-                        "The required property DataSpecificationContent has not been given " +
-                        "in the XML representation of an instance of class DataSpecification");
-                    return null;
-                }
-
-                return new Aas.DataSpecification(
-                    theId
-                         ?? throw new System.InvalidOperationException(
-                            "Unexpected null, had to be handled before"),
-                    theDataSpecificationContent
-                         ?? throw new System.InvalidOperationException(
-                            "Unexpected null, had to be handled before"),
-                    theAdministration,
-                    theDescription);
-            }  // internal static Aas.DataSpecification? DataSpecificationFromSequence
-
-            /// <summary>
-            /// Deserialize an instance of class DataSpecification from an XML element.
-            /// </summary>
-            internal static Aas.DataSpecification? DataSpecificationFromElement(
-                Xml.XmlReader reader,
-                string? ns,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                if (reader.EOF)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element representing an instance of class DataSpecification, " +
-                        "but reached the end-of-file");
-                    return null;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element representing an instance of class DataSpecification, " +
-                        $"but got a node of type {reader.NodeType} " +
-                        $"with value {reader.Value}");
-                    return null;
-                }
-
-                string elementName = TryElementName(
-                    reader, ns, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "dataSpecification")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class DataSpecification " +
-                        $"with element name dataSpecification, but got: {elementName}");
-                    return null;
-                }
-
-                bool isEmptyElement = reader.IsEmptyElement;
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.DataSpecification? result = (
-                    DataSpecificationFromSequence(
-                        reader, isEmptyElement, ns, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                if (!isEmptyElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML end element concluding an instance of class DataSpecification, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML end element concluding an instance of class DataSpecification, " +
-                            $"but got a node of type {reader.NodeType} " +
-                            $"with value {reader.Value}");
-                        return null;
-                    }
-
-                    string endElementName = TryElementName(
-                        reader, ns, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-
-                    if (endElementName != elementName)
-                    {
-                        error = new Reporting.Error(
-                            $"Expected an XML end element with an name {elementName}, " +
-                            $"but got: {endElementName}");
-                        return null;
-                    }
-
-                    // Skip the end element
-                    reader.Read();
-                }
-
-                return result;
-            }  // internal static Aas.DataSpecification? DataSpecificationFromElement
-
-            /// <summary>
             /// Deserialize an instance of class Environment from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -17010,7 +16499,6 @@ namespace AasCore.Aas3_0_RC02
             internal static Aas.Environment? EnvironmentFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -17033,7 +16521,7 @@ namespace AasCore.Aas3_0_RC02
                     while (reader.NodeType == Xml.XmlNodeType.Element)
                     {
                         string elementName = TryElementName(
-                            reader, ns, out error);
+                            reader, out error);
                         if (error != null)
                         {
                             return null;
@@ -17058,7 +16546,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         AssetAdministrationShell? item = AssetAdministrationShellFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -17091,7 +16579,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         Submodel? item = SubmodelFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -17124,7 +16612,7 @@ namespace AasCore.Aas3_0_RC02
                                     while (reader.NodeType == Xml.XmlNodeType.Element)
                                     {
                                         ConceptDescription? item = ConceptDescriptionFromElement(
-                                            reader, ns, out error);
+                                            reader, out error);
 
                                         if (error != null)
                                         {
@@ -17178,7 +16666,7 @@ namespace AasCore.Aas3_0_RC02
                             }
 
                             string endElementName = TryElementName(
-                                reader, ns, out error);
+                                reader, out error);
                             if (error != null)
                             {
                                 return null;
@@ -17216,7 +16704,6 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             internal static Aas.Environment? EnvironmentFromElement(
                 Xml.XmlReader reader,
-                string? ns,
                 out Reporting.Error? error)
             {
                 error = null;
@@ -17241,7 +16728,7 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 string elementName = TryElementName(
-                    reader, ns, out error);
+                    reader, out error);
                 if (error != null)
                 {
                     return null;
@@ -17262,7 +16749,7 @@ namespace AasCore.Aas3_0_RC02
 
                 Aas.Environment? result = (
                     EnvironmentFromSequence(
-                        reader, isEmptyElement, ns, out error));
+                        reader, isEmptyElement, out error));
                 if (error != null)
                 {
                     return null;
@@ -17290,7 +16777,7 @@ namespace AasCore.Aas3_0_RC02
                     }
 
                     string endElementName = TryElementName(
-                        reader, ns, out error);
+                        reader, out error);
                     if (error != null)
                     {
                         return null;
@@ -17310,6 +16797,2238 @@ namespace AasCore.Aas3_0_RC02
 
                 return result;
             }  // internal static Aas.Environment? EnvironmentFromElement
+
+            /// <summary>
+            /// Deserialize an instance of IDataSpecificationContent from an XML element.
+            /// </summary>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+            internal static Aas.IDataSpecificationContent? IDataSpecificationContentFromElement(
+                Xml.XmlReader reader,
+                out Reporting.Error? error)
+            {
+                error = null;
+
+                SkipNoneWhitespaceAndComments(reader);
+
+                if (reader.EOF)
+                {
+                    error = new Reporting.Error(
+                        "Expected an XML element, but reached end-of-file");
+                    return null;
+                }
+
+                if (reader.NodeType != Xml.XmlNodeType.Element)
+                {
+                    error = new Reporting.Error(
+                        "Expected an XML element, " +
+                        $"but got a node of type {reader.NodeType} " +
+                        $"with value {reader.Value}");
+                    return null;
+                }
+
+                string elementName = TryElementName(
+                    reader, out error);
+                if (error != null)
+                {
+                    return null;
+                }
+
+                switch (elementName)
+                {
+                    case "dataSpecificationIec61360":
+                        return DataSpecificationIec61360FromElement(
+                            reader, out error);
+                    case "dataSpecificationPhysicalUnit":
+                        return DataSpecificationPhysicalUnitFromElement(
+                            reader, out error);
+                    default:
+                        error = new Reporting.Error(
+                            $"Unexpected element with the name {elementName}");
+                        return null;
+                }
+            }  // internal static Aas.IDataSpecificationContent? IDataSpecificationContentFromElement
+
+            /// <summary>
+            /// Deserialize an instance of class EmbeddedDataSpecification from a sequence of XML elements.
+            /// </summary>
+            /// <remarks>
+            /// If <paramref name="isEmptySequence" /> is set, we should try to deserialize
+            /// the instance from an empty sequence. That is, the parent element
+            /// was a self-closing element.
+            /// </remarks>
+            internal static Aas.EmbeddedDataSpecification? EmbeddedDataSpecificationFromSequence(
+                Xml.XmlReader reader,
+                bool isEmptySequence,
+                out Reporting.Error? error)
+            {
+                error = null;
+
+                Reference? theDataSpecification = null;
+                IDataSpecificationContent? theDataSpecificationContent = null;
+
+                if (!isEmptySequence)
+                {
+                    SkipNoneWhitespaceAndComments(reader);
+                    if (reader.EOF)
+                    {
+                        error = new Reporting.Error(
+                            "Expected an XML element representing " +
+                            "a property of an instance of class EmbeddedDataSpecification, " +
+                            "but reached the end-of-file");
+                        return null;
+                    }
+                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    {
+                        string elementName = TryElementName(
+                            reader, out error);
+                        if (error != null)
+                        {
+                            return null;
+                        }
+
+                        bool isEmptyProperty = reader.IsEmptyElement;
+
+                        // Skip the expected element
+                        reader.Read();
+
+                        switch (elementName)
+                        {
+                            case "dataSpecification":
+                            {
+                                theDataSpecification = ReferenceFromSequence(
+                                    reader, isEmptyProperty, out error);
+
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "dataSpecification"));
+                                    return null;
+                                }
+                                break;
+                            }
+                            case "dataSpecificationContent":
+                            {
+                                if (isEmptyProperty)
+                                {
+                                    error = new Reporting.Error(
+                                        $"Expected an XML element within the element {elementName} representing " +
+                                        "the property DataSpecificationContent of an instance of class EmbeddedDataSpecification, " +
+                                        "but encountered a self-closing element {elementName}");
+                                    return null;
+                                }
+
+                                if (reader.EOF)
+                                {
+                                    error = new Reporting.Error(
+                                        $"Expected an XML element within the element {elementName} representing " +
+                                        "the property DataSpecificationContent of an instance of class EmbeddedDataSpecification, " +
+                                        "but reached the end-of-file");
+                                    return null;
+                                }
+
+                                theDataSpecificationContent = IDataSpecificationContentFromElement(
+                                    reader, out error);
+
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "dataSpecificationContent"));
+                                    return null;
+                                }
+                                break;
+                            }
+                            default:
+                                error = new Reporting.Error(
+                                    "We expected properties of the class EmbeddedDataSpecification, " +
+                                    "but got an unexpected element " +
+                                    $"with the name {elementName}");
+                                return null;
+                        }
+
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (!isEmptyProperty)
+                        {
+                            // Read the end element
+
+                            if (reader.EOF)
+                            {
+                                error = new Reporting.Error(
+                                    "Expected an XML end element to conclude a property of class EmbeddedDataSpecification " +
+                                    $"with the element name {elementName}, " +
+                                    "but got the end-of-file.");
+                                return null;
+                            }
+                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
+                            {
+                                error = new Reporting.Error(
+                                    "Expected an XML end element to conclude a property of class EmbeddedDataSpecification " +
+                                    $"with the element name {elementName}, " +
+                                    $"but got the node of type {reader.NodeType} " +
+                                    $"with the value {reader.Value}");
+                                return null;
+                            }
+
+                            string endElementName = TryElementName(
+                                reader, out error);
+                            if (error != null)
+                            {
+                                return null;
+                            }
+
+                            if (endElementName != elementName)
+                            {
+                                error = new Reporting.Error(
+                                    "Expected an XML end element to conclude a property of class EmbeddedDataSpecification " +
+                                    $"with the element name {elementName}, " +
+                                    $"but got the end element with the name {reader.Name}");
+                                return null;
+                            }
+                            // Skip the expected end element
+                            reader.Read();
+
+                            SkipNoneWhitespaceAndComments(reader);
+                        }
+
+                        if (reader.EOF)
+                        {
+                            break;
+                        }
+                    }
+                }
+
+                if (theDataSpecification == null)
+                {
+                    error = new Reporting.Error(
+                        "The required property DataSpecification has not been given " +
+                        "in the XML representation of an instance of class EmbeddedDataSpecification");
+                    return null;
+                }
+
+                if (theDataSpecificationContent == null)
+                {
+                    error = new Reporting.Error(
+                        "The required property DataSpecificationContent has not been given " +
+                        "in the XML representation of an instance of class EmbeddedDataSpecification");
+                    return null;
+                }
+
+                return new Aas.EmbeddedDataSpecification(
+                    theDataSpecification
+                         ?? throw new System.InvalidOperationException(
+                            "Unexpected null, had to be handled before"),
+                    theDataSpecificationContent
+                         ?? throw new System.InvalidOperationException(
+                            "Unexpected null, had to be handled before"));
+            }  // internal static Aas.EmbeddedDataSpecification? EmbeddedDataSpecificationFromSequence
+
+            /// <summary>
+            /// Deserialize an instance of class EmbeddedDataSpecification from an XML element.
+            /// </summary>
+            internal static Aas.EmbeddedDataSpecification? EmbeddedDataSpecificationFromElement(
+                Xml.XmlReader reader,
+                out Reporting.Error? error)
+            {
+                error = null;
+
+                SkipNoneWhitespaceAndComments(reader);
+
+                if (reader.EOF)
+                {
+                    error = new Reporting.Error(
+                        "Expected an XML element representing an instance of class EmbeddedDataSpecification, " +
+                        "but reached the end-of-file");
+                    return null;
+                }
+
+                if (reader.NodeType != Xml.XmlNodeType.Element)
+                {
+                    error = new Reporting.Error(
+                        "Expected an XML element representing an instance of class EmbeddedDataSpecification, " +
+                        $"but got a node of type {reader.NodeType} " +
+                        $"with value {reader.Value}");
+                    return null;
+                }
+
+                string elementName = TryElementName(
+                    reader, out error);
+                if (error != null)
+                {
+                    return null;
+                }
+
+                if (elementName != "embeddedDataSpecification")
+                {
+                    error = new Reporting.Error(
+                        "Expected an element representing an instance of class EmbeddedDataSpecification " +
+                        $"with element name embeddedDataSpecification, but got: {elementName}");
+                    return null;
+                }
+
+                bool isEmptyElement = reader.IsEmptyElement;
+
+                // Skip the element node and go to the content
+                reader.Read();
+
+                Aas.EmbeddedDataSpecification? result = (
+                    EmbeddedDataSpecificationFromSequence(
+                        reader, isEmptyElement, out error));
+                if (error != null)
+                {
+                    return null;
+                }
+
+                SkipNoneWhitespaceAndComments(reader);
+
+                if (!isEmptyElement)
+                {
+                    if (reader.EOF)
+                    {
+                        error = new Reporting.Error(
+                            "Expected an XML end element concluding an instance of class EmbeddedDataSpecification, " +
+                            "but reached the end-of-file");
+                        return null;
+                    }
+
+                    if (reader.NodeType != Xml.XmlNodeType.EndElement)
+                    {
+                        error = new Reporting.Error(
+                            "Expected an XML end element concluding an instance of class EmbeddedDataSpecification, " +
+                            $"but got a node of type {reader.NodeType} " +
+                            $"with value {reader.Value}");
+                        return null;
+                    }
+
+                    string endElementName = TryElementName(
+                        reader, out error);
+                    if (error != null)
+                    {
+                        return null;
+                    }
+
+                    if (endElementName != elementName)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML end element with an name {elementName}, " +
+                            $"but got: {endElementName}");
+                        return null;
+                    }
+
+                    // Skip the end element
+                    reader.Read();
+                }
+
+                return result;
+            }  // internal static Aas.EmbeddedDataSpecification? EmbeddedDataSpecificationFromElement
+
+            /// <summary>
+            /// Deserialize an instance of class ValueReferencePair from a sequence of XML elements.
+            /// </summary>
+            /// <remarks>
+            /// If <paramref name="isEmptySequence" /> is set, we should try to deserialize
+            /// the instance from an empty sequence. That is, the parent element
+            /// was a self-closing element.
+            /// </remarks>
+            internal static Aas.ValueReferencePair? ValueReferencePairFromSequence(
+                Xml.XmlReader reader,
+                bool isEmptySequence,
+                out Reporting.Error? error)
+            {
+                error = null;
+
+                string? theValue = null;
+                Reference? theValueId = null;
+
+                if (!isEmptySequence)
+                {
+                    SkipNoneWhitespaceAndComments(reader);
+                    if (reader.EOF)
+                    {
+                        error = new Reporting.Error(
+                            "Expected an XML element representing " +
+                            "a property of an instance of class ValueReferencePair, " +
+                            "but reached the end-of-file");
+                        return null;
+                    }
+                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    {
+                        string elementName = TryElementName(
+                            reader, out error);
+                        if (error != null)
+                        {
+                            return null;
+                        }
+
+                        bool isEmptyProperty = reader.IsEmptyElement;
+
+                        // Skip the expected element
+                        reader.Read();
+
+                        switch (elementName)
+                        {
+                            case "value":
+                            {
+                                if (isEmptyProperty)
+                                {
+                                    theValue = "";
+                                }
+                                else
+                                {
+                                    if (reader.EOF)
+                                    {
+                                        error = new Reporting.Error(
+                                            "Expected an XML content representing " +
+                                            "the property Value of an instance of class ValueReferencePair, " +
+                                            "but reached the end-of-file");
+                                        return null;
+                                    }
+
+                                    try
+                                    {
+                                        theValue = reader.ReadContentAsString();
+                                    }
+                                    catch (System.Exception exception)
+                                    {
+                                        if (exception is System.FormatException
+                                            || exception is System.Xml.XmlException)
+                                        {
+                                            error = new Reporting.Error(
+                                                "The property Value of an instance of class ValueReferencePair " +
+                                                $"could not be de-serialized: {exception.Message}");
+                                            error.PrependSegment(
+                                                new Reporting.NameSegment(
+                                                    "value"));
+                                            return null;
+                                        }
+
+                                        throw;
+                                    }
+                                }
+                                break;
+                            }
+                            case "valueId":
+                            {
+                                theValueId = ReferenceFromSequence(
+                                    reader, isEmptyProperty, out error);
+
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "valueId"));
+                                    return null;
+                                }
+                                break;
+                            }
+                            default:
+                                error = new Reporting.Error(
+                                    "We expected properties of the class ValueReferencePair, " +
+                                    "but got an unexpected element " +
+                                    $"with the name {elementName}");
+                                return null;
+                        }
+
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (!isEmptyProperty)
+                        {
+                            // Read the end element
+
+                            if (reader.EOF)
+                            {
+                                error = new Reporting.Error(
+                                    "Expected an XML end element to conclude a property of class ValueReferencePair " +
+                                    $"with the element name {elementName}, " +
+                                    "but got the end-of-file.");
+                                return null;
+                            }
+                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
+                            {
+                                error = new Reporting.Error(
+                                    "Expected an XML end element to conclude a property of class ValueReferencePair " +
+                                    $"with the element name {elementName}, " +
+                                    $"but got the node of type {reader.NodeType} " +
+                                    $"with the value {reader.Value}");
+                                return null;
+                            }
+
+                            string endElementName = TryElementName(
+                                reader, out error);
+                            if (error != null)
+                            {
+                                return null;
+                            }
+
+                            if (endElementName != elementName)
+                            {
+                                error = new Reporting.Error(
+                                    "Expected an XML end element to conclude a property of class ValueReferencePair " +
+                                    $"with the element name {elementName}, " +
+                                    $"but got the end element with the name {reader.Name}");
+                                return null;
+                            }
+                            // Skip the expected end element
+                            reader.Read();
+
+                            SkipNoneWhitespaceAndComments(reader);
+                        }
+
+                        if (reader.EOF)
+                        {
+                            break;
+                        }
+                    }
+                }
+
+                if (theValue == null)
+                {
+                    error = new Reporting.Error(
+                        "The required property Value has not been given " +
+                        "in the XML representation of an instance of class ValueReferencePair");
+                    return null;
+                }
+
+                if (theValueId == null)
+                {
+                    error = new Reporting.Error(
+                        "The required property ValueId has not been given " +
+                        "in the XML representation of an instance of class ValueReferencePair");
+                    return null;
+                }
+
+                return new Aas.ValueReferencePair(
+                    theValue
+                         ?? throw new System.InvalidOperationException(
+                            "Unexpected null, had to be handled before"),
+                    theValueId
+                         ?? throw new System.InvalidOperationException(
+                            "Unexpected null, had to be handled before"));
+            }  // internal static Aas.ValueReferencePair? ValueReferencePairFromSequence
+
+            /// <summary>
+            /// Deserialize an instance of class ValueReferencePair from an XML element.
+            /// </summary>
+            internal static Aas.ValueReferencePair? ValueReferencePairFromElement(
+                Xml.XmlReader reader,
+                out Reporting.Error? error)
+            {
+                error = null;
+
+                SkipNoneWhitespaceAndComments(reader);
+
+                if (reader.EOF)
+                {
+                    error = new Reporting.Error(
+                        "Expected an XML element representing an instance of class ValueReferencePair, " +
+                        "but reached the end-of-file");
+                    return null;
+                }
+
+                if (reader.NodeType != Xml.XmlNodeType.Element)
+                {
+                    error = new Reporting.Error(
+                        "Expected an XML element representing an instance of class ValueReferencePair, " +
+                        $"but got a node of type {reader.NodeType} " +
+                        $"with value {reader.Value}");
+                    return null;
+                }
+
+                string elementName = TryElementName(
+                    reader, out error);
+                if (error != null)
+                {
+                    return null;
+                }
+
+                if (elementName != "valueReferencePair")
+                {
+                    error = new Reporting.Error(
+                        "Expected an element representing an instance of class ValueReferencePair " +
+                        $"with element name valueReferencePair, but got: {elementName}");
+                    return null;
+                }
+
+                bool isEmptyElement = reader.IsEmptyElement;
+
+                // Skip the element node and go to the content
+                reader.Read();
+
+                Aas.ValueReferencePair? result = (
+                    ValueReferencePairFromSequence(
+                        reader, isEmptyElement, out error));
+                if (error != null)
+                {
+                    return null;
+                }
+
+                SkipNoneWhitespaceAndComments(reader);
+
+                if (!isEmptyElement)
+                {
+                    if (reader.EOF)
+                    {
+                        error = new Reporting.Error(
+                            "Expected an XML end element concluding an instance of class ValueReferencePair, " +
+                            "but reached the end-of-file");
+                        return null;
+                    }
+
+                    if (reader.NodeType != Xml.XmlNodeType.EndElement)
+                    {
+                        error = new Reporting.Error(
+                            "Expected an XML end element concluding an instance of class ValueReferencePair, " +
+                            $"but got a node of type {reader.NodeType} " +
+                            $"with value {reader.Value}");
+                        return null;
+                    }
+
+                    string endElementName = TryElementName(
+                        reader, out error);
+                    if (error != null)
+                    {
+                        return null;
+                    }
+
+                    if (endElementName != elementName)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML end element with an name {elementName}, " +
+                            $"but got: {endElementName}");
+                        return null;
+                    }
+
+                    // Skip the end element
+                    reader.Read();
+                }
+
+                return result;
+            }  // internal static Aas.ValueReferencePair? ValueReferencePairFromElement
+
+            /// <summary>
+            /// Deserialize an instance of class ValueList from a sequence of XML elements.
+            /// </summary>
+            /// <remarks>
+            /// If <paramref name="isEmptySequence" /> is set, we should try to deserialize
+            /// the instance from an empty sequence. That is, the parent element
+            /// was a self-closing element.
+            /// </remarks>
+            internal static Aas.ValueList? ValueListFromSequence(
+                Xml.XmlReader reader,
+                bool isEmptySequence,
+                out Reporting.Error? error)
+            {
+                error = null;
+
+                List<ValueReferencePair>? theValueReferencePairTypes = null;
+
+                if (!isEmptySequence)
+                {
+                    SkipNoneWhitespaceAndComments(reader);
+                    if (reader.EOF)
+                    {
+                        error = new Reporting.Error(
+                            "Expected an XML element representing " +
+                            "a property of an instance of class ValueList, " +
+                            "but reached the end-of-file");
+                        return null;
+                    }
+                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    {
+                        string elementName = TryElementName(
+                            reader, out error);
+                        if (error != null)
+                        {
+                            return null;
+                        }
+
+                        bool isEmptyProperty = reader.IsEmptyElement;
+
+                        // Skip the expected element
+                        reader.Read();
+
+                        switch (elementName)
+                        {
+                            case "valueReferencePairTypes":
+                            {
+                                theValueReferencePairTypes = new List<ValueReferencePair>();
+
+                                if (!isEmptyProperty)
+                                {
+                                    SkipNoneWhitespaceAndComments(reader);
+
+                                    int indexValueReferencePairTypes = 0;
+                                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                                    {
+                                        ValueReferencePair? item = ValueReferencePairFromElement(
+                                            reader, out error);
+
+                                        if (error != null)
+                                        {
+                                            error.PrependSegment(
+                                                new Reporting.IndexSegment(
+                                                    indexValueReferencePairTypes));
+                                            return null;
+                                        }
+
+                                        theValueReferencePairTypes.Add(
+                                            item
+                                                ?? throw new System.InvalidOperationException(
+                                                    "Unexpected item null when error null"));
+
+                                        indexValueReferencePairTypes++;
+                                        SkipNoneWhitespaceAndComments(reader);
+                                    }
+                                }
+                                break;
+                            }
+                            default:
+                                error = new Reporting.Error(
+                                    "We expected properties of the class ValueList, " +
+                                    "but got an unexpected element " +
+                                    $"with the name {elementName}");
+                                return null;
+                        }
+
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (!isEmptyProperty)
+                        {
+                            // Read the end element
+
+                            if (reader.EOF)
+                            {
+                                error = new Reporting.Error(
+                                    "Expected an XML end element to conclude a property of class ValueList " +
+                                    $"with the element name {elementName}, " +
+                                    "but got the end-of-file.");
+                                return null;
+                            }
+                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
+                            {
+                                error = new Reporting.Error(
+                                    "Expected an XML end element to conclude a property of class ValueList " +
+                                    $"with the element name {elementName}, " +
+                                    $"but got the node of type {reader.NodeType} " +
+                                    $"with the value {reader.Value}");
+                                return null;
+                            }
+
+                            string endElementName = TryElementName(
+                                reader, out error);
+                            if (error != null)
+                            {
+                                return null;
+                            }
+
+                            if (endElementName != elementName)
+                            {
+                                error = new Reporting.Error(
+                                    "Expected an XML end element to conclude a property of class ValueList " +
+                                    $"with the element name {elementName}, " +
+                                    $"but got the end element with the name {reader.Name}");
+                                return null;
+                            }
+                            // Skip the expected end element
+                            reader.Read();
+
+                            SkipNoneWhitespaceAndComments(reader);
+                        }
+
+                        if (reader.EOF)
+                        {
+                            break;
+                        }
+                    }
+                }
+
+                if (theValueReferencePairTypes == null)
+                {
+                    error = new Reporting.Error(
+                        "The required property ValueReferencePairTypes has not been given " +
+                        "in the XML representation of an instance of class ValueList");
+                    return null;
+                }
+
+                return new Aas.ValueList(
+                    theValueReferencePairTypes
+                         ?? throw new System.InvalidOperationException(
+                            "Unexpected null, had to be handled before"));
+            }  // internal static Aas.ValueList? ValueListFromSequence
+
+            /// <summary>
+            /// Deserialize an instance of class ValueList from an XML element.
+            /// </summary>
+            internal static Aas.ValueList? ValueListFromElement(
+                Xml.XmlReader reader,
+                out Reporting.Error? error)
+            {
+                error = null;
+
+                SkipNoneWhitespaceAndComments(reader);
+
+                if (reader.EOF)
+                {
+                    error = new Reporting.Error(
+                        "Expected an XML element representing an instance of class ValueList, " +
+                        "but reached the end-of-file");
+                    return null;
+                }
+
+                if (reader.NodeType != Xml.XmlNodeType.Element)
+                {
+                    error = new Reporting.Error(
+                        "Expected an XML element representing an instance of class ValueList, " +
+                        $"but got a node of type {reader.NodeType} " +
+                        $"with value {reader.Value}");
+                    return null;
+                }
+
+                string elementName = TryElementName(
+                    reader, out error);
+                if (error != null)
+                {
+                    return null;
+                }
+
+                if (elementName != "valueList")
+                {
+                    error = new Reporting.Error(
+                        "Expected an element representing an instance of class ValueList " +
+                        $"with element name valueList, but got: {elementName}");
+                    return null;
+                }
+
+                bool isEmptyElement = reader.IsEmptyElement;
+
+                // Skip the element node and go to the content
+                reader.Read();
+
+                Aas.ValueList? result = (
+                    ValueListFromSequence(
+                        reader, isEmptyElement, out error));
+                if (error != null)
+                {
+                    return null;
+                }
+
+                SkipNoneWhitespaceAndComments(reader);
+
+                if (!isEmptyElement)
+                {
+                    if (reader.EOF)
+                    {
+                        error = new Reporting.Error(
+                            "Expected an XML end element concluding an instance of class ValueList, " +
+                            "but reached the end-of-file");
+                        return null;
+                    }
+
+                    if (reader.NodeType != Xml.XmlNodeType.EndElement)
+                    {
+                        error = new Reporting.Error(
+                            "Expected an XML end element concluding an instance of class ValueList, " +
+                            $"but got a node of type {reader.NodeType} " +
+                            $"with value {reader.Value}");
+                        return null;
+                    }
+
+                    string endElementName = TryElementName(
+                        reader, out error);
+                    if (error != null)
+                    {
+                        return null;
+                    }
+
+                    if (endElementName != elementName)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML end element with an name {elementName}, " +
+                            $"but got: {endElementName}");
+                        return null;
+                    }
+
+                    // Skip the end element
+                    reader.Read();
+                }
+
+                return result;
+            }  // internal static Aas.ValueList? ValueListFromElement
+
+            /// <summary>
+            /// Deserialize an instance of class DataSpecificationIec61360 from a sequence of XML elements.
+            /// </summary>
+            /// <remarks>
+            /// If <paramref name="isEmptySequence" /> is set, we should try to deserialize
+            /// the instance from an empty sequence. That is, the parent element
+            /// was a self-closing element.
+            /// </remarks>
+            internal static Aas.DataSpecificationIec61360? DataSpecificationIec61360FromSequence(
+                Xml.XmlReader reader,
+                bool isEmptySequence,
+                out Reporting.Error? error)
+            {
+                error = null;
+
+                LangStringSet? thePreferredName = null;
+                LangStringSet? theShortName = null;
+                string? theUnit = null;
+                Reference? theUnitId = null;
+                string? theSourceOfDefinition = null;
+                string? theSymbol = null;
+                DataTypeIec61360? theDataType = null;
+                LangStringSet? theDefinition = null;
+                string? theValueFormat = null;
+                ValueList? theValueList = null;
+                string? theValue = null;
+                LevelType? theLevelType = null;
+
+                if (!isEmptySequence)
+                {
+                    SkipNoneWhitespaceAndComments(reader);
+                    if (reader.EOF)
+                    {
+                        error = new Reporting.Error(
+                            "Expected an XML element representing " +
+                            "a property of an instance of class DataSpecificationIec61360, " +
+                            "but reached the end-of-file");
+                        return null;
+                    }
+                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    {
+                        string elementName = TryElementName(
+                            reader, out error);
+                        if (error != null)
+                        {
+                            return null;
+                        }
+
+                        bool isEmptyProperty = reader.IsEmptyElement;
+
+                        // Skip the expected element
+                        reader.Read();
+
+                        switch (elementName)
+                        {
+                            case "preferredName":
+                            {
+                                thePreferredName = LangStringSetFromSequence(
+                                    reader, isEmptyProperty, out error);
+
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "preferredName"));
+                                    return null;
+                                }
+                                break;
+                            }
+                            case "shortName":
+                            {
+                                theShortName = LangStringSetFromSequence(
+                                    reader, isEmptyProperty, out error);
+
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "shortName"));
+                                    return null;
+                                }
+                                break;
+                            }
+                            case "unit":
+                            {
+                                if (isEmptyProperty)
+                                {
+                                    theUnit = "";
+                                }
+                                else
+                                {
+                                    if (reader.EOF)
+                                    {
+                                        error = new Reporting.Error(
+                                            "Expected an XML content representing " +
+                                            "the property Unit of an instance of class DataSpecificationIec61360, " +
+                                            "but reached the end-of-file");
+                                        return null;
+                                    }
+
+                                    try
+                                    {
+                                        theUnit = reader.ReadContentAsString();
+                                    }
+                                    catch (System.Exception exception)
+                                    {
+                                        if (exception is System.FormatException
+                                            || exception is System.Xml.XmlException)
+                                        {
+                                            error = new Reporting.Error(
+                                                "The property Unit of an instance of class DataSpecificationIec61360 " +
+                                                $"could not be de-serialized: {exception.Message}");
+                                            error.PrependSegment(
+                                                new Reporting.NameSegment(
+                                                    "unit"));
+                                            return null;
+                                        }
+
+                                        throw;
+                                    }
+                                }
+                                break;
+                            }
+                            case "unitId":
+                            {
+                                theUnitId = ReferenceFromSequence(
+                                    reader, isEmptyProperty, out error);
+
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "unitId"));
+                                    return null;
+                                }
+                                break;
+                            }
+                            case "sourceOfDefinition":
+                            {
+                                if (isEmptyProperty)
+                                {
+                                    theSourceOfDefinition = "";
+                                }
+                                else
+                                {
+                                    if (reader.EOF)
+                                    {
+                                        error = new Reporting.Error(
+                                            "Expected an XML content representing " +
+                                            "the property SourceOfDefinition of an instance of class DataSpecificationIec61360, " +
+                                            "but reached the end-of-file");
+                                        return null;
+                                    }
+
+                                    try
+                                    {
+                                        theSourceOfDefinition = reader.ReadContentAsString();
+                                    }
+                                    catch (System.Exception exception)
+                                    {
+                                        if (exception is System.FormatException
+                                            || exception is System.Xml.XmlException)
+                                        {
+                                            error = new Reporting.Error(
+                                                "The property SourceOfDefinition of an instance of class DataSpecificationIec61360 " +
+                                                $"could not be de-serialized: {exception.Message}");
+                                            error.PrependSegment(
+                                                new Reporting.NameSegment(
+                                                    "sourceOfDefinition"));
+                                            return null;
+                                        }
+
+                                        throw;
+                                    }
+                                }
+                                break;
+                            }
+                            case "symbol":
+                            {
+                                if (isEmptyProperty)
+                                {
+                                    theSymbol = "";
+                                }
+                                else
+                                {
+                                    if (reader.EOF)
+                                    {
+                                        error = new Reporting.Error(
+                                            "Expected an XML content representing " +
+                                            "the property Symbol of an instance of class DataSpecificationIec61360, " +
+                                            "but reached the end-of-file");
+                                        return null;
+                                    }
+
+                                    try
+                                    {
+                                        theSymbol = reader.ReadContentAsString();
+                                    }
+                                    catch (System.Exception exception)
+                                    {
+                                        if (exception is System.FormatException
+                                            || exception is System.Xml.XmlException)
+                                        {
+                                            error = new Reporting.Error(
+                                                "The property Symbol of an instance of class DataSpecificationIec61360 " +
+                                                $"could not be de-serialized: {exception.Message}");
+                                            error.PrependSegment(
+                                                new Reporting.NameSegment(
+                                                    "symbol"));
+                                            return null;
+                                        }
+
+                                        throw;
+                                    }
+                                }
+                                break;
+                            }
+                            case "dataType":
+                            {
+                                if (isEmptyProperty)
+                                {
+                                    error = new Reporting.Error(
+                                        "The property DataType of an instance of class DataSpecificationIec61360 " +
+                                        "can not be de-serialized from a self-closing element " +
+                                        "since it needs content");
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "dataType"));
+                                    return null;
+                                }
+
+                                    if (reader.EOF)
+                                {
+                                        error = new Reporting.Error(
+                                            "Expected an XML content representing " +
+                                            "the property DataType of an instance of class DataSpecificationIec61360, " +
+                                            "but reached the end-of-file");
+                                        return null;
+                                }
+
+                                string textDataType;
+                                try
+                                {
+                                    textDataType = reader.ReadContentAsString();
+                                }
+                                catch (System.FormatException exception)
+                                {
+                                    error = new Reporting.Error(
+                                        "The property DataType of an instance of class DataSpecificationIec61360 " +
+                                        $"could not be de-serialized as a string: {exception}");
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "dataType"));
+                                    return null;
+                                }
+
+                                theDataType = Stringification.DataTypeIec61360FromString(
+                                    textDataType);
+
+                                if (theDataType == null)
+                                {
+                                    error = new Reporting.Error(
+                                        "The property DataType of an instance of class DataSpecificationIec61360 " +
+                                        "could not be de-serialized from an unexpected enumeration literal: " +
+                                        textDataType);
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "dataType"));
+                                    return null;
+                                }
+                                break;
+                            }
+                            case "definition":
+                            {
+                                theDefinition = LangStringSetFromSequence(
+                                    reader, isEmptyProperty, out error);
+
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "definition"));
+                                    return null;
+                                }
+                                break;
+                            }
+                            case "valueFormat":
+                            {
+                                if (isEmptyProperty)
+                                {
+                                    theValueFormat = "";
+                                }
+                                else
+                                {
+                                    if (reader.EOF)
+                                    {
+                                        error = new Reporting.Error(
+                                            "Expected an XML content representing " +
+                                            "the property ValueFormat of an instance of class DataSpecificationIec61360, " +
+                                            "but reached the end-of-file");
+                                        return null;
+                                    }
+
+                                    try
+                                    {
+                                        theValueFormat = reader.ReadContentAsString();
+                                    }
+                                    catch (System.Exception exception)
+                                    {
+                                        if (exception is System.FormatException
+                                            || exception is System.Xml.XmlException)
+                                        {
+                                            error = new Reporting.Error(
+                                                "The property ValueFormat of an instance of class DataSpecificationIec61360 " +
+                                                $"could not be de-serialized: {exception.Message}");
+                                            error.PrependSegment(
+                                                new Reporting.NameSegment(
+                                                    "valueFormat"));
+                                            return null;
+                                        }
+
+                                        throw;
+                                    }
+                                }
+                                break;
+                            }
+                            case "valueList":
+                            {
+                                theValueList = ValueListFromSequence(
+                                    reader, isEmptyProperty, out error);
+
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "valueList"));
+                                    return null;
+                                }
+                                break;
+                            }
+                            case "value":
+                            {
+                                if (isEmptyProperty)
+                                {
+                                    theValue = "";
+                                }
+                                else
+                                {
+                                    if (reader.EOF)
+                                    {
+                                        error = new Reporting.Error(
+                                            "Expected an XML content representing " +
+                                            "the property Value of an instance of class DataSpecificationIec61360, " +
+                                            "but reached the end-of-file");
+                                        return null;
+                                    }
+
+                                    try
+                                    {
+                                        theValue = reader.ReadContentAsString();
+                                    }
+                                    catch (System.Exception exception)
+                                    {
+                                        if (exception is System.FormatException
+                                            || exception is System.Xml.XmlException)
+                                        {
+                                            error = new Reporting.Error(
+                                                "The property Value of an instance of class DataSpecificationIec61360 " +
+                                                $"could not be de-serialized: {exception.Message}");
+                                            error.PrependSegment(
+                                                new Reporting.NameSegment(
+                                                    "value"));
+                                            return null;
+                                        }
+
+                                        throw;
+                                    }
+                                }
+                                break;
+                            }
+                            case "levelType":
+                            {
+                                if (isEmptyProperty)
+                                {
+                                    error = new Reporting.Error(
+                                        "The property LevelType of an instance of class DataSpecificationIec61360 " +
+                                        "can not be de-serialized from a self-closing element " +
+                                        "since it needs content");
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "levelType"));
+                                    return null;
+                                }
+
+                                    if (reader.EOF)
+                                {
+                                        error = new Reporting.Error(
+                                            "Expected an XML content representing " +
+                                            "the property LevelType of an instance of class DataSpecificationIec61360, " +
+                                            "but reached the end-of-file");
+                                        return null;
+                                }
+
+                                string textLevelType;
+                                try
+                                {
+                                    textLevelType = reader.ReadContentAsString();
+                                }
+                                catch (System.FormatException exception)
+                                {
+                                    error = new Reporting.Error(
+                                        "The property LevelType of an instance of class DataSpecificationIec61360 " +
+                                        $"could not be de-serialized as a string: {exception}");
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "levelType"));
+                                    return null;
+                                }
+
+                                theLevelType = Stringification.LevelTypeFromString(
+                                    textLevelType);
+
+                                if (theLevelType == null)
+                                {
+                                    error = new Reporting.Error(
+                                        "The property LevelType of an instance of class DataSpecificationIec61360 " +
+                                        "could not be de-serialized from an unexpected enumeration literal: " +
+                                        textLevelType);
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "levelType"));
+                                    return null;
+                                }
+                                break;
+                            }
+                            default:
+                                error = new Reporting.Error(
+                                    "We expected properties of the class DataSpecificationIec61360, " +
+                                    "but got an unexpected element " +
+                                    $"with the name {elementName}");
+                                return null;
+                        }
+
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (!isEmptyProperty)
+                        {
+                            // Read the end element
+
+                            if (reader.EOF)
+                            {
+                                error = new Reporting.Error(
+                                    "Expected an XML end element to conclude a property of class DataSpecificationIec61360 " +
+                                    $"with the element name {elementName}, " +
+                                    "but got the end-of-file.");
+                                return null;
+                            }
+                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
+                            {
+                                error = new Reporting.Error(
+                                    "Expected an XML end element to conclude a property of class DataSpecificationIec61360 " +
+                                    $"with the element name {elementName}, " +
+                                    $"but got the node of type {reader.NodeType} " +
+                                    $"with the value {reader.Value}");
+                                return null;
+                            }
+
+                            string endElementName = TryElementName(
+                                reader, out error);
+                            if (error != null)
+                            {
+                                return null;
+                            }
+
+                            if (endElementName != elementName)
+                            {
+                                error = new Reporting.Error(
+                                    "Expected an XML end element to conclude a property of class DataSpecificationIec61360 " +
+                                    $"with the element name {elementName}, " +
+                                    $"but got the end element with the name {reader.Name}");
+                                return null;
+                            }
+                            // Skip the expected end element
+                            reader.Read();
+
+                            SkipNoneWhitespaceAndComments(reader);
+                        }
+
+                        if (reader.EOF)
+                        {
+                            break;
+                        }
+                    }
+                }
+
+                if (thePreferredName == null)
+                {
+                    error = new Reporting.Error(
+                        "The required property PreferredName has not been given " +
+                        "in the XML representation of an instance of class DataSpecificationIec61360");
+                    return null;
+                }
+
+                return new Aas.DataSpecificationIec61360(
+                    thePreferredName
+                         ?? throw new System.InvalidOperationException(
+                            "Unexpected null, had to be handled before"),
+                    theShortName,
+                    theUnit,
+                    theUnitId,
+                    theSourceOfDefinition,
+                    theSymbol,
+                    theDataType,
+                    theDefinition,
+                    theValueFormat,
+                    theValueList,
+                    theValue,
+                    theLevelType);
+            }  // internal static Aas.DataSpecificationIec61360? DataSpecificationIec61360FromSequence
+
+            /// <summary>
+            /// Deserialize an instance of class DataSpecificationIec61360 from an XML element.
+            /// </summary>
+            internal static Aas.DataSpecificationIec61360? DataSpecificationIec61360FromElement(
+                Xml.XmlReader reader,
+                out Reporting.Error? error)
+            {
+                error = null;
+
+                SkipNoneWhitespaceAndComments(reader);
+
+                if (reader.EOF)
+                {
+                    error = new Reporting.Error(
+                        "Expected an XML element representing an instance of class DataSpecificationIec61360, " +
+                        "but reached the end-of-file");
+                    return null;
+                }
+
+                if (reader.NodeType != Xml.XmlNodeType.Element)
+                {
+                    error = new Reporting.Error(
+                        "Expected an XML element representing an instance of class DataSpecificationIec61360, " +
+                        $"but got a node of type {reader.NodeType} " +
+                        $"with value {reader.Value}");
+                    return null;
+                }
+
+                string elementName = TryElementName(
+                    reader, out error);
+                if (error != null)
+                {
+                    return null;
+                }
+
+                if (elementName != "dataSpecificationIec61360")
+                {
+                    error = new Reporting.Error(
+                        "Expected an element representing an instance of class DataSpecificationIec61360 " +
+                        $"with element name dataSpecificationIec61360, but got: {elementName}");
+                    return null;
+                }
+
+                bool isEmptyElement = reader.IsEmptyElement;
+
+                // Skip the element node and go to the content
+                reader.Read();
+
+                Aas.DataSpecificationIec61360? result = (
+                    DataSpecificationIec61360FromSequence(
+                        reader, isEmptyElement, out error));
+                if (error != null)
+                {
+                    return null;
+                }
+
+                SkipNoneWhitespaceAndComments(reader);
+
+                if (!isEmptyElement)
+                {
+                    if (reader.EOF)
+                    {
+                        error = new Reporting.Error(
+                            "Expected an XML end element concluding an instance of class DataSpecificationIec61360, " +
+                            "but reached the end-of-file");
+                        return null;
+                    }
+
+                    if (reader.NodeType != Xml.XmlNodeType.EndElement)
+                    {
+                        error = new Reporting.Error(
+                            "Expected an XML end element concluding an instance of class DataSpecificationIec61360, " +
+                            $"but got a node of type {reader.NodeType} " +
+                            $"with value {reader.Value}");
+                        return null;
+                    }
+
+                    string endElementName = TryElementName(
+                        reader, out error);
+                    if (error != null)
+                    {
+                        return null;
+                    }
+
+                    if (endElementName != elementName)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML end element with an name {elementName}, " +
+                            $"but got: {endElementName}");
+                        return null;
+                    }
+
+                    // Skip the end element
+                    reader.Read();
+                }
+
+                return result;
+            }  // internal static Aas.DataSpecificationIec61360? DataSpecificationIec61360FromElement
+
+            /// <summary>
+            /// Deserialize an instance of class DataSpecificationPhysicalUnit from a sequence of XML elements.
+            /// </summary>
+            /// <remarks>
+            /// If <paramref name="isEmptySequence" /> is set, we should try to deserialize
+            /// the instance from an empty sequence. That is, the parent element
+            /// was a self-closing element.
+            /// </remarks>
+            internal static Aas.DataSpecificationPhysicalUnit? DataSpecificationPhysicalUnitFromSequence(
+                Xml.XmlReader reader,
+                bool isEmptySequence,
+                out Reporting.Error? error)
+            {
+                error = null;
+
+                string? theUnitName = null;
+                string? theUnitSymbol = null;
+                LangStringSet? theDefinition = null;
+                string? theSiNotation = null;
+                string? theSiName = null;
+                string? theDinNotation = null;
+                string? theEceName = null;
+                string? theEceCode = null;
+                string? theNistName = null;
+                string? theSourceOfDefinition = null;
+                string? theConversionFactor = null;
+                string? theRegistrationAuthorityId = null;
+                string? theSupplier = null;
+
+                if (!isEmptySequence)
+                {
+                    SkipNoneWhitespaceAndComments(reader);
+                    if (reader.EOF)
+                    {
+                        error = new Reporting.Error(
+                            "Expected an XML element representing " +
+                            "a property of an instance of class DataSpecificationPhysicalUnit, " +
+                            "but reached the end-of-file");
+                        return null;
+                    }
+                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    {
+                        string elementName = TryElementName(
+                            reader, out error);
+                        if (error != null)
+                        {
+                            return null;
+                        }
+
+                        bool isEmptyProperty = reader.IsEmptyElement;
+
+                        // Skip the expected element
+                        reader.Read();
+
+                        switch (elementName)
+                        {
+                            case "unitName":
+                            {
+                                if (isEmptyProperty)
+                                {
+                                    theUnitName = "";
+                                }
+                                else
+                                {
+                                    if (reader.EOF)
+                                    {
+                                        error = new Reporting.Error(
+                                            "Expected an XML content representing " +
+                                            "the property UnitName of an instance of class DataSpecificationPhysicalUnit, " +
+                                            "but reached the end-of-file");
+                                        return null;
+                                    }
+
+                                    try
+                                    {
+                                        theUnitName = reader.ReadContentAsString();
+                                    }
+                                    catch (System.Exception exception)
+                                    {
+                                        if (exception is System.FormatException
+                                            || exception is System.Xml.XmlException)
+                                        {
+                                            error = new Reporting.Error(
+                                                "The property UnitName of an instance of class DataSpecificationPhysicalUnit " +
+                                                $"could not be de-serialized: {exception.Message}");
+                                            error.PrependSegment(
+                                                new Reporting.NameSegment(
+                                                    "unitName"));
+                                            return null;
+                                        }
+
+                                        throw;
+                                    }
+                                }
+                                break;
+                            }
+                            case "unitSymbol":
+                            {
+                                if (isEmptyProperty)
+                                {
+                                    theUnitSymbol = "";
+                                }
+                                else
+                                {
+                                    if (reader.EOF)
+                                    {
+                                        error = new Reporting.Error(
+                                            "Expected an XML content representing " +
+                                            "the property UnitSymbol of an instance of class DataSpecificationPhysicalUnit, " +
+                                            "but reached the end-of-file");
+                                        return null;
+                                    }
+
+                                    try
+                                    {
+                                        theUnitSymbol = reader.ReadContentAsString();
+                                    }
+                                    catch (System.Exception exception)
+                                    {
+                                        if (exception is System.FormatException
+                                            || exception is System.Xml.XmlException)
+                                        {
+                                            error = new Reporting.Error(
+                                                "The property UnitSymbol of an instance of class DataSpecificationPhysicalUnit " +
+                                                $"could not be de-serialized: {exception.Message}");
+                                            error.PrependSegment(
+                                                new Reporting.NameSegment(
+                                                    "unitSymbol"));
+                                            return null;
+                                        }
+
+                                        throw;
+                                    }
+                                }
+                                break;
+                            }
+                            case "definition":
+                            {
+                                theDefinition = LangStringSetFromSequence(
+                                    reader, isEmptyProperty, out error);
+
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "definition"));
+                                    return null;
+                                }
+                                break;
+                            }
+                            case "siNotation":
+                            {
+                                if (isEmptyProperty)
+                                {
+                                    theSiNotation = "";
+                                }
+                                else
+                                {
+                                    if (reader.EOF)
+                                    {
+                                        error = new Reporting.Error(
+                                            "Expected an XML content representing " +
+                                            "the property SiNotation of an instance of class DataSpecificationPhysicalUnit, " +
+                                            "but reached the end-of-file");
+                                        return null;
+                                    }
+
+                                    try
+                                    {
+                                        theSiNotation = reader.ReadContentAsString();
+                                    }
+                                    catch (System.Exception exception)
+                                    {
+                                        if (exception is System.FormatException
+                                            || exception is System.Xml.XmlException)
+                                        {
+                                            error = new Reporting.Error(
+                                                "The property SiNotation of an instance of class DataSpecificationPhysicalUnit " +
+                                                $"could not be de-serialized: {exception.Message}");
+                                            error.PrependSegment(
+                                                new Reporting.NameSegment(
+                                                    "siNotation"));
+                                            return null;
+                                        }
+
+                                        throw;
+                                    }
+                                }
+                                break;
+                            }
+                            case "siName":
+                            {
+                                if (isEmptyProperty)
+                                {
+                                    theSiName = "";
+                                }
+                                else
+                                {
+                                    if (reader.EOF)
+                                    {
+                                        error = new Reporting.Error(
+                                            "Expected an XML content representing " +
+                                            "the property SiName of an instance of class DataSpecificationPhysicalUnit, " +
+                                            "but reached the end-of-file");
+                                        return null;
+                                    }
+
+                                    try
+                                    {
+                                        theSiName = reader.ReadContentAsString();
+                                    }
+                                    catch (System.Exception exception)
+                                    {
+                                        if (exception is System.FormatException
+                                            || exception is System.Xml.XmlException)
+                                        {
+                                            error = new Reporting.Error(
+                                                "The property SiName of an instance of class DataSpecificationPhysicalUnit " +
+                                                $"could not be de-serialized: {exception.Message}");
+                                            error.PrependSegment(
+                                                new Reporting.NameSegment(
+                                                    "siName"));
+                                            return null;
+                                        }
+
+                                        throw;
+                                    }
+                                }
+                                break;
+                            }
+                            case "dinNotation":
+                            {
+                                if (isEmptyProperty)
+                                {
+                                    theDinNotation = "";
+                                }
+                                else
+                                {
+                                    if (reader.EOF)
+                                    {
+                                        error = new Reporting.Error(
+                                            "Expected an XML content representing " +
+                                            "the property DinNotation of an instance of class DataSpecificationPhysicalUnit, " +
+                                            "but reached the end-of-file");
+                                        return null;
+                                    }
+
+                                    try
+                                    {
+                                        theDinNotation = reader.ReadContentAsString();
+                                    }
+                                    catch (System.Exception exception)
+                                    {
+                                        if (exception is System.FormatException
+                                            || exception is System.Xml.XmlException)
+                                        {
+                                            error = new Reporting.Error(
+                                                "The property DinNotation of an instance of class DataSpecificationPhysicalUnit " +
+                                                $"could not be de-serialized: {exception.Message}");
+                                            error.PrependSegment(
+                                                new Reporting.NameSegment(
+                                                    "dinNotation"));
+                                            return null;
+                                        }
+
+                                        throw;
+                                    }
+                                }
+                                break;
+                            }
+                            case "eceName":
+                            {
+                                if (isEmptyProperty)
+                                {
+                                    theEceName = "";
+                                }
+                                else
+                                {
+                                    if (reader.EOF)
+                                    {
+                                        error = new Reporting.Error(
+                                            "Expected an XML content representing " +
+                                            "the property EceName of an instance of class DataSpecificationPhysicalUnit, " +
+                                            "but reached the end-of-file");
+                                        return null;
+                                    }
+
+                                    try
+                                    {
+                                        theEceName = reader.ReadContentAsString();
+                                    }
+                                    catch (System.Exception exception)
+                                    {
+                                        if (exception is System.FormatException
+                                            || exception is System.Xml.XmlException)
+                                        {
+                                            error = new Reporting.Error(
+                                                "The property EceName of an instance of class DataSpecificationPhysicalUnit " +
+                                                $"could not be de-serialized: {exception.Message}");
+                                            error.PrependSegment(
+                                                new Reporting.NameSegment(
+                                                    "eceName"));
+                                            return null;
+                                        }
+
+                                        throw;
+                                    }
+                                }
+                                break;
+                            }
+                            case "eceCode":
+                            {
+                                if (isEmptyProperty)
+                                {
+                                    theEceCode = "";
+                                }
+                                else
+                                {
+                                    if (reader.EOF)
+                                    {
+                                        error = new Reporting.Error(
+                                            "Expected an XML content representing " +
+                                            "the property EceCode of an instance of class DataSpecificationPhysicalUnit, " +
+                                            "but reached the end-of-file");
+                                        return null;
+                                    }
+
+                                    try
+                                    {
+                                        theEceCode = reader.ReadContentAsString();
+                                    }
+                                    catch (System.Exception exception)
+                                    {
+                                        if (exception is System.FormatException
+                                            || exception is System.Xml.XmlException)
+                                        {
+                                            error = new Reporting.Error(
+                                                "The property EceCode of an instance of class DataSpecificationPhysicalUnit " +
+                                                $"could not be de-serialized: {exception.Message}");
+                                            error.PrependSegment(
+                                                new Reporting.NameSegment(
+                                                    "eceCode"));
+                                            return null;
+                                        }
+
+                                        throw;
+                                    }
+                                }
+                                break;
+                            }
+                            case "nistName":
+                            {
+                                if (isEmptyProperty)
+                                {
+                                    theNistName = "";
+                                }
+                                else
+                                {
+                                    if (reader.EOF)
+                                    {
+                                        error = new Reporting.Error(
+                                            "Expected an XML content representing " +
+                                            "the property NistName of an instance of class DataSpecificationPhysicalUnit, " +
+                                            "but reached the end-of-file");
+                                        return null;
+                                    }
+
+                                    try
+                                    {
+                                        theNistName = reader.ReadContentAsString();
+                                    }
+                                    catch (System.Exception exception)
+                                    {
+                                        if (exception is System.FormatException
+                                            || exception is System.Xml.XmlException)
+                                        {
+                                            error = new Reporting.Error(
+                                                "The property NistName of an instance of class DataSpecificationPhysicalUnit " +
+                                                $"could not be de-serialized: {exception.Message}");
+                                            error.PrependSegment(
+                                                new Reporting.NameSegment(
+                                                    "nistName"));
+                                            return null;
+                                        }
+
+                                        throw;
+                                    }
+                                }
+                                break;
+                            }
+                            case "sourceOfDefinition":
+                            {
+                                if (isEmptyProperty)
+                                {
+                                    theSourceOfDefinition = "";
+                                }
+                                else
+                                {
+                                    if (reader.EOF)
+                                    {
+                                        error = new Reporting.Error(
+                                            "Expected an XML content representing " +
+                                            "the property SourceOfDefinition of an instance of class DataSpecificationPhysicalUnit, " +
+                                            "but reached the end-of-file");
+                                        return null;
+                                    }
+
+                                    try
+                                    {
+                                        theSourceOfDefinition = reader.ReadContentAsString();
+                                    }
+                                    catch (System.Exception exception)
+                                    {
+                                        if (exception is System.FormatException
+                                            || exception is System.Xml.XmlException)
+                                        {
+                                            error = new Reporting.Error(
+                                                "The property SourceOfDefinition of an instance of class DataSpecificationPhysicalUnit " +
+                                                $"could not be de-serialized: {exception.Message}");
+                                            error.PrependSegment(
+                                                new Reporting.NameSegment(
+                                                    "sourceOfDefinition"));
+                                            return null;
+                                        }
+
+                                        throw;
+                                    }
+                                }
+                                break;
+                            }
+                            case "conversionFactor":
+                            {
+                                if (isEmptyProperty)
+                                {
+                                    theConversionFactor = "";
+                                }
+                                else
+                                {
+                                    if (reader.EOF)
+                                    {
+                                        error = new Reporting.Error(
+                                            "Expected an XML content representing " +
+                                            "the property ConversionFactor of an instance of class DataSpecificationPhysicalUnit, " +
+                                            "but reached the end-of-file");
+                                        return null;
+                                    }
+
+                                    try
+                                    {
+                                        theConversionFactor = reader.ReadContentAsString();
+                                    }
+                                    catch (System.Exception exception)
+                                    {
+                                        if (exception is System.FormatException
+                                            || exception is System.Xml.XmlException)
+                                        {
+                                            error = new Reporting.Error(
+                                                "The property ConversionFactor of an instance of class DataSpecificationPhysicalUnit " +
+                                                $"could not be de-serialized: {exception.Message}");
+                                            error.PrependSegment(
+                                                new Reporting.NameSegment(
+                                                    "conversionFactor"));
+                                            return null;
+                                        }
+
+                                        throw;
+                                    }
+                                }
+                                break;
+                            }
+                            case "registrationAuthorityId":
+                            {
+                                if (isEmptyProperty)
+                                {
+                                    theRegistrationAuthorityId = "";
+                                }
+                                else
+                                {
+                                    if (reader.EOF)
+                                    {
+                                        error = new Reporting.Error(
+                                            "Expected an XML content representing " +
+                                            "the property RegistrationAuthorityId of an instance of class DataSpecificationPhysicalUnit, " +
+                                            "but reached the end-of-file");
+                                        return null;
+                                    }
+
+                                    try
+                                    {
+                                        theRegistrationAuthorityId = reader.ReadContentAsString();
+                                    }
+                                    catch (System.Exception exception)
+                                    {
+                                        if (exception is System.FormatException
+                                            || exception is System.Xml.XmlException)
+                                        {
+                                            error = new Reporting.Error(
+                                                "The property RegistrationAuthorityId of an instance of class DataSpecificationPhysicalUnit " +
+                                                $"could not be de-serialized: {exception.Message}");
+                                            error.PrependSegment(
+                                                new Reporting.NameSegment(
+                                                    "registrationAuthorityId"));
+                                            return null;
+                                        }
+
+                                        throw;
+                                    }
+                                }
+                                break;
+                            }
+                            case "supplier":
+                            {
+                                if (isEmptyProperty)
+                                {
+                                    theSupplier = "";
+                                }
+                                else
+                                {
+                                    if (reader.EOF)
+                                    {
+                                        error = new Reporting.Error(
+                                            "Expected an XML content representing " +
+                                            "the property Supplier of an instance of class DataSpecificationPhysicalUnit, " +
+                                            "but reached the end-of-file");
+                                        return null;
+                                    }
+
+                                    try
+                                    {
+                                        theSupplier = reader.ReadContentAsString();
+                                    }
+                                    catch (System.Exception exception)
+                                    {
+                                        if (exception is System.FormatException
+                                            || exception is System.Xml.XmlException)
+                                        {
+                                            error = new Reporting.Error(
+                                                "The property Supplier of an instance of class DataSpecificationPhysicalUnit " +
+                                                $"could not be de-serialized: {exception.Message}");
+                                            error.PrependSegment(
+                                                new Reporting.NameSegment(
+                                                    "supplier"));
+                                            return null;
+                                        }
+
+                                        throw;
+                                    }
+                                }
+                                break;
+                            }
+                            default:
+                                error = new Reporting.Error(
+                                    "We expected properties of the class DataSpecificationPhysicalUnit, " +
+                                    "but got an unexpected element " +
+                                    $"with the name {elementName}");
+                                return null;
+                        }
+
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (!isEmptyProperty)
+                        {
+                            // Read the end element
+
+                            if (reader.EOF)
+                            {
+                                error = new Reporting.Error(
+                                    "Expected an XML end element to conclude a property of class DataSpecificationPhysicalUnit " +
+                                    $"with the element name {elementName}, " +
+                                    "but got the end-of-file.");
+                                return null;
+                            }
+                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
+                            {
+                                error = new Reporting.Error(
+                                    "Expected an XML end element to conclude a property of class DataSpecificationPhysicalUnit " +
+                                    $"with the element name {elementName}, " +
+                                    $"but got the node of type {reader.NodeType} " +
+                                    $"with the value {reader.Value}");
+                                return null;
+                            }
+
+                            string endElementName = TryElementName(
+                                reader, out error);
+                            if (error != null)
+                            {
+                                return null;
+                            }
+
+                            if (endElementName != elementName)
+                            {
+                                error = new Reporting.Error(
+                                    "Expected an XML end element to conclude a property of class DataSpecificationPhysicalUnit " +
+                                    $"with the element name {elementName}, " +
+                                    $"but got the end element with the name {reader.Name}");
+                                return null;
+                            }
+                            // Skip the expected end element
+                            reader.Read();
+
+                            SkipNoneWhitespaceAndComments(reader);
+                        }
+
+                        if (reader.EOF)
+                        {
+                            break;
+                        }
+                    }
+                }
+
+                if (theUnitName == null)
+                {
+                    error = new Reporting.Error(
+                        "The required property UnitName has not been given " +
+                        "in the XML representation of an instance of class DataSpecificationPhysicalUnit");
+                    return null;
+                }
+
+                if (theUnitSymbol == null)
+                {
+                    error = new Reporting.Error(
+                        "The required property UnitSymbol has not been given " +
+                        "in the XML representation of an instance of class DataSpecificationPhysicalUnit");
+                    return null;
+                }
+
+                if (theDefinition == null)
+                {
+                    error = new Reporting.Error(
+                        "The required property Definition has not been given " +
+                        "in the XML representation of an instance of class DataSpecificationPhysicalUnit");
+                    return null;
+                }
+
+                return new Aas.DataSpecificationPhysicalUnit(
+                    theUnitName
+                         ?? throw new System.InvalidOperationException(
+                            "Unexpected null, had to be handled before"),
+                    theUnitSymbol
+                         ?? throw new System.InvalidOperationException(
+                            "Unexpected null, had to be handled before"),
+                    theDefinition
+                         ?? throw new System.InvalidOperationException(
+                            "Unexpected null, had to be handled before"),
+                    theSiNotation,
+                    theSiName,
+                    theDinNotation,
+                    theEceName,
+                    theEceCode,
+                    theNistName,
+                    theSourceOfDefinition,
+                    theConversionFactor,
+                    theRegistrationAuthorityId,
+                    theSupplier);
+            }  // internal static Aas.DataSpecificationPhysicalUnit? DataSpecificationPhysicalUnitFromSequence
+
+            /// <summary>
+            /// Deserialize an instance of class DataSpecificationPhysicalUnit from an XML element.
+            /// </summary>
+            internal static Aas.DataSpecificationPhysicalUnit? DataSpecificationPhysicalUnitFromElement(
+                Xml.XmlReader reader,
+                out Reporting.Error? error)
+            {
+                error = null;
+
+                SkipNoneWhitespaceAndComments(reader);
+
+                if (reader.EOF)
+                {
+                    error = new Reporting.Error(
+                        "Expected an XML element representing an instance of class DataSpecificationPhysicalUnit, " +
+                        "but reached the end-of-file");
+                    return null;
+                }
+
+                if (reader.NodeType != Xml.XmlNodeType.Element)
+                {
+                    error = new Reporting.Error(
+                        "Expected an XML element representing an instance of class DataSpecificationPhysicalUnit, " +
+                        $"but got a node of type {reader.NodeType} " +
+                        $"with value {reader.Value}");
+                    return null;
+                }
+
+                string elementName = TryElementName(
+                    reader, out error);
+                if (error != null)
+                {
+                    return null;
+                }
+
+                if (elementName != "dataSpecificationPhysicalUnit")
+                {
+                    error = new Reporting.Error(
+                        "Expected an element representing an instance of class DataSpecificationPhysicalUnit " +
+                        $"with element name dataSpecificationPhysicalUnit, but got: {elementName}");
+                    return null;
+                }
+
+                bool isEmptyElement = reader.IsEmptyElement;
+
+                // Skip the element node and go to the content
+                reader.Read();
+
+                Aas.DataSpecificationPhysicalUnit? result = (
+                    DataSpecificationPhysicalUnitFromSequence(
+                        reader, isEmptyElement, out error));
+                if (error != null)
+                {
+                    return null;
+                }
+
+                SkipNoneWhitespaceAndComments(reader);
+
+                if (!isEmptyElement)
+                {
+                    if (reader.EOF)
+                    {
+                        error = new Reporting.Error(
+                            "Expected an XML end element concluding an instance of class DataSpecificationPhysicalUnit, " +
+                            "but reached the end-of-file");
+                        return null;
+                    }
+
+                    if (reader.NodeType != Xml.XmlNodeType.EndElement)
+                    {
+                        error = new Reporting.Error(
+                            "Expected an XML end element concluding an instance of class DataSpecificationPhysicalUnit, " +
+                            $"but got a node of type {reader.NodeType} " +
+                            $"with value {reader.Value}");
+                        return null;
+                    }
+
+                    string endElementName = TryElementName(
+                        reader, out error);
+                    if (error != null)
+                    {
+                        return null;
+                    }
+
+                    if (endElementName != elementName)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML end element with an name {elementName}, " +
+                            $"but got: {endElementName}");
+                        return null;
+                    }
+
+                    // Skip the end element
+                    reader.Read();
+                }
+
+                return result;
+            }  // internal static Aas.DataSpecificationPhysicalUnit? DataSpecificationPhysicalUnitFromElement
         }  // internal static class DeserializeImplementation
 
         /// <summary>
@@ -17354,22 +19073,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of IHasSemantics from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of IHasSemantics.
             /// </exception>
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]public static Aas.IHasSemantics IHasSemanticsFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.IHasSemantics? result = (
                     DeserializeImplementation.IHasSemanticsFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -17386,22 +19099,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of Extension from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of Extension.
             /// </exception>
             public static Aas.Extension ExtensionFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.Extension? result = (
                     DeserializeImplementation.ExtensionFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -17418,22 +19125,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of IHasExtensions from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of IHasExtensions.
             /// </exception>
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]public static Aas.IHasExtensions IHasExtensionsFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.IHasExtensions? result = (
                     DeserializeImplementation.IHasExtensionsFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -17450,22 +19151,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of IReferable from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of IReferable.
             /// </exception>
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]public static Aas.IReferable IReferableFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.IReferable? result = (
                     DeserializeImplementation.IReferableFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -17482,22 +19177,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of IIdentifiable from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of IIdentifiable.
             /// </exception>
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]public static Aas.IIdentifiable IIdentifiableFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.IIdentifiable? result = (
                     DeserializeImplementation.IIdentifiableFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -17514,22 +19203,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of IHasKind from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of IHasKind.
             /// </exception>
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]public static Aas.IHasKind IHasKindFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.IHasKind? result = (
                     DeserializeImplementation.IHasKindFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -17546,22 +19229,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of IHasDataSpecification from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of IHasDataSpecification.
             /// </exception>
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]public static Aas.IHasDataSpecification IHasDataSpecificationFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.IHasDataSpecification? result = (
                     DeserializeImplementation.IHasDataSpecificationFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -17578,22 +19255,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of AdministrativeInformation from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of AdministrativeInformation.
             /// </exception>
             public static Aas.AdministrativeInformation AdministrativeInformationFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.AdministrativeInformation? result = (
                     DeserializeImplementation.AdministrativeInformationFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -17610,22 +19281,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of IQualifiable from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of IQualifiable.
             /// </exception>
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]public static Aas.IQualifiable IQualifiableFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.IQualifiable? result = (
                     DeserializeImplementation.IQualifiableFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -17642,22 +19307,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of Qualifier from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of Qualifier.
             /// </exception>
             public static Aas.Qualifier QualifierFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.Qualifier? result = (
                     DeserializeImplementation.QualifierFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -17674,22 +19333,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of AssetAdministrationShell from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of AssetAdministrationShell.
             /// </exception>
             public static Aas.AssetAdministrationShell AssetAdministrationShellFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.AssetAdministrationShell? result = (
                     DeserializeImplementation.AssetAdministrationShellFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -17706,22 +19359,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of AssetInformation from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of AssetInformation.
             /// </exception>
             public static Aas.AssetInformation AssetInformationFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.AssetInformation? result = (
                     DeserializeImplementation.AssetInformationFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -17738,22 +19385,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of Resource from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of Resource.
             /// </exception>
             public static Aas.Resource ResourceFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.Resource? result = (
                     DeserializeImplementation.ResourceFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -17770,22 +19411,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of SpecificAssetId from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of SpecificAssetId.
             /// </exception>
             public static Aas.SpecificAssetId SpecificAssetIdFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.SpecificAssetId? result = (
                     DeserializeImplementation.SpecificAssetIdFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -17802,22 +19437,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of Submodel from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of Submodel.
             /// </exception>
             public static Aas.Submodel SubmodelFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.Submodel? result = (
                     DeserializeImplementation.SubmodelFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -17834,22 +19463,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of ISubmodelElement from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of ISubmodelElement.
             /// </exception>
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]public static Aas.ISubmodelElement ISubmodelElementFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.ISubmodelElement? result = (
                     DeserializeImplementation.ISubmodelElementFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -17866,22 +19489,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of IRelationshipElement from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of IRelationshipElement.
             /// </exception>
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]public static Aas.IRelationshipElement IRelationshipElementFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.IRelationshipElement? result = (
                     DeserializeImplementation.IRelationshipElementFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -17898,22 +19515,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of RelationshipElement from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of RelationshipElement.
             /// </exception>
             public static Aas.RelationshipElement RelationshipElementFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.RelationshipElement? result = (
                     DeserializeImplementation.RelationshipElementFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -17930,22 +19541,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of SubmodelElementList from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of SubmodelElementList.
             /// </exception>
             public static Aas.SubmodelElementList SubmodelElementListFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.SubmodelElementList? result = (
                     DeserializeImplementation.SubmodelElementListFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -17962,22 +19567,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of SubmodelElementCollection from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of SubmodelElementCollection.
             /// </exception>
             public static Aas.SubmodelElementCollection SubmodelElementCollectionFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.SubmodelElementCollection? result = (
                     DeserializeImplementation.SubmodelElementCollectionFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -17994,22 +19593,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of IDataElement from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of IDataElement.
             /// </exception>
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]public static Aas.IDataElement IDataElementFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.IDataElement? result = (
                     DeserializeImplementation.IDataElementFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -18026,22 +19619,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of Property from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of Property.
             /// </exception>
             public static Aas.Property PropertyFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.Property? result = (
                     DeserializeImplementation.PropertyFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -18058,22 +19645,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of MultiLanguageProperty from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of MultiLanguageProperty.
             /// </exception>
             public static Aas.MultiLanguageProperty MultiLanguagePropertyFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.MultiLanguageProperty? result = (
                     DeserializeImplementation.MultiLanguagePropertyFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -18090,22 +19671,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of Range from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of Range.
             /// </exception>
             public static Aas.Range RangeFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.Range? result = (
                     DeserializeImplementation.RangeFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -18122,22 +19697,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of ReferenceElement from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of ReferenceElement.
             /// </exception>
             public static Aas.ReferenceElement ReferenceElementFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.ReferenceElement? result = (
                     DeserializeImplementation.ReferenceElementFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -18154,22 +19723,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of Blob from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of Blob.
             /// </exception>
             public static Aas.Blob BlobFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.Blob? result = (
                     DeserializeImplementation.BlobFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -18186,22 +19749,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of File from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of File.
             /// </exception>
             public static Aas.File FileFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.File? result = (
                     DeserializeImplementation.FileFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -18218,22 +19775,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of AnnotatedRelationshipElement from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of AnnotatedRelationshipElement.
             /// </exception>
             public static Aas.AnnotatedRelationshipElement AnnotatedRelationshipElementFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.AnnotatedRelationshipElement? result = (
                     DeserializeImplementation.AnnotatedRelationshipElementFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -18250,22 +19801,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of Entity from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of Entity.
             /// </exception>
             public static Aas.Entity EntityFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.Entity? result = (
                     DeserializeImplementation.EntityFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -18282,22 +19827,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of EventPayload from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of EventPayload.
             /// </exception>
             public static Aas.EventPayload EventPayloadFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.EventPayload? result = (
                     DeserializeImplementation.EventPayloadFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -18314,22 +19853,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of IEventElement from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of IEventElement.
             /// </exception>
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]public static Aas.IEventElement IEventElementFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.IEventElement? result = (
                     DeserializeImplementation.IEventElementFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -18346,22 +19879,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of BasicEventElement from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of BasicEventElement.
             /// </exception>
             public static Aas.BasicEventElement BasicEventElementFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.BasicEventElement? result = (
                     DeserializeImplementation.BasicEventElementFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -18378,22 +19905,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of Operation from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of Operation.
             /// </exception>
             public static Aas.Operation OperationFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.Operation? result = (
                     DeserializeImplementation.OperationFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -18410,22 +19931,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of OperationVariable from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of OperationVariable.
             /// </exception>
             public static Aas.OperationVariable OperationVariableFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.OperationVariable? result = (
                     DeserializeImplementation.OperationVariableFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -18442,22 +19957,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of Capability from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of Capability.
             /// </exception>
             public static Aas.Capability CapabilityFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.Capability? result = (
                     DeserializeImplementation.CapabilityFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -18474,22 +19983,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of ConceptDescription from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of ConceptDescription.
             /// </exception>
             public static Aas.ConceptDescription ConceptDescriptionFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.ConceptDescription? result = (
                     DeserializeImplementation.ConceptDescriptionFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -18506,22 +20009,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of Reference from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of Reference.
             /// </exception>
             public static Aas.Reference ReferenceFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.Reference? result = (
                     DeserializeImplementation.ReferenceFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -18538,22 +20035,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of Key from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of Key.
             /// </exception>
             public static Aas.Key KeyFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.Key? result = (
                     DeserializeImplementation.KeyFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -18570,22 +20061,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of LangString from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of LangString.
             /// </exception>
             public static Aas.LangString LangStringFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.LangString? result = (
                     DeserializeImplementation.LangStringFromElement(
                         reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -18602,86 +20087,16 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of LangStringSet from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of LangStringSet.
             /// </exception>
             public static Aas.LangStringSet LangStringSetFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.LangStringSet? result = (
                     DeserializeImplementation.LangStringSetFromElement(
                         reader,
-                        ns,
-                        out Reporting.Error? error));
-                if (error != null)
-                {
-                    throw new Xmlization.Exception(
-                        Reporting.GenerateRelativeXPath(error.PathSegments),
-                        error.Cause);
-                }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
-            }
-
-            /// <summary>
-            /// Deserialize an instance of DataSpecificationContent from <paramref name="reader" />.
-            /// </summary>
-            /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
-            /// <exception cref="Xmlization.Exception">
-            /// Thrown when the element is not a valid XML
-            /// representation of DataSpecificationContent.
-            /// </exception>
-            public static Aas.DataSpecificationContent DataSpecificationContentFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
-            {
-                Aas.DataSpecificationContent? result = (
-                    DeserializeImplementation.DataSpecificationContentFromElement(
-                        reader,
-                        ns,
-                        out Reporting.Error? error));
-                if (error != null)
-                {
-                    throw new Xmlization.Exception(
-                        Reporting.GenerateRelativeXPath(error.PathSegments),
-                        error.Cause);
-                }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
-            }
-
-            /// <summary>
-            /// Deserialize an instance of DataSpecification from <paramref name="reader" />.
-            /// </summary>
-            /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
-            /// <exception cref="Xmlization.Exception">
-            /// Thrown when the element is not a valid XML
-            /// representation of DataSpecification.
-            /// </exception>
-            public static Aas.DataSpecification DataSpecificationFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
-            {
-                Aas.DataSpecification? result = (
-                    DeserializeImplementation.DataSpecificationFromElement(
-                        reader,
-                        ns,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -18698,22 +20113,172 @@ namespace AasCore.Aas3_0_RC02
             /// Deserialize an instance of Environment from <paramref name="reader" />.
             /// </summary>
             /// <param name="reader">Initialized XML reader with cursor set to the element</param>
-            /// <param name="ns">
-            /// The expected namespace that the XML elements live in.
-            /// If not specified, assume the element names as-are instead of the local names.
-            /// </param>
             /// <exception cref="Xmlization.Exception">
             /// Thrown when the element is not a valid XML
             /// representation of Environment.
             /// </exception>
             public static Aas.Environment EnvironmentFrom(
-                Xml.XmlReader reader,
-                string? ns = null)
+                Xml.XmlReader reader)
             {
                 Aas.Environment? result = (
                     DeserializeImplementation.EnvironmentFromElement(
                         reader,
-                        ns,
+                        out Reporting.Error? error));
+                if (error != null)
+                {
+                    throw new Xmlization.Exception(
+                        Reporting.GenerateRelativeXPath(error.PathSegments),
+                        error.Cause);
+                }
+                return result
+                    ?? throw new System.InvalidOperationException(
+                        "Unexpected output null when error is null");
+            }
+
+            /// <summary>
+            /// Deserialize an instance of IDataSpecificationContent from <paramref name="reader" />.
+            /// </summary>
+            /// <param name="reader">Initialized XML reader with cursor set to the element</param>
+            /// <exception cref="Xmlization.Exception">
+            /// Thrown when the element is not a valid XML
+            /// representation of IDataSpecificationContent.
+            /// </exception>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]public static Aas.IDataSpecificationContent IDataSpecificationContentFrom(
+                Xml.XmlReader reader)
+            {
+                Aas.IDataSpecificationContent? result = (
+                    DeserializeImplementation.IDataSpecificationContentFromElement(
+                        reader,
+                        out Reporting.Error? error));
+                if (error != null)
+                {
+                    throw new Xmlization.Exception(
+                        Reporting.GenerateRelativeXPath(error.PathSegments),
+                        error.Cause);
+                }
+                return result
+                    ?? throw new System.InvalidOperationException(
+                        "Unexpected output null when error is null");
+            }
+
+            /// <summary>
+            /// Deserialize an instance of EmbeddedDataSpecification from <paramref name="reader" />.
+            /// </summary>
+            /// <param name="reader">Initialized XML reader with cursor set to the element</param>
+            /// <exception cref="Xmlization.Exception">
+            /// Thrown when the element is not a valid XML
+            /// representation of EmbeddedDataSpecification.
+            /// </exception>
+            public static Aas.EmbeddedDataSpecification EmbeddedDataSpecificationFrom(
+                Xml.XmlReader reader)
+            {
+                Aas.EmbeddedDataSpecification? result = (
+                    DeserializeImplementation.EmbeddedDataSpecificationFromElement(
+                        reader,
+                        out Reporting.Error? error));
+                if (error != null)
+                {
+                    throw new Xmlization.Exception(
+                        Reporting.GenerateRelativeXPath(error.PathSegments),
+                        error.Cause);
+                }
+                return result
+                    ?? throw new System.InvalidOperationException(
+                        "Unexpected output null when error is null");
+            }
+
+            /// <summary>
+            /// Deserialize an instance of ValueReferencePair from <paramref name="reader" />.
+            /// </summary>
+            /// <param name="reader">Initialized XML reader with cursor set to the element</param>
+            /// <exception cref="Xmlization.Exception">
+            /// Thrown when the element is not a valid XML
+            /// representation of ValueReferencePair.
+            /// </exception>
+            public static Aas.ValueReferencePair ValueReferencePairFrom(
+                Xml.XmlReader reader)
+            {
+                Aas.ValueReferencePair? result = (
+                    DeserializeImplementation.ValueReferencePairFromElement(
+                        reader,
+                        out Reporting.Error? error));
+                if (error != null)
+                {
+                    throw new Xmlization.Exception(
+                        Reporting.GenerateRelativeXPath(error.PathSegments),
+                        error.Cause);
+                }
+                return result
+                    ?? throw new System.InvalidOperationException(
+                        "Unexpected output null when error is null");
+            }
+
+            /// <summary>
+            /// Deserialize an instance of ValueList from <paramref name="reader" />.
+            /// </summary>
+            /// <param name="reader">Initialized XML reader with cursor set to the element</param>
+            /// <exception cref="Xmlization.Exception">
+            /// Thrown when the element is not a valid XML
+            /// representation of ValueList.
+            /// </exception>
+            public static Aas.ValueList ValueListFrom(
+                Xml.XmlReader reader)
+            {
+                Aas.ValueList? result = (
+                    DeserializeImplementation.ValueListFromElement(
+                        reader,
+                        out Reporting.Error? error));
+                if (error != null)
+                {
+                    throw new Xmlization.Exception(
+                        Reporting.GenerateRelativeXPath(error.PathSegments),
+                        error.Cause);
+                }
+                return result
+                    ?? throw new System.InvalidOperationException(
+                        "Unexpected output null when error is null");
+            }
+
+            /// <summary>
+            /// Deserialize an instance of DataSpecificationIec61360 from <paramref name="reader" />.
+            /// </summary>
+            /// <param name="reader">Initialized XML reader with cursor set to the element</param>
+            /// <exception cref="Xmlization.Exception">
+            /// Thrown when the element is not a valid XML
+            /// representation of DataSpecificationIec61360.
+            /// </exception>
+            public static Aas.DataSpecificationIec61360 DataSpecificationIec61360From(
+                Xml.XmlReader reader)
+            {
+                Aas.DataSpecificationIec61360? result = (
+                    DeserializeImplementation.DataSpecificationIec61360FromElement(
+                        reader,
+                        out Reporting.Error? error));
+                if (error != null)
+                {
+                    throw new Xmlization.Exception(
+                        Reporting.GenerateRelativeXPath(error.PathSegments),
+                        error.Cause);
+                }
+                return result
+                    ?? throw new System.InvalidOperationException(
+                        "Unexpected output null when error is null");
+            }
+
+            /// <summary>
+            /// Deserialize an instance of DataSpecificationPhysicalUnit from <paramref name="reader" />.
+            /// </summary>
+            /// <param name="reader">Initialized XML reader with cursor set to the element</param>
+            /// <exception cref="Xmlization.Exception">
+            /// Thrown when the element is not a valid XML
+            /// representation of DataSpecificationPhysicalUnit.
+            /// </exception>
+            public static Aas.DataSpecificationPhysicalUnit DataSpecificationPhysicalUnitFrom(
+                Xml.XmlReader reader)
+            {
+                Aas.DataSpecificationPhysicalUnit? result = (
+                    DeserializeImplementation.DataSpecificationPhysicalUnitFromElement(
+                        reader,
                         out Reporting.Error? error));
                 if (error != null)
                 {
@@ -18731,16 +20296,17 @@ namespace AasCore.Aas3_0_RC02
         /// Serialize recursively the instances as XML elements.
         /// </summary>
         internal class VisitorWithWriter
-            : Visitation.AbstractVisitorWithContext<WrappedXmlWriter>
+            : Visitation.AbstractVisitorWithContext<Xml.XmlWriter>
         {
             private void ExtensionToSequence(
                 Extension that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 if (that.SemanticId != null)
                 {
                     writer.WriteStartElement(
-                        "semanticId");
+                        "semanticId",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.SemanticId,
@@ -18752,7 +20318,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SupplementalSemanticIds != null)
                 {
                     writer.WriteStartElement(
-                        "supplementalSemanticIds");
+                        "supplementalSemanticIds",
+                        NS);
 
                     foreach (var item in that.SupplementalSemanticIds)
                     {
@@ -18765,7 +20332,8 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 writer.WriteStartElement(
-                    "name");
+                    "name",
+                    NS);
 
                 writer.WriteValue(
                     that.Name);
@@ -18775,7 +20343,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.ValueType != null)
                 {
                     writer.WriteStartElement(
-                        "valueType");
+                        "valueType",
+                        NS);
 
                     string? textValueType = Stringification.ToString(
                         that.ValueType);
@@ -18791,7 +20360,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Value != null)
                 {
                     writer.WriteStartElement(
-                        "value");
+                        "value",
+                        NS);
 
                     writer.WriteValue(
                         that.Value);
@@ -18802,7 +20372,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.RefersTo != null)
                 {
                     writer.WriteStartElement(
-                        "refersTo");
+                        "refersTo",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.RefersTo,
@@ -18814,10 +20385,11 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.Extension that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "extension");
+                    "extension",
+                    NS);
                 this.ExtensionToSequence(
                     that,
                     writer);
@@ -18826,14 +20398,15 @@ namespace AasCore.Aas3_0_RC02
 
             private void AdministrativeInformationToSequence(
                 AdministrativeInformation that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
                     writer.WriteStartElement(
-                        "dataSpecifications");
+                        "embeddedDataSpecifications",
+                        NS);
 
-                    foreach (var item in that.DataSpecifications)
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         this.Visit(
                             item,
@@ -18846,7 +20419,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Version != null)
                 {
                     writer.WriteStartElement(
-                        "version");
+                        "version",
+                        NS);
 
                     writer.WriteValue(
                         that.Version);
@@ -18857,7 +20431,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Revision != null)
                 {
                     writer.WriteStartElement(
-                        "revision");
+                        "revision",
+                        NS);
 
                     writer.WriteValue(
                         that.Revision);
@@ -18868,10 +20443,11 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.AdministrativeInformation that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "administrativeInformation");
+                    "administrativeInformation",
+                    NS);
                 this.AdministrativeInformationToSequence(
                     that,
                     writer);
@@ -18880,12 +20456,13 @@ namespace AasCore.Aas3_0_RC02
 
             private void QualifierToSequence(
                 Qualifier that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 if (that.SemanticId != null)
                 {
                     writer.WriteStartElement(
-                        "semanticId");
+                        "semanticId",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.SemanticId,
@@ -18897,7 +20474,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SupplementalSemanticIds != null)
                 {
                     writer.WriteStartElement(
-                        "supplementalSemanticIds");
+                        "supplementalSemanticIds",
+                        NS);
 
                     foreach (var item in that.SupplementalSemanticIds)
                     {
@@ -18912,7 +20490,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Kind != null)
                 {
                     writer.WriteStartElement(
-                        "kind");
+                        "kind",
+                        NS);
 
                     string? textKind = Stringification.ToString(
                         that.Kind);
@@ -18926,7 +20505,8 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 writer.WriteStartElement(
-                    "type");
+                    "type",
+                    NS);
 
                 writer.WriteValue(
                     that.Type);
@@ -18934,7 +20514,8 @@ namespace AasCore.Aas3_0_RC02
                 writer.WriteEndElement();
 
                 writer.WriteStartElement(
-                    "valueType");
+                    "valueType",
+                    NS);
 
                 string? textValueType = Stringification.ToString(
                     that.ValueType);
@@ -18949,7 +20530,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Value != null)
                 {
                     writer.WriteStartElement(
-                        "value");
+                        "value",
+                        NS);
 
                     writer.WriteValue(
                         that.Value);
@@ -18960,7 +20542,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.ValueId != null)
                 {
                     writer.WriteStartElement(
-                        "valueId");
+                        "valueId",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.ValueId,
@@ -18972,10 +20555,11 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.Qualifier that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "qualifier");
+                    "qualifier",
+                    NS);
                 this.QualifierToSequence(
                     that,
                     writer);
@@ -18984,12 +20568,13 @@ namespace AasCore.Aas3_0_RC02
 
             private void AssetAdministrationShellToSequence(
                 AssetAdministrationShell that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
                 {
                     writer.WriteStartElement(
-                        "extensions");
+                        "extensions",
+                        NS);
 
                     foreach (var item in that.Extensions)
                     {
@@ -19004,7 +20589,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Category != null)
                 {
                     writer.WriteStartElement(
-                        "category");
+                        "category",
+                        NS);
 
                     writer.WriteValue(
                         that.Category);
@@ -19015,7 +20601,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.IdShort != null)
                 {
                     writer.WriteStartElement(
-                        "idShort");
+                        "idShort",
+                        NS);
 
                     writer.WriteValue(
                         that.IdShort);
@@ -19026,7 +20613,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.DisplayName != null)
                 {
                     writer.WriteStartElement(
-                        "displayName");
+                        "displayName",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.DisplayName,
@@ -19038,7 +20626,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Description != null)
                 {
                     writer.WriteStartElement(
-                        "description");
+                        "description",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.Description,
@@ -19050,7 +20639,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Checksum != null)
                 {
                     writer.WriteStartElement(
-                        "checksum");
+                        "checksum",
+                        NS);
 
                     writer.WriteValue(
                         that.Checksum);
@@ -19061,7 +20651,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Administration != null)
                 {
                     writer.WriteStartElement(
-                        "administration");
+                        "administration",
+                        NS);
 
                     this.AdministrativeInformationToSequence(
                         that.Administration,
@@ -19071,19 +20662,21 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 writer.WriteStartElement(
-                    "id");
+                    "id",
+                    NS);
 
                 writer.WriteValue(
                     that.Id);
 
                 writer.WriteEndElement();
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
                     writer.WriteStartElement(
-                        "dataSpecifications");
+                        "embeddedDataSpecifications",
+                        NS);
 
-                    foreach (var item in that.DataSpecifications)
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         this.Visit(
                             item,
@@ -19096,7 +20689,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.DerivedFrom != null)
                 {
                     writer.WriteStartElement(
-                        "derivedFrom");
+                        "derivedFrom",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.DerivedFrom,
@@ -19106,7 +20700,8 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 writer.WriteStartElement(
-                    "assetInformation");
+                    "assetInformation",
+                    NS);
 
                 this.AssetInformationToSequence(
                     that.AssetInformation,
@@ -19117,7 +20712,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Submodels != null)
                 {
                     writer.WriteStartElement(
-                        "submodels");
+                        "submodels",
+                        NS);
 
                     foreach (var item in that.Submodels)
                     {
@@ -19132,10 +20728,11 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.AssetAdministrationShell that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "assetAdministrationShell");
+                    "assetAdministrationShell",
+                    NS);
                 this.AssetAdministrationShellToSequence(
                     that,
                     writer);
@@ -19144,10 +20741,11 @@ namespace AasCore.Aas3_0_RC02
 
             private void AssetInformationToSequence(
                 AssetInformation that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "assetKind");
+                    "assetKind",
+                    NS);
 
                 string? textAssetKind = Stringification.ToString(
                     that.AssetKind);
@@ -19162,7 +20760,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.GlobalAssetId != null)
                 {
                     writer.WriteStartElement(
-                        "globalAssetId");
+                        "globalAssetId",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.GlobalAssetId,
@@ -19174,7 +20773,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SpecificAssetIds != null)
                 {
                     writer.WriteStartElement(
-                        "specificAssetIds");
+                        "specificAssetIds",
+                        NS);
 
                     foreach (var item in that.SpecificAssetIds)
                     {
@@ -19189,7 +20789,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.DefaultThumbnail != null)
                 {
                     writer.WriteStartElement(
-                        "defaultThumbnail");
+                        "defaultThumbnail",
+                        NS);
 
                     this.ResourceToSequence(
                         that.DefaultThumbnail,
@@ -19201,10 +20802,11 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.AssetInformation that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "assetInformation");
+                    "assetInformation",
+                    NS);
                 this.AssetInformationToSequence(
                     that,
                     writer);
@@ -19213,10 +20815,11 @@ namespace AasCore.Aas3_0_RC02
 
             private void ResourceToSequence(
                 Resource that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "path");
+                    "path",
+                    NS);
 
                 writer.WriteValue(
                     that.Path);
@@ -19226,7 +20829,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.ContentType != null)
                 {
                     writer.WriteStartElement(
-                        "contentType");
+                        "contentType",
+                        NS);
 
                     writer.WriteValue(
                         that.ContentType);
@@ -19237,10 +20841,11 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.Resource that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "resource");
+                    "resource",
+                    NS);
                 this.ResourceToSequence(
                     that,
                     writer);
@@ -19249,12 +20854,13 @@ namespace AasCore.Aas3_0_RC02
 
             private void SpecificAssetIdToSequence(
                 SpecificAssetId that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 if (that.SemanticId != null)
                 {
                     writer.WriteStartElement(
-                        "semanticId");
+                        "semanticId",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.SemanticId,
@@ -19266,7 +20872,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SupplementalSemanticIds != null)
                 {
                     writer.WriteStartElement(
-                        "supplementalSemanticIds");
+                        "supplementalSemanticIds",
+                        NS);
 
                     foreach (var item in that.SupplementalSemanticIds)
                     {
@@ -19279,7 +20886,8 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 writer.WriteStartElement(
-                    "name");
+                    "name",
+                    NS);
 
                 writer.WriteValue(
                     that.Name);
@@ -19287,7 +20895,8 @@ namespace AasCore.Aas3_0_RC02
                 writer.WriteEndElement();
 
                 writer.WriteStartElement(
-                    "value");
+                    "value",
+                    NS);
 
                 writer.WriteValue(
                     that.Value);
@@ -19295,7 +20904,8 @@ namespace AasCore.Aas3_0_RC02
                 writer.WriteEndElement();
 
                 writer.WriteStartElement(
-                    "externalSubjectId");
+                    "externalSubjectId",
+                    NS);
 
                 this.ReferenceToSequence(
                     that.ExternalSubjectId,
@@ -19306,10 +20916,11 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.SpecificAssetId that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "specificAssetId");
+                    "specificAssetId",
+                    NS);
                 this.SpecificAssetIdToSequence(
                     that,
                     writer);
@@ -19318,12 +20929,13 @@ namespace AasCore.Aas3_0_RC02
 
             private void SubmodelToSequence(
                 Submodel that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
                 {
                     writer.WriteStartElement(
-                        "extensions");
+                        "extensions",
+                        NS);
 
                     foreach (var item in that.Extensions)
                     {
@@ -19338,7 +20950,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Category != null)
                 {
                     writer.WriteStartElement(
-                        "category");
+                        "category",
+                        NS);
 
                     writer.WriteValue(
                         that.Category);
@@ -19349,7 +20962,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.IdShort != null)
                 {
                     writer.WriteStartElement(
-                        "idShort");
+                        "idShort",
+                        NS);
 
                     writer.WriteValue(
                         that.IdShort);
@@ -19360,7 +20974,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.DisplayName != null)
                 {
                     writer.WriteStartElement(
-                        "displayName");
+                        "displayName",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.DisplayName,
@@ -19372,7 +20987,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Description != null)
                 {
                     writer.WriteStartElement(
-                        "description");
+                        "description",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.Description,
@@ -19384,7 +21000,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Checksum != null)
                 {
                     writer.WriteStartElement(
-                        "checksum");
+                        "checksum",
+                        NS);
 
                     writer.WriteValue(
                         that.Checksum);
@@ -19395,7 +21012,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Administration != null)
                 {
                     writer.WriteStartElement(
-                        "administration");
+                        "administration",
+                        NS);
 
                     this.AdministrativeInformationToSequence(
                         that.Administration,
@@ -19405,7 +21023,8 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 writer.WriteStartElement(
-                    "id");
+                    "id",
+                    NS);
 
                 writer.WriteValue(
                     that.Id);
@@ -19415,7 +21034,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Kind != null)
                 {
                     writer.WriteStartElement(
-                        "kind");
+                        "kind",
+                        NS);
 
                     string? textKind = Stringification.ToString(
                         that.Kind);
@@ -19431,7 +21051,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SemanticId != null)
                 {
                     writer.WriteStartElement(
-                        "semanticId");
+                        "semanticId",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.SemanticId,
@@ -19443,7 +21064,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SupplementalSemanticIds != null)
                 {
                     writer.WriteStartElement(
-                        "supplementalSemanticIds");
+                        "supplementalSemanticIds",
+                        NS);
 
                     foreach (var item in that.SupplementalSemanticIds)
                     {
@@ -19458,7 +21080,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Qualifiers != null)
                 {
                     writer.WriteStartElement(
-                        "qualifiers");
+                        "qualifiers",
+                        NS);
 
                     foreach (var item in that.Qualifiers)
                     {
@@ -19470,12 +21093,13 @@ namespace AasCore.Aas3_0_RC02
                     writer.WriteEndElement();
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
                     writer.WriteStartElement(
-                        "dataSpecifications");
+                        "embeddedDataSpecifications",
+                        NS);
 
-                    foreach (var item in that.DataSpecifications)
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         this.Visit(
                             item,
@@ -19488,7 +21112,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SubmodelElements != null)
                 {
                     writer.WriteStartElement(
-                        "submodelElements");
+                        "submodelElements",
+                        NS);
 
                     foreach (var item in that.SubmodelElements)
                     {
@@ -19503,10 +21128,11 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.Submodel that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "submodel");
+                    "submodel",
+                    NS);
                 this.SubmodelToSequence(
                     that,
                     writer);
@@ -19515,12 +21141,13 @@ namespace AasCore.Aas3_0_RC02
 
             private void RelationshipElementToSequence(
                 RelationshipElement that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
                 {
                     writer.WriteStartElement(
-                        "extensions");
+                        "extensions",
+                        NS);
 
                     foreach (var item in that.Extensions)
                     {
@@ -19535,7 +21162,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Category != null)
                 {
                     writer.WriteStartElement(
-                        "category");
+                        "category",
+                        NS);
 
                     writer.WriteValue(
                         that.Category);
@@ -19546,7 +21174,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.IdShort != null)
                 {
                     writer.WriteStartElement(
-                        "idShort");
+                        "idShort",
+                        NS);
 
                     writer.WriteValue(
                         that.IdShort);
@@ -19557,7 +21186,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.DisplayName != null)
                 {
                     writer.WriteStartElement(
-                        "displayName");
+                        "displayName",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.DisplayName,
@@ -19569,7 +21199,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Description != null)
                 {
                     writer.WriteStartElement(
-                        "description");
+                        "description",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.Description,
@@ -19581,7 +21212,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Checksum != null)
                 {
                     writer.WriteStartElement(
-                        "checksum");
+                        "checksum",
+                        NS);
 
                     writer.WriteValue(
                         that.Checksum);
@@ -19592,7 +21224,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Kind != null)
                 {
                     writer.WriteStartElement(
-                        "kind");
+                        "kind",
+                        NS);
 
                     string? textKind = Stringification.ToString(
                         that.Kind);
@@ -19608,7 +21241,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SemanticId != null)
                 {
                     writer.WriteStartElement(
-                        "semanticId");
+                        "semanticId",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.SemanticId,
@@ -19620,7 +21254,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SupplementalSemanticIds != null)
                 {
                     writer.WriteStartElement(
-                        "supplementalSemanticIds");
+                        "supplementalSemanticIds",
+                        NS);
 
                     foreach (var item in that.SupplementalSemanticIds)
                     {
@@ -19635,7 +21270,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Qualifiers != null)
                 {
                     writer.WriteStartElement(
-                        "qualifiers");
+                        "qualifiers",
+                        NS);
 
                     foreach (var item in that.Qualifiers)
                     {
@@ -19647,12 +21283,13 @@ namespace AasCore.Aas3_0_RC02
                     writer.WriteEndElement();
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
                     writer.WriteStartElement(
-                        "dataSpecifications");
+                        "embeddedDataSpecifications",
+                        NS);
 
-                    foreach (var item in that.DataSpecifications)
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         this.Visit(
                             item,
@@ -19663,7 +21300,8 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 writer.WriteStartElement(
-                    "first");
+                    "first",
+                    NS);
 
                 this.ReferenceToSequence(
                     that.First,
@@ -19672,7 +21310,8 @@ namespace AasCore.Aas3_0_RC02
                 writer.WriteEndElement();
 
                 writer.WriteStartElement(
-                    "second");
+                    "second",
+                    NS);
 
                 this.ReferenceToSequence(
                     that.Second,
@@ -19683,10 +21322,11 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.RelationshipElement that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "relationshipElement");
+                    "relationshipElement",
+                    NS);
                 this.RelationshipElementToSequence(
                     that,
                     writer);
@@ -19695,12 +21335,13 @@ namespace AasCore.Aas3_0_RC02
 
             private void SubmodelElementListToSequence(
                 SubmodelElementList that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
                 {
                     writer.WriteStartElement(
-                        "extensions");
+                        "extensions",
+                        NS);
 
                     foreach (var item in that.Extensions)
                     {
@@ -19715,7 +21356,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Category != null)
                 {
                     writer.WriteStartElement(
-                        "category");
+                        "category",
+                        NS);
 
                     writer.WriteValue(
                         that.Category);
@@ -19726,7 +21368,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.IdShort != null)
                 {
                     writer.WriteStartElement(
-                        "idShort");
+                        "idShort",
+                        NS);
 
                     writer.WriteValue(
                         that.IdShort);
@@ -19737,7 +21380,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.DisplayName != null)
                 {
                     writer.WriteStartElement(
-                        "displayName");
+                        "displayName",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.DisplayName,
@@ -19749,7 +21393,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Description != null)
                 {
                     writer.WriteStartElement(
-                        "description");
+                        "description",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.Description,
@@ -19761,7 +21406,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Checksum != null)
                 {
                     writer.WriteStartElement(
-                        "checksum");
+                        "checksum",
+                        NS);
 
                     writer.WriteValue(
                         that.Checksum);
@@ -19772,7 +21418,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Kind != null)
                 {
                     writer.WriteStartElement(
-                        "kind");
+                        "kind",
+                        NS);
 
                     string? textKind = Stringification.ToString(
                         that.Kind);
@@ -19788,7 +21435,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SemanticId != null)
                 {
                     writer.WriteStartElement(
-                        "semanticId");
+                        "semanticId",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.SemanticId,
@@ -19800,7 +21448,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SupplementalSemanticIds != null)
                 {
                     writer.WriteStartElement(
-                        "supplementalSemanticIds");
+                        "supplementalSemanticIds",
+                        NS);
 
                     foreach (var item in that.SupplementalSemanticIds)
                     {
@@ -19815,7 +21464,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Qualifiers != null)
                 {
                     writer.WriteStartElement(
-                        "qualifiers");
+                        "qualifiers",
+                        NS);
 
                     foreach (var item in that.Qualifiers)
                     {
@@ -19827,12 +21477,13 @@ namespace AasCore.Aas3_0_RC02
                     writer.WriteEndElement();
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
                     writer.WriteStartElement(
-                        "dataSpecifications");
+                        "embeddedDataSpecifications",
+                        NS);
 
-                    foreach (var item in that.DataSpecifications)
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         this.Visit(
                             item,
@@ -19845,7 +21496,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.OrderRelevant.HasValue)
                 {
                     writer.WriteStartElement(
-                        "orderRelevant");
+                        "orderRelevant",
+                        NS);
 
                     writer.WriteValue(
                         that.OrderRelevant.Value);
@@ -19856,7 +21508,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Value != null)
                 {
                     writer.WriteStartElement(
-                        "value");
+                        "value",
+                        NS);
 
                     foreach (var item in that.Value)
                     {
@@ -19871,7 +21524,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SemanticIdListElement != null)
                 {
                     writer.WriteStartElement(
-                        "semanticIdListElement");
+                        "semanticIdListElement",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.SemanticIdListElement,
@@ -19881,7 +21535,8 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 writer.WriteStartElement(
-                    "typeValueListElement");
+                    "typeValueListElement",
+                    NS);
 
                 string? textTypeValueListElement = Stringification.ToString(
                     that.TypeValueListElement);
@@ -19896,7 +21551,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.ValueTypeListElement != null)
                 {
                     writer.WriteStartElement(
-                        "valueTypeListElement");
+                        "valueTypeListElement",
+                        NS);
 
                     string? textValueTypeListElement = Stringification.ToString(
                         that.ValueTypeListElement);
@@ -19912,10 +21568,11 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.SubmodelElementList that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "submodelElementList");
+                    "submodelElementList",
+                    NS);
                 this.SubmodelElementListToSequence(
                     that,
                     writer);
@@ -19924,12 +21581,13 @@ namespace AasCore.Aas3_0_RC02
 
             private void SubmodelElementCollectionToSequence(
                 SubmodelElementCollection that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
                 {
                     writer.WriteStartElement(
-                        "extensions");
+                        "extensions",
+                        NS);
 
                     foreach (var item in that.Extensions)
                     {
@@ -19944,7 +21602,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Category != null)
                 {
                     writer.WriteStartElement(
-                        "category");
+                        "category",
+                        NS);
 
                     writer.WriteValue(
                         that.Category);
@@ -19955,7 +21614,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.IdShort != null)
                 {
                     writer.WriteStartElement(
-                        "idShort");
+                        "idShort",
+                        NS);
 
                     writer.WriteValue(
                         that.IdShort);
@@ -19966,7 +21626,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.DisplayName != null)
                 {
                     writer.WriteStartElement(
-                        "displayName");
+                        "displayName",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.DisplayName,
@@ -19978,7 +21639,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Description != null)
                 {
                     writer.WriteStartElement(
-                        "description");
+                        "description",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.Description,
@@ -19990,7 +21652,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Checksum != null)
                 {
                     writer.WriteStartElement(
-                        "checksum");
+                        "checksum",
+                        NS);
 
                     writer.WriteValue(
                         that.Checksum);
@@ -20001,7 +21664,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Kind != null)
                 {
                     writer.WriteStartElement(
-                        "kind");
+                        "kind",
+                        NS);
 
                     string? textKind = Stringification.ToString(
                         that.Kind);
@@ -20017,7 +21681,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SemanticId != null)
                 {
                     writer.WriteStartElement(
-                        "semanticId");
+                        "semanticId",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.SemanticId,
@@ -20029,7 +21694,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SupplementalSemanticIds != null)
                 {
                     writer.WriteStartElement(
-                        "supplementalSemanticIds");
+                        "supplementalSemanticIds",
+                        NS);
 
                     foreach (var item in that.SupplementalSemanticIds)
                     {
@@ -20044,7 +21710,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Qualifiers != null)
                 {
                     writer.WriteStartElement(
-                        "qualifiers");
+                        "qualifiers",
+                        NS);
 
                     foreach (var item in that.Qualifiers)
                     {
@@ -20056,12 +21723,13 @@ namespace AasCore.Aas3_0_RC02
                     writer.WriteEndElement();
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
                     writer.WriteStartElement(
-                        "dataSpecifications");
+                        "embeddedDataSpecifications",
+                        NS);
 
-                    foreach (var item in that.DataSpecifications)
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         this.Visit(
                             item,
@@ -20074,7 +21742,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Value != null)
                 {
                     writer.WriteStartElement(
-                        "value");
+                        "value",
+                        NS);
 
                     foreach (var item in that.Value)
                     {
@@ -20089,10 +21758,11 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.SubmodelElementCollection that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "submodelElementCollection");
+                    "submodelElementCollection",
+                    NS);
                 this.SubmodelElementCollectionToSequence(
                     that,
                     writer);
@@ -20101,12 +21771,13 @@ namespace AasCore.Aas3_0_RC02
 
             private void PropertyToSequence(
                 Property that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
                 {
                     writer.WriteStartElement(
-                        "extensions");
+                        "extensions",
+                        NS);
 
                     foreach (var item in that.Extensions)
                     {
@@ -20121,7 +21792,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Category != null)
                 {
                     writer.WriteStartElement(
-                        "category");
+                        "category",
+                        NS);
 
                     writer.WriteValue(
                         that.Category);
@@ -20132,7 +21804,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.IdShort != null)
                 {
                     writer.WriteStartElement(
-                        "idShort");
+                        "idShort",
+                        NS);
 
                     writer.WriteValue(
                         that.IdShort);
@@ -20143,7 +21816,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.DisplayName != null)
                 {
                     writer.WriteStartElement(
-                        "displayName");
+                        "displayName",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.DisplayName,
@@ -20155,7 +21829,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Description != null)
                 {
                     writer.WriteStartElement(
-                        "description");
+                        "description",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.Description,
@@ -20167,7 +21842,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Checksum != null)
                 {
                     writer.WriteStartElement(
-                        "checksum");
+                        "checksum",
+                        NS);
 
                     writer.WriteValue(
                         that.Checksum);
@@ -20178,7 +21854,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Kind != null)
                 {
                     writer.WriteStartElement(
-                        "kind");
+                        "kind",
+                        NS);
 
                     string? textKind = Stringification.ToString(
                         that.Kind);
@@ -20194,7 +21871,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SemanticId != null)
                 {
                     writer.WriteStartElement(
-                        "semanticId");
+                        "semanticId",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.SemanticId,
@@ -20206,7 +21884,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SupplementalSemanticIds != null)
                 {
                     writer.WriteStartElement(
-                        "supplementalSemanticIds");
+                        "supplementalSemanticIds",
+                        NS);
 
                     foreach (var item in that.SupplementalSemanticIds)
                     {
@@ -20221,7 +21900,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Qualifiers != null)
                 {
                     writer.WriteStartElement(
-                        "qualifiers");
+                        "qualifiers",
+                        NS);
 
                     foreach (var item in that.Qualifiers)
                     {
@@ -20233,12 +21913,13 @@ namespace AasCore.Aas3_0_RC02
                     writer.WriteEndElement();
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
                     writer.WriteStartElement(
-                        "dataSpecifications");
+                        "embeddedDataSpecifications",
+                        NS);
 
-                    foreach (var item in that.DataSpecifications)
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         this.Visit(
                             item,
@@ -20249,7 +21930,8 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 writer.WriteStartElement(
-                    "valueType");
+                    "valueType",
+                    NS);
 
                 string? textValueType = Stringification.ToString(
                     that.ValueType);
@@ -20264,7 +21946,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Value != null)
                 {
                     writer.WriteStartElement(
-                        "value");
+                        "value",
+                        NS);
 
                     writer.WriteValue(
                         that.Value);
@@ -20275,7 +21958,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.ValueId != null)
                 {
                     writer.WriteStartElement(
-                        "valueId");
+                        "valueId",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.ValueId,
@@ -20287,10 +21971,11 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.Property that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "property");
+                    "property",
+                    NS);
                 this.PropertyToSequence(
                     that,
                     writer);
@@ -20299,12 +21984,13 @@ namespace AasCore.Aas3_0_RC02
 
             private void MultiLanguagePropertyToSequence(
                 MultiLanguageProperty that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
                 {
                     writer.WriteStartElement(
-                        "extensions");
+                        "extensions",
+                        NS);
 
                     foreach (var item in that.Extensions)
                     {
@@ -20319,7 +22005,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Category != null)
                 {
                     writer.WriteStartElement(
-                        "category");
+                        "category",
+                        NS);
 
                     writer.WriteValue(
                         that.Category);
@@ -20330,7 +22017,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.IdShort != null)
                 {
                     writer.WriteStartElement(
-                        "idShort");
+                        "idShort",
+                        NS);
 
                     writer.WriteValue(
                         that.IdShort);
@@ -20341,7 +22029,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.DisplayName != null)
                 {
                     writer.WriteStartElement(
-                        "displayName");
+                        "displayName",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.DisplayName,
@@ -20353,7 +22042,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Description != null)
                 {
                     writer.WriteStartElement(
-                        "description");
+                        "description",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.Description,
@@ -20365,7 +22055,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Checksum != null)
                 {
                     writer.WriteStartElement(
-                        "checksum");
+                        "checksum",
+                        NS);
 
                     writer.WriteValue(
                         that.Checksum);
@@ -20376,7 +22067,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Kind != null)
                 {
                     writer.WriteStartElement(
-                        "kind");
+                        "kind",
+                        NS);
 
                     string? textKind = Stringification.ToString(
                         that.Kind);
@@ -20392,7 +22084,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SemanticId != null)
                 {
                     writer.WriteStartElement(
-                        "semanticId");
+                        "semanticId",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.SemanticId,
@@ -20404,7 +22097,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SupplementalSemanticIds != null)
                 {
                     writer.WriteStartElement(
-                        "supplementalSemanticIds");
+                        "supplementalSemanticIds",
+                        NS);
 
                     foreach (var item in that.SupplementalSemanticIds)
                     {
@@ -20419,7 +22113,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Qualifiers != null)
                 {
                     writer.WriteStartElement(
-                        "qualifiers");
+                        "qualifiers",
+                        NS);
 
                     foreach (var item in that.Qualifiers)
                     {
@@ -20431,12 +22126,13 @@ namespace AasCore.Aas3_0_RC02
                     writer.WriteEndElement();
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
                     writer.WriteStartElement(
-                        "dataSpecifications");
+                        "embeddedDataSpecifications",
+                        NS);
 
-                    foreach (var item in that.DataSpecifications)
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         this.Visit(
                             item,
@@ -20449,7 +22145,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Value != null)
                 {
                     writer.WriteStartElement(
-                        "value");
+                        "value",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.Value,
@@ -20461,7 +22158,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.ValueId != null)
                 {
                     writer.WriteStartElement(
-                        "valueId");
+                        "valueId",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.ValueId,
@@ -20473,10 +22171,11 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.MultiLanguageProperty that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "multiLanguageProperty");
+                    "multiLanguageProperty",
+                    NS);
                 this.MultiLanguagePropertyToSequence(
                     that,
                     writer);
@@ -20485,12 +22184,13 @@ namespace AasCore.Aas3_0_RC02
 
             private void RangeToSequence(
                 Range that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
                 {
                     writer.WriteStartElement(
-                        "extensions");
+                        "extensions",
+                        NS);
 
                     foreach (var item in that.Extensions)
                     {
@@ -20505,7 +22205,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Category != null)
                 {
                     writer.WriteStartElement(
-                        "category");
+                        "category",
+                        NS);
 
                     writer.WriteValue(
                         that.Category);
@@ -20516,7 +22217,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.IdShort != null)
                 {
                     writer.WriteStartElement(
-                        "idShort");
+                        "idShort",
+                        NS);
 
                     writer.WriteValue(
                         that.IdShort);
@@ -20527,7 +22229,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.DisplayName != null)
                 {
                     writer.WriteStartElement(
-                        "displayName");
+                        "displayName",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.DisplayName,
@@ -20539,7 +22242,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Description != null)
                 {
                     writer.WriteStartElement(
-                        "description");
+                        "description",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.Description,
@@ -20551,7 +22255,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Checksum != null)
                 {
                     writer.WriteStartElement(
-                        "checksum");
+                        "checksum",
+                        NS);
 
                     writer.WriteValue(
                         that.Checksum);
@@ -20562,7 +22267,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Kind != null)
                 {
                     writer.WriteStartElement(
-                        "kind");
+                        "kind",
+                        NS);
 
                     string? textKind = Stringification.ToString(
                         that.Kind);
@@ -20578,7 +22284,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SemanticId != null)
                 {
                     writer.WriteStartElement(
-                        "semanticId");
+                        "semanticId",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.SemanticId,
@@ -20590,7 +22297,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SupplementalSemanticIds != null)
                 {
                     writer.WriteStartElement(
-                        "supplementalSemanticIds");
+                        "supplementalSemanticIds",
+                        NS);
 
                     foreach (var item in that.SupplementalSemanticIds)
                     {
@@ -20605,7 +22313,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Qualifiers != null)
                 {
                     writer.WriteStartElement(
-                        "qualifiers");
+                        "qualifiers",
+                        NS);
 
                     foreach (var item in that.Qualifiers)
                     {
@@ -20617,12 +22326,13 @@ namespace AasCore.Aas3_0_RC02
                     writer.WriteEndElement();
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
                     writer.WriteStartElement(
-                        "dataSpecifications");
+                        "embeddedDataSpecifications",
+                        NS);
 
-                    foreach (var item in that.DataSpecifications)
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         this.Visit(
                             item,
@@ -20633,7 +22343,8 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 writer.WriteStartElement(
-                    "valueType");
+                    "valueType",
+                    NS);
 
                 string? textValueType = Stringification.ToString(
                     that.ValueType);
@@ -20648,7 +22359,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Min != null)
                 {
                     writer.WriteStartElement(
-                        "min");
+                        "min",
+                        NS);
 
                     writer.WriteValue(
                         that.Min);
@@ -20659,7 +22371,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Max != null)
                 {
                     writer.WriteStartElement(
-                        "max");
+                        "max",
+                        NS);
 
                     writer.WriteValue(
                         that.Max);
@@ -20670,10 +22383,11 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.Range that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "range");
+                    "range",
+                    NS);
                 this.RangeToSequence(
                     that,
                     writer);
@@ -20682,12 +22396,13 @@ namespace AasCore.Aas3_0_RC02
 
             private void ReferenceElementToSequence(
                 ReferenceElement that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
                 {
                     writer.WriteStartElement(
-                        "extensions");
+                        "extensions",
+                        NS);
 
                     foreach (var item in that.Extensions)
                     {
@@ -20702,7 +22417,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Category != null)
                 {
                     writer.WriteStartElement(
-                        "category");
+                        "category",
+                        NS);
 
                     writer.WriteValue(
                         that.Category);
@@ -20713,7 +22429,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.IdShort != null)
                 {
                     writer.WriteStartElement(
-                        "idShort");
+                        "idShort",
+                        NS);
 
                     writer.WriteValue(
                         that.IdShort);
@@ -20724,7 +22441,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.DisplayName != null)
                 {
                     writer.WriteStartElement(
-                        "displayName");
+                        "displayName",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.DisplayName,
@@ -20736,7 +22454,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Description != null)
                 {
                     writer.WriteStartElement(
-                        "description");
+                        "description",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.Description,
@@ -20748,7 +22467,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Checksum != null)
                 {
                     writer.WriteStartElement(
-                        "checksum");
+                        "checksum",
+                        NS);
 
                     writer.WriteValue(
                         that.Checksum);
@@ -20759,7 +22479,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Kind != null)
                 {
                     writer.WriteStartElement(
-                        "kind");
+                        "kind",
+                        NS);
 
                     string? textKind = Stringification.ToString(
                         that.Kind);
@@ -20775,7 +22496,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SemanticId != null)
                 {
                     writer.WriteStartElement(
-                        "semanticId");
+                        "semanticId",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.SemanticId,
@@ -20787,7 +22509,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SupplementalSemanticIds != null)
                 {
                     writer.WriteStartElement(
-                        "supplementalSemanticIds");
+                        "supplementalSemanticIds",
+                        NS);
 
                     foreach (var item in that.SupplementalSemanticIds)
                     {
@@ -20802,7 +22525,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Qualifiers != null)
                 {
                     writer.WriteStartElement(
-                        "qualifiers");
+                        "qualifiers",
+                        NS);
 
                     foreach (var item in that.Qualifiers)
                     {
@@ -20814,12 +22538,13 @@ namespace AasCore.Aas3_0_RC02
                     writer.WriteEndElement();
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
                     writer.WriteStartElement(
-                        "dataSpecifications");
+                        "embeddedDataSpecifications",
+                        NS);
 
-                    foreach (var item in that.DataSpecifications)
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         this.Visit(
                             item,
@@ -20832,7 +22557,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Value != null)
                 {
                     writer.WriteStartElement(
-                        "value");
+                        "value",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.Value,
@@ -20844,10 +22570,11 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.ReferenceElement that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "referenceElement");
+                    "referenceElement",
+                    NS);
                 this.ReferenceElementToSequence(
                     that,
                     writer);
@@ -20856,12 +22583,13 @@ namespace AasCore.Aas3_0_RC02
 
             private void BlobToSequence(
                 Blob that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
                 {
                     writer.WriteStartElement(
-                        "extensions");
+                        "extensions",
+                        NS);
 
                     foreach (var item in that.Extensions)
                     {
@@ -20876,7 +22604,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Category != null)
                 {
                     writer.WriteStartElement(
-                        "category");
+                        "category",
+                        NS);
 
                     writer.WriteValue(
                         that.Category);
@@ -20887,7 +22616,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.IdShort != null)
                 {
                     writer.WriteStartElement(
-                        "idShort");
+                        "idShort",
+                        NS);
 
                     writer.WriteValue(
                         that.IdShort);
@@ -20898,7 +22628,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.DisplayName != null)
                 {
                     writer.WriteStartElement(
-                        "displayName");
+                        "displayName",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.DisplayName,
@@ -20910,7 +22641,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Description != null)
                 {
                     writer.WriteStartElement(
-                        "description");
+                        "description",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.Description,
@@ -20922,7 +22654,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Checksum != null)
                 {
                     writer.WriteStartElement(
-                        "checksum");
+                        "checksum",
+                        NS);
 
                     writer.WriteValue(
                         that.Checksum);
@@ -20933,7 +22666,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Kind != null)
                 {
                     writer.WriteStartElement(
-                        "kind");
+                        "kind",
+                        NS);
 
                     string? textKind = Stringification.ToString(
                         that.Kind);
@@ -20949,7 +22683,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SemanticId != null)
                 {
                     writer.WriteStartElement(
-                        "semanticId");
+                        "semanticId",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.SemanticId,
@@ -20961,7 +22696,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SupplementalSemanticIds != null)
                 {
                     writer.WriteStartElement(
-                        "supplementalSemanticIds");
+                        "supplementalSemanticIds",
+                        NS);
 
                     foreach (var item in that.SupplementalSemanticIds)
                     {
@@ -20976,7 +22712,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Qualifiers != null)
                 {
                     writer.WriteStartElement(
-                        "qualifiers");
+                        "qualifiers",
+                        NS);
 
                     foreach (var item in that.Qualifiers)
                     {
@@ -20988,12 +22725,13 @@ namespace AasCore.Aas3_0_RC02
                     writer.WriteEndElement();
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
                     writer.WriteStartElement(
-                        "dataSpecifications");
+                        "embeddedDataSpecifications",
+                        NS);
 
-                    foreach (var item in that.DataSpecifications)
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         this.Visit(
                             item,
@@ -21006,16 +22744,20 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Value != null)
                 {
                     writer.WriteStartElement(
-                        "value");
+                        "value",
+                        NS);
 
                     writer.WriteBase64(
-                        that.Value);
+                        that.Value,
+                        0,
+                        that.Value.Length);
 
                     writer.WriteEndElement();
                 }
 
                 writer.WriteStartElement(
-                    "contentType");
+                    "contentType",
+                    NS);
 
                 writer.WriteValue(
                     that.ContentType);
@@ -21025,10 +22767,11 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.Blob that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "blob");
+                    "blob",
+                    NS);
                 this.BlobToSequence(
                     that,
                     writer);
@@ -21037,12 +22780,13 @@ namespace AasCore.Aas3_0_RC02
 
             private void FileToSequence(
                 File that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
                 {
                     writer.WriteStartElement(
-                        "extensions");
+                        "extensions",
+                        NS);
 
                     foreach (var item in that.Extensions)
                     {
@@ -21057,7 +22801,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Category != null)
                 {
                     writer.WriteStartElement(
-                        "category");
+                        "category",
+                        NS);
 
                     writer.WriteValue(
                         that.Category);
@@ -21068,7 +22813,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.IdShort != null)
                 {
                     writer.WriteStartElement(
-                        "idShort");
+                        "idShort",
+                        NS);
 
                     writer.WriteValue(
                         that.IdShort);
@@ -21079,7 +22825,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.DisplayName != null)
                 {
                     writer.WriteStartElement(
-                        "displayName");
+                        "displayName",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.DisplayName,
@@ -21091,7 +22838,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Description != null)
                 {
                     writer.WriteStartElement(
-                        "description");
+                        "description",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.Description,
@@ -21103,7 +22851,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Checksum != null)
                 {
                     writer.WriteStartElement(
-                        "checksum");
+                        "checksum",
+                        NS);
 
                     writer.WriteValue(
                         that.Checksum);
@@ -21114,7 +22863,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Kind != null)
                 {
                     writer.WriteStartElement(
-                        "kind");
+                        "kind",
+                        NS);
 
                     string? textKind = Stringification.ToString(
                         that.Kind);
@@ -21130,7 +22880,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SemanticId != null)
                 {
                     writer.WriteStartElement(
-                        "semanticId");
+                        "semanticId",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.SemanticId,
@@ -21142,7 +22893,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SupplementalSemanticIds != null)
                 {
                     writer.WriteStartElement(
-                        "supplementalSemanticIds");
+                        "supplementalSemanticIds",
+                        NS);
 
                     foreach (var item in that.SupplementalSemanticIds)
                     {
@@ -21157,7 +22909,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Qualifiers != null)
                 {
                     writer.WriteStartElement(
-                        "qualifiers");
+                        "qualifiers",
+                        NS);
 
                     foreach (var item in that.Qualifiers)
                     {
@@ -21169,12 +22922,13 @@ namespace AasCore.Aas3_0_RC02
                     writer.WriteEndElement();
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
                     writer.WriteStartElement(
-                        "dataSpecifications");
+                        "embeddedDataSpecifications",
+                        NS);
 
-                    foreach (var item in that.DataSpecifications)
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         this.Visit(
                             item,
@@ -21187,7 +22941,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Value != null)
                 {
                     writer.WriteStartElement(
-                        "value");
+                        "value",
+                        NS);
 
                     writer.WriteValue(
                         that.Value);
@@ -21196,7 +22951,8 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 writer.WriteStartElement(
-                    "contentType");
+                    "contentType",
+                    NS);
 
                 writer.WriteValue(
                     that.ContentType);
@@ -21206,10 +22962,11 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.File that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "file");
+                    "file",
+                    NS);
                 this.FileToSequence(
                     that,
                     writer);
@@ -21218,12 +22975,13 @@ namespace AasCore.Aas3_0_RC02
 
             private void AnnotatedRelationshipElementToSequence(
                 AnnotatedRelationshipElement that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
                 {
                     writer.WriteStartElement(
-                        "extensions");
+                        "extensions",
+                        NS);
 
                     foreach (var item in that.Extensions)
                     {
@@ -21238,7 +22996,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Category != null)
                 {
                     writer.WriteStartElement(
-                        "category");
+                        "category",
+                        NS);
 
                     writer.WriteValue(
                         that.Category);
@@ -21249,7 +23008,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.IdShort != null)
                 {
                     writer.WriteStartElement(
-                        "idShort");
+                        "idShort",
+                        NS);
 
                     writer.WriteValue(
                         that.IdShort);
@@ -21260,7 +23020,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.DisplayName != null)
                 {
                     writer.WriteStartElement(
-                        "displayName");
+                        "displayName",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.DisplayName,
@@ -21272,7 +23033,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Description != null)
                 {
                     writer.WriteStartElement(
-                        "description");
+                        "description",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.Description,
@@ -21284,7 +23046,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Checksum != null)
                 {
                     writer.WriteStartElement(
-                        "checksum");
+                        "checksum",
+                        NS);
 
                     writer.WriteValue(
                         that.Checksum);
@@ -21295,7 +23058,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Kind != null)
                 {
                     writer.WriteStartElement(
-                        "kind");
+                        "kind",
+                        NS);
 
                     string? textKind = Stringification.ToString(
                         that.Kind);
@@ -21311,7 +23075,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SemanticId != null)
                 {
                     writer.WriteStartElement(
-                        "semanticId");
+                        "semanticId",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.SemanticId,
@@ -21323,7 +23088,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SupplementalSemanticIds != null)
                 {
                     writer.WriteStartElement(
-                        "supplementalSemanticIds");
+                        "supplementalSemanticIds",
+                        NS);
 
                     foreach (var item in that.SupplementalSemanticIds)
                     {
@@ -21338,7 +23104,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Qualifiers != null)
                 {
                     writer.WriteStartElement(
-                        "qualifiers");
+                        "qualifiers",
+                        NS);
 
                     foreach (var item in that.Qualifiers)
                     {
@@ -21350,12 +23117,13 @@ namespace AasCore.Aas3_0_RC02
                     writer.WriteEndElement();
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
                     writer.WriteStartElement(
-                        "dataSpecifications");
+                        "embeddedDataSpecifications",
+                        NS);
 
-                    foreach (var item in that.DataSpecifications)
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         this.Visit(
                             item,
@@ -21366,7 +23134,8 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 writer.WriteStartElement(
-                    "first");
+                    "first",
+                    NS);
 
                 this.ReferenceToSequence(
                     that.First,
@@ -21375,7 +23144,8 @@ namespace AasCore.Aas3_0_RC02
                 writer.WriteEndElement();
 
                 writer.WriteStartElement(
-                    "second");
+                    "second",
+                    NS);
 
                 this.ReferenceToSequence(
                     that.Second,
@@ -21386,7 +23156,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Annotations != null)
                 {
                     writer.WriteStartElement(
-                        "annotations");
+                        "annotations",
+                        NS);
 
                     foreach (var item in that.Annotations)
                     {
@@ -21401,10 +23172,11 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.AnnotatedRelationshipElement that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "annotatedRelationshipElement");
+                    "annotatedRelationshipElement",
+                    NS);
                 this.AnnotatedRelationshipElementToSequence(
                     that,
                     writer);
@@ -21413,12 +23185,13 @@ namespace AasCore.Aas3_0_RC02
 
             private void EntityToSequence(
                 Entity that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
                 {
                     writer.WriteStartElement(
-                        "extensions");
+                        "extensions",
+                        NS);
 
                     foreach (var item in that.Extensions)
                     {
@@ -21433,7 +23206,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Category != null)
                 {
                     writer.WriteStartElement(
-                        "category");
+                        "category",
+                        NS);
 
                     writer.WriteValue(
                         that.Category);
@@ -21444,7 +23218,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.IdShort != null)
                 {
                     writer.WriteStartElement(
-                        "idShort");
+                        "idShort",
+                        NS);
 
                     writer.WriteValue(
                         that.IdShort);
@@ -21455,7 +23230,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.DisplayName != null)
                 {
                     writer.WriteStartElement(
-                        "displayName");
+                        "displayName",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.DisplayName,
@@ -21467,7 +23243,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Description != null)
                 {
                     writer.WriteStartElement(
-                        "description");
+                        "description",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.Description,
@@ -21479,7 +23256,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Checksum != null)
                 {
                     writer.WriteStartElement(
-                        "checksum");
+                        "checksum",
+                        NS);
 
                     writer.WriteValue(
                         that.Checksum);
@@ -21490,7 +23268,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Kind != null)
                 {
                     writer.WriteStartElement(
-                        "kind");
+                        "kind",
+                        NS);
 
                     string? textKind = Stringification.ToString(
                         that.Kind);
@@ -21506,7 +23285,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SemanticId != null)
                 {
                     writer.WriteStartElement(
-                        "semanticId");
+                        "semanticId",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.SemanticId,
@@ -21518,7 +23298,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SupplementalSemanticIds != null)
                 {
                     writer.WriteStartElement(
-                        "supplementalSemanticIds");
+                        "supplementalSemanticIds",
+                        NS);
 
                     foreach (var item in that.SupplementalSemanticIds)
                     {
@@ -21533,7 +23314,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Qualifiers != null)
                 {
                     writer.WriteStartElement(
-                        "qualifiers");
+                        "qualifiers",
+                        NS);
 
                     foreach (var item in that.Qualifiers)
                     {
@@ -21545,12 +23327,13 @@ namespace AasCore.Aas3_0_RC02
                     writer.WriteEndElement();
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
                     writer.WriteStartElement(
-                        "dataSpecifications");
+                        "embeddedDataSpecifications",
+                        NS);
 
-                    foreach (var item in that.DataSpecifications)
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         this.Visit(
                             item,
@@ -21563,7 +23346,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Statements != null)
                 {
                     writer.WriteStartElement(
-                        "statements");
+                        "statements",
+                        NS);
 
                     foreach (var item in that.Statements)
                     {
@@ -21576,7 +23360,8 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 writer.WriteStartElement(
-                    "entityType");
+                    "entityType",
+                    NS);
 
                 string? textEntityType = Stringification.ToString(
                     that.EntityType);
@@ -21591,7 +23376,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.GlobalAssetId != null)
                 {
                     writer.WriteStartElement(
-                        "globalAssetId");
+                        "globalAssetId",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.GlobalAssetId,
@@ -21603,7 +23389,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SpecificAssetId != null)
                 {
                     writer.WriteStartElement(
-                        "specificAssetId");
+                        "specificAssetId",
+                        NS);
 
                     this.SpecificAssetIdToSequence(
                         that.SpecificAssetId,
@@ -21615,10 +23402,11 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.Entity that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "entity");
+                    "entity",
+                    NS);
                 this.EntityToSequence(
                     that,
                     writer);
@@ -21627,10 +23415,11 @@ namespace AasCore.Aas3_0_RC02
 
             private void EventPayloadToSequence(
                 EventPayload that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "source");
+                    "source",
+                    NS);
 
                 this.ReferenceToSequence(
                     that.Source,
@@ -21641,7 +23430,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SourceSemanticId != null)
                 {
                     writer.WriteStartElement(
-                        "sourceSemanticId");
+                        "sourceSemanticId",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.SourceSemanticId,
@@ -21651,7 +23441,8 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 writer.WriteStartElement(
-                    "observableReference");
+                    "observableReference",
+                    NS);
 
                 this.ReferenceToSequence(
                     that.ObservableReference,
@@ -21662,7 +23453,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.ObservableSemanticId != null)
                 {
                     writer.WriteStartElement(
-                        "observableSemanticId");
+                        "observableSemanticId",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.ObservableSemanticId,
@@ -21674,7 +23466,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Topic != null)
                 {
                     writer.WriteStartElement(
-                        "topic");
+                        "topic",
+                        NS);
 
                     writer.WriteValue(
                         that.Topic);
@@ -21685,7 +23478,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SubjectId != null)
                 {
                     writer.WriteStartElement(
-                        "subjectId");
+                        "subjectId",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.SubjectId,
@@ -21695,7 +23489,8 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 writer.WriteStartElement(
-                    "timeStamp");
+                    "timeStamp",
+                    NS);
 
                 writer.WriteValue(
                     that.TimeStamp);
@@ -21705,7 +23500,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Payload != null)
                 {
                     writer.WriteStartElement(
-                        "payload");
+                        "payload",
+                        NS);
 
                     writer.WriteValue(
                         that.Payload);
@@ -21716,10 +23512,11 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.EventPayload that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "eventPayload");
+                    "eventPayload",
+                    NS);
                 this.EventPayloadToSequence(
                     that,
                     writer);
@@ -21728,12 +23525,13 @@ namespace AasCore.Aas3_0_RC02
 
             private void BasicEventElementToSequence(
                 BasicEventElement that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
                 {
                     writer.WriteStartElement(
-                        "extensions");
+                        "extensions",
+                        NS);
 
                     foreach (var item in that.Extensions)
                     {
@@ -21748,7 +23546,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Category != null)
                 {
                     writer.WriteStartElement(
-                        "category");
+                        "category",
+                        NS);
 
                     writer.WriteValue(
                         that.Category);
@@ -21759,7 +23558,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.IdShort != null)
                 {
                     writer.WriteStartElement(
-                        "idShort");
+                        "idShort",
+                        NS);
 
                     writer.WriteValue(
                         that.IdShort);
@@ -21770,7 +23570,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.DisplayName != null)
                 {
                     writer.WriteStartElement(
-                        "displayName");
+                        "displayName",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.DisplayName,
@@ -21782,7 +23583,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Description != null)
                 {
                     writer.WriteStartElement(
-                        "description");
+                        "description",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.Description,
@@ -21794,7 +23596,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Checksum != null)
                 {
                     writer.WriteStartElement(
-                        "checksum");
+                        "checksum",
+                        NS);
 
                     writer.WriteValue(
                         that.Checksum);
@@ -21805,7 +23608,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Kind != null)
                 {
                     writer.WriteStartElement(
-                        "kind");
+                        "kind",
+                        NS);
 
                     string? textKind = Stringification.ToString(
                         that.Kind);
@@ -21821,7 +23625,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SemanticId != null)
                 {
                     writer.WriteStartElement(
-                        "semanticId");
+                        "semanticId",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.SemanticId,
@@ -21833,7 +23638,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SupplementalSemanticIds != null)
                 {
                     writer.WriteStartElement(
-                        "supplementalSemanticIds");
+                        "supplementalSemanticIds",
+                        NS);
 
                     foreach (var item in that.SupplementalSemanticIds)
                     {
@@ -21848,7 +23654,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Qualifiers != null)
                 {
                     writer.WriteStartElement(
-                        "qualifiers");
+                        "qualifiers",
+                        NS);
 
                     foreach (var item in that.Qualifiers)
                     {
@@ -21860,12 +23667,13 @@ namespace AasCore.Aas3_0_RC02
                     writer.WriteEndElement();
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
                     writer.WriteStartElement(
-                        "dataSpecifications");
+                        "embeddedDataSpecifications",
+                        NS);
 
-                    foreach (var item in that.DataSpecifications)
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         this.Visit(
                             item,
@@ -21876,7 +23684,8 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 writer.WriteStartElement(
-                    "observed");
+                    "observed",
+                    NS);
 
                 this.ReferenceToSequence(
                     that.Observed,
@@ -21885,7 +23694,8 @@ namespace AasCore.Aas3_0_RC02
                 writer.WriteEndElement();
 
                 writer.WriteStartElement(
-                    "direction");
+                    "direction",
+                    NS);
 
                 string? textDirection = Stringification.ToString(
                     that.Direction);
@@ -21898,7 +23708,8 @@ namespace AasCore.Aas3_0_RC02
                 writer.WriteEndElement();
 
                 writer.WriteStartElement(
-                    "state");
+                    "state",
+                    NS);
 
                 string? textState = Stringification.ToString(
                     that.State);
@@ -21913,7 +23724,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.MessageTopic != null)
                 {
                     writer.WriteStartElement(
-                        "messageTopic");
+                        "messageTopic",
+                        NS);
 
                     writer.WriteValue(
                         that.MessageTopic);
@@ -21924,7 +23736,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.MessageBroker != null)
                 {
                     writer.WriteStartElement(
-                        "messageBroker");
+                        "messageBroker",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.MessageBroker,
@@ -21936,7 +23749,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.LastUpdate != null)
                 {
                     writer.WriteStartElement(
-                        "lastUpdate");
+                        "lastUpdate",
+                        NS);
 
                     writer.WriteValue(
                         that.LastUpdate);
@@ -21947,7 +23761,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.MinInterval != null)
                 {
                     writer.WriteStartElement(
-                        "minInterval");
+                        "minInterval",
+                        NS);
 
                     writer.WriteValue(
                         that.MinInterval);
@@ -21958,7 +23773,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.MaxInterval != null)
                 {
                     writer.WriteStartElement(
-                        "maxInterval");
+                        "maxInterval",
+                        NS);
 
                     writer.WriteValue(
                         that.MaxInterval);
@@ -21969,10 +23785,11 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.BasicEventElement that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "basicEventElement");
+                    "basicEventElement",
+                    NS);
                 this.BasicEventElementToSequence(
                     that,
                     writer);
@@ -21981,12 +23798,13 @@ namespace AasCore.Aas3_0_RC02
 
             private void OperationToSequence(
                 Operation that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
                 {
                     writer.WriteStartElement(
-                        "extensions");
+                        "extensions",
+                        NS);
 
                     foreach (var item in that.Extensions)
                     {
@@ -22001,7 +23819,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Category != null)
                 {
                     writer.WriteStartElement(
-                        "category");
+                        "category",
+                        NS);
 
                     writer.WriteValue(
                         that.Category);
@@ -22012,7 +23831,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.IdShort != null)
                 {
                     writer.WriteStartElement(
-                        "idShort");
+                        "idShort",
+                        NS);
 
                     writer.WriteValue(
                         that.IdShort);
@@ -22023,7 +23843,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.DisplayName != null)
                 {
                     writer.WriteStartElement(
-                        "displayName");
+                        "displayName",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.DisplayName,
@@ -22035,7 +23856,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Description != null)
                 {
                     writer.WriteStartElement(
-                        "description");
+                        "description",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.Description,
@@ -22047,7 +23869,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Checksum != null)
                 {
                     writer.WriteStartElement(
-                        "checksum");
+                        "checksum",
+                        NS);
 
                     writer.WriteValue(
                         that.Checksum);
@@ -22058,7 +23881,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Kind != null)
                 {
                     writer.WriteStartElement(
-                        "kind");
+                        "kind",
+                        NS);
 
                     string? textKind = Stringification.ToString(
                         that.Kind);
@@ -22074,7 +23898,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SemanticId != null)
                 {
                     writer.WriteStartElement(
-                        "semanticId");
+                        "semanticId",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.SemanticId,
@@ -22086,7 +23911,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SupplementalSemanticIds != null)
                 {
                     writer.WriteStartElement(
-                        "supplementalSemanticIds");
+                        "supplementalSemanticIds",
+                        NS);
 
                     foreach (var item in that.SupplementalSemanticIds)
                     {
@@ -22101,7 +23927,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Qualifiers != null)
                 {
                     writer.WriteStartElement(
-                        "qualifiers");
+                        "qualifiers",
+                        NS);
 
                     foreach (var item in that.Qualifiers)
                     {
@@ -22113,12 +23940,13 @@ namespace AasCore.Aas3_0_RC02
                     writer.WriteEndElement();
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
                     writer.WriteStartElement(
-                        "dataSpecifications");
+                        "embeddedDataSpecifications",
+                        NS);
 
-                    foreach (var item in that.DataSpecifications)
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         this.Visit(
                             item,
@@ -22131,7 +23959,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.InputVariables != null)
                 {
                     writer.WriteStartElement(
-                        "inputVariables");
+                        "inputVariables",
+                        NS);
 
                     foreach (var item in that.InputVariables)
                     {
@@ -22146,7 +23975,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.OutputVariables != null)
                 {
                     writer.WriteStartElement(
-                        "outputVariables");
+                        "outputVariables",
+                        NS);
 
                     foreach (var item in that.OutputVariables)
                     {
@@ -22161,7 +23991,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.InoutputVariables != null)
                 {
                     writer.WriteStartElement(
-                        "inoutputVariables");
+                        "inoutputVariables",
+                        NS);
 
                     foreach (var item in that.InoutputVariables)
                     {
@@ -22176,10 +24007,11 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.Operation that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "operation");
+                    "operation",
+                    NS);
                 this.OperationToSequence(
                     that,
                     writer);
@@ -22188,10 +24020,11 @@ namespace AasCore.Aas3_0_RC02
 
             private void OperationVariableToSequence(
                 OperationVariable that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "value");
+                    "value",
+                    NS);
 
                 this.Visit(
                     that.Value,
@@ -22202,10 +24035,11 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.OperationVariable that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "operationVariable");
+                    "operationVariable",
+                    NS);
                 this.OperationVariableToSequence(
                     that,
                     writer);
@@ -22214,12 +24048,13 @@ namespace AasCore.Aas3_0_RC02
 
             private void CapabilityToSequence(
                 Capability that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
                 {
                     writer.WriteStartElement(
-                        "extensions");
+                        "extensions",
+                        NS);
 
                     foreach (var item in that.Extensions)
                     {
@@ -22234,7 +24069,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Category != null)
                 {
                     writer.WriteStartElement(
-                        "category");
+                        "category",
+                        NS);
 
                     writer.WriteValue(
                         that.Category);
@@ -22245,7 +24081,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.IdShort != null)
                 {
                     writer.WriteStartElement(
-                        "idShort");
+                        "idShort",
+                        NS);
 
                     writer.WriteValue(
                         that.IdShort);
@@ -22256,7 +24093,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.DisplayName != null)
                 {
                     writer.WriteStartElement(
-                        "displayName");
+                        "displayName",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.DisplayName,
@@ -22268,7 +24106,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Description != null)
                 {
                     writer.WriteStartElement(
-                        "description");
+                        "description",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.Description,
@@ -22280,7 +24119,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Checksum != null)
                 {
                     writer.WriteStartElement(
-                        "checksum");
+                        "checksum",
+                        NS);
 
                     writer.WriteValue(
                         that.Checksum);
@@ -22291,7 +24131,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Kind != null)
                 {
                     writer.WriteStartElement(
-                        "kind");
+                        "kind",
+                        NS);
 
                     string? textKind = Stringification.ToString(
                         that.Kind);
@@ -22307,7 +24148,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SemanticId != null)
                 {
                     writer.WriteStartElement(
-                        "semanticId");
+                        "semanticId",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.SemanticId,
@@ -22319,7 +24161,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.SupplementalSemanticIds != null)
                 {
                     writer.WriteStartElement(
-                        "supplementalSemanticIds");
+                        "supplementalSemanticIds",
+                        NS);
 
                     foreach (var item in that.SupplementalSemanticIds)
                     {
@@ -22334,7 +24177,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Qualifiers != null)
                 {
                     writer.WriteStartElement(
-                        "qualifiers");
+                        "qualifiers",
+                        NS);
 
                     foreach (var item in that.Qualifiers)
                     {
@@ -22346,12 +24190,13 @@ namespace AasCore.Aas3_0_RC02
                     writer.WriteEndElement();
                 }
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
                     writer.WriteStartElement(
-                        "dataSpecifications");
+                        "embeddedDataSpecifications",
+                        NS);
 
-                    foreach (var item in that.DataSpecifications)
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         this.Visit(
                             item,
@@ -22364,10 +24209,11 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.Capability that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "capability");
+                    "capability",
+                    NS);
                 this.CapabilityToSequence(
                     that,
                     writer);
@@ -22376,12 +24222,13 @@ namespace AasCore.Aas3_0_RC02
 
             private void ConceptDescriptionToSequence(
                 ConceptDescription that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
                 {
                     writer.WriteStartElement(
-                        "extensions");
+                        "extensions",
+                        NS);
 
                     foreach (var item in that.Extensions)
                     {
@@ -22396,7 +24243,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Category != null)
                 {
                     writer.WriteStartElement(
-                        "category");
+                        "category",
+                        NS);
 
                     writer.WriteValue(
                         that.Category);
@@ -22407,7 +24255,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.IdShort != null)
                 {
                     writer.WriteStartElement(
-                        "idShort");
+                        "idShort",
+                        NS);
 
                     writer.WriteValue(
                         that.IdShort);
@@ -22418,7 +24267,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.DisplayName != null)
                 {
                     writer.WriteStartElement(
-                        "displayName");
+                        "displayName",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.DisplayName,
@@ -22430,7 +24280,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Description != null)
                 {
                     writer.WriteStartElement(
-                        "description");
+                        "description",
+                        NS);
 
                     this.LangStringSetToSequence(
                         that.Description,
@@ -22442,7 +24293,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Checksum != null)
                 {
                     writer.WriteStartElement(
-                        "checksum");
+                        "checksum",
+                        NS);
 
                     writer.WriteValue(
                         that.Checksum);
@@ -22453,7 +24305,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Administration != null)
                 {
                     writer.WriteStartElement(
-                        "administration");
+                        "administration",
+                        NS);
 
                     this.AdministrativeInformationToSequence(
                         that.Administration,
@@ -22463,19 +24316,21 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 writer.WriteStartElement(
-                    "id");
+                    "id",
+                    NS);
 
                 writer.WriteValue(
                     that.Id);
 
                 writer.WriteEndElement();
 
-                if (that.DataSpecifications != null)
+                if (that.EmbeddedDataSpecifications != null)
                 {
                     writer.WriteStartElement(
-                        "dataSpecifications");
+                        "embeddedDataSpecifications",
+                        NS);
 
-                    foreach (var item in that.DataSpecifications)
+                    foreach (var item in that.EmbeddedDataSpecifications)
                     {
                         this.Visit(
                             item,
@@ -22488,7 +24343,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.IsCaseOf != null)
                 {
                     writer.WriteStartElement(
-                        "isCaseOf");
+                        "isCaseOf",
+                        NS);
 
                     foreach (var item in that.IsCaseOf)
                     {
@@ -22503,10 +24359,11 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.ConceptDescription that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "conceptDescription");
+                    "conceptDescription",
+                    NS);
                 this.ConceptDescriptionToSequence(
                     that,
                     writer);
@@ -22515,10 +24372,11 @@ namespace AasCore.Aas3_0_RC02
 
             private void ReferenceToSequence(
                 Reference that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "type");
+                    "type",
+                    NS);
 
                 string? textType = Stringification.ToString(
                     that.Type);
@@ -22533,7 +24391,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.ReferredSemanticId != null)
                 {
                     writer.WriteStartElement(
-                        "referredSemanticId");
+                        "referredSemanticId",
+                        NS);
 
                     this.ReferenceToSequence(
                         that.ReferredSemanticId,
@@ -22543,7 +24402,8 @@ namespace AasCore.Aas3_0_RC02
                 }
 
                 writer.WriteStartElement(
-                    "keys");
+                    "keys",
+                    NS);
 
                 foreach (var item in that.Keys)
                 {
@@ -22557,10 +24417,11 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.Reference that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "reference");
+                    "reference",
+                    NS);
                 this.ReferenceToSequence(
                     that,
                     writer);
@@ -22569,10 +24430,11 @@ namespace AasCore.Aas3_0_RC02
 
             private void KeyToSequence(
                 Key that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "type");
+                    "type",
+                    NS);
 
                 string? textType = Stringification.ToString(
                     that.Type);
@@ -22585,7 +24447,8 @@ namespace AasCore.Aas3_0_RC02
                 writer.WriteEndElement();
 
                 writer.WriteStartElement(
-                    "value");
+                    "value",
+                    NS);
 
                 writer.WriteValue(
                     that.Value);
@@ -22595,10 +24458,11 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.Key that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "key");
+                    "key",
+                    NS);
                 this.KeyToSequence(
                     that,
                     writer);
@@ -22607,10 +24471,11 @@ namespace AasCore.Aas3_0_RC02
 
             private void LangStringToSequence(
                 LangString that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "language");
+                    "language",
+                    NS);
 
                 writer.WriteValue(
                     that.Language);
@@ -22618,7 +24483,8 @@ namespace AasCore.Aas3_0_RC02
                 writer.WriteEndElement();
 
                 writer.WriteStartElement(
-                    "text");
+                    "text",
+                    NS);
 
                 writer.WriteValue(
                     that.Text);
@@ -22628,10 +24494,11 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.LangString that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "langString");
+                    "langString",
+                    NS);
                 this.LangStringToSequence(
                     that,
                     writer);
@@ -22640,10 +24507,11 @@ namespace AasCore.Aas3_0_RC02
 
             private void LangStringSetToSequence(
                 LangStringSet that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "langStrings");
+                    "langStrings",
+                    NS);
 
                 foreach (var item in that.LangStrings)
                 {
@@ -22657,89 +24525,12 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.LangStringSet that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "langStringSet");
+                    "langStringSet",
+                    NS);
                 this.LangStringSetToSequence(
-                    that,
-                    writer);
-                writer.WriteEndElement();
-            }
-
-            [CodeAnalysis.SuppressMessage("ReSharper", "UnusedParameter.Local")]
-            private void DataSpecificationContentToSequence(
-                DataSpecificationContent that,
-                WrappedXmlWriter writer)
-            {
-                // Intentionally empty.
-            }  // private void DataSpecificationContentToSequence
-
-            public override void Visit(
-                Aas.DataSpecificationContent that,
-                WrappedXmlWriter writer)
-            {
-                writer.WriteStartElement(
-                    "dataSpecificationContent");
-                this.DataSpecificationContentToSequence(
-                    that,
-                    writer);
-                writer.WriteEndElement();
-            }
-
-            private void DataSpecificationToSequence(
-                DataSpecification that,
-                WrappedXmlWriter writer)
-            {
-                writer.WriteStartElement(
-                    "id");
-
-                writer.WriteValue(
-                    that.Id);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
-                    "dataSpecificationContent");
-
-                this.DataSpecificationContentToSequence(
-                    that.DataSpecificationContent,
-                    writer);
-
-                writer.WriteEndElement();
-
-                if (that.Administration != null)
-                {
-                    writer.WriteStartElement(
-                        "administration");
-
-                    this.AdministrativeInformationToSequence(
-                        that.Administration,
-                        writer);
-
-                    writer.WriteEndElement();
-                }
-
-                if (that.Description != null)
-                {
-                    writer.WriteStartElement(
-                        "description");
-
-                    this.LangStringSetToSequence(
-                        that.Description,
-                        writer);
-
-                    writer.WriteEndElement();
-                }
-            }  // private void DataSpecificationToSequence
-
-            public override void Visit(
-                Aas.DataSpecification that,
-                WrappedXmlWriter writer)
-            {
-                writer.WriteStartElement(
-                    "dataSpecification");
-                this.DataSpecificationToSequence(
                     that,
                     writer);
                 writer.WriteEndElement();
@@ -22747,12 +24538,13 @@ namespace AasCore.Aas3_0_RC02
 
             private void EnvironmentToSequence(
                 Environment that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 if (that.AssetAdministrationShells != null)
                 {
                     writer.WriteStartElement(
-                        "assetAdministrationShells");
+                        "assetAdministrationShells",
+                        NS);
 
                     foreach (var item in that.AssetAdministrationShells)
                     {
@@ -22767,7 +24559,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.Submodels != null)
                 {
                     writer.WriteStartElement(
-                        "submodels");
+                        "submodels",
+                        NS);
 
                     foreach (var item in that.Submodels)
                     {
@@ -22782,7 +24575,8 @@ namespace AasCore.Aas3_0_RC02
                 if (that.ConceptDescriptions != null)
                 {
                     writer.WriteStartElement(
-                        "conceptDescriptions");
+                        "conceptDescriptions",
+                        NS);
 
                     foreach (var item in that.ConceptDescriptions)
                     {
@@ -22797,75 +24591,463 @@ namespace AasCore.Aas3_0_RC02
 
             public override void Visit(
                 Aas.Environment that,
-                WrappedXmlWriter writer)
+                Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "environment");
+                    "environment",
+                    NS);
                 this.EnvironmentToSequence(
                     that,
                     writer);
                 writer.WriteEndElement();
             }
+
+            private void EmbeddedDataSpecificationToSequence(
+                EmbeddedDataSpecification that,
+                Xml.XmlWriter writer)
+            {
+                writer.WriteStartElement(
+                    "dataSpecification",
+                    NS);
+
+                this.ReferenceToSequence(
+                    that.DataSpecification,
+                    writer);
+
+                writer.WriteEndElement();
+
+                writer.WriteStartElement(
+                    "dataSpecificationContent",
+                    NS);
+
+                this.Visit(
+                    that.DataSpecificationContent,
+                    writer);
+
+                writer.WriteEndElement();
+            }  // private void EmbeddedDataSpecificationToSequence
+
+            public override void Visit(
+                Aas.EmbeddedDataSpecification that,
+                Xml.XmlWriter writer)
+            {
+                writer.WriteStartElement(
+                    "embeddedDataSpecification",
+                    NS);
+                this.EmbeddedDataSpecificationToSequence(
+                    that,
+                    writer);
+                writer.WriteEndElement();
+            }
+
+            private void ValueReferencePairToSequence(
+                ValueReferencePair that,
+                Xml.XmlWriter writer)
+            {
+                writer.WriteStartElement(
+                    "value",
+                    NS);
+
+                writer.WriteValue(
+                    that.Value);
+
+                writer.WriteEndElement();
+
+                writer.WriteStartElement(
+                    "valueId",
+                    NS);
+
+                this.ReferenceToSequence(
+                    that.ValueId,
+                    writer);
+
+                writer.WriteEndElement();
+            }  // private void ValueReferencePairToSequence
+
+            public override void Visit(
+                Aas.ValueReferencePair that,
+                Xml.XmlWriter writer)
+            {
+                writer.WriteStartElement(
+                    "valueReferencePair",
+                    NS);
+                this.ValueReferencePairToSequence(
+                    that,
+                    writer);
+                writer.WriteEndElement();
+            }
+
+            private void ValueListToSequence(
+                ValueList that,
+                Xml.XmlWriter writer)
+            {
+                writer.WriteStartElement(
+                    "valueReferencePairTypes",
+                    NS);
+
+                foreach (var item in that.ValueReferencePairTypes)
+                {
+                    this.Visit(
+                        item,
+                        writer);
+                }
+
+                writer.WriteEndElement();
+            }  // private void ValueListToSequence
+
+            public override void Visit(
+                Aas.ValueList that,
+                Xml.XmlWriter writer)
+            {
+                writer.WriteStartElement(
+                    "valueList",
+                    NS);
+                this.ValueListToSequence(
+                    that,
+                    writer);
+                writer.WriteEndElement();
+            }
+
+            private void DataSpecificationIec61360ToSequence(
+                DataSpecificationIec61360 that,
+                Xml.XmlWriter writer)
+            {
+                writer.WriteStartElement(
+                    "preferredName",
+                    NS);
+
+                this.LangStringSetToSequence(
+                    that.PreferredName,
+                    writer);
+
+                writer.WriteEndElement();
+
+                if (that.ShortName != null)
+                {
+                    writer.WriteStartElement(
+                        "shortName",
+                        NS);
+
+                    this.LangStringSetToSequence(
+                        that.ShortName,
+                        writer);
+
+                    writer.WriteEndElement();
+                }
+
+                if (that.Unit != null)
+                {
+                    writer.WriteStartElement(
+                        "unit",
+                        NS);
+
+                    writer.WriteValue(
+                        that.Unit);
+
+                    writer.WriteEndElement();
+                }
+
+                if (that.UnitId != null)
+                {
+                    writer.WriteStartElement(
+                        "unitId",
+                        NS);
+
+                    this.ReferenceToSequence(
+                        that.UnitId,
+                        writer);
+
+                    writer.WriteEndElement();
+                }
+
+                if (that.SourceOfDefinition != null)
+                {
+                    writer.WriteStartElement(
+                        "sourceOfDefinition",
+                        NS);
+
+                    writer.WriteValue(
+                        that.SourceOfDefinition);
+
+                    writer.WriteEndElement();
+                }
+
+                if (that.Symbol != null)
+                {
+                    writer.WriteStartElement(
+                        "symbol",
+                        NS);
+
+                    writer.WriteValue(
+                        that.Symbol);
+
+                    writer.WriteEndElement();
+                }
+
+                if (that.DataType != null)
+                {
+                    writer.WriteStartElement(
+                        "dataType",
+                        NS);
+
+                    string? textDataType = Stringification.ToString(
+                        that.DataType);
+                    writer.WriteValue(
+                        textDataType
+                            ?? throw new System.ArgumentException(
+                                "Invalid literal for the enumeration DataTypeIec61360: " +
+                                that.DataType.ToString()));
+
+                    writer.WriteEndElement();
+                }
+
+                if (that.Definition != null)
+                {
+                    writer.WriteStartElement(
+                        "definition",
+                        NS);
+
+                    this.LangStringSetToSequence(
+                        that.Definition,
+                        writer);
+
+                    writer.WriteEndElement();
+                }
+
+                if (that.ValueFormat != null)
+                {
+                    writer.WriteStartElement(
+                        "valueFormat",
+                        NS);
+
+                    writer.WriteValue(
+                        that.ValueFormat);
+
+                    writer.WriteEndElement();
+                }
+
+                if (that.ValueList != null)
+                {
+                    writer.WriteStartElement(
+                        "valueList",
+                        NS);
+
+                    this.ValueListToSequence(
+                        that.ValueList,
+                        writer);
+
+                    writer.WriteEndElement();
+                }
+
+                if (that.Value != null)
+                {
+                    writer.WriteStartElement(
+                        "value",
+                        NS);
+
+                    writer.WriteValue(
+                        that.Value);
+
+                    writer.WriteEndElement();
+                }
+
+                if (that.LevelType != null)
+                {
+                    writer.WriteStartElement(
+                        "levelType",
+                        NS);
+
+                    string? textLevelType = Stringification.ToString(
+                        that.LevelType);
+                    writer.WriteValue(
+                        textLevelType
+                            ?? throw new System.ArgumentException(
+                                "Invalid literal for the enumeration LevelType: " +
+                                that.LevelType.ToString()));
+
+                    writer.WriteEndElement();
+                }
+            }  // private void DataSpecificationIec61360ToSequence
+
+            public override void Visit(
+                Aas.DataSpecificationIec61360 that,
+                Xml.XmlWriter writer)
+            {
+                writer.WriteStartElement(
+                    "dataSpecificationIec61360",
+                    NS);
+                this.DataSpecificationIec61360ToSequence(
+                    that,
+                    writer);
+                writer.WriteEndElement();
+            }
+
+            private void DataSpecificationPhysicalUnitToSequence(
+                DataSpecificationPhysicalUnit that,
+                Xml.XmlWriter writer)
+            {
+                writer.WriteStartElement(
+                    "unitName",
+                    NS);
+
+                writer.WriteValue(
+                    that.UnitName);
+
+                writer.WriteEndElement();
+
+                writer.WriteStartElement(
+                    "unitSymbol",
+                    NS);
+
+                writer.WriteValue(
+                    that.UnitSymbol);
+
+                writer.WriteEndElement();
+
+                writer.WriteStartElement(
+                    "definition",
+                    NS);
+
+                this.LangStringSetToSequence(
+                    that.Definition,
+                    writer);
+
+                writer.WriteEndElement();
+
+                if (that.SiNotation != null)
+                {
+                    writer.WriteStartElement(
+                        "siNotation",
+                        NS);
+
+                    writer.WriteValue(
+                        that.SiNotation);
+
+                    writer.WriteEndElement();
+                }
+
+                if (that.SiName != null)
+                {
+                    writer.WriteStartElement(
+                        "siName",
+                        NS);
+
+                    writer.WriteValue(
+                        that.SiName);
+
+                    writer.WriteEndElement();
+                }
+
+                if (that.DinNotation != null)
+                {
+                    writer.WriteStartElement(
+                        "dinNotation",
+                        NS);
+
+                    writer.WriteValue(
+                        that.DinNotation);
+
+                    writer.WriteEndElement();
+                }
+
+                if (that.EceName != null)
+                {
+                    writer.WriteStartElement(
+                        "eceName",
+                        NS);
+
+                    writer.WriteValue(
+                        that.EceName);
+
+                    writer.WriteEndElement();
+                }
+
+                if (that.EceCode != null)
+                {
+                    writer.WriteStartElement(
+                        "eceCode",
+                        NS);
+
+                    writer.WriteValue(
+                        that.EceCode);
+
+                    writer.WriteEndElement();
+                }
+
+                if (that.NistName != null)
+                {
+                    writer.WriteStartElement(
+                        "nistName",
+                        NS);
+
+                    writer.WriteValue(
+                        that.NistName);
+
+                    writer.WriteEndElement();
+                }
+
+                if (that.SourceOfDefinition != null)
+                {
+                    writer.WriteStartElement(
+                        "sourceOfDefinition",
+                        NS);
+
+                    writer.WriteValue(
+                        that.SourceOfDefinition);
+
+                    writer.WriteEndElement();
+                }
+
+                if (that.ConversionFactor != null)
+                {
+                    writer.WriteStartElement(
+                        "conversionFactor",
+                        NS);
+
+                    writer.WriteValue(
+                        that.ConversionFactor);
+
+                    writer.WriteEndElement();
+                }
+
+                if (that.RegistrationAuthorityId != null)
+                {
+                    writer.WriteStartElement(
+                        "registrationAuthorityId",
+                        NS);
+
+                    writer.WriteValue(
+                        that.RegistrationAuthorityId);
+
+                    writer.WriteEndElement();
+                }
+
+                if (that.Supplier != null)
+                {
+                    writer.WriteStartElement(
+                        "supplier",
+                        NS);
+
+                    writer.WriteValue(
+                        that.Supplier);
+
+                    writer.WriteEndElement();
+                }
+            }  // private void DataSpecificationPhysicalUnitToSequence
+
+            public override void Visit(
+                Aas.DataSpecificationPhysicalUnit that,
+                Xml.XmlWriter writer)
+            {
+                writer.WriteStartElement(
+                    "dataSpecificationPhysicalUnit",
+                    NS);
+                this.DataSpecificationPhysicalUnitToSequence(
+                    that,
+                    writer);
+                writer.WriteEndElement();
+            }
         }  // internal class VisitorWithWriter
-
-        /// <summary>
-        /// Wrap the writer so that we can omit the namespace and the prefix.
-        /// </summary>
-        internal class WrappedXmlWriter
-        {
-            private readonly Xml.XmlWriter _writer;
-            private readonly string? _prefix;
-            private readonly string? _ns;
-
-            internal WrappedXmlWriter(
-                Xml.XmlWriter writer,
-                string? prefix,
-                string? ns)
-            {
-                _writer = writer;
-                _prefix = prefix;
-                _ns = ns;
-            }
-
-            internal void WriteStartElement(string localName)
-            {
-                _writer.WriteStartElement(
-                    _prefix, localName, _ns);
-            }
-
-            internal void WriteEndElement()
-            {
-                _writer.WriteEndElement();
-            }
-
-            internal virtual void WriteValue(bool value)
-            {
-                _writer.WriteValue(value);
-            }
-
-            internal virtual void WriteValue(long value)
-            {
-                _writer.WriteValue(value);
-            }
-
-            internal virtual void WriteValue(double value)
-            {
-                _writer.WriteValue(value);
-            }
-
-            internal virtual void WriteValue(string? value)
-            {
-                _writer.WriteValue(value);
-            }
-
-            internal virtual void WriteBase64(byte[] buffer)
-            {
-                _writer.WriteBase64(
-                    buffer,
-                    0,
-                    buffer.Length);
-            }
-        }  // WrappedXmlWriter
 
         /// <summary>
         /// Serialize instances of meta-model classes to XML.
@@ -22908,15 +25090,10 @@ namespace AasCore.Aas3_0_RC02
             /// </summary>
             public static void To(
                 Aas.IClass that,
-                Xml.XmlWriter writer,
-                string? prefix = null,
-                string? ns = null)
+                Xml.XmlWriter writer)
             {
-                var wrappedWriter = new WrappedXmlWriter(
-                    writer, prefix, ns);
-
                 Serialize._visitorWithWriter.Visit(
-                    that, wrappedWriter);
+                    that, writer);
             }
         }  // public static class Serialize
     }  // public static class Xmlization

--- a/test_data/csharp/test_structure/concrete_class_with_descendants/model.py
+++ b/test_data/csharp/test_structure/concrete_class_with_descendants/model.py
@@ -13,3 +13,4 @@ class Child(Parent):
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/csharp/test_structure/constructor_without_arguments/all_properties_optional/model.py
+++ b/test_data/csharp/test_structure/constructor_without_arguments/all_properties_optional/model.py
@@ -7,3 +7,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/csharp/test_structure/constructor_without_arguments/no_properties/model.py
+++ b/test_data/csharp/test_structure/constructor_without_arguments/no_properties/model.py
@@ -4,3 +4,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/csharp/test_verification/builtin_functions/len/on_list/model.py
+++ b/test_data/csharp/test_verification/builtin_functions/len/on_list/model.py
@@ -17,3 +17,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/csharp/test_verification/builtin_functions/len/on_str/model.py
+++ b/test_data/csharp/test_verification/builtin_functions/len/on_str/model.py
@@ -13,3 +13,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/as_prefix/model.py
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/as_prefix/model.py
@@ -6,3 +6,4 @@ def match_something(text: str) -> bool:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/as_suffix/model.py
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/as_suffix/model.py
@@ -6,3 +6,4 @@ def match_something(text: str) -> bool:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/in_group_with_quantifier/model.py
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/in_group_with_quantifier/model.py
@@ -6,3 +6,4 @@ def match_something(text: str) -> bool:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/in_the_middle/model.py
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/in_the_middle/model.py
@@ -6,3 +6,4 @@ def match_something(text: str) -> bool:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/in_union/model.py
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/in_union/model.py
@@ -6,3 +6,4 @@ def match_something(text: str) -> bool:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/single_utf32_literal/model.py
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/single_utf32_literal/model.py
@@ -6,3 +6,4 @@ def match_something(text: str) -> bool:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/with_quantifier_within_group/model.py
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/with_quantifier_within_group/model.py
@@ -6,3 +6,4 @@ def match_something(text: str) -> bool:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/with_quantifier_without_group/model.py
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/with_quantifier_without_group/model.py
@@ -6,3 +6,4 @@ def match_something(text: str) -> bool:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/at_the_beginning/model.py
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/at_the_beginning/model.py
@@ -6,3 +6,4 @@ def match_something(text: str) -> bool:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/at_the_end/model.py
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/at_the_end/model.py
@@ -6,3 +6,4 @@ def match_something(text: str) -> bool:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/in_the_middle/model.py
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/in_the_middle/model.py
@@ -6,3 +6,4 @@ def match_something(text: str) -> bool:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/multiple/model.py
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/multiple/model.py
@@ -6,3 +6,4 @@ def match_something(text: str) -> bool:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/single/model.py
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/single/model.py
@@ -6,3 +6,4 @@ def match_something(text: str) -> bool:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/single_with_quantifier/model.py
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/literal/single_with_quantifier/model.py
@@ -6,3 +6,4 @@ def match_something(text: str) -> bool:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/mixed_with_non_utf32/model.py
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/mixed_with_non_utf32/model.py
@@ -6,3 +6,4 @@ def match_something(text: str) -> bool:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/more_than_two_high_surrogates/model.py
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/more_than_two_high_surrogates/model.py
@@ -6,3 +6,4 @@ def match_something(text: str) -> bool:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/multiple_utf32_ranges/model.py
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/multiple_utf32_ranges/model.py
@@ -6,3 +6,4 @@ def match_something(text: str) -> bool:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/multiple_utf32_ranges_mixed_with_non_utf32/model.py
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/multiple_utf32_ranges_mixed_with_non_utf32/model.py
@@ -6,3 +6,4 @@ def match_something(text: str) -> bool:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/same_high_surrogate/model.py
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/same_high_surrogate/model.py
@@ -6,3 +6,4 @@ def match_something(text: str) -> bool:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/same_high_surrogate_with_quantifier/model.py
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/same_high_surrogate_with_quantifier/model.py
@@ -6,3 +6,4 @@ def match_something(text: str) -> bool:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/two_high_surrogates/model.py
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_in_character_set/range/two_high_surrogates/model.py
@@ -6,3 +6,4 @@ def match_something(text: str) -> bool:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/expected/class/empty/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/class/empty/expected_symbol_table.txt
@@ -42,4 +42,5 @@ SymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/intermediate/expected/class/empty/meta_model.py
+++ b/test_data/intermediate/expected/class/empty/meta_model.py
@@ -4,3 +4,4 @@ class Concrete:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/expected/class/implementation_specific_method/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/class/implementation_specific_method/expected_symbol_table.txt
@@ -63,4 +63,5 @@ SymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/intermediate/expected/class/implementation_specific_method/meta_model.py
+++ b/test_data/intermediate/expected/class/implementation_specific_method/meta_model.py
@@ -6,3 +6,4 @@ class Concrete:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/expected/class/inheritance/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/class/inheritance/expected_symbol_table.txt
@@ -466,4 +466,5 @@ SymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/intermediate/expected/class/inheritance/meta_model.py
+++ b/test_data/intermediate/expected/class/inheritance/meta_model.py
@@ -39,3 +39,4 @@ class Concrete(Abstract):
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/expected/class/methods_with_contracts/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/class/methods_with_contracts/expected_symbol_table.txt
@@ -137,4 +137,5 @@ SymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/intermediate/expected/class/methods_with_contracts/meta_model.py
+++ b/test_data/intermediate/expected/class/methods_with_contracts/meta_model.py
@@ -13,3 +13,4 @@ class Concrete:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/expected/class/only_method_no_property/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/class/only_method_no_property/expected_symbol_table.txt
@@ -64,4 +64,5 @@ SymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/intermediate/expected/class/only_method_no_property/meta_model.py
+++ b/test_data/intermediate/expected/class/only_method_no_property/meta_model.py
@@ -5,3 +5,4 @@ class Concrete:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/expected/class/only_property_no_method/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/class/only_property_no_method/expected_symbol_table.txt
@@ -62,4 +62,5 @@ SymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/intermediate/expected/class/only_property_no_method/meta_model.py
+++ b/test_data/intermediate/expected/class/only_property_no_method/meta_model.py
@@ -7,3 +7,4 @@ class Concrete:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/expected/constant/constant_set/of_enum/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/constant/constant_set/of_enum/expected_symbol_table.txt
@@ -42,4 +42,5 @@ SymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/intermediate/expected/constant/constant_set/of_enum/meta_model.py
+++ b/test_data/intermediate/expected/constant/constant_set/of_enum/meta_model.py
@@ -10,3 +10,4 @@ Something: Set[SomeEnum] = constant_set(
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/expected/constant/constant_set/of_str/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/constant/constant_set/of_str/expected_symbol_table.txt
@@ -25,4 +25,5 @@ SymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/intermediate/expected/constant/constant_set/of_str/meta_model.py
+++ b/test_data/intermediate/expected/constant/constant_set/of_str/meta_model.py
@@ -2,3 +2,4 @@ Something: Set[str] = constant_set(values=["some literal", "another literal"])
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/expected/constant/constant_set/with_description/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/constant/constant_set/with_description/expected_symbol_table.txt
@@ -28,4 +28,5 @@ SymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/intermediate/expected/constant/constant_set/with_description/meta_model.py
+++ b/test_data/intermediate/expected/constant/constant_set/with_description/meta_model.py
@@ -4,3 +4,4 @@ Something: Set[str] = constant_set(
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/expected/constant/constant_set/with_reference_in_the_book/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/constant/constant_set/with_reference_in_the_book/expected_symbol_table.txt
@@ -32,4 +32,5 @@ SymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/intermediate/expected/constant/constant_set/with_reference_in_the_book/meta_model.py
+++ b/test_data/intermediate/expected/constant/constant_set/with_reference_in_the_book/meta_model.py
@@ -5,3 +5,4 @@ Something: Set[str] = constant_set(
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/expected/constant/constant_set/with_superset_of/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/constant/constant_set/with_superset_of/expected_symbol_table.txt
@@ -47,4 +47,5 @@ SymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/intermediate/expected/constant/constant_set/with_superset_of/meta_model.py
+++ b/test_data/intermediate/expected/constant/constant_set/with_superset_of/meta_model.py
@@ -12,3 +12,4 @@ Something_extended: Set[str] = constant_set(
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/expected/constant/constant_str/only_value/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/constant/constant_str/only_value/expected_symbol_table.txt
@@ -15,4 +15,5 @@ SymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/intermediate/expected/constant/constant_str/only_value/meta_model.py
+++ b/test_data/intermediate/expected/constant/constant_str/only_value/meta_model.py
@@ -5,3 +5,4 @@ Something: str = constant_str(
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/expected/constant/constant_str/with_description/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/constant/constant_str/with_description/expected_symbol_table.txt
@@ -18,4 +18,5 @@ SymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/intermediate/expected/constant/constant_str/with_description/meta_model.py
+++ b/test_data/intermediate/expected/constant/constant_str/with_description/meta_model.py
@@ -3,3 +3,4 @@ Something: str = constant_str(value="some value", description="Represent somethi
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/expected/constant/constant_str/with_reference_in_the_book/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/constant/constant_str/with_reference_in_the_book/expected_symbol_table.txt
@@ -22,4 +22,5 @@ SymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/intermediate/expected/constant/constant_str/with_reference_in_the_book/meta_model.py
+++ b/test_data/intermediate/expected/constant/constant_str/with_reference_in_the_book/meta_model.py
@@ -6,3 +6,4 @@ Something: str = constant_str(
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/expected/empty/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/empty/expected_symbol_table.txt
@@ -8,4 +8,5 @@ SymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/intermediate/expected/empty/meta_model.py
+++ b/test_data/intermediate/expected/empty/meta_model.py
@@ -1,2 +1,3 @@
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/expected/enumeration/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/enumeration/expected_symbol_table.txt
@@ -28,4 +28,5 @@ SymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/intermediate/expected/enumeration/meta_model.py
+++ b/test_data/intermediate/expected/enumeration/meta_model.py
@@ -7,3 +7,4 @@ class Some_enum(Enum):
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/expected/interface/basic/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/interface/basic/expected_symbol_table.txt
@@ -119,4 +119,5 @@ SymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/intermediate/expected/interface/basic/meta_model.py
+++ b/test_data/intermediate/expected/interface/basic/meta_model.py
@@ -12,3 +12,4 @@ class Abstract:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/expected/interface/empty/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/interface/empty/expected_symbol_table.txt
@@ -52,4 +52,5 @@ SymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/intermediate/expected/interface/empty/meta_model.py
+++ b/test_data/intermediate/expected/interface/empty/meta_model.py
@@ -5,3 +5,4 @@ class Abstract:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/expected/interface/inheritance/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/interface/inheritance/expected_symbol_table.txt
@@ -273,4 +273,5 @@ SymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/intermediate/expected/interface/inheritance/meta_model.py
+++ b/test_data/intermediate/expected/interface/inheritance/meta_model.py
@@ -25,3 +25,4 @@ class Abstract(VeryAbstract):
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/expected/interface/method_signature/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/interface/method_signature/expected_symbol_table.txt
@@ -124,4 +124,5 @@ SymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/intermediate/expected/interface/method_signature/meta_model.py
+++ b/test_data/intermediate/expected/interface/method_signature/meta_model.py
@@ -8,3 +8,4 @@ class Abstract:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/expected/interface/only_constructor/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/interface/only_constructor/expected_symbol_table.txt
@@ -80,4 +80,5 @@ SymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/intermediate/expected/interface/only_constructor/meta_model.py
+++ b/test_data/intermediate/expected/interface/only_constructor/meta_model.py
@@ -9,3 +9,4 @@ class Abstract:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/expected/type_annotation/atomic/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/type_annotation/atomic/expected_symbol_table.txt
@@ -62,4 +62,5 @@ SymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/intermediate/expected/type_annotation/atomic/meta_model.py
+++ b/test_data/intermediate/expected/type_annotation/atomic/meta_model.py
@@ -7,3 +7,4 @@ class Concrete:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/expected/type_annotation/subscripted/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/type_annotation/subscripted/expected_symbol_table.txt
@@ -104,4 +104,5 @@ SymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/intermediate/expected/type_annotation/subscripted/meta_model.py
+++ b/test_data/intermediate/expected/type_annotation/subscripted/meta_model.py
@@ -11,3 +11,4 @@ class SomeContainerClass:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/real_meta_models/aas_core_meta.v3rc2/expected_symbol_table.txt
+++ b/test_data/intermediate/real_meta_models/aas_core_meta.v3rc2/expected_symbol_table.txt
@@ -2362,18 +2362,17 @@ SymbolTable(
           'Reference to ConcreteClass Submodel_element_list'],
         properties=[
           Property(
-            name='data_specifications',
+            name='embedded_data_specifications',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
-                  our_type='Reference to our type Reference',
+                  our_type='Reference to our type Embedded_data_specification',
                   parsed=...),
                 parsed=...),
               parsed=...),
             description=DescriptionOfProperty(
-              summary='<paragraph>Global reference to the data specification template used by the element.</paragraph>',
-              remarks=[
-                '<note><paragraph>This is a global reference.</paragraph></note>'],
+              summary='<paragraph>Embedded data specification.</paragraph>',
+              remarks=[],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Has_data_specification',
@@ -2413,18 +2412,17 @@ SymbolTable(
         'Reference to ConcreteClass Submodel_element_list'],
       properties=[
         Property(
-          name='data_specifications',
+          name='embedded_data_specifications',
           type_annotation=OptionalTypeAnnotation(
             value=ListTypeAnnotation(
               items=OurTypeAnnotation(
-                our_type='Reference to our type Reference',
+                our_type='Reference to our type Embedded_data_specification',
                 parsed=...),
               parsed=...),
             parsed=...),
           description=DescriptionOfProperty(
-            summary='<paragraph>Global reference to the data specification template used by the element.</paragraph>',
-            remarks=[
-              '<note><paragraph>This is a global reference.</paragraph></note>'],
+            summary='<paragraph>Embedded data specification.</paragraph>',
+            remarks=[],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_data_specification',
@@ -2434,11 +2432,11 @@ SymbolTable(
         name='__init__',
         arguments=[
           Argument(
-            name='data_specifications',
+            name='embedded_data_specifications',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
-                  our_type='Reference to our type Reference',
+                  our_type='Reference to our type Embedded_data_specification',
                   parsed=...),
                 parsed=...),
               parsed=...),
@@ -2458,53 +2456,10 @@ SymbolTable(
         statements=[
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specifications',
-              argument='data_specifications',
+              name='embedded_data_specifications',
+              argument='embedded_data_specifications',
               default=None)""")]),
-      invariants=[
-        Invariant(
-          description='References to data specifications are global references.',
-          body=textwrap.dedent("""\
-            Implication(
-              antecedent=IsNotNone(
-                value=Member(
-                  instance=Name(
-                    identifier='self',
-                    original_node=...),
-                  name='data_specifications',
-                  original_node=...),
-                original_node=...),
-              consequent=All(
-                generator=ForEach(
-                  variable=Name(
-                    identifier='data_specification',
-                    original_node=...),
-                  iteration=Member(
-                    instance=Name(
-                      identifier='self',
-                      original_node=...),
-                    name='data_specifications',
-                    original_node=...),
-                  original_node=...),
-                condition=Comparison(
-                  left=Member(
-                    instance=Name(
-                      identifier='data_specification',
-                      original_node=...),
-                    name='type',
-                    original_node=...),
-                  op='EQ',
-                  right=Member(
-                    instance=Name(
-                      identifier='Reference_types',
-                      original_node=...),
-                    name='Global_reference',
-                    original_node=...),
-                  original_node=...),
-                original_node=...),
-              original_node=...)"""),
-          specified_for='Reference to AbstractClass Has_data_specification',
-          parsed=...)],
+      invariants=[],
       serialization=Serialization(
         with_model_type=False),
       reference_in_the_book=ReferenceInTheBook(
@@ -2540,18 +2495,17 @@ SymbolTable(
       concrete_descendants=[],
       properties=[
         Property(
-          name='data_specifications',
+          name='embedded_data_specifications',
           type_annotation=OptionalTypeAnnotation(
             value=ListTypeAnnotation(
               items=OurTypeAnnotation(
-                our_type='Reference to our type Reference',
+                our_type='Reference to our type Embedded_data_specification',
                 parsed=...),
               parsed=...),
             parsed=...),
           description=DescriptionOfProperty(
-            summary='<paragraph>Global reference to the data specification template used by the element.</paragraph>',
-            remarks=[
-              '<note><paragraph>This is a global reference.</paragraph></note>'],
+            summary='<paragraph>Embedded data specification.</paragraph>',
+            remarks=[],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_data_specification',
@@ -2589,11 +2543,11 @@ SymbolTable(
         name='__init__',
         arguments=[
           Argument(
-            name='data_specifications',
+            name='embedded_data_specifications',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
-                  our_type='Reference to our type Reference',
+                  our_type='Reference to our type Embedded_data_specification',
                   parsed=...),
                 parsed=...),
               parsed=...),
@@ -2635,8 +2589,8 @@ SymbolTable(
         statements=[
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specifications',
-              argument='data_specifications',
+              name='embedded_data_specifications',
+              argument='embedded_data_specifications',
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
@@ -2649,49 +2603,6 @@ SymbolTable(
               argument='revision',
               default=None)""")]),
       invariants=[
-        Invariant(
-          description='References to data specifications are global references.',
-          body=textwrap.dedent("""\
-            Implication(
-              antecedent=IsNotNone(
-                value=Member(
-                  instance=Name(
-                    identifier='self',
-                    original_node=...),
-                  name='data_specifications',
-                  original_node=...),
-                original_node=...),
-              consequent=All(
-                generator=ForEach(
-                  variable=Name(
-                    identifier='data_specification',
-                    original_node=...),
-                  iteration=Member(
-                    instance=Name(
-                      identifier='self',
-                      original_node=...),
-                    name='data_specifications',
-                    original_node=...),
-                  original_node=...),
-                condition=Comparison(
-                  left=Member(
-                    instance=Name(
-                      identifier='data_specification',
-                      original_node=...),
-                    name='type',
-                    original_node=...),
-                  op='EQ',
-                  right=Member(
-                    instance=Name(
-                      identifier='Reference_types',
-                      original_node=...),
-                    name='Global_reference',
-                    original_node=...),
-                  original_node=...),
-                original_node=...),
-              original_node=...)"""),
-          specified_for='Reference to AbstractClass Has_data_specification',
-          parsed=...),
         Invariant(
           description='Constraint AASd-005: If version is not specified then also revision shall be unspecified. This means, a revision requires a version. If there is no version there is no revision either. Revision is optional.',
           body=textwrap.dedent("""\
@@ -3494,18 +3405,17 @@ SymbolTable(
           specified_for='Reference to AbstractClass Identifiable',
           parsed=...),
         Property(
-          name='data_specifications',
+          name='embedded_data_specifications',
           type_annotation=OptionalTypeAnnotation(
             value=ListTypeAnnotation(
               items=OurTypeAnnotation(
-                our_type='Reference to our type Reference',
+                our_type='Reference to our type Embedded_data_specification',
                 parsed=...),
               parsed=...),
             parsed=...),
           description=DescriptionOfProperty(
-            summary='<paragraph>Global reference to the data specification template used by the element.</paragraph>',
-            remarks=[
-              '<note><paragraph>This is a global reference.</paragraph></note>'],
+            summary='<paragraph>Embedded data specification.</paragraph>',
+            remarks=[],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_data_specification',
@@ -3653,11 +3563,11 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='data_specifications',
+            name='embedded_data_specifications',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
-                  our_type='Reference to our type Reference',
+                  our_type='Reference to our type Embedded_data_specification',
                   parsed=...),
                 parsed=...),
               parsed=...),
@@ -3741,8 +3651,8 @@ SymbolTable(
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specifications',
-              argument='data_specifications',
+              name='embedded_data_specifications',
+              argument='embedded_data_specifications',
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
@@ -3784,49 +3694,6 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Has_extensions',
-          parsed=...),
-        Invariant(
-          description='References to data specifications are global references.',
-          body=textwrap.dedent("""\
-            Implication(
-              antecedent=IsNotNone(
-                value=Member(
-                  instance=Name(
-                    identifier='self',
-                    original_node=...),
-                  name='data_specifications',
-                  original_node=...),
-                original_node=...),
-              consequent=All(
-                generator=ForEach(
-                  variable=Name(
-                    identifier='data_specification',
-                    original_node=...),
-                  iteration=Member(
-                    instance=Name(
-                      identifier='self',
-                      original_node=...),
-                    name='data_specifications',
-                    original_node=...),
-                  original_node=...),
-                condition=Comparison(
-                  left=Member(
-                    instance=Name(
-                      identifier='data_specification',
-                      original_node=...),
-                    name='type',
-                    original_node=...),
-                  op='EQ',
-                  right=Member(
-                    instance=Name(
-                      identifier='Reference_types',
-                      original_node=...),
-                    name='Global_reference',
-                    original_node=...),
-                  original_node=...),
-                original_node=...),
-              original_node=...)"""),
-          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description=None,
@@ -4706,18 +4573,17 @@ SymbolTable(
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Property(
-          name='data_specifications',
+          name='embedded_data_specifications',
           type_annotation=OptionalTypeAnnotation(
             value=ListTypeAnnotation(
               items=OurTypeAnnotation(
-                our_type='Reference to our type Reference',
+                our_type='Reference to our type Embedded_data_specification',
                 parsed=...),
               parsed=...),
             parsed=...),
           description=DescriptionOfProperty(
-            summary='<paragraph>Global reference to the data specification template used by the element.</paragraph>',
-            remarks=[
-              '<note><paragraph>This is a global reference.</paragraph></note>'],
+            summary='<paragraph>Embedded data specification.</paragraph>',
+            remarks=[],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_data_specification',
@@ -4891,11 +4757,11 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='data_specifications',
+            name='embedded_data_specifications',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
-                  our_type='Reference to our type Reference',
+                  our_type='Reference to our type Embedded_data_specification',
                   parsed=...),
                 parsed=...),
               parsed=...),
@@ -4988,8 +4854,8 @@ SymbolTable(
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specifications',
-              argument='data_specifications',
+              name='embedded_data_specifications',
+              argument='embedded_data_specifications',
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
@@ -5069,49 +4935,6 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
-          parsed=...),
-        Invariant(
-          description='References to data specifications are global references.',
-          body=textwrap.dedent("""\
-            Implication(
-              antecedent=IsNotNone(
-                value=Member(
-                  instance=Name(
-                    identifier='self',
-                    original_node=...),
-                  name='data_specifications',
-                  original_node=...),
-                original_node=...),
-              consequent=All(
-                generator=ForEach(
-                  variable=Name(
-                    identifier='data_specification',
-                    original_node=...),
-                  iteration=Member(
-                    instance=Name(
-                      identifier='self',
-                      original_node=...),
-                    name='data_specifications',
-                    original_node=...),
-                  original_node=...),
-                condition=Comparison(
-                  left=Member(
-                    instance=Name(
-                      identifier='data_specification',
-                      original_node=...),
-                    name='type',
-                    original_node=...),
-                  op='EQ',
-                  right=Member(
-                    instance=Name(
-                      identifier='Reference_types',
-                      original_node=...),
-                    name='Global_reference',
-                    original_node=...),
-                  original_node=...),
-                original_node=...),
-              original_node=...)"""),
-          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='ID-shorts need to be defined for all the submodel elements.',
@@ -5496,18 +5319,17 @@ SymbolTable(
             specified_for='Reference to AbstractClass Qualifiable',
             parsed=...),
           Property(
-            name='data_specifications',
+            name='embedded_data_specifications',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
-                  our_type='Reference to our type Reference',
+                  our_type='Reference to our type Embedded_data_specification',
                   parsed=...),
                 parsed=...),
               parsed=...),
             description=DescriptionOfProperty(
-              summary='<paragraph>Global reference to the data specification template used by the element.</paragraph>',
-              remarks=[
-                '<note><paragraph>This is a global reference.</paragraph></note>'],
+              summary='<paragraph>Embedded data specification.</paragraph>',
+              remarks=[],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Has_data_specification',
@@ -5741,18 +5563,17 @@ SymbolTable(
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Property(
-          name='data_specifications',
+          name='embedded_data_specifications',
           type_annotation=OptionalTypeAnnotation(
             value=ListTypeAnnotation(
               items=OurTypeAnnotation(
-                our_type='Reference to our type Reference',
+                our_type='Reference to our type Embedded_data_specification',
                 parsed=...),
               parsed=...),
             parsed=...),
           description=DescriptionOfProperty(
-            summary='<paragraph>Global reference to the data specification template used by the element.</paragraph>',
-            remarks=[
-              '<note><paragraph>This is a global reference.</paragraph></note>'],
+            summary='<paragraph>Embedded data specification.</paragraph>',
+            remarks=[],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_data_specification',
@@ -5892,11 +5713,11 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='data_specifications',
+            name='embedded_data_specifications',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
-                  our_type='Reference to our type Reference',
+                  our_type='Reference to our type Embedded_data_specification',
                   parsed=...),
                 parsed=...),
               parsed=...),
@@ -5966,8 +5787,8 @@ SymbolTable(
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specifications',
-              argument='data_specifications',
+              name='embedded_data_specifications',
+              argument='embedded_data_specifications',
               default=None)""")]),
       invariants=[
         Invariant(
@@ -6042,49 +5863,6 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
-          parsed=...),
-        Invariant(
-          description='References to data specifications are global references.',
-          body=textwrap.dedent("""\
-            Implication(
-              antecedent=IsNotNone(
-                value=Member(
-                  instance=Name(
-                    identifier='self',
-                    original_node=...),
-                  name='data_specifications',
-                  original_node=...),
-                original_node=...),
-              consequent=All(
-                generator=ForEach(
-                  variable=Name(
-                    identifier='data_specification',
-                    original_node=...),
-                  iteration=Member(
-                    instance=Name(
-                      identifier='self',
-                      original_node=...),
-                    name='data_specifications',
-                    original_node=...),
-                  original_node=...),
-                condition=Comparison(
-                  left=Member(
-                    instance=Name(
-                      identifier='data_specification',
-                      original_node=...),
-                    name='type',
-                    original_node=...),
-                  op='EQ',
-                  right=Member(
-                    instance=Name(
-                      identifier='Reference_types',
-                      original_node=...),
-                    name='Global_reference',
-                    original_node=...),
-                  original_node=...),
-                original_node=...),
-              original_node=...)"""),
-          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -6386,18 +6164,17 @@ SymbolTable(
             specified_for='Reference to AbstractClass Qualifiable',
             parsed=...),
           Property(
-            name='data_specifications',
+            name='embedded_data_specifications',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
-                  our_type='Reference to our type Reference',
+                  our_type='Reference to our type Embedded_data_specification',
                   parsed=...),
                 parsed=...),
               parsed=...),
             description=DescriptionOfProperty(
-              summary='<paragraph>Global reference to the data specification template used by the element.</paragraph>',
-              remarks=[
-                '<note><paragraph>This is a global reference.</paragraph></note>'],
+              summary='<paragraph>Embedded data specification.</paragraph>',
+              remarks=[],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Has_data_specification',
@@ -6641,18 +6418,17 @@ SymbolTable(
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Property(
-          name='data_specifications',
+          name='embedded_data_specifications',
           type_annotation=OptionalTypeAnnotation(
             value=ListTypeAnnotation(
               items=OurTypeAnnotation(
-                our_type='Reference to our type Reference',
+                our_type='Reference to our type Embedded_data_specification',
                 parsed=...),
               parsed=...),
             parsed=...),
           description=DescriptionOfProperty(
-            summary='<paragraph>Global reference to the data specification template used by the element.</paragraph>',
-            remarks=[
-              '<note><paragraph>This is a global reference.</paragraph></note>'],
+            summary='<paragraph>Embedded data specification.</paragraph>',
+            remarks=[],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_data_specification',
@@ -6830,11 +6606,11 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='data_specifications',
+            name='embedded_data_specifications',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
-                  our_type='Reference to our type Reference',
+                  our_type='Reference to our type Embedded_data_specification',
                   parsed=...),
                 parsed=...),
               parsed=...),
@@ -6904,8 +6680,8 @@ SymbolTable(
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specifications',
-              argument='data_specifications',
+              name='embedded_data_specifications',
+              argument='embedded_data_specifications',
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
@@ -6990,49 +6766,6 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
-          parsed=...),
-        Invariant(
-          description='References to data specifications are global references.',
-          body=textwrap.dedent("""\
-            Implication(
-              antecedent=IsNotNone(
-                value=Member(
-                  instance=Name(
-                    identifier='self',
-                    original_node=...),
-                  name='data_specifications',
-                  original_node=...),
-                original_node=...),
-              consequent=All(
-                generator=ForEach(
-                  variable=Name(
-                    identifier='data_specification',
-                    original_node=...),
-                  iteration=Member(
-                    instance=Name(
-                      identifier='self',
-                      original_node=...),
-                    name='data_specifications',
-                    original_node=...),
-                  original_node=...),
-                condition=Comparison(
-                  left=Member(
-                    instance=Name(
-                      identifier='data_specification',
-                      original_node=...),
-                    name='type',
-                    original_node=...),
-                  op='EQ',
-                  right=Member(
-                    instance=Name(
-                      identifier='Reference_types',
-                      original_node=...),
-                    name='Global_reference',
-                    original_node=...),
-                  original_node=...),
-                original_node=...),
-              original_node=...)"""),
-          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -7426,18 +7159,17 @@ SymbolTable(
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Property(
-          name='data_specifications',
+          name='embedded_data_specifications',
           type_annotation=OptionalTypeAnnotation(
             value=ListTypeAnnotation(
               items=OurTypeAnnotation(
-                our_type='Reference to our type Reference',
+                our_type='Reference to our type Embedded_data_specification',
                 parsed=...),
               parsed=...),
             parsed=...),
           description=DescriptionOfProperty(
-            summary='<paragraph>Global reference to the data specification template used by the element.</paragraph>',
-            remarks=[
-              '<note><paragraph>This is a global reference.</paragraph></note>'],
+            summary='<paragraph>Embedded data specification.</paragraph>',
+            remarks=[],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_data_specification',
@@ -7673,11 +7405,11 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='data_specifications',
+            name='embedded_data_specifications',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
-                  our_type='Reference to our type Reference',
+                  our_type='Reference to our type Embedded_data_specification',
                   parsed=...),
                 parsed=...),
               parsed=...),
@@ -7793,8 +7525,8 @@ SymbolTable(
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specifications',
-              argument='data_specifications',
+              name='embedded_data_specifications',
+              argument='embedded_data_specifications',
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
@@ -7894,49 +7626,6 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
-          parsed=...),
-        Invariant(
-          description='References to data specifications are global references.',
-          body=textwrap.dedent("""\
-            Implication(
-              antecedent=IsNotNone(
-                value=Member(
-                  instance=Name(
-                    identifier='self',
-                    original_node=...),
-                  name='data_specifications',
-                  original_node=...),
-                original_node=...),
-              consequent=All(
-                generator=ForEach(
-                  variable=Name(
-                    identifier='data_specification',
-                    original_node=...),
-                  iteration=Member(
-                    instance=Name(
-                      identifier='self',
-                      original_node=...),
-                    name='data_specifications',
-                    original_node=...),
-                  original_node=...),
-                condition=Comparison(
-                  left=Member(
-                    instance=Name(
-                      identifier='data_specification',
-                      original_node=...),
-                    name='type',
-                    original_node=...),
-                  op='EQ',
-                  right=Member(
-                    instance=Name(
-                      identifier='Reference_types',
-                      original_node=...),
-                    name='Global_reference',
-                    original_node=...),
-                  original_node=...),
-                original_node=...),
-              original_node=...)"""),
-          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -8508,18 +8197,17 @@ SymbolTable(
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Property(
-          name='data_specifications',
+          name='embedded_data_specifications',
           type_annotation=OptionalTypeAnnotation(
             value=ListTypeAnnotation(
               items=OurTypeAnnotation(
-                our_type='Reference to our type Reference',
+                our_type='Reference to our type Embedded_data_specification',
                 parsed=...),
               parsed=...),
             parsed=...),
           description=DescriptionOfProperty(
-            summary='<paragraph>Global reference to the data specification template used by the element.</paragraph>',
-            remarks=[
-              '<note><paragraph>This is a global reference.</paragraph></note>'],
+            summary='<paragraph>Embedded data specification.</paragraph>',
+            remarks=[],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_data_specification',
@@ -8675,11 +8363,11 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='data_specifications',
+            name='embedded_data_specifications',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
-                  our_type='Reference to our type Reference',
+                  our_type='Reference to our type Embedded_data_specification',
                   parsed=...),
                 parsed=...),
               parsed=...),
@@ -8762,8 +8450,8 @@ SymbolTable(
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specifications',
-              argument='data_specifications',
+              name='embedded_data_specifications',
+              argument='embedded_data_specifications',
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
@@ -8843,49 +8531,6 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
-          parsed=...),
-        Invariant(
-          description='References to data specifications are global references.',
-          body=textwrap.dedent("""\
-            Implication(
-              antecedent=IsNotNone(
-                value=Member(
-                  instance=Name(
-                    identifier='self',
-                    original_node=...),
-                  name='data_specifications',
-                  original_node=...),
-                original_node=...),
-              consequent=All(
-                generator=ForEach(
-                  variable=Name(
-                    identifier='data_specification',
-                    original_node=...),
-                  iteration=Member(
-                    instance=Name(
-                      identifier='self',
-                      original_node=...),
-                    name='data_specifications',
-                    original_node=...),
-                  original_node=...),
-                condition=Comparison(
-                  left=Member(
-                    instance=Name(
-                      identifier='data_specification',
-                      original_node=...),
-                    name='type',
-                    original_node=...),
-                  op='EQ',
-                  right=Member(
-                    instance=Name(
-                      identifier='Reference_types',
-                      original_node=...),
-                    name='Global_reference',
-                    original_node=...),
-                  original_node=...),
-                original_node=...),
-              original_node=...)"""),
-          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -9252,18 +8897,17 @@ SymbolTable(
             specified_for='Reference to AbstractClass Qualifiable',
             parsed=...),
           Property(
-            name='data_specifications',
+            name='embedded_data_specifications',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
-                  our_type='Reference to our type Reference',
+                  our_type='Reference to our type Embedded_data_specification',
                   parsed=...),
                 parsed=...),
               parsed=...),
             description=DescriptionOfProperty(
-              summary='<paragraph>Global reference to the data specification template used by the element.</paragraph>',
-              remarks=[
-                '<note><paragraph>This is a global reference.</paragraph></note>'],
+              summary='<paragraph>Embedded data specification.</paragraph>',
+              remarks=[],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Has_data_specification',
@@ -9523,18 +9167,17 @@ SymbolTable(
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Property(
-          name='data_specifications',
+          name='embedded_data_specifications',
           type_annotation=OptionalTypeAnnotation(
             value=ListTypeAnnotation(
               items=OurTypeAnnotation(
-                our_type='Reference to our type Reference',
+                our_type='Reference to our type Embedded_data_specification',
                 parsed=...),
               parsed=...),
             parsed=...),
           description=DescriptionOfProperty(
-            summary='<paragraph>Global reference to the data specification template used by the element.</paragraph>',
-            remarks=[
-              '<note><paragraph>This is a global reference.</paragraph></note>'],
+            summary='<paragraph>Embedded data specification.</paragraph>',
+            remarks=[],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_data_specification',
@@ -9702,11 +9345,11 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='data_specifications',
+            name='embedded_data_specifications',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
-                  our_type='Reference to our type Reference',
+                  our_type='Reference to our type Embedded_data_specification',
                   parsed=...),
                 parsed=...),
               parsed=...),
@@ -9776,8 +9419,8 @@ SymbolTable(
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specifications',
-              argument='data_specifications',
+              name='embedded_data_specifications',
+              argument='embedded_data_specifications',
               default=None)""")]),
       invariants=[
         Invariant(
@@ -9852,49 +9495,6 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
-          parsed=...),
-        Invariant(
-          description='References to data specifications are global references.',
-          body=textwrap.dedent("""\
-            Implication(
-              antecedent=IsNotNone(
-                value=Member(
-                  instance=Name(
-                    identifier='self',
-                    original_node=...),
-                  name='data_specifications',
-                  original_node=...),
-                original_node=...),
-              consequent=All(
-                generator=ForEach(
-                  variable=Name(
-                    identifier='data_specification',
-                    original_node=...),
-                  iteration=Member(
-                    instance=Name(
-                      identifier='self',
-                      original_node=...),
-                    name='data_specifications',
-                    original_node=...),
-                  original_node=...),
-                condition=Comparison(
-                  left=Member(
-                    instance=Name(
-                      identifier='data_specification',
-                      original_node=...),
-                    name='type',
-                    original_node=...),
-                  op='EQ',
-                  right=Member(
-                    instance=Name(
-                      identifier='Reference_types',
-                      original_node=...),
-                    name='Global_reference',
-                    original_node=...),
-                  original_node=...),
-                original_node=...),
-              original_node=...)"""),
-          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -10225,18 +9825,17 @@ SymbolTable(
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Property(
-          name='data_specifications',
+          name='embedded_data_specifications',
           type_annotation=OptionalTypeAnnotation(
             value=ListTypeAnnotation(
               items=OurTypeAnnotation(
-                our_type='Reference to our type Reference',
+                our_type='Reference to our type Embedded_data_specification',
                 parsed=...),
               parsed=...),
             parsed=...),
           description=DescriptionOfProperty(
-            summary='<paragraph>Global reference to the data specification template used by the element.</paragraph>',
-            remarks=[
-              '<note><paragraph>This is a global reference.</paragraph></note>'],
+            summary='<paragraph>Embedded data specification.</paragraph>',
+            remarks=[],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_data_specification',
@@ -10452,11 +10051,11 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='data_specifications',
+            name='embedded_data_specifications',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
-                  our_type='Reference to our type Reference',
+                  our_type='Reference to our type Embedded_data_specification',
                   parsed=...),
                 parsed=...),
               parsed=...),
@@ -10548,8 +10147,8 @@ SymbolTable(
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specifications',
-              argument='data_specifications',
+              name='embedded_data_specifications',
+              argument='embedded_data_specifications',
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
@@ -10639,49 +10238,6 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
-          parsed=...),
-        Invariant(
-          description='References to data specifications are global references.',
-          body=textwrap.dedent("""\
-            Implication(
-              antecedent=IsNotNone(
-                value=Member(
-                  instance=Name(
-                    identifier='self',
-                    original_node=...),
-                  name='data_specifications',
-                  original_node=...),
-                original_node=...),
-              consequent=All(
-                generator=ForEach(
-                  variable=Name(
-                    identifier='data_specification',
-                    original_node=...),
-                  iteration=Member(
-                    instance=Name(
-                      identifier='self',
-                      original_node=...),
-                    name='data_specifications',
-                    original_node=...),
-                  original_node=...),
-                condition=Comparison(
-                  left=Member(
-                    instance=Name(
-                      identifier='data_specification',
-                      original_node=...),
-                    name='type',
-                    original_node=...),
-                  op='EQ',
-                  right=Member(
-                    instance=Name(
-                      identifier='Reference_types',
-                      original_node=...),
-                    name='Global_reference',
-                    original_node=...),
-                  original_node=...),
-                original_node=...),
-              original_node=...)"""),
-          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -11039,18 +10595,17 @@ SymbolTable(
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Property(
-          name='data_specifications',
+          name='embedded_data_specifications',
           type_annotation=OptionalTypeAnnotation(
             value=ListTypeAnnotation(
               items=OurTypeAnnotation(
-                our_type='Reference to our type Reference',
+                our_type='Reference to our type Embedded_data_specification',
                 parsed=...),
               parsed=...),
             parsed=...),
           description=DescriptionOfProperty(
-            summary='<paragraph>Global reference to the data specification template used by the element.</paragraph>',
-            remarks=[
-              '<note><paragraph>This is a global reference.</paragraph></note>'],
+            summary='<paragraph>Embedded data specification.</paragraph>',
+            remarks=[],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_data_specification',
@@ -11247,11 +10802,11 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='data_specifications',
+            name='embedded_data_specifications',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
-                  our_type='Reference to our type Reference',
+                  our_type='Reference to our type Embedded_data_specification',
                   parsed=...),
                 parsed=...),
               parsed=...),
@@ -11343,8 +10898,8 @@ SymbolTable(
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specifications',
-              argument='data_specifications',
+              name='embedded_data_specifications',
+              argument='embedded_data_specifications',
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
@@ -11429,49 +10984,6 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
-          parsed=...),
-        Invariant(
-          description='References to data specifications are global references.',
-          body=textwrap.dedent("""\
-            Implication(
-              antecedent=IsNotNone(
-                value=Member(
-                  instance=Name(
-                    identifier='self',
-                    original_node=...),
-                  name='data_specifications',
-                  original_node=...),
-                original_node=...),
-              consequent=All(
-                generator=ForEach(
-                  variable=Name(
-                    identifier='data_specification',
-                    original_node=...),
-                  iteration=Member(
-                    instance=Name(
-                      identifier='self',
-                      original_node=...),
-                    name='data_specifications',
-                    original_node=...),
-                  original_node=...),
-                condition=Comparison(
-                  left=Member(
-                    instance=Name(
-                      identifier='data_specification',
-                      original_node=...),
-                    name='type',
-                    original_node=...),
-                  op='EQ',
-                  right=Member(
-                    instance=Name(
-                      identifier='Reference_types',
-                      original_node=...),
-                    name='Global_reference',
-                    original_node=...),
-                  original_node=...),
-                original_node=...),
-              original_node=...)"""),
-          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -11798,18 +11310,17 @@ SymbolTable(
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Property(
-          name='data_specifications',
+          name='embedded_data_specifications',
           type_annotation=OptionalTypeAnnotation(
             value=ListTypeAnnotation(
               items=OurTypeAnnotation(
-                our_type='Reference to our type Reference',
+                our_type='Reference to our type Embedded_data_specification',
                 parsed=...),
               parsed=...),
             parsed=...),
           description=DescriptionOfProperty(
-            summary='<paragraph>Global reference to the data specification template used by the element.</paragraph>',
-            remarks=[
-              '<note><paragraph>This is a global reference.</paragraph></note>'],
+            summary='<paragraph>Embedded data specification.</paragraph>',
+            remarks=[],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_data_specification',
@@ -12026,11 +11537,11 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='data_specifications',
+            name='embedded_data_specifications',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
-                  our_type='Reference to our type Reference',
+                  our_type='Reference to our type Embedded_data_specification',
                   parsed=...),
                 parsed=...),
               parsed=...),
@@ -12122,8 +11633,8 @@ SymbolTable(
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specifications',
-              argument='data_specifications',
+              name='embedded_data_specifications',
+              argument='embedded_data_specifications',
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
@@ -12213,49 +11724,6 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
-          parsed=...),
-        Invariant(
-          description='References to data specifications are global references.',
-          body=textwrap.dedent("""\
-            Implication(
-              antecedent=IsNotNone(
-                value=Member(
-                  instance=Name(
-                    identifier='self',
-                    original_node=...),
-                  name='data_specifications',
-                  original_node=...),
-                original_node=...),
-              consequent=All(
-                generator=ForEach(
-                  variable=Name(
-                    identifier='data_specification',
-                    original_node=...),
-                  iteration=Member(
-                    instance=Name(
-                      identifier='self',
-                      original_node=...),
-                    name='data_specifications',
-                    original_node=...),
-                  original_node=...),
-                condition=Comparison(
-                  left=Member(
-                    instance=Name(
-                      identifier='data_specification',
-                      original_node=...),
-                    name='type',
-                    original_node=...),
-                  op='EQ',
-                  right=Member(
-                    instance=Name(
-                      identifier='Reference_types',
-                      original_node=...),
-                    name='Global_reference',
-                    original_node=...),
-                  original_node=...),
-                original_node=...),
-              original_node=...)"""),
-          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -12638,18 +12106,17 @@ SymbolTable(
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Property(
-          name='data_specifications',
+          name='embedded_data_specifications',
           type_annotation=OptionalTypeAnnotation(
             value=ListTypeAnnotation(
               items=OurTypeAnnotation(
-                our_type='Reference to our type Reference',
+                our_type='Reference to our type Embedded_data_specification',
                 parsed=...),
               parsed=...),
             parsed=...),
           description=DescriptionOfProperty(
-            summary='<paragraph>Global reference to the data specification template used by the element.</paragraph>',
-            remarks=[
-              '<note><paragraph>This is a global reference.</paragraph></note>'],
+            summary='<paragraph>Embedded data specification.</paragraph>',
+            remarks=[],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_data_specification',
@@ -12834,11 +12301,11 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='data_specifications',
+            name='embedded_data_specifications',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
-                  our_type='Reference to our type Reference',
+                  our_type='Reference to our type Embedded_data_specification',
                   parsed=...),
                 parsed=...),
               parsed=...),
@@ -12919,8 +12386,8 @@ SymbolTable(
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specifications',
-              argument='data_specifications',
+              name='embedded_data_specifications',
+              argument='embedded_data_specifications',
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
@@ -13000,49 +12467,6 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
-          parsed=...),
-        Invariant(
-          description='References to data specifications are global references.',
-          body=textwrap.dedent("""\
-            Implication(
-              antecedent=IsNotNone(
-                value=Member(
-                  instance=Name(
-                    identifier='self',
-                    original_node=...),
-                  name='data_specifications',
-                  original_node=...),
-                original_node=...),
-              consequent=All(
-                generator=ForEach(
-                  variable=Name(
-                    identifier='data_specification',
-                    original_node=...),
-                  iteration=Member(
-                    instance=Name(
-                      identifier='self',
-                      original_node=...),
-                    name='data_specifications',
-                    original_node=...),
-                  original_node=...),
-                condition=Comparison(
-                  left=Member(
-                    instance=Name(
-                      identifier='data_specification',
-                      original_node=...),
-                    name='type',
-                    original_node=...),
-                  op='EQ',
-                  right=Member(
-                    instance=Name(
-                      identifier='Reference_types',
-                      original_node=...),
-                    name='Global_reference',
-                    original_node=...),
-                  original_node=...),
-                original_node=...),
-              original_node=...)"""),
-          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -13366,18 +12790,17 @@ SymbolTable(
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Property(
-          name='data_specifications',
+          name='embedded_data_specifications',
           type_annotation=OptionalTypeAnnotation(
             value=ListTypeAnnotation(
               items=OurTypeAnnotation(
-                our_type='Reference to our type Reference',
+                our_type='Reference to our type Embedded_data_specification',
                 parsed=...),
               parsed=...),
             parsed=...),
           description=DescriptionOfProperty(
-            summary='<paragraph>Global reference to the data specification template used by the element.</paragraph>',
-            remarks=[
-              '<note><paragraph>This is a global reference.</paragraph></note>'],
+            summary='<paragraph>Embedded data specification.</paragraph>',
+            remarks=[],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_data_specification',
@@ -13586,11 +13009,11 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='data_specifications',
+            name='embedded_data_specifications',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
-                  our_type='Reference to our type Reference',
+                  our_type='Reference to our type Embedded_data_specification',
                   parsed=...),
                 parsed=...),
               parsed=...),
@@ -13671,8 +13094,8 @@ SymbolTable(
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specifications',
-              argument='data_specifications',
+              name='embedded_data_specifications',
+              argument='embedded_data_specifications',
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
@@ -13757,49 +13180,6 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
-          parsed=...),
-        Invariant(
-          description='References to data specifications are global references.',
-          body=textwrap.dedent("""\
-            Implication(
-              antecedent=IsNotNone(
-                value=Member(
-                  instance=Name(
-                    identifier='self',
-                    original_node=...),
-                  name='data_specifications',
-                  original_node=...),
-                original_node=...),
-              consequent=All(
-                generator=ForEach(
-                  variable=Name(
-                    identifier='data_specification',
-                    original_node=...),
-                  iteration=Member(
-                    instance=Name(
-                      identifier='self',
-                      original_node=...),
-                    name='data_specifications',
-                    original_node=...),
-                  original_node=...),
-                condition=Comparison(
-                  left=Member(
-                    instance=Name(
-                      identifier='data_specification',
-                      original_node=...),
-                    name='type',
-                    original_node=...),
-                  op='EQ',
-                  right=Member(
-                    instance=Name(
-                      identifier='Reference_types',
-                      original_node=...),
-                    name='Global_reference',
-                    original_node=...),
-                  original_node=...),
-                original_node=...),
-              original_node=...)"""),
-          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -14122,18 +13502,17 @@ SymbolTable(
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Property(
-          name='data_specifications',
+          name='embedded_data_specifications',
           type_annotation=OptionalTypeAnnotation(
             value=ListTypeAnnotation(
               items=OurTypeAnnotation(
-                our_type='Reference to our type Reference',
+                our_type='Reference to our type Embedded_data_specification',
                 parsed=...),
               parsed=...),
             parsed=...),
           description=DescriptionOfProperty(
-            summary='<paragraph>Global reference to the data specification template used by the element.</paragraph>',
-            remarks=[
-              '<note><paragraph>This is a global reference.</paragraph></note>'],
+            summary='<paragraph>Embedded data specification.</paragraph>',
+            remarks=[],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_data_specification',
@@ -14336,11 +13715,11 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='data_specifications',
+            name='embedded_data_specifications',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
-                  our_type='Reference to our type Reference',
+                  our_type='Reference to our type Embedded_data_specification',
                   parsed=...),
                 parsed=...),
               parsed=...),
@@ -14421,8 +13800,8 @@ SymbolTable(
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specifications',
-              argument='data_specifications',
+              name='embedded_data_specifications',
+              argument='embedded_data_specifications',
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
@@ -14507,49 +13886,6 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
-          parsed=...),
-        Invariant(
-          description='References to data specifications are global references.',
-          body=textwrap.dedent("""\
-            Implication(
-              antecedent=IsNotNone(
-                value=Member(
-                  instance=Name(
-                    identifier='self',
-                    original_node=...),
-                  name='data_specifications',
-                  original_node=...),
-                original_node=...),
-              consequent=All(
-                generator=ForEach(
-                  variable=Name(
-                    identifier='data_specification',
-                    original_node=...),
-                  iteration=Member(
-                    instance=Name(
-                      identifier='self',
-                      original_node=...),
-                    name='data_specifications',
-                    original_node=...),
-                  original_node=...),
-                condition=Comparison(
-                  left=Member(
-                    instance=Name(
-                      identifier='data_specification',
-                      original_node=...),
-                    name='type',
-                    original_node=...),
-                  op='EQ',
-                  right=Member(
-                    instance=Name(
-                      identifier='Reference_types',
-                      original_node=...),
-                    name='Global_reference',
-                    original_node=...),
-                  original_node=...),
-                original_node=...),
-              original_node=...)"""),
-          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -14871,18 +14207,17 @@ SymbolTable(
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Property(
-          name='data_specifications',
+          name='embedded_data_specifications',
           type_annotation=OptionalTypeAnnotation(
             value=ListTypeAnnotation(
               items=OurTypeAnnotation(
-                our_type='Reference to our type Reference',
+                our_type='Reference to our type Embedded_data_specification',
                 parsed=...),
               parsed=...),
             parsed=...),
           description=DescriptionOfProperty(
-            summary='<paragraph>Global reference to the data specification template used by the element.</paragraph>',
-            remarks=[
-              '<note><paragraph>This is a global reference.</paragraph></note>'],
+            summary='<paragraph>Embedded data specification.</paragraph>',
+            remarks=[],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_data_specification',
@@ -15078,11 +14413,11 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='data_specifications',
+            name='embedded_data_specifications',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
-                  our_type='Reference to our type Reference',
+                  our_type='Reference to our type Embedded_data_specification',
                   parsed=...),
                 parsed=...),
               parsed=...),
@@ -15165,8 +14500,8 @@ SymbolTable(
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specifications',
-              argument='data_specifications',
+              name='embedded_data_specifications',
+              argument='embedded_data_specifications',
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
@@ -15256,49 +14591,6 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
-          parsed=...),
-        Invariant(
-          description='References to data specifications are global references.',
-          body=textwrap.dedent("""\
-            Implication(
-              antecedent=IsNotNone(
-                value=Member(
-                  instance=Name(
-                    identifier='self',
-                    original_node=...),
-                  name='data_specifications',
-                  original_node=...),
-                original_node=...),
-              consequent=All(
-                generator=ForEach(
-                  variable=Name(
-                    identifier='data_specification',
-                    original_node=...),
-                  iteration=Member(
-                    instance=Name(
-                      identifier='self',
-                      original_node=...),
-                    name='data_specifications',
-                    original_node=...),
-                  original_node=...),
-                condition=Comparison(
-                  left=Member(
-                    instance=Name(
-                      identifier='data_specification',
-                      original_node=...),
-                    name='type',
-                    original_node=...),
-                  op='EQ',
-                  right=Member(
-                    instance=Name(
-                      identifier='Reference_types',
-                      original_node=...),
-                    name='Global_reference',
-                    original_node=...),
-                  original_node=...),
-                original_node=...),
-              original_node=...)"""),
-          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -15637,18 +14929,17 @@ SymbolTable(
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Property(
-          name='data_specifications',
+          name='embedded_data_specifications',
           type_annotation=OptionalTypeAnnotation(
             value=ListTypeAnnotation(
               items=OurTypeAnnotation(
-                our_type='Reference to our type Reference',
+                our_type='Reference to our type Embedded_data_specification',
                 parsed=...),
               parsed=...),
             parsed=...),
           description=DescriptionOfProperty(
-            summary='<paragraph>Global reference to the data specification template used by the element.</paragraph>',
-            remarks=[
-              '<note><paragraph>This is a global reference.</paragraph></note>'],
+            summary='<paragraph>Embedded data specification.</paragraph>',
+            remarks=[],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_data_specification',
@@ -15856,11 +15147,11 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='data_specifications',
+            name='embedded_data_specifications',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
-                  our_type='Reference to our type Reference',
+                  our_type='Reference to our type Embedded_data_specification',
                   parsed=...),
                 parsed=...),
               parsed=...),
@@ -15965,8 +15256,8 @@ SymbolTable(
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specifications',
-              argument='data_specifications',
+              name='embedded_data_specifications',
+              argument='embedded_data_specifications',
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
@@ -16061,49 +15352,6 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
-          parsed=...),
-        Invariant(
-          description='References to data specifications are global references.',
-          body=textwrap.dedent("""\
-            Implication(
-              antecedent=IsNotNone(
-                value=Member(
-                  instance=Name(
-                    identifier='self',
-                    original_node=...),
-                  name='data_specifications',
-                  original_node=...),
-                original_node=...),
-              consequent=All(
-                generator=ForEach(
-                  variable=Name(
-                    identifier='data_specification',
-                    original_node=...),
-                  iteration=Member(
-                    instance=Name(
-                      identifier='self',
-                      original_node=...),
-                    name='data_specifications',
-                    original_node=...),
-                  original_node=...),
-                condition=Comparison(
-                  left=Member(
-                    instance=Name(
-                      identifier='data_specification',
-                      original_node=...),
-                    name='type',
-                    original_node=...),
-                  op='EQ',
-                  right=Member(
-                    instance=Name(
-                      identifier='Reference_types',
-                      original_node=...),
-                    name='Global_reference',
-                    original_node=...),
-                  original_node=...),
-                original_node=...),
-              original_node=...)"""),
-          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -16873,18 +16121,17 @@ SymbolTable(
             specified_for='Reference to AbstractClass Qualifiable',
             parsed=...),
           Property(
-            name='data_specifications',
+            name='embedded_data_specifications',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
-                  our_type='Reference to our type Reference',
+                  our_type='Reference to our type Embedded_data_specification',
                   parsed=...),
                 parsed=...),
               parsed=...),
             description=DescriptionOfProperty(
-              summary='<paragraph>Global reference to the data specification template used by the element.</paragraph>',
-              remarks=[
-                '<note><paragraph>This is a global reference.</paragraph></note>'],
+              summary='<paragraph>Embedded data specification.</paragraph>',
+              remarks=[],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Has_data_specification',
@@ -17102,18 +16349,17 @@ SymbolTable(
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Property(
-          name='data_specifications',
+          name='embedded_data_specifications',
           type_annotation=OptionalTypeAnnotation(
             value=ListTypeAnnotation(
               items=OurTypeAnnotation(
-                our_type='Reference to our type Reference',
+                our_type='Reference to our type Embedded_data_specification',
                 parsed=...),
               parsed=...),
             parsed=...),
           description=DescriptionOfProperty(
-            summary='<paragraph>Global reference to the data specification template used by the element.</paragraph>',
-            remarks=[
-              '<note><paragraph>This is a global reference.</paragraph></note>'],
+            summary='<paragraph>Embedded data specification.</paragraph>',
+            remarks=[],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_data_specification',
@@ -17253,11 +16499,11 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='data_specifications',
+            name='embedded_data_specifications',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
-                  our_type='Reference to our type Reference',
+                  our_type='Reference to our type Embedded_data_specification',
                   parsed=...),
                 parsed=...),
               parsed=...),
@@ -17327,8 +16573,8 @@ SymbolTable(
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specifications',
-              argument='data_specifications',
+              name='embedded_data_specifications',
+              argument='embedded_data_specifications',
               default=None)""")]),
       invariants=[
         Invariant(
@@ -17403,49 +16649,6 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
-          parsed=...),
-        Invariant(
-          description='References to data specifications are global references.',
-          body=textwrap.dedent("""\
-            Implication(
-              antecedent=IsNotNone(
-                value=Member(
-                  instance=Name(
-                    identifier='self',
-                    original_node=...),
-                  name='data_specifications',
-                  original_node=...),
-                original_node=...),
-              consequent=All(
-                generator=ForEach(
-                  variable=Name(
-                    identifier='data_specification',
-                    original_node=...),
-                  iteration=Member(
-                    instance=Name(
-                      identifier='self',
-                      original_node=...),
-                    name='data_specifications',
-                    original_node=...),
-                  original_node=...),
-                condition=Comparison(
-                  left=Member(
-                    instance=Name(
-                      identifier='data_specification',
-                      original_node=...),
-                    name='type',
-                    original_node=...),
-                  op='EQ',
-                  right=Member(
-                    instance=Name(
-                      identifier='Reference_types',
-                      original_node=...),
-                    name='Global_reference',
-                    original_node=...),
-                  original_node=...),
-                original_node=...),
-              original_node=...)"""),
-          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -17740,18 +16943,17 @@ SymbolTable(
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Property(
-          name='data_specifications',
+          name='embedded_data_specifications',
           type_annotation=OptionalTypeAnnotation(
             value=ListTypeAnnotation(
               items=OurTypeAnnotation(
-                our_type='Reference to our type Reference',
+                our_type='Reference to our type Embedded_data_specification',
                 parsed=...),
               parsed=...),
             parsed=...),
           description=DescriptionOfProperty(
-            summary='<paragraph>Global reference to the data specification template used by the element.</paragraph>',
-            remarks=[
-              '<note><paragraph>This is a global reference.</paragraph></note>'],
+            summary='<paragraph>Embedded data specification.</paragraph>',
+            remarks=[],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_data_specification',
@@ -18049,11 +17251,11 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='data_specifications',
+            name='embedded_data_specifications',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
-                  our_type='Reference to our type Reference',
+                  our_type='Reference to our type Embedded_data_specification',
                   parsed=...),
                 parsed=...),
               parsed=...),
@@ -18178,8 +17380,8 @@ SymbolTable(
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specifications',
-              argument='data_specifications',
+              name='embedded_data_specifications',
+              argument='embedded_data_specifications',
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
@@ -18294,49 +17496,6 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
-          parsed=...),
-        Invariant(
-          description='References to data specifications are global references.',
-          body=textwrap.dedent("""\
-            Implication(
-              antecedent=IsNotNone(
-                value=Member(
-                  instance=Name(
-                    identifier='self',
-                    original_node=...),
-                  name='data_specifications',
-                  original_node=...),
-                original_node=...),
-              consequent=All(
-                generator=ForEach(
-                  variable=Name(
-                    identifier='data_specification',
-                    original_node=...),
-                  iteration=Member(
-                    instance=Name(
-                      identifier='self',
-                      original_node=...),
-                    name='data_specifications',
-                    original_node=...),
-                  original_node=...),
-                condition=Comparison(
-                  left=Member(
-                    instance=Name(
-                      identifier='data_specification',
-                      original_node=...),
-                    name='type',
-                    original_node=...),
-                  op='EQ',
-                  right=Member(
-                    instance=Name(
-                      identifier='Reference_types',
-                      original_node=...),
-                    name='Global_reference',
-                    original_node=...),
-                  original_node=...),
-                original_node=...),
-              original_node=...)"""),
-          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -18701,18 +17860,17 @@ SymbolTable(
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Property(
-          name='data_specifications',
+          name='embedded_data_specifications',
           type_annotation=OptionalTypeAnnotation(
             value=ListTypeAnnotation(
               items=OurTypeAnnotation(
-                our_type='Reference to our type Reference',
+                our_type='Reference to our type Embedded_data_specification',
                 parsed=...),
               parsed=...),
             parsed=...),
           description=DescriptionOfProperty(
-            summary='<paragraph>Global reference to the data specification template used by the element.</paragraph>',
-            remarks=[
-              '<note><paragraph>This is a global reference.</paragraph></note>'],
+            summary='<paragraph>Embedded data specification.</paragraph>',
+            remarks=[],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_data_specification',
@@ -18900,11 +18058,11 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='data_specifications',
+            name='embedded_data_specifications',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
-                  our_type='Reference to our type Reference',
+                  our_type='Reference to our type Embedded_data_specification',
                   parsed=...),
                 parsed=...),
               parsed=...),
@@ -19013,8 +18171,8 @@ SymbolTable(
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specifications',
-              argument='data_specifications',
+              name='embedded_data_specifications',
+              argument='embedded_data_specifications',
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
@@ -19104,49 +18262,6 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
-          parsed=...),
-        Invariant(
-          description='References to data specifications are global references.',
-          body=textwrap.dedent("""\
-            Implication(
-              antecedent=IsNotNone(
-                value=Member(
-                  instance=Name(
-                    identifier='self',
-                    original_node=...),
-                  name='data_specifications',
-                  original_node=...),
-                original_node=...),
-              consequent=All(
-                generator=ForEach(
-                  variable=Name(
-                    identifier='data_specification',
-                    original_node=...),
-                  iteration=Member(
-                    instance=Name(
-                      identifier='self',
-                      original_node=...),
-                    name='data_specifications',
-                    original_node=...),
-                  original_node=...),
-                condition=Comparison(
-                  left=Member(
-                    instance=Name(
-                      identifier='data_specification',
-                      original_node=...),
-                    name='type',
-                    original_node=...),
-                  op='EQ',
-                  right=Member(
-                    instance=Name(
-                      identifier='Reference_types',
-                      original_node=...),
-                    name='Global_reference',
-                    original_node=...),
-                  original_node=...),
-                original_node=...),
-              original_node=...)"""),
-          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -19511,18 +18626,17 @@ SymbolTable(
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Property(
-          name='data_specifications',
+          name='embedded_data_specifications',
           type_annotation=OptionalTypeAnnotation(
             value=ListTypeAnnotation(
               items=OurTypeAnnotation(
-                our_type='Reference to our type Reference',
+                our_type='Reference to our type Embedded_data_specification',
                 parsed=...),
               parsed=...),
             parsed=...),
           description=DescriptionOfProperty(
-            summary='<paragraph>Global reference to the data specification template used by the element.</paragraph>',
-            remarks=[
-              '<note><paragraph>This is a global reference.</paragraph></note>'],
+            summary='<paragraph>Embedded data specification.</paragraph>',
+            remarks=[],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_data_specification',
@@ -19662,11 +18776,11 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='data_specifications',
+            name='embedded_data_specifications',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
-                  our_type='Reference to our type Reference',
+                  our_type='Reference to our type Embedded_data_specification',
                   parsed=...),
                 parsed=...),
               parsed=...),
@@ -19736,8 +18850,8 @@ SymbolTable(
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specifications',
-              argument='data_specifications',
+              name='embedded_data_specifications',
+              argument='embedded_data_specifications',
               default=None)""")]),
       invariants=[
         Invariant(
@@ -19812,49 +18926,6 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
-          parsed=...),
-        Invariant(
-          description='References to data specifications are global references.',
-          body=textwrap.dedent("""\
-            Implication(
-              antecedent=IsNotNone(
-                value=Member(
-                  instance=Name(
-                    identifier='self',
-                    original_node=...),
-                  name='data_specifications',
-                  original_node=...),
-                original_node=...),
-              consequent=All(
-                generator=ForEach(
-                  variable=Name(
-                    identifier='data_specification',
-                    original_node=...),
-                  iteration=Member(
-                    instance=Name(
-                      identifier='self',
-                      original_node=...),
-                    name='data_specifications',
-                    original_node=...),
-                  original_node=...),
-                condition=Comparison(
-                  left=Member(
-                    instance=Name(
-                      identifier='data_specification',
-                      original_node=...),
-                    name='type',
-                    original_node=...),
-                  op='EQ',
-                  right=Member(
-                    instance=Name(
-                      identifier='Reference_types',
-                      original_node=...),
-                    name='Global_reference',
-                    original_node=...),
-                  original_node=...),
-                original_node=...),
-              original_node=...)"""),
-          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -20112,18 +19183,17 @@ SymbolTable(
           specified_for='Reference to AbstractClass Identifiable',
           parsed=...),
         Property(
-          name='data_specifications',
+          name='embedded_data_specifications',
           type_annotation=OptionalTypeAnnotation(
             value=ListTypeAnnotation(
               items=OurTypeAnnotation(
-                our_type='Reference to our type Reference',
+                our_type='Reference to our type Embedded_data_specification',
                 parsed=...),
               parsed=...),
             parsed=...),
           description=DescriptionOfProperty(
-            summary='<paragraph>Global reference to the data specification template used by the element.</paragraph>',
-            remarks=[
-              '<note><paragraph>This is a global reference.</paragraph></note>'],
+            summary='<paragraph>Embedded data specification.</paragraph>',
+            remarks=[],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_data_specification',
@@ -20267,11 +19337,11 @@ SymbolTable(
               parsed=...),
             parsed=...),
           Argument(
-            name='data_specifications',
+            name='embedded_data_specifications',
             type_annotation=OptionalTypeAnnotation(
               value=ListTypeAnnotation(
                 items=OurTypeAnnotation(
-                  our_type='Reference to our type Reference',
+                  our_type='Reference to our type Embedded_data_specification',
                   parsed=...),
                 parsed=...),
               parsed=...),
@@ -20344,8 +19414,8 @@ SymbolTable(
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specifications',
-              argument='data_specifications',
+              name='embedded_data_specifications',
+              argument='embedded_data_specifications',
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
@@ -20377,49 +19447,6 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Has_extensions',
-          parsed=...),
-        Invariant(
-          description='References to data specifications are global references.',
-          body=textwrap.dedent("""\
-            Implication(
-              antecedent=IsNotNone(
-                value=Member(
-                  instance=Name(
-                    identifier='self',
-                    original_node=...),
-                  name='data_specifications',
-                  original_node=...),
-                original_node=...),
-              consequent=All(
-                generator=ForEach(
-                  variable=Name(
-                    identifier='data_specification',
-                    original_node=...),
-                  iteration=Member(
-                    instance=Name(
-                      identifier='self',
-                      original_node=...),
-                    name='data_specifications',
-                    original_node=...),
-                  original_node=...),
-                condition=Comparison(
-                  left=Member(
-                    instance=Name(
-                      identifier='data_specification',
-                      original_node=...),
-                    name='type',
-                    original_node=...),
-                  op='EQ',
-                  right=Member(
-                    instance=Name(
-                      identifier='Reference_types',
-                      original_node=...),
-                    name='Global_reference',
-                    original_node=...),
-                  original_node=...),
-                original_node=...),
-              original_node=...)"""),
-          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description="Constraint AASd-051: A concept description shall have one of the following categories: 'VALUE', 'PROPERTY', 'REFERENCE', 'DOCUMENT', 'CAPABILITY',; 'RELATIONSHIP', 'COLLECTION', 'FUNCTION', 'EVENT', 'ENTITY', 'APPLICATION_CLASS', 'QUALIFIER', 'VIEW'.",
@@ -22046,206 +21073,6 @@ SymbolTable(
       methods_by_name=...,
       invariant_id_set=...),
     ConcreteClass(
-      name='Data_specification_content',
-      inheritances=[],
-      inheritance_id_set=...,
-      is_implementation_specific=False,
-      interface=None,
-      descendant_id_set=...,
-      concrete_descendants=[],
-      properties=[],
-      methods=[],
-      constructor=Constructor(
-        name='__init__',
-        arguments=[],
-        returns=None,
-        description=None,
-        contracts=Contracts(
-          preconditions=[],
-          snapshots=[],
-          postconditions=[]),
-        parsed=None,
-        arguments_by_name=...,
-        is_implementation_specific=False,
-        statements=[]),
-      invariants=[],
-      serialization=Serialization(
-        with_model_type=False),
-      reference_in_the_book=ReferenceInTheBook(
-        section=[
-          6,
-          2,
-          1,
-          1],
-        index=1,
-        fragment=None),
-      description=DescriptionOfOurType(
-        summary=textwrap.dedent("""\
-          <paragraph>Data specification content is part of a data specification template and defines
-          which additional attributes shall be added to the element instance that references
-          the data specification template and meta information about the template itself.</paragraph>"""),
-        remarks=[],
-        constraints_by_identifier=[],
-        parsed=...),
-      parsed=...,
-      properties_by_name=...,
-      property_id_set=...,
-      methods_by_name=...,
-      invariant_id_set=...),
-    ConcreteClass(
-      name='Data_specification',
-      inheritances=[],
-      inheritance_id_set=...,
-      is_implementation_specific=False,
-      interface=None,
-      descendant_id_set=...,
-      concrete_descendants=[],
-      properties=[
-        Property(
-          name='id',
-          type_annotation=OurTypeAnnotation(
-            our_type='Reference to our type Identifier',
-            parsed=...),
-          description=DescriptionOfProperty(
-            summary='<paragraph>The globally unique identification of the element.</paragraph>',
-            remarks=[],
-            constraints_by_identifier=[],
-            parsed=...),
-          specified_for='Reference to ConcreteClass Data_specification',
-          parsed=...),
-        Property(
-          name='data_specification_content',
-          type_annotation=OurTypeAnnotation(
-            our_type='Reference to our type Data_specification_content',
-            parsed=...),
-          description=DescriptionOfProperty(
-            summary='<paragraph>The content of the template without meta data</paragraph>',
-            remarks=[],
-            constraints_by_identifier=[],
-            parsed=...),
-          specified_for='Reference to ConcreteClass Data_specification',
-          parsed=...),
-        Property(
-          name='administration',
-          type_annotation=OptionalTypeAnnotation(
-            value=OurTypeAnnotation(
-              our_type='Reference to our type Administrative_information',
-              parsed=...),
-            parsed=...),
-          description=DescriptionOfProperty(
-            summary='<paragraph>Administrative information of an identifiable element.</paragraph>',
-            remarks=[
-              textwrap.dedent("""\
-                <note><paragraph>Some of the administrative information like the version number might need to
-                be part of the identification.</paragraph></note>""")],
-            constraints_by_identifier=[],
-            parsed=...),
-          specified_for='Reference to ConcreteClass Data_specification',
-          parsed=...),
-        Property(
-          name='description',
-          type_annotation=OptionalTypeAnnotation(
-            value=OurTypeAnnotation(
-              our_type='Reference to our type Lang_string_set',
-              parsed=...),
-            parsed=...),
-          description=DescriptionOfProperty(
-            summary=textwrap.dedent("""\
-              <paragraph>Description how and in which context the data specification template is applicable.
-              The description can be provided in several languages.</paragraph>"""),
-            remarks=[],
-            constraints_by_identifier=[],
-            parsed=...),
-          specified_for='Reference to ConcreteClass Data_specification',
-          parsed=...)],
-      methods=[],
-      constructor=Constructor(
-        name='__init__',
-        arguments=[
-          Argument(
-            name='id',
-            type_annotation=OurTypeAnnotation(
-              our_type='Reference to our type Identifier',
-              parsed=...),
-            default=None,
-            parsed=...),
-          Argument(
-            name='data_specification_content',
-            type_annotation=OurTypeAnnotation(
-              our_type='Reference to our type Data_specification_content',
-              parsed=...),
-            default=None,
-            parsed=...),
-          Argument(
-            name='administration',
-            type_annotation=OptionalTypeAnnotation(
-              value=OurTypeAnnotation(
-                our_type='Reference to our type Administrative_information',
-                parsed=...),
-              parsed=...),
-            default=None,
-            parsed=...),
-          Argument(
-            name='description',
-            type_annotation=OptionalTypeAnnotation(
-              value=OurTypeAnnotation(
-                our_type='Reference to our type Lang_string_set',
-                parsed=...),
-              parsed=...),
-            default=None,
-            parsed=...)],
-        returns=None,
-        description=None,
-        contracts=Contracts(
-          preconditions=[],
-          snapshots=[],
-          postconditions=[]),
-        parsed=...,
-        arguments_by_name=...,
-        is_implementation_specific=False,
-        statements=[
-          textwrap.dedent("""\
-            AssignArgument(
-              name='id',
-              argument='id',
-              default=None)"""),
-          textwrap.dedent("""\
-            AssignArgument(
-              name='data_specification_content',
-              argument='data_specification_content',
-              default=None)"""),
-          textwrap.dedent("""\
-            AssignArgument(
-              name='administration',
-              argument='administration',
-              default=None)"""),
-          textwrap.dedent("""\
-            AssignArgument(
-              name='description',
-              argument='description',
-              default=None)""")]),
-      invariants=[],
-      serialization=Serialization(
-        with_model_type=False),
-      reference_in_the_book=ReferenceInTheBook(
-        section=[
-          6,
-          2,
-          1,
-          1],
-        index=0,
-        fragment=None),
-      description=DescriptionOfOurType(
-        summary='<paragraph>Data Specification Template</paragraph>',
-        remarks=[],
-        constraints_by_identifier=[],
-        parsed=...),
-      parsed=...,
-      properties_by_name=...,
-      property_id_set=...,
-      methods_by_name=...,
-      invariant_id_set=...),
-    ConcreteClass(
       name='Environment',
       inheritances=[],
       inheritance_id_set=...,
@@ -22393,6 +21220,1531 @@ SymbolTable(
       properties_by_name=...,
       property_id_set=...,
       methods_by_name=...,
+      invariant_id_set=...),
+    AbstractClass(
+      name='Data_specification_content',
+      inheritances=[],
+      inheritance_id_set=...,
+      is_implementation_specific=False,
+      interface=Interface(
+        base='Reference to AbstractClass Data_specification_content',
+        name='Data_specification_content',
+        inheritances=[],
+        implementers=[
+          'Reference to ConcreteClass Data_specification_IEC_61360',
+          'Reference to ConcreteClass Data_specification_physical_unit'],
+        properties=[],
+        signatures=[],
+        description=DescriptionOfOurType(
+          summary=textwrap.dedent("""\
+            <paragraph>Data specification content is part of a data specification template and defines
+            which additional attributes shall be added to the element instance that references
+            the data specification template and meta information about the template itself.</paragraph>"""),
+          remarks=[],
+          constraints_by_identifier=[],
+          parsed=...),
+        parsed=...,
+        properties_by_name=...,
+        property_id_set=...),
+      descendant_id_set=...,
+      concrete_descendants=[
+        'Reference to ConcreteClass Data_specification_IEC_61360',
+        'Reference to ConcreteClass Data_specification_physical_unit'],
+      properties=[],
+      methods=[],
+      constructor=Constructor(
+        name='__init__',
+        arguments=[],
+        returns=None,
+        description=None,
+        contracts=Contracts(
+          preconditions=[],
+          snapshots=[],
+          postconditions=[]),
+        parsed=None,
+        arguments_by_name=...,
+        is_implementation_specific=False,
+        statements=[]),
+      invariants=[],
+      serialization=Serialization(
+        with_model_type=True),
+      reference_in_the_book=ReferenceInTheBook(
+        section=[
+          6,
+          2,
+          1,
+          1],
+        index=1,
+        fragment='6.2.1.1 Data Specification Template Attributes'),
+      description=DescriptionOfOurType(
+        summary=textwrap.dedent("""\
+          <paragraph>Data specification content is part of a data specification template and defines
+          which additional attributes shall be added to the element instance that references
+          the data specification template and meta information about the template itself.</paragraph>"""),
+        remarks=[],
+        constraints_by_identifier=[],
+        parsed=...),
+      parsed=...,
+      properties_by_name=...,
+      property_id_set=...,
+      methods_by_name=...,
+      invariant_id_set=...),
+    ConcreteClass(
+      name='Embedded_data_specification',
+      inheritances=[],
+      inheritance_id_set=...,
+      is_implementation_specific=False,
+      interface=None,
+      descendant_id_set=...,
+      concrete_descendants=[],
+      properties=[
+        Property(
+          name='data_specification',
+          type_annotation=OurTypeAnnotation(
+            our_type='Reference to our type Reference',
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>Reference to the data specification</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Embedded_data_specification',
+          parsed=...),
+        Property(
+          name='data_specification_content',
+          type_annotation=OurTypeAnnotation(
+            our_type='Reference to our type Data_specification_content',
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>Actual content of the data specification</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Embedded_data_specification',
+          parsed=...)],
+      methods=[],
+      constructor=Constructor(
+        name='__init__',
+        arguments=[
+          Argument(
+            name='data_specification',
+            type_annotation=OurTypeAnnotation(
+              our_type='Reference to our type Reference',
+              parsed=...),
+            default=None,
+            parsed=...),
+          Argument(
+            name='data_specification_content',
+            type_annotation=OurTypeAnnotation(
+              our_type='Reference to our type Data_specification_content',
+              parsed=...),
+            default=None,
+            parsed=...)],
+        returns=None,
+        description=None,
+        contracts=Contracts(
+          preconditions=[],
+          snapshots=[],
+          postconditions=[]),
+        parsed=...,
+        arguments_by_name=...,
+        is_implementation_specific=False,
+        statements=[
+          textwrap.dedent("""\
+            AssignArgument(
+              name='data_specification',
+              argument='data_specification',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='data_specification_content',
+              argument='data_specification_content',
+              default=None)""")]),
+      invariants=[],
+      serialization=Serialization(
+        with_model_type=False),
+      reference_in_the_book=ReferenceInTheBook(
+        section=[
+          9,
+          2,
+          5],
+        index=0,
+        fragment='9.2.5 Embedded Data Specifications'),
+      description=DescriptionOfOurType(
+        summary='<paragraph>Embed the content of a data specification.</paragraph>',
+        remarks=[],
+        constraints_by_identifier=[],
+        parsed=...),
+      parsed=...,
+      properties_by_name=...,
+      property_id_set=...,
+      methods_by_name=...,
+      invariant_id_set=...),
+    Enumeration(
+      name='Data_type_IEC_61360',
+      literals=[
+        EnumerationLiteral(
+          name='Date',
+          value='DATE',
+          description=DescriptionOfEnumerationLiteral(
+            summary=textwrap.dedent("""\
+              <paragraph>values containing a calendar date, conformant to ISO 8601:2004 Format yyyy-mm-dd
+              Example from IEC 61360-1:2017: "1999-05-31" is the [DATE] representation of:
+              "31 May 1999".</paragraph>"""),
+            remarks=[],
+            parsed=...),
+          parsed=...),
+        EnumerationLiteral(
+          name='String',
+          value='STRING',
+          description=DescriptionOfEnumerationLiteral(
+            summary=textwrap.dedent("""\
+              <paragraph>values consisting of sequence of characters but cannot be translated into other
+              languages</paragraph>"""),
+            remarks=[],
+            parsed=...),
+          parsed=...),
+        EnumerationLiteral(
+          name='String_translatable',
+          value='STRING_TRANSLATABLE',
+          description=DescriptionOfEnumerationLiteral(
+            summary=textwrap.dedent("""\
+              <paragraph>values containing string but shall be represented as different string in different
+              languages</paragraph>"""),
+            remarks=[],
+            parsed=...),
+          parsed=...),
+        EnumerationLiteral(
+          name='Integer_measure',
+          value='INTEGER_MEASURE',
+          description=DescriptionOfEnumerationLiteral(
+            summary=textwrap.dedent("""\
+              <paragraph>values containing values that are measure of type INTEGER. In addition such a value
+              comes with a physical unit.</paragraph>"""),
+            remarks=[],
+            parsed=...),
+          parsed=...),
+        EnumerationLiteral(
+          name='Integer_count',
+          value='INTEGER_COUNT',
+          description=DescriptionOfEnumerationLiteral(
+            summary='<paragraph>values containing values of type INTEGER but are no currencies or measures</paragraph>',
+            remarks=[],
+            parsed=...),
+          parsed=...),
+        EnumerationLiteral(
+          name='Integer_currency',
+          value='INTEGER_CURRENCY',
+          description=DescriptionOfEnumerationLiteral(
+            summary='<paragraph>values containing values of type INTEGER that are currencies</paragraph>',
+            remarks=[],
+            parsed=...),
+          parsed=...),
+        EnumerationLiteral(
+          name='Real_measure',
+          value='REAL_MEASURE',
+          description=DescriptionOfEnumerationLiteral(
+            summary=textwrap.dedent("""\
+              <paragraph>values containing values that are measures of type REAL. In addition such a value
+              comes with a physical unit.</paragraph>"""),
+            remarks=[],
+            parsed=...),
+          parsed=...),
+        EnumerationLiteral(
+          name='Real_count',
+          value='REAL_COUNT',
+          description=DescriptionOfEnumerationLiteral(
+            summary=textwrap.dedent("""\
+              <paragraph>values containing numbers that can be written as a terminating or non-terminating
+              decimal; a rational or irrational number but are no currencies or measures</paragraph>"""),
+            remarks=[],
+            parsed=...),
+          parsed=...),
+        EnumerationLiteral(
+          name='Real_currency',
+          value='REAL_CURRENCY',
+          description=DescriptionOfEnumerationLiteral(
+            summary='<paragraph>values containing values of type REAL that are currencies</paragraph>',
+            remarks=[],
+            parsed=...),
+          parsed=...),
+        EnumerationLiteral(
+          name='Boolean',
+          value='BOOLEAN',
+          description=DescriptionOfEnumerationLiteral(
+            summary='<paragraph>values representing truth of logic or Boolean algebra (TRUE, FALSE)</paragraph>',
+            remarks=[],
+            parsed=...),
+          parsed=...),
+        EnumerationLiteral(
+          name='IRI',
+          value='IRI',
+          description=DescriptionOfEnumerationLiteral(
+            summary='<paragraph>values containing values of type STRING conformant to Rfc 3987</paragraph>',
+            remarks=[
+              textwrap.dedent("""\
+                <note><paragraph>In IEC61360-1 (2017) only URI is supported.
+                An IRI type allows in particular to express an URL or an URI.</paragraph></note>""")],
+            parsed=...),
+          parsed=...),
+        EnumerationLiteral(
+          name='IRDI',
+          value='IRDI',
+          description=DescriptionOfEnumerationLiteral(
+            summary='<paragraph>values conforming to ISO/IEC 11179 series global identifier sequences</paragraph>',
+            remarks=[
+              '<paragraph>IRDI can be used instead of the more specific data types ICID or ISO29002_IRDI.</paragraph>',
+              textwrap.dedent("""\
+                <paragraph>ICID values are value conformant to an IRDI, where the delimiter between RAI and ID
+                is “#” while the delimiter between DI and VI is confined to “##”</paragraph>"""),
+              textwrap.dedent("""\
+                <paragraph>ISO29002_IRDI values are values containing a global identifier that identifies an
+                administrated item in a registry. The structure of this identifier complies with
+                identifier syntax defined in ISO/TS 29002-5. The identifier shall fulfil the
+                requirements specified in ISO/TS 29002-5 for an "international registration data
+                identifier" (IRDI).</paragraph>""")],
+            parsed=...),
+          parsed=...),
+        EnumerationLiteral(
+          name='Rational',
+          value='RATIONAL',
+          description=DescriptionOfEnumerationLiteral(
+            summary='<paragraph>values containing values of type rational</paragraph>',
+            remarks=[],
+            parsed=...),
+          parsed=...),
+        EnumerationLiteral(
+          name='Rational_measure',
+          value='RATIONAL_MEASURE',
+          description=DescriptionOfEnumerationLiteral(
+            summary=textwrap.dedent("""\
+              <paragraph>values containing values of type rational. In addition such a value comes with a
+              physical unit.</paragraph>"""),
+            remarks=[],
+            parsed=...),
+          parsed=...),
+        EnumerationLiteral(
+          name='Time',
+          value='TIME',
+          description=DescriptionOfEnumerationLiteral(
+            summary=textwrap.dedent("""\
+              <paragraph>values containing a time, conformant to ISO 8601:2004 but restricted to what is
+              allowed in the corresponding type in xml.</paragraph>"""),
+            remarks=[
+              '<paragraph>Format hh:mm (ECLASS)</paragraph>',
+              textwrap.dedent("""\
+                <paragraph>Example from IEC 61360-1:2017: "13:20:00-05:00" is the [TIME] representation of:
+                1.20 p.m. for Eastern Standard Time, which is 5 hours behind Coordinated
+                Universal Time (UTC).</paragraph>""")],
+            parsed=...),
+          parsed=...),
+        EnumerationLiteral(
+          name='Timestamp',
+          value='TIMESTAMP',
+          description=DescriptionOfEnumerationLiteral(
+            summary=textwrap.dedent("""\
+              <paragraph>values containing a time, conformant to ISO 8601:2004 but restricted to what is
+              allowed in the corresponding type in xml.</paragraph>"""),
+            remarks=[
+              '<paragraph>Format yyyy-mm-dd hh:mm (ECLASS)</paragraph>'],
+            parsed=...),
+          parsed=...),
+        EnumerationLiteral(
+          name='File',
+          value='FILE',
+          description=DescriptionOfEnumerationLiteral(
+            summary=textwrap.dedent("""\
+              <paragraph>values containing an address to a file. The values are of type URI and can represent
+              an absolute or relative path.</paragraph>"""),
+            remarks=[
+              '<note><paragraph>IEC61360 does not support the file type.</paragraph></note>'],
+            parsed=...),
+          parsed=...),
+        EnumerationLiteral(
+          name='HTML',
+          value='HTML',
+          description=DescriptionOfEnumerationLiteral(
+            summary=textwrap.dedent("""\
+              <paragraph>Values containing string with any sequence of characters, using the syntax of HTML5
+              (see W3C Recommendation 28:2014)</paragraph>"""),
+            remarks=[],
+            parsed=...),
+          parsed=...),
+        EnumerationLiteral(
+          name='Blob',
+          value='BLOB',
+          description=DescriptionOfEnumerationLiteral(
+            summary='<paragraph>values containing the content of a file. Values may be binaries.</paragraph>',
+            remarks=[
+              '<paragraph>HTML conformant to HTML5 is a special blob.</paragraph>',
+              textwrap.dedent("""\
+                <paragraph>In IEC61360 binary is for a sequence of bits, each bit being represented by “0” and
+                “1” only. A binary is a blob but a blob may also contain other source code.</paragraph>""")],
+            parsed=...),
+          parsed=...)],
+      reference_in_the_book=ReferenceInTheBook(
+        section=[
+          6,
+          3,
+          3,
+          1],
+        index=1,
+        fragment='6.3.3.1 Data Specification IEC61360 Template Attributes'),
+      description=None,
+      literals_by_name=...,
+      literal_id_set=...,
+      parsed=...),
+    Enumeration(
+      name='Concept_descriptions_categories',
+      literals=[
+        EnumerationLiteral(
+          name='Application_class',
+          value='APPLICATION_CLASS',
+          description=None,
+          parsed=...),
+        EnumerationLiteral(
+          name='Capability',
+          value='CAPABILITY',
+          description=None,
+          parsed=...),
+        EnumerationLiteral(
+          name='Collections',
+          value='COLLECTIONS',
+          description=None,
+          parsed=...),
+        EnumerationLiteral(
+          name='Documentation',
+          value='DOCUMENTATION',
+          description=None,
+          parsed=...),
+        EnumerationLiteral(
+          name='Entity',
+          value='ENTITY',
+          description=None,
+          parsed=...),
+        EnumerationLiteral(
+          name='Event',
+          value='EVENT',
+          description=None,
+          parsed=...),
+        EnumerationLiteral(
+          name='Function',
+          value='FUNCTION',
+          description=None,
+          parsed=...),
+        EnumerationLiteral(
+          name='Property',
+          value='PROPERTY',
+          description=None,
+          parsed=...),
+        EnumerationLiteral(
+          name='Value',
+          value='VALUE',
+          description=None,
+          parsed=...),
+        EnumerationLiteral(
+          name='Range',
+          value='RANGE',
+          description=None,
+          parsed=...),
+        EnumerationLiteral(
+          name='Qualifier_type',
+          value='QUALIFIER_TYPE',
+          description=None,
+          parsed=...),
+        EnumerationLiteral(
+          name='Referencing',
+          value='REFERENCING',
+          description=None,
+          parsed=...),
+        EnumerationLiteral(
+          name='Relationship',
+          value='RELATIONSHIP',
+          description=None,
+          parsed=...)],
+      reference_in_the_book=ReferenceInTheBook(
+        section=[
+          6,
+          3,
+          4],
+        index=0,
+        fragment='6.3.4 Category of Concept Descriptions'),
+      description=None,
+      literals_by_name=...,
+      literal_id_set=...,
+      parsed=...),
+    Enumeration(
+      name='Level_type',
+      literals=[
+        EnumerationLiteral(
+          name='Min',
+          value='Min',
+          description=None,
+          parsed=...),
+        EnumerationLiteral(
+          name='Max',
+          value='Max',
+          description=None,
+          parsed=...),
+        EnumerationLiteral(
+          name='Nom',
+          value='Nom',
+          description=None,
+          parsed=...),
+        EnumerationLiteral(
+          name='Typ',
+          value='Typ',
+          description=None,
+          parsed=...)],
+      reference_in_the_book=ReferenceInTheBook(
+        section=[
+          6,
+          3,
+          3,
+          1],
+        index=4,
+        fragment='6.3.3.1 Data Specification IEC61360 Template Attributes'),
+      description=None,
+      literals_by_name=...,
+      literal_id_set=...,
+      parsed=...),
+    ConcreteClass(
+      name='Value_reference_pair',
+      inheritances=[],
+      inheritance_id_set=...,
+      is_implementation_specific=False,
+      interface=None,
+      descendant_id_set=...,
+      concrete_descendants=[],
+      properties=[
+        Property(
+          name='value',
+          type_annotation=PrimitiveTypeAnnotation(
+            a_type='STR',
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>The value of the referenced concept definition of the value in valueId.</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Value_reference_pair',
+          parsed=...),
+        Property(
+          name='value_id',
+          type_annotation=OurTypeAnnotation(
+            our_type='Reference to our type Reference',
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>Global unique id of the value.</paragraph>',
+            remarks=[
+              '<note><paragraph>It is recommended to use a global reference.</paragraph></note>'],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Value_reference_pair',
+          parsed=...)],
+      methods=[],
+      constructor=Constructor(
+        name='__init__',
+        arguments=[
+          Argument(
+            name='value',
+            type_annotation=PrimitiveTypeAnnotation(
+              a_type='STR',
+              parsed=...),
+            default=None,
+            parsed=...),
+          Argument(
+            name='value_id',
+            type_annotation=OurTypeAnnotation(
+              our_type='Reference to our type Reference',
+              parsed=...),
+            default=None,
+            parsed=...)],
+        returns=None,
+        description=None,
+        contracts=Contracts(
+          preconditions=[],
+          snapshots=[],
+          postconditions=[]),
+        parsed=...,
+        arguments_by_name=...,
+        is_implementation_specific=False,
+        statements=[
+          textwrap.dedent("""\
+            AssignArgument(
+              name='value',
+              argument='value',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='value_id',
+              argument='value_id',
+              default=None)""")]),
+      invariants=[],
+      serialization=Serialization(
+        with_model_type=False),
+      reference_in_the_book=ReferenceInTheBook(
+        section=[
+          6,
+          3,
+          3,
+          1],
+        index=3,
+        fragment='4.8.2 Predefined Templates for Property and Value Descriptions'),
+      description=DescriptionOfOurType(
+        summary=textwrap.dedent("""\
+          <paragraph>A value reference pair within a value list. Each value has a global unique id
+          defining its semantic.</paragraph>"""),
+        remarks=[],
+        constraints_by_identifier=[],
+        parsed=...),
+      parsed=...,
+      properties_by_name=...,
+      property_id_set=...,
+      methods_by_name=...,
+      invariant_id_set=...),
+    ConcreteClass(
+      name='Value_list',
+      inheritances=[],
+      inheritance_id_set=...,
+      is_implementation_specific=False,
+      interface=None,
+      descendant_id_set=...,
+      concrete_descendants=[],
+      properties=[
+        Property(
+          name='value_reference_pair_types',
+          type_annotation=ListTypeAnnotation(
+            items=OurTypeAnnotation(
+              our_type='Reference to our type Value_reference_pair',
+              parsed=...),
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>A pair of a value together with its global unique id.</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Value_list',
+          parsed=...)],
+      methods=[],
+      constructor=Constructor(
+        name='__init__',
+        arguments=[
+          Argument(
+            name='value_reference_pair_types',
+            type_annotation=ListTypeAnnotation(
+              items=OurTypeAnnotation(
+                our_type='Reference to our type Value_reference_pair',
+                parsed=...),
+              parsed=...),
+            default=None,
+            parsed=...)],
+        returns=None,
+        description=None,
+        contracts=Contracts(
+          preconditions=[],
+          snapshots=[],
+          postconditions=[]),
+        parsed=...,
+        arguments_by_name=...,
+        is_implementation_specific=False,
+        statements=[
+          textwrap.dedent("""\
+            AssignArgument(
+              name='value_reference_pair_types',
+              argument='value_reference_pair_types',
+              default=None)""")]),
+      invariants=[
+        Invariant(
+          description=None,
+          body=textwrap.dedent("""\
+            Comparison(
+              left=FunctionCall(
+                name='len',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='value_reference_pair_types',
+                    original_node=...)],
+                original_node=...),
+              op='GE',
+              right=Constant(
+                value=1,
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to ConcreteClass Value_list',
+          parsed=...)],
+      serialization=Serialization(
+        with_model_type=False),
+      reference_in_the_book=ReferenceInTheBook(
+        section=[
+          6,
+          3,
+          3,
+          1],
+        index=2,
+        fragment='6.3.3.1 Data Specification IEC61360 Template Attributes'),
+      description=DescriptionOfOurType(
+        summary='<paragraph>A set of value reference pairs.</paragraph>',
+        remarks=[],
+        constraints_by_identifier=[],
+        parsed=...),
+      parsed=...,
+      properties_by_name=...,
+      property_id_set=...,
+      methods_by_name=...,
+      invariant_id_set=...),
+    ConcreteClass(
+      name='Data_specification_IEC_61360',
+      inheritances=[
+        'Reference to AbstractClass Data_specification_content'],
+      inheritance_id_set=...,
+      is_implementation_specific=False,
+      interface=None,
+      descendant_id_set=...,
+      concrete_descendants=[],
+      properties=[
+        Property(
+          name='preferred_name',
+          type_annotation=OurTypeAnnotation(
+            our_type='Reference to our type Lang_string_set',
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>Preferred name</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[
+              [
+                'AASc-002',
+                '<field_body><paragraph><ReferenceToAttribute refuri="~preferred_name">~preferred_name</ReferenceToAttribute> shall be provided at least in English.</paragraph></field_body>']],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Data_specification_IEC_61360',
+          parsed=...),
+        Property(
+          name='short_name',
+          type_annotation=OptionalTypeAnnotation(
+            value=OurTypeAnnotation(
+              our_type='Reference to our type Lang_string_set',
+              parsed=...),
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>Short name</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Data_specification_IEC_61360',
+          parsed=...),
+        Property(
+          name='unit',
+          type_annotation=OptionalTypeAnnotation(
+            value=OurTypeAnnotation(
+              our_type='Reference to our type Non_empty_string',
+              parsed=...),
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>Unit</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Data_specification_IEC_61360',
+          parsed=...),
+        Property(
+          name='unit_id',
+          type_annotation=OptionalTypeAnnotation(
+            value=OurTypeAnnotation(
+              our_type='Reference to our type Reference',
+              parsed=...),
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>Unique unit id</paragraph>',
+            remarks=[
+              textwrap.dedent("""\
+                <paragraph><ReferenceToAttribute refuri="~unit">~unit</ReferenceToAttribute> and <ReferenceToAttribute refuri="~unit_id">~unit_id</ReferenceToAttribute> need to be consistent if both attributes
+                are set</paragraph>"""),
+              '<note><paragraph>It is recommended to use a global reference.</paragraph></note>',
+              textwrap.dedent("""\
+                <note><paragraph>Although the <ReferenceToAttribute refuri="~unit_id">~unit_id</ReferenceToAttribute> is a global reference there might exist a
+                <ReferenceToOurType refuri=".Concept_description">.Concept_description</ReferenceToOurType>
+                with data specification <ReferenceToOurType refuri=".Data_specification_physical_unit">.Data_specification_physical_unit</ReferenceToOurType> with
+                the same ID.</paragraph></note>""")],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Data_specification_IEC_61360',
+          parsed=...),
+        Property(
+          name='source_of_definition',
+          type_annotation=OptionalTypeAnnotation(
+            value=OurTypeAnnotation(
+              our_type='Reference to our type Non_empty_string',
+              parsed=...),
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>Source of definition</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Data_specification_IEC_61360',
+          parsed=...),
+        Property(
+          name='symbol',
+          type_annotation=OptionalTypeAnnotation(
+            value=OurTypeAnnotation(
+              our_type='Reference to our type Non_empty_string',
+              parsed=...),
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>Symbol</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Data_specification_IEC_61360',
+          parsed=...),
+        Property(
+          name='data_type',
+          type_annotation=OptionalTypeAnnotation(
+            value=OurTypeAnnotation(
+              our_type='Reference to our type Data_type_IEC_61360',
+              parsed=...),
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>Data Type</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Data_specification_IEC_61360',
+          parsed=...),
+        Property(
+          name='definition',
+          type_annotation=OptionalTypeAnnotation(
+            value=OurTypeAnnotation(
+              our_type='Reference to our type Lang_string_set',
+              parsed=...),
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>Definition in different languages</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Data_specification_IEC_61360',
+          parsed=...),
+        Property(
+          name='value_format',
+          type_annotation=OptionalTypeAnnotation(
+            value=OurTypeAnnotation(
+              our_type='Reference to our type Non_empty_string',
+              parsed=...),
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>Value Format</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Data_specification_IEC_61360',
+          parsed=...),
+        Property(
+          name='value_list',
+          type_annotation=OptionalTypeAnnotation(
+            value=OurTypeAnnotation(
+              our_type='Reference to our type Value_list',
+              parsed=...),
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>List of allowed values</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Data_specification_IEC_61360',
+          parsed=...),
+        Property(
+          name='value',
+          type_annotation=OptionalTypeAnnotation(
+            value=PrimitiveTypeAnnotation(
+              a_type='STR',
+              parsed=...),
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>Value</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Data_specification_IEC_61360',
+          parsed=...),
+        Property(
+          name='level_type',
+          type_annotation=OptionalTypeAnnotation(
+            value=OurTypeAnnotation(
+              our_type='Reference to our type Level_type',
+              parsed=...),
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>Set of levels.</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Data_specification_IEC_61360',
+          parsed=...)],
+      methods=[],
+      constructor=Constructor(
+        name='__init__',
+        arguments=[
+          Argument(
+            name='preferred_name',
+            type_annotation=OurTypeAnnotation(
+              our_type='Reference to our type Lang_string_set',
+              parsed=...),
+            default=None,
+            parsed=...),
+          Argument(
+            name='short_name',
+            type_annotation=OptionalTypeAnnotation(
+              value=OurTypeAnnotation(
+                our_type='Reference to our type Lang_string_set',
+                parsed=...),
+              parsed=...),
+            default=DefaultPrimitive(
+              value=None,
+              parsed=...),
+            parsed=...),
+          Argument(
+            name='unit',
+            type_annotation=OptionalTypeAnnotation(
+              value=OurTypeAnnotation(
+                our_type='Reference to our type Non_empty_string',
+                parsed=...),
+              parsed=...),
+            default=DefaultPrimitive(
+              value=None,
+              parsed=...),
+            parsed=...),
+          Argument(
+            name='unit_id',
+            type_annotation=OptionalTypeAnnotation(
+              value=OurTypeAnnotation(
+                our_type='Reference to our type Reference',
+                parsed=...),
+              parsed=...),
+            default=DefaultPrimitive(
+              value=None,
+              parsed=...),
+            parsed=...),
+          Argument(
+            name='source_of_definition',
+            type_annotation=OptionalTypeAnnotation(
+              value=OurTypeAnnotation(
+                our_type='Reference to our type Non_empty_string',
+                parsed=...),
+              parsed=...),
+            default=DefaultPrimitive(
+              value=None,
+              parsed=...),
+            parsed=...),
+          Argument(
+            name='symbol',
+            type_annotation=OptionalTypeAnnotation(
+              value=OurTypeAnnotation(
+                our_type='Reference to our type Non_empty_string',
+                parsed=...),
+              parsed=...),
+            default=DefaultPrimitive(
+              value=None,
+              parsed=...),
+            parsed=...),
+          Argument(
+            name='data_type',
+            type_annotation=OptionalTypeAnnotation(
+              value=OurTypeAnnotation(
+                our_type='Reference to our type Data_type_IEC_61360',
+                parsed=...),
+              parsed=...),
+            default=DefaultPrimitive(
+              value=None,
+              parsed=...),
+            parsed=...),
+          Argument(
+            name='definition',
+            type_annotation=OptionalTypeAnnotation(
+              value=OurTypeAnnotation(
+                our_type='Reference to our type Lang_string_set',
+                parsed=...),
+              parsed=...),
+            default=DefaultPrimitive(
+              value=None,
+              parsed=...),
+            parsed=...),
+          Argument(
+            name='value_format',
+            type_annotation=OptionalTypeAnnotation(
+              value=OurTypeAnnotation(
+                our_type='Reference to our type Non_empty_string',
+                parsed=...),
+              parsed=...),
+            default=DefaultPrimitive(
+              value=None,
+              parsed=...),
+            parsed=...),
+          Argument(
+            name='value_list',
+            type_annotation=OptionalTypeAnnotation(
+              value=OurTypeAnnotation(
+                our_type='Reference to our type Value_list',
+                parsed=...),
+              parsed=...),
+            default=DefaultPrimitive(
+              value=None,
+              parsed=...),
+            parsed=...),
+          Argument(
+            name='value',
+            type_annotation=OptionalTypeAnnotation(
+              value=PrimitiveTypeAnnotation(
+                a_type='STR',
+                parsed=...),
+              parsed=...),
+            default=DefaultPrimitive(
+              value=None,
+              parsed=...),
+            parsed=...),
+          Argument(
+            name='level_type',
+            type_annotation=OptionalTypeAnnotation(
+              value=OurTypeAnnotation(
+                our_type='Reference to our type Level_type',
+                parsed=...),
+              parsed=...),
+            default=DefaultPrimitive(
+              value=None,
+              parsed=...),
+            parsed=...)],
+        returns=None,
+        description=None,
+        contracts=Contracts(
+          preconditions=[],
+          snapshots=[],
+          postconditions=[]),
+        parsed=...,
+        arguments_by_name=...,
+        is_implementation_specific=False,
+        statements=[
+          textwrap.dedent("""\
+            AssignArgument(
+              name='preferred_name',
+              argument='preferred_name',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='short_name',
+              argument='short_name',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='unit',
+              argument='unit',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='unit_id',
+              argument='unit_id',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='source_of_definition',
+              argument='source_of_definition',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='symbol',
+              argument='symbol',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='data_type',
+              argument='data_type',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='definition',
+              argument='definition',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='value_format',
+              argument='value_format',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='value_list',
+              argument='value_list',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='value',
+              argument='value',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='level_type',
+              argument='level_type',
+              default=None)""")]),
+      invariants=[],
+      serialization=Serialization(
+        with_model_type=True),
+      reference_in_the_book=ReferenceInTheBook(
+        section=[
+          6,
+          3,
+          3,
+          1],
+        index=0,
+        fragment='6.3.3.1 Data Specification IEC61360 Template Attributes'),
+      description=DescriptionOfOurType(
+        summary=textwrap.dedent("""\
+          <paragraph>Content of data specification template for concept descriptions for properties,
+          values and value lists conformant to IEC 61360.</paragraph>"""),
+        remarks=[
+          textwrap.dedent("""\
+            <note><paragraph>IEC61360 requires also a globally unique identifier for a concept
+            description. This ID is not part of the data specification template.
+            Instead the <ReferenceToAttribute refuri="~Concept_description.id">~Concept_description.id</ReferenceToAttribute> as inherited via
+            <ReferenceToOurType refuri=".Identifiable">.Identifiable</ReferenceToOurType> is used. Same holds for administrative
+            information like the version and revision.</paragraph></note>"""),
+          textwrap.dedent("""\
+            <note><paragraph><ReferenceToAttribute refuri="Concept_description.id_short">Concept_description.id_short</ReferenceToAttribute> and <ReferenceToAttribute refuri="~short_name">~short_name</ReferenceToAttribute> are very
+            similar. However, in this case the decision was to add
+            <ReferenceToAttribute refuri="~short_name">~short_name</ReferenceToAttribute> explicitly to the data specification. Same holds for
+            <ReferenceToAttribute refuri="~Concept_description.display_name">~Concept_description.display_name</ReferenceToAttribute> and
+            <ReferenceToAttribute refuri="~preferred_name">~preferred_name</ReferenceToAttribute>. Same holds for
+            <ReferenceToAttribute refuri="Concept_description.description">Concept_description.description</ReferenceToAttribute> and <ReferenceToAttribute refuri="~definition">~definition</ReferenceToAttribute>.</paragraph></note>""")],
+        constraints_by_identifier=[
+          [
+            'AASd-010',
+            textwrap.dedent("""\
+              <field_body><paragraph>If <ReferenceToAttribute refuri="~value">~value</ReferenceToAttribute> is not empty then <ReferenceToAttribute refuri="~value_list">~value_list</ReferenceToAttribute> shall be empty
+              and vice versa.</paragraph></field_body>""")],
+          [
+            'AASd-009',
+            textwrap.dedent("""\
+              <field_body><paragraph>If <ReferenceToAttribute refuri="~data_type">~data_type</ReferenceToAttribute> one of: <literal>INTEGER_MEASURE</literal>, <literal>REAL_MEASURE</literal>,
+              <literal>RATIONAL_MEASURE</literal>, <literal>INTEGER_CURRENCY</literal>, <literal>REAL_CURRENCY</literal>, then
+              <ReferenceToAttribute refuri="~unit">~unit</ReferenceToAttribute> or <ReferenceToAttribute refuri="~unit_id">~unit_id</ReferenceToAttribute> shall be defined.</paragraph></field_body>""")]],
+        parsed=...),
+      parsed=...,
+      properties_by_name=...,
+      property_id_set=...,
+      methods_by_name=...,
+      invariant_id_set=...),
+    ConcreteClass(
+      name='Data_specification_physical_unit',
+      inheritances=[
+        'Reference to AbstractClass Data_specification_content'],
+      inheritance_id_set=...,
+      is_implementation_specific=False,
+      interface=None,
+      descendant_id_set=...,
+      concrete_descendants=[],
+      properties=[
+        Property(
+          name='unit_name',
+          type_annotation=OurTypeAnnotation(
+            our_type='Reference to our type Non_empty_string',
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>Name of the physical unit</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Data_specification_physical_unit',
+          parsed=...),
+        Property(
+          name='unit_symbol',
+          type_annotation=OurTypeAnnotation(
+            our_type='Reference to our type Non_empty_string',
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>Symbol for the physical unit</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Data_specification_physical_unit',
+          parsed=...),
+        Property(
+          name='definition',
+          type_annotation=OurTypeAnnotation(
+            our_type='Reference to our type Lang_string_set',
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>Definition in different languages</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Data_specification_physical_unit',
+          parsed=...),
+        Property(
+          name='SI_notation',
+          type_annotation=OptionalTypeAnnotation(
+            value=OurTypeAnnotation(
+              our_type='Reference to our type Non_empty_string',
+              parsed=...),
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>Notation of SI physical unit</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Data_specification_physical_unit',
+          parsed=...),
+        Property(
+          name='SI_name',
+          type_annotation=OptionalTypeAnnotation(
+            value=OurTypeAnnotation(
+              our_type='Reference to our type Non_empty_string',
+              parsed=...),
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>Name of SI physical unit</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Data_specification_physical_unit',
+          parsed=...),
+        Property(
+          name='DIN_notation',
+          type_annotation=OptionalTypeAnnotation(
+            value=OurTypeAnnotation(
+              our_type='Reference to our type Non_empty_string',
+              parsed=...),
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>Notation of physical unit conformant to DIN</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Data_specification_physical_unit',
+          parsed=...),
+        Property(
+          name='ECE_name',
+          type_annotation=OptionalTypeAnnotation(
+            value=OurTypeAnnotation(
+              our_type='Reference to our type Non_empty_string',
+              parsed=...),
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>Name of physical unit conformant to ECE</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Data_specification_physical_unit',
+          parsed=...),
+        Property(
+          name='ECE_code',
+          type_annotation=OptionalTypeAnnotation(
+            value=OurTypeAnnotation(
+              our_type='Reference to our type Non_empty_string',
+              parsed=...),
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>Code of physical unit conformant to ECE</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Data_specification_physical_unit',
+          parsed=...),
+        Property(
+          name='NIST_name',
+          type_annotation=OptionalTypeAnnotation(
+            value=OurTypeAnnotation(
+              our_type='Reference to our type Non_empty_string',
+              parsed=...),
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>Name of NIST physical unit</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Data_specification_physical_unit',
+          parsed=...),
+        Property(
+          name='source_of_definition',
+          type_annotation=OptionalTypeAnnotation(
+            value=OurTypeAnnotation(
+              our_type='Reference to our type Non_empty_string',
+              parsed=...),
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>Source of definition</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Data_specification_physical_unit',
+          parsed=...),
+        Property(
+          name='conversion_factor',
+          type_annotation=OptionalTypeAnnotation(
+            value=OurTypeAnnotation(
+              our_type='Reference to our type Non_empty_string',
+              parsed=...),
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>Conversion factor</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Data_specification_physical_unit',
+          parsed=...),
+        Property(
+          name='registration_authority_id',
+          type_annotation=OptionalTypeAnnotation(
+            value=OurTypeAnnotation(
+              our_type='Reference to our type Non_empty_string',
+              parsed=...),
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>Registration authority ID</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Data_specification_physical_unit',
+          parsed=...),
+        Property(
+          name='supplier',
+          type_annotation=OptionalTypeAnnotation(
+            value=OurTypeAnnotation(
+              our_type='Reference to our type Non_empty_string',
+              parsed=...),
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>Supplier</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Data_specification_physical_unit',
+          parsed=...)],
+      methods=[],
+      constructor=Constructor(
+        name='__init__',
+        arguments=[
+          Argument(
+            name='unit_name',
+            type_annotation=OurTypeAnnotation(
+              our_type='Reference to our type Non_empty_string',
+              parsed=...),
+            default=None,
+            parsed=...),
+          Argument(
+            name='unit_symbol',
+            type_annotation=OurTypeAnnotation(
+              our_type='Reference to our type Non_empty_string',
+              parsed=...),
+            default=None,
+            parsed=...),
+          Argument(
+            name='definition',
+            type_annotation=OurTypeAnnotation(
+              our_type='Reference to our type Lang_string_set',
+              parsed=...),
+            default=None,
+            parsed=...),
+          Argument(
+            name='SI_notation',
+            type_annotation=OptionalTypeAnnotation(
+              value=OurTypeAnnotation(
+                our_type='Reference to our type Non_empty_string',
+                parsed=...),
+              parsed=...),
+            default=DefaultPrimitive(
+              value=None,
+              parsed=...),
+            parsed=...),
+          Argument(
+            name='SI_name',
+            type_annotation=OptionalTypeAnnotation(
+              value=OurTypeAnnotation(
+                our_type='Reference to our type Non_empty_string',
+                parsed=...),
+              parsed=...),
+            default=DefaultPrimitive(
+              value=None,
+              parsed=...),
+            parsed=...),
+          Argument(
+            name='DIN_notation',
+            type_annotation=OptionalTypeAnnotation(
+              value=OurTypeAnnotation(
+                our_type='Reference to our type Non_empty_string',
+                parsed=...),
+              parsed=...),
+            default=DefaultPrimitive(
+              value=None,
+              parsed=...),
+            parsed=...),
+          Argument(
+            name='ECE_name',
+            type_annotation=OptionalTypeAnnotation(
+              value=OurTypeAnnotation(
+                our_type='Reference to our type Non_empty_string',
+                parsed=...),
+              parsed=...),
+            default=DefaultPrimitive(
+              value=None,
+              parsed=...),
+            parsed=...),
+          Argument(
+            name='ECE_code',
+            type_annotation=OptionalTypeAnnotation(
+              value=OurTypeAnnotation(
+                our_type='Reference to our type Non_empty_string',
+                parsed=...),
+              parsed=...),
+            default=DefaultPrimitive(
+              value=None,
+              parsed=...),
+            parsed=...),
+          Argument(
+            name='NIST_name',
+            type_annotation=OptionalTypeAnnotation(
+              value=OurTypeAnnotation(
+                our_type='Reference to our type Non_empty_string',
+                parsed=...),
+              parsed=...),
+            default=DefaultPrimitive(
+              value=None,
+              parsed=...),
+            parsed=...),
+          Argument(
+            name='source_of_definition',
+            type_annotation=OptionalTypeAnnotation(
+              value=OurTypeAnnotation(
+                our_type='Reference to our type Non_empty_string',
+                parsed=...),
+              parsed=...),
+            default=DefaultPrimitive(
+              value=None,
+              parsed=...),
+            parsed=...),
+          Argument(
+            name='conversion_factor',
+            type_annotation=OptionalTypeAnnotation(
+              value=OurTypeAnnotation(
+                our_type='Reference to our type Non_empty_string',
+                parsed=...),
+              parsed=...),
+            default=DefaultPrimitive(
+              value=None,
+              parsed=...),
+            parsed=...),
+          Argument(
+            name='registration_authority_id',
+            type_annotation=OptionalTypeAnnotation(
+              value=OurTypeAnnotation(
+                our_type='Reference to our type Non_empty_string',
+                parsed=...),
+              parsed=...),
+            default=DefaultPrimitive(
+              value=None,
+              parsed=...),
+            parsed=...),
+          Argument(
+            name='supplier',
+            type_annotation=OptionalTypeAnnotation(
+              value=OurTypeAnnotation(
+                our_type='Reference to our type Non_empty_string',
+                parsed=...),
+              parsed=...),
+            default=DefaultPrimitive(
+              value=None,
+              parsed=...),
+            parsed=...)],
+        returns=None,
+        description=None,
+        contracts=Contracts(
+          preconditions=[],
+          snapshots=[],
+          postconditions=[]),
+        parsed=...,
+        arguments_by_name=...,
+        is_implementation_specific=False,
+        statements=[
+          textwrap.dedent("""\
+            AssignArgument(
+              name='unit_name',
+              argument='unit_name',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='unit_symbol',
+              argument='unit_symbol',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='definition',
+              argument='definition',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='SI_notation',
+              argument='SI_notation',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='SI_name',
+              argument='SI_name',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='DIN_notation',
+              argument='DIN_notation',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='ECE_name',
+              argument='ECE_name',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='ECE_code',
+              argument='ECE_code',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='NIST_name',
+              argument='NIST_name',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='source_of_definition',
+              argument='source_of_definition',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='conversion_factor',
+              argument='conversion_factor',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='registration_authority_id',
+              argument='registration_authority_id',
+              default=None)"""),
+          textwrap.dedent("""\
+            AssignArgument(
+              name='supplier',
+              argument='supplier',
+              default=None)""")]),
+      invariants=[],
+      serialization=Serialization(
+        with_model_type=True),
+      reference_in_the_book=ReferenceInTheBook(
+        section=[
+          6,
+          4,
+          2,
+          1],
+        index=0,
+        fragment='6.4.2.1 Data Specification Template Physical Unit Attributes'),
+      description=None,
+      parsed=...,
+      properties_by_name=...,
+      property_id_set=...,
+      methods_by_name=...,
       invariant_id_set=...)],
   our_types_topologically_sorted=[
     'Reference to our type Has_data_specification',
@@ -22418,9 +22770,11 @@ SymbolTable(
     'Reference to our type Concept_description',
     'Reference to our type Non_empty_string',
     'Reference to our type Content_type',
-    'Reference to our type Data_specification',
     'Reference to our type Data_specification_content',
+    'Reference to our type Data_specification_IEC_61360',
+    'Reference to our type Data_specification_physical_unit',
     'Reference to our type Date_time_stamp_UTC',
+    'Reference to our type Embedded_data_specification',
     'Reference to our type Entity',
     'Reference to our type Environment',
     'Reference to our type Event_payload',
@@ -22446,7 +22800,9 @@ SymbolTable(
     'Reference to our type Submodel',
     'Reference to our type Submodel_element_collection',
     'Reference to our type Submodel_element_list',
-    'Reference to our type Value_data_type'],
+    'Reference to our type Value_data_type',
+    'Reference to our type Value_list',
+    'Reference to our type Value_reference_pair'],
   constants=[
     ConstantSetOfPrimitives(
       name='Valid_categories_for_data_element',
@@ -24377,7 +24733,14 @@ SymbolTable(
           <literal>AasSubmodelElements</literal>.</paragraph><paragraph>To avoid confusion, we introduce a set of <ReferenceToOurType refuri=".Key_types">.Key_types</ReferenceToOurType>,
           <ReferenceToConstant refuri=".AAS_submodel_elements_as_keys">.AAS_submodel_elements_as_keys</ReferenceToConstant> to represent the first context (key type
           in a reference). The enumeration <ReferenceToOurType refuri=".AAS_submodel_elements">.AAS_submodel_elements</ReferenceToOurType> is kept as designator
-          for <ReferenceToAttribute refuri="~Submodel_element_list.type_value_list_element">~Submodel_element_list.type_value_list_element</ReferenceToAttribute>.</paragraph></list_item></bullet_list>""")],
+          for <ReferenceToAttribute refuri="~Submodel_element_list.type_value_list_element">~Submodel_element_list.type_value_list_element</ReferenceToAttribute>.</paragraph></list_item></bullet_list>"""),
+        textwrap.dedent("""\
+          <paragraph>Concerning the data specifications, we embed them within
+          <ReferenceToOurType refuri=".Has_data_specification">.Has_data_specification</ReferenceToOurType> instead of referencing them <emphasis>via</emphasis> a global reference.
+          The working group decided to change the rules for serialization <emphasis>after</emphasis> the book was
+          published. The data specifications are critical in applications, but there is no
+          possibility to access them through a data channel as they are not part of
+          an environment.</paragraph>""")],
       constraints_by_identifier=[
         [
           'AASd-120',
@@ -24389,4 +24752,5 @@ SymbolTable(
           '<field_body><paragraph><ReferenceToAttribute refuri="Referable.id_short">Referable.id_short</ReferenceToAttribute> of <ReferenceToOurType refuri=".Referable">.Referable</ReferenceToOurType>\'s shall be matched case-sensitive.</paragraph></field_body>']],
       parsed=...),
     book_url='https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/Details_of_the_Asset_Administration_Shell_Part1_V3.pdf?__blob=publicationFile&v=10',
-    book_version='V3.0RC02'))
+    book_version='V3.0RC02',
+    xml_namespace='http://www.admin-shell.io/aas/3/0/RC02'))

--- a/test_data/intermediate/unexpected/constant_set/of_enum/enumeration_literals_in_subset_outside_of_superset/meta_model.py
+++ b/test_data/intermediate/unexpected/constant_set/of_enum/enumeration_literals_in_subset_outside_of_superset/meta_model.py
@@ -18,3 +18,4 @@ Another_set: Set[Some_enum] = constant_set(
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/unexpected/constant_set/of_enum/invalid_literal/meta_model.py
+++ b/test_data/intermediate/unexpected/constant_set/of_enum/invalid_literal/meta_model.py
@@ -9,3 +9,4 @@ Some_set: Set[Some_enum] = constant_set(
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/unexpected/constant_set/of_enum/mismatch_between_enumeration_and_literal/meta_model.py
+++ b/test_data/intermediate/unexpected/constant_set/of_enum/mismatch_between_enumeration_and_literal/meta_model.py
@@ -28,3 +28,4 @@ Another_set: Set[Another_enum] = constant_set(
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/unexpected/constant_set/of_enum/mismatch_in_enumerations_between_subset_and_superset/meta_model.py
+++ b/test_data/intermediate/unexpected/constant_set/of_enum/mismatch_in_enumerations_between_subset_and_superset/meta_model.py
@@ -19,3 +19,4 @@ Some_set: Set[Some_enum] = constant_set(
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/unexpected/constant_set/of_str/literals_in_subset_outside_of_superset/meta_model.py
+++ b/test_data/intermediate/unexpected/constant_set/of_str/literals_in_subset_outside_of_superset/meta_model.py
@@ -16,3 +16,4 @@ Another_set: Set[str] = constant_set(
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/unexpected/constant_set/of_str/mismatch_between_type_annotation_and_literals/meta_model.py
+++ b/test_data/intermediate/unexpected/constant_set/of_str/mismatch_between_type_annotation_and_literals/meta_model.py
@@ -8,3 +8,4 @@ Some_set: Set[int] = constant_set(
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/unexpected/constant_set/of_str/superset_and_subset_mismatch_in_type/meta_model.py
+++ b/test_data/intermediate/unexpected/constant_set/of_str/superset_and_subset_mismatch_in_type/meta_model.py
@@ -10,3 +10,4 @@ Another_set: Set[str] = constant_set(
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/unexpected/constraints/dangling_constraintref/meta_model.py
+++ b/test_data/intermediate/unexpected/constraints/dangling_constraintref/meta_model.py
@@ -16,3 +16,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/unexpected/constraints/duplicate_constraints/meta_model.py
+++ b/test_data/intermediate/unexpected/constraints/duplicate_constraints/meta_model.py
@@ -18,3 +18,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/unexpected/documentation/unexpected_documentation_elements/meta_model.py
+++ b/test_data/intermediate/unexpected/documentation/unexpected_documentation_elements/meta_model.py
@@ -32,3 +32,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/unexpected/invariant/class_invariant_uses_re/meta_model.py
+++ b/test_data/intermediate/unexpected/invariant/class_invariant_uses_re/meta_model.py
@@ -8,3 +8,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/unexpected/invariant/invariant_of_constrained_primitive_uses_re/meta_model.py
+++ b/test_data/intermediate/unexpected/invariant/invariant_of_constrained_primitive_uses_re/meta_model.py
@@ -5,3 +5,4 @@ class Something(str):
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/unexpected/invariant/unexpected_argument_count_to_len/meta_model.py
+++ b/test_data/intermediate/unexpected/invariant/unexpected_argument_count_to_len/meta_model.py
@@ -17,3 +17,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/unexpected/invariant/unhandled_built_in_function/meta_model.py
+++ b/test_data/intermediate/unexpected/invariant/unhandled_built_in_function/meta_model.py
@@ -13,3 +13,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/unexpected/method_definitions/non_constant_default/meta_model.py
+++ b/test_data/intermediate/unexpected/method_definitions/non_constant_default/meta_model.py
@@ -5,3 +5,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/unexpected/properties_and_constructor_arguments_do_not_match/after_inheritance/meta_model.py
+++ b/test_data/intermediate/unexpected/properties_and_constructor_arguments_do_not_match/after_inheritance/meta_model.py
@@ -56,3 +56,4 @@ class Something(SomethingAbstract):
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/unexpected/properties_and_constructor_arguments_do_not_match/within_class/meta_model.py
+++ b/test_data/intermediate/unexpected/properties_and_constructor_arguments_do_not_match/within_class/meta_model.py
@@ -20,3 +20,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/jsonschema/test_main/aas_core_meta.v3rc2/expected_output/schema.json
+++ b/test_data/jsonschema/test_main/aas_core_meta.v3rc2/expected_output/schema.json
@@ -219,30 +219,137 @@
     "DataElement": {
       "$ref": "#/definitions/SubmodelElement"
     },
-    "DataSpecification": {
+    "DataSpecificationContent": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "string",
-          "minLength": 1
-        },
-        "dataSpecificationContent": {
-          "$ref": "#/definitions/DataSpecificationContent"
-        },
-        "administration": {
-          "$ref": "#/definitions/AdministrativeInformation"
-        },
-        "description": {
-          "$ref": "#/definitions/LangStringSet"
+        "modelType": {
+          "$ref": "#/definitions/ModelType"
         }
       },
       "required": [
-        "id",
-        "dataSpecificationContent"
+        "modelType"
       ]
     },
-    "DataSpecificationContent": {
-      "type": "object"
+    "DataSpecificationIEC61360": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/DataSpecificationContent"
+        },
+        {
+          "properties": {
+            "preferredName": {
+              "$ref": "#/definitions/LangStringSet"
+            },
+            "shortName": {
+              "$ref": "#/definitions/LangStringSet"
+            },
+            "unit": {
+              "type": "string",
+              "minLength": 1
+            },
+            "unitId": {
+              "$ref": "#/definitions/Reference"
+            },
+            "sourceOfDefinition": {
+              "type": "string",
+              "minLength": 1
+            },
+            "symbol": {
+              "type": "string",
+              "minLength": 1
+            },
+            "dataType": {
+              "$ref": "#/definitions/DataTypeIEC61360"
+            },
+            "definition": {
+              "$ref": "#/definitions/LangStringSet"
+            },
+            "valueFormat": {
+              "type": "string",
+              "minLength": 1
+            },
+            "valueList": {
+              "$ref": "#/definitions/ValueList"
+            },
+            "value": {
+              "type": "string"
+            },
+            "levelType": {
+              "$ref": "#/definitions/LevelType"
+            }
+          },
+          "required": [
+            "preferredName"
+          ]
+        }
+      ]
+    },
+    "DataSpecificationPhysicalUnit": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/DataSpecificationContent"
+        },
+        {
+          "properties": {
+            "unitName": {
+              "type": "string",
+              "minLength": 1
+            },
+            "unitSymbol": {
+              "type": "string",
+              "minLength": 1
+            },
+            "definition": {
+              "$ref": "#/definitions/LangStringSet"
+            },
+            "siNotation": {
+              "type": "string",
+              "minLength": 1
+            },
+            "siName": {
+              "type": "string",
+              "minLength": 1
+            },
+            "dinNotation": {
+              "type": "string",
+              "minLength": 1
+            },
+            "eceName": {
+              "type": "string",
+              "minLength": 1
+            },
+            "eceCode": {
+              "type": "string",
+              "minLength": 1
+            },
+            "nistName": {
+              "type": "string",
+              "minLength": 1
+            },
+            "sourceOfDefinition": {
+              "type": "string",
+              "minLength": 1
+            },
+            "conversionFactor": {
+              "type": "string",
+              "minLength": 1
+            },
+            "registrationAuthorityId": {
+              "type": "string",
+              "minLength": 1
+            },
+            "supplier": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": [
+            "unitName",
+            "unitSymbol",
+            "definition"
+          ]
+        }
+      ]
     },
     "DataTypeDefXsd": {
       "type": "string",
@@ -282,11 +389,50 @@
         "xs:negativeInteger"
       ]
     },
+    "DataTypeIEC61360": {
+      "type": "string",
+      "enum": [
+        "DATE",
+        "STRING",
+        "STRING_TRANSLATABLE",
+        "INTEGER_MEASURE",
+        "INTEGER_COUNT",
+        "INTEGER_CURRENCY",
+        "REAL_MEASURE",
+        "REAL_COUNT",
+        "REAL_CURRENCY",
+        "BOOLEAN",
+        "IRI",
+        "IRDI",
+        "RATIONAL",
+        "RATIONAL_MEASURE",
+        "TIME",
+        "TIMESTAMP",
+        "FILE",
+        "HTML",
+        "BLOB"
+      ]
+    },
     "Direction": {
       "type": "string",
       "enum": [
         "INPUT",
         "OUTPUT"
+      ]
+    },
+    "EmbeddedDataSpecification": {
+      "type": "object",
+      "properties": {
+        "dataSpecification": {
+          "$ref": "#/definitions/Reference"
+        },
+        "dataSpecificationContent": {
+          "$ref": "#/definitions/DataSpecificationContent"
+        }
+      },
+      "required": [
+        "dataSpecification",
+        "dataSpecificationContent"
       ]
     },
     "Entity": {
@@ -442,10 +588,10 @@
     "HasDataSpecification": {
       "type": "object",
       "properties": {
-        "dataSpecifications": {
+        "embeddedDataSpecifications": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Reference"
+            "$ref": "#/definitions/EmbeddedDataSpecification"
           }
         }
       }
@@ -580,6 +726,15 @@
         "langStrings"
       ]
     },
+    "LevelType": {
+      "type": "string",
+      "enum": [
+        "Min",
+        "Max",
+        "Nom",
+        "Typ"
+      ]
+    },
     "ModelType": {
       "type": "string",
       "enum": [
@@ -599,7 +754,9 @@
         "BasicEventElement",
         "Operation",
         "Capability",
-        "ConceptDescription"
+        "ConceptDescription",
+        "DataSpecificationIEC61360",
+        "DataSpecificationPhysicalUnit"
       ]
     },
     "ModelingKind": {
@@ -1015,6 +1172,36 @@
             "typeValueListElement"
           ]
         }
+      ]
+    },
+    "ValueList": {
+      "type": "object",
+      "properties": {
+        "valueReferencePairTypes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ValueReferencePair"
+          },
+          "minItems": 1
+        }
+      },
+      "required": [
+        "valueReferencePairTypes"
+      ]
+    },
+    "ValueReferencePair": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "valueId": {
+          "$ref": "#/definitions/Reference"
+        }
+      },
+      "required": [
+        "value",
+        "valueId"
       ]
     }
   }

--- a/test_data/parse/expected/constant/constant_set/of_enum/expected_symbol_table.txt
+++ b/test_data/parse/expected/constant/constant_set/of_enum/expected_symbol_table.txt
@@ -41,4 +41,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/constant/constant_set/of_enum/meta_model.py
+++ b/test_data/parse/expected/constant/constant_set/of_enum/meta_model.py
@@ -10,3 +10,4 @@ Something: Set[Some_enum] = constant_set(
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/constant/constant_set/of_str/expected_symbol_table.txt
+++ b/test_data/parse/expected/constant/constant_set/of_str/expected_symbol_table.txt
@@ -19,4 +19,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/constant/constant_set/of_str/meta_model.py
+++ b/test_data/parse/expected/constant/constant_set/of_str/meta_model.py
@@ -2,3 +2,4 @@ Something: Set[str] = constant_set(values=["some literal", "another literal"])
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/constant/constant_set/with_description/expected_symbol_table.txt
+++ b/test_data/parse/expected/constant/constant_set/with_description/expected_symbol_table.txt
@@ -21,4 +21,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/constant/constant_set/with_description/meta_model.py
+++ b/test_data/parse/expected/constant/constant_set/with_description/meta_model.py
@@ -4,3 +4,4 @@ Something: Set[str] = constant_set(
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/constant/constant_set/with_reference_in_the_book/expected_symbol_table.txt
+++ b/test_data/parse/expected/constant/constant_set/with_reference_in_the_book/expected_symbol_table.txt
@@ -26,4 +26,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/constant/constant_set/with_reference_in_the_book/meta_model.py
+++ b/test_data/parse/expected/constant/constant_set/with_reference_in_the_book/meta_model.py
@@ -5,3 +5,4 @@ Something: Set[str] = constant_set(
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/constant/constant_set/with_superset_of/expected_symbol_table.txt
+++ b/test_data/parse/expected/constant/constant_set/with_superset_of/expected_symbol_table.txt
@@ -36,4 +36,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/constant/constant_set/with_superset_of/meta_model.py
+++ b/test_data/parse/expected/constant/constant_set/with_superset_of/meta_model.py
@@ -12,3 +12,4 @@ Something_extended: Set[str] = constant_set(
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/constant/constant_str/only_value/expected_symbol_table.txt
+++ b/test_data/parse/expected/constant/constant_str/only_value/expected_symbol_table.txt
@@ -11,4 +11,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/constant/constant_str/only_value/meta_model.py
+++ b/test_data/parse/expected/constant/constant_str/only_value/meta_model.py
@@ -5,3 +5,4 @@ Something: str = constant_str(
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/constant/constant_str/with_description/expected_symbol_table.txt
+++ b/test_data/parse/expected/constant/constant_str/with_description/expected_symbol_table.txt
@@ -13,4 +13,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/constant/constant_str/with_description/meta_model.py
+++ b/test_data/parse/expected/constant/constant_str/with_description/meta_model.py
@@ -3,3 +3,4 @@ Something: str = constant_str(value="some value", description="Represent somethi
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/constant/constant_str/with_reference_in_the_book/expected_symbol_table.txt
+++ b/test_data/parse/expected/constant/constant_str/with_reference_in_the_book/expected_symbol_table.txt
@@ -18,4 +18,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/constant/constant_str/with_reference_in_the_book/meta_model.py
+++ b/test_data/parse/expected/constant/constant_str/with_reference_in_the_book/meta_model.py
@@ -6,3 +6,4 @@ Something: str = constant_str(
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/enum/ok/expected_symbol_table.txt
+++ b/test_data/parse/expected/enum/ok/expected_symbol_table.txt
@@ -26,4 +26,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/enum/ok/meta_model.py
+++ b/test_data/parse/expected/enum/ok/meta_model.py
@@ -13,3 +13,4 @@ class Some_enum(Enum):
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/implementation_specific_class/properties_and_methods_in_implementation_specific_class/expected_symbol_table.txt
+++ b/test_data/parse/expected/implementation_specific_class/properties_and_methods_in_implementation_specific_class/expected_symbol_table.txt
@@ -43,4 +43,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/implementation_specific_class/properties_and_methods_in_implementation_specific_class/meta_model.py
+++ b/test_data/parse/expected/implementation_specific_class/properties_and_methods_in_implementation_specific_class/meta_model.py
@@ -15,3 +15,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/inheritance/basic/expected_symbol_table.txt
+++ b/test_data/parse/expected/inheritance/basic/expected_symbol_table.txt
@@ -32,4 +32,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/inheritance/basic/meta_model.py
+++ b/test_data/parse/expected/inheritance/basic/meta_model.py
@@ -9,3 +9,4 @@ class Something(DBC, Parent):
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/inheritance/diamond/expected_symbol_table.txt
+++ b/test_data/parse/expected/inheritance/diamond/expected_symbol_table.txt
@@ -76,4 +76,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/inheritance/diamond/meta_model.py
+++ b/test_data/parse/expected/inheritance/diamond/meta_model.py
@@ -24,3 +24,4 @@ class Something(DBC, Parent, Another_parent):
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/inheritance/inheritance_from_concrete_class/expected_symbol_table.txt
+++ b/test_data/parse/expected/inheritance/inheritance_from_concrete_class/expected_symbol_table.txt
@@ -32,4 +32,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/inheritance/inheritance_from_concrete_class/meta_model.py
+++ b/test_data/parse/expected/inheritance/inheritance_from_concrete_class/meta_model.py
@@ -8,3 +8,4 @@ class Another_concrete(Concrete):
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/invariants/in_relation/expected_symbol_table.txt
+++ b/test_data/parse/expected/invariants/in_relation/expected_symbol_table.txt
@@ -79,4 +79,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/invariants/in_relation/meta_model.py
+++ b/test_data/parse/expected/invariants/in_relation/meta_model.py
@@ -11,3 +11,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/method/arguments/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/arguments/expected_symbol_table.txt
@@ -43,4 +43,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/method/arguments/meta_model.py
+++ b/test_data/parse/expected/method/arguments/meta_model.py
@@ -5,3 +5,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/method/basic/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/basic/expected_symbol_table.txt
@@ -36,4 +36,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/method/basic/meta_model.py
+++ b/test_data/parse/expected/method/basic/meta_model.py
@@ -5,3 +5,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/method/contracts/condition_as_keyword_argument/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/contracts/condition_as_keyword_argument/expected_symbol_table.txt
@@ -52,4 +52,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/method/contracts/condition_as_keyword_argument/meta_model.py
+++ b/test_data/parse/expected/method/contracts/condition_as_keyword_argument/meta_model.py
@@ -6,3 +6,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/method/contracts/condition_as_positional_argument/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/contracts/condition_as_positional_argument/expected_symbol_table.txt
@@ -52,4 +52,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/method/contracts/condition_as_positional_argument/meta_model.py
+++ b/test_data/parse/expected/method/contracts/condition_as_positional_argument/meta_model.py
@@ -6,3 +6,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/method/contracts/description_as_keyword_argument/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/contracts/description_as_keyword_argument/expected_symbol_table.txt
@@ -52,4 +52,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/method/contracts/description_as_keyword_argument/meta_model.py
+++ b/test_data/parse/expected/method/contracts/description_as_keyword_argument/meta_model.py
@@ -6,3 +6,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/method/contracts/description_as_positional_argument/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/contracts/description_as_positional_argument/expected_symbol_table.txt
@@ -52,4 +52,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/method/contracts/description_as_positional_argument/meta_model.py
+++ b/test_data/parse/expected/method/contracts/description_as_positional_argument/meta_model.py
@@ -6,3 +6,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/method/contracts/multiple_contracts_in_order/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/contracts/multiple_contracts_in_order/expected_symbol_table.txt
@@ -87,4 +87,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/method/contracts/multiple_contracts_in_order/meta_model.py
+++ b/test_data/parse/expected/method/contracts/multiple_contracts_in_order/meta_model.py
@@ -15,3 +15,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/method/contracts/postcondition/basic/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/contracts/postcondition/basic/expected_symbol_table.txt
@@ -59,4 +59,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/method/contracts/postcondition/basic/meta_model.py
+++ b/test_data/parse/expected/method/contracts/postcondition/basic/meta_model.py
@@ -8,3 +8,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/method/contracts/postcondition/snapshot/with_keyword_arguments/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/contracts/postcondition/snapshot/with_keyword_arguments/expected_symbol_table.txt
@@ -69,4 +69,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/method/contracts/postcondition/snapshot/with_keyword_arguments/meta_model.py
+++ b/test_data/parse/expected/method/contracts/postcondition/snapshot/with_keyword_arguments/meta_model.py
@@ -7,3 +7,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/method/contracts/postcondition/snapshot/with_positional_arguments/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/contracts/postcondition/snapshot/with_positional_arguments/expected_symbol_table.txt
@@ -69,4 +69,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/method/contracts/postcondition/snapshot/with_positional_arguments/meta_model.py
+++ b/test_data/parse/expected/method/contracts/postcondition/snapshot/with_positional_arguments/meta_model.py
@@ -7,3 +7,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/method/default/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/default/expected_symbol_table.txt
@@ -64,4 +64,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/method/default/meta_model.py
+++ b/test_data/parse/expected/method/default/meta_model.py
@@ -7,3 +7,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/method/description/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/description/expected_symbol_table.txt
@@ -38,4 +38,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/method/description/meta_model.py
+++ b/test_data/parse/expected/method/description/meta_model.py
@@ -6,3 +6,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/method/is_implementation_specific/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/is_implementation_specific/expected_symbol_table.txt
@@ -35,4 +35,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/method/is_implementation_specific/meta_model.py
+++ b/test_data/parse/expected/method/is_implementation_specific/meta_model.py
@@ -6,3 +6,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/method/returns_none/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/returns_none/expected_symbol_table.txt
@@ -36,4 +36,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/method/returns_none/meta_model.py
+++ b/test_data/parse/expected/method/returns_none/meta_model.py
@@ -5,3 +5,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/method/returns_something/expected_symbol_table.txt
+++ b/test_data/parse/expected/method/returns_something/expected_symbol_table.txt
@@ -38,4 +38,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/method/returns_something/meta_model.py
+++ b/test_data/parse/expected/method/returns_something/meta_model.py
@@ -5,3 +5,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/reference_in_the_book/on_all_symbols/expected_symbol_table.txt
+++ b/test_data/parse/expected/reference_in_the_book/on_all_symbols/expected_symbol_table.txt
@@ -60,4 +60,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/reference_in_the_book/on_all_symbols/meta_model.py
+++ b/test_data/parse/expected/reference_in_the_book/on_all_symbols/meta_model.py
@@ -15,3 +15,4 @@ class SomeClass:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/reference_in_the_book/only_section/expected_symbol_table.txt
+++ b/test_data/parse/expected/reference_in_the_book/only_section/expected_symbol_table.txt
@@ -41,4 +41,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/reference_in_the_book/only_section/meta_model.py
+++ b/test_data/parse/expected/reference_in_the_book/only_section/meta_model.py
@@ -7,3 +7,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/reference_in_the_book/section_and_index/expected_symbol_table.txt
+++ b/test_data/parse/expected/reference_in_the_book/section_and_index/expected_symbol_table.txt
@@ -41,4 +41,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/reference_in_the_book/section_and_index/meta_model.py
+++ b/test_data/parse/expected/reference_in_the_book/section_and_index/meta_model.py
@@ -7,3 +7,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/reference_in_the_book/section_index_and_fragment/expected_symbol_table.txt
+++ b/test_data/parse/expected/reference_in_the_book/section_index_and_fragment/expected_symbol_table.txt
@@ -41,4 +41,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/reference_in_the_book/section_index_and_fragment/meta_model.py
+++ b/test_data/parse/expected/reference_in_the_book/section_index_and_fragment/meta_model.py
@@ -7,3 +7,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/single_class/description/expected_symbol_table.txt
+++ b/test_data/parse/expected/single_class/description/expected_symbol_table.txt
@@ -20,4 +20,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/single_class/description/meta_model.py
+++ b/test_data/parse/expected/single_class/description/meta_model.py
@@ -10,3 +10,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/single_class/empty/expected_symbol_table.txt
+++ b/test_data/parse/expected/single_class/empty/expected_symbol_table.txt
@@ -18,4 +18,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/single_class/empty/meta_model.py
+++ b/test_data/parse/expected/single_class/empty/meta_model.py
@@ -4,3 +4,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/single_class/property/description/expected_symbol_table.txt
+++ b/test_data/parse/expected/single_class/property/description/expected_symbol_table.txt
@@ -45,4 +45,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/single_class/property/description/meta_model.py
+++ b/test_data/parse/expected/single_class/property/description/meta_model.py
@@ -12,3 +12,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/single_class/property/mandatory/expected_symbol_table.txt
+++ b/test_data/parse/expected/single_class/property/mandatory/expected_symbol_table.txt
@@ -25,4 +25,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/single_class/property/mandatory/meta_model.py
+++ b/test_data/parse/expected/single_class/property/mandatory/meta_model.py
@@ -4,3 +4,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/single_class/property/optional/expected_symbol_table.txt
+++ b/test_data/parse/expected/single_class/property/optional/expected_symbol_table.txt
@@ -29,4 +29,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/single_class/property/optional/meta_model.py
+++ b/test_data/parse/expected/single_class/property/optional/meta_model.py
@@ -4,3 +4,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/expected/single_class/property/recursion_to_entity/expected_symbol_table.txt
+++ b/test_data/parse/expected/single_class/property/recursion_to_entity/expected_symbol_table.txt
@@ -25,4 +25,5 @@ UnverifiedSymbolTable(
   meta_model=MetaModel(
     description=None,
     book_url='dummy',
-    book_version='dummy'))
+    book_version='dummy',
+    xml_namespace='https://dummy.com'))

--- a/test_data/parse/expected/single_class/property/recursion_to_entity/meta_model.py
+++ b/test_data/parse/expected/single_class/property/recursion_to_entity/meta_model.py
@@ -4,3 +4,4 @@ class Something(DBC):
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/real_meta_models/aas_core_meta.v3rc2/expected_symbol_table.txt
+++ b/test_data/parse/real_meta_models/aas_core_meta.v3rc2/expected_symbol_table.txt
@@ -1185,7 +1185,7 @@ UnverifiedSymbolTable(
       inheritances=[],
       properties=[
         Property(
-          name='data_specifications',
+          name='embedded_data_specifications',
           type_annotation=SubscriptedTypeAnnotation(
             identifier='Optional',
             subscripts=[
@@ -1193,7 +1193,7 @@ UnverifiedSymbolTable(
                 identifier='List',
                 subscripts=[
                   AtomicTypeAnnotation(
-                    identifier='Reference',
+                    identifier='Embedded_data_specification',
                     node=...)],
                 node=...)],
             node=...),
@@ -1212,7 +1212,7 @@ UnverifiedSymbolTable(
               default=None,
               node=...),
             Argument(
-              name='data_specifications',
+              name='embedded_data_specifications',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
                 subscripts=[
@@ -1220,7 +1220,7 @@ UnverifiedSymbolTable(
                     identifier='List',
                     subscripts=[
                       AtomicTypeAnnotation(
-                        identifier='Reference',
+                        identifier='Embedded_data_specification',
                         node=...)],
                     node=...)],
                 node=...),
@@ -1236,49 +1236,7 @@ UnverifiedSymbolTable(
           node=...,
           arguments_by_name=...,
           body=...)],
-      invariants=[
-        Invariant(
-          description='References to data specifications are global references.',
-          body=textwrap.dedent("""\
-            Implication(
-              antecedent=IsNotNone(
-                value=Member(
-                  instance=Name(
-                    identifier='self',
-                    original_node=...),
-                  name='data_specifications',
-                  original_node=...),
-                original_node=...),
-              consequent=All(
-                generator=ForEach(
-                  variable=Name(
-                    identifier='data_specification',
-                    original_node=...),
-                  iteration=Member(
-                    instance=Name(
-                      identifier='self',
-                      original_node=...),
-                    name='data_specifications',
-                    original_node=...),
-                  original_node=...),
-                condition=Comparison(
-                  left=Member(
-                    instance=Name(
-                      identifier='data_specification',
-                      original_node=...),
-                    name='type',
-                    original_node=...),
-                  op='EQ',
-                  right=Member(
-                    instance=Name(
-                      identifier='Reference_types',
-                      original_node=...),
-                    name='Global_reference',
-                    original_node=...),
-                  original_node=...),
-                original_node=...),
-              original_node=...)"""),
-          node=...)],
+      invariants=[],
       serialization=None,
       reference_in_the_book=ReferenceInTheBook(
         section=[
@@ -1337,7 +1295,7 @@ UnverifiedSymbolTable(
               default=None,
               node=...),
             Argument(
-              name='data_specifications',
+              name='embedded_data_specifications',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
                 subscripts=[
@@ -1345,7 +1303,7 @@ UnverifiedSymbolTable(
                     identifier='List',
                     subscripts=[
                       AtomicTypeAnnotation(
-                        identifier='Reference',
+                        identifier='Embedded_data_specification',
                         node=...)],
                     node=...)],
                 node=...),
@@ -1942,7 +1900,7 @@ UnverifiedSymbolTable(
                 node=...),
               node=...),
             Argument(
-              name='data_specifications',
+              name='embedded_data_specifications',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
                 subscripts=[
@@ -1950,7 +1908,7 @@ UnverifiedSymbolTable(
                     identifier='List',
                     subscripts=[
                       AtomicTypeAnnotation(
-                        identifier='Reference',
+                        identifier='Embedded_data_specification',
                         node=...)],
                     node=...)],
                 node=...),
@@ -2631,7 +2589,7 @@ UnverifiedSymbolTable(
                 node=...),
               node=...),
             Argument(
-              name='data_specifications',
+              name='embedded_data_specifications',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
                 subscripts=[
@@ -2639,7 +2597,7 @@ UnverifiedSymbolTable(
                     identifier='List',
                     subscripts=[
                       AtomicTypeAnnotation(
-                        identifier='Reference',
+                        identifier='Embedded_data_specification',
                         node=...)],
                     node=...)],
                 node=...),
@@ -2960,7 +2918,7 @@ UnverifiedSymbolTable(
                 node=...),
               node=...),
             Argument(
-              name='data_specifications',
+              name='embedded_data_specifications',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
                 subscripts=[
@@ -2968,7 +2926,7 @@ UnverifiedSymbolTable(
                     identifier='List',
                     subscripts=[
                       AtomicTypeAnnotation(
-                        identifier='Reference',
+                        identifier='Embedded_data_specification',
                         node=...)],
                     node=...)],
                 node=...),
@@ -3242,7 +3200,7 @@ UnverifiedSymbolTable(
                 node=...),
               node=...),
             Argument(
-              name='data_specifications',
+              name='embedded_data_specifications',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
                 subscripts=[
@@ -3250,7 +3208,7 @@ UnverifiedSymbolTable(
                     identifier='List',
                     subscripts=[
                       AtomicTypeAnnotation(
-                        identifier='Reference',
+                        identifier='Embedded_data_specification',
                         node=...)],
                     node=...)],
                 node=...),
@@ -3616,7 +3574,7 @@ UnverifiedSymbolTable(
                 node=...),
               node=...),
             Argument(
-              name='data_specifications',
+              name='embedded_data_specifications',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
                 subscripts=[
@@ -3624,7 +3582,7 @@ UnverifiedSymbolTable(
                     identifier='List',
                     subscripts=[
                       AtomicTypeAnnotation(
-                        identifier='Reference',
+                        identifier='Embedded_data_specification',
                         node=...)],
                     node=...)],
                 node=...),
@@ -4114,7 +4072,7 @@ UnverifiedSymbolTable(
                 node=...),
               node=...),
             Argument(
-              name='data_specifications',
+              name='embedded_data_specifications',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
                 subscripts=[
@@ -4122,7 +4080,7 @@ UnverifiedSymbolTable(
                     identifier='List',
                     subscripts=[
                       AtomicTypeAnnotation(
-                        identifier='Reference',
+                        identifier='Embedded_data_specification',
                         node=...)],
                     node=...)],
                 node=...),
@@ -4378,7 +4336,7 @@ UnverifiedSymbolTable(
                 node=...),
               node=...),
             Argument(
-              name='data_specifications',
+              name='embedded_data_specifications',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
                 subscripts=[
@@ -4386,7 +4344,7 @@ UnverifiedSymbolTable(
                     identifier='List',
                     subscripts=[
                       AtomicTypeAnnotation(
-                        identifier='Reference',
+                        identifier='Embedded_data_specification',
                         node=...)],
                     node=...)],
                 node=...),
@@ -4659,7 +4617,7 @@ UnverifiedSymbolTable(
                 node=...),
               node=...),
             Argument(
-              name='data_specifications',
+              name='embedded_data_specifications',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
                 subscripts=[
@@ -4667,7 +4625,7 @@ UnverifiedSymbolTable(
                     identifier='List',
                     subscripts=[
                       AtomicTypeAnnotation(
-                        identifier='Reference',
+                        identifier='Embedded_data_specification',
                         node=...)],
                     node=...)],
                 node=...),
@@ -4928,7 +4886,7 @@ UnverifiedSymbolTable(
                 node=...),
               node=...),
             Argument(
-              name='data_specifications',
+              name='embedded_data_specifications',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
                 subscripts=[
@@ -4936,7 +4894,7 @@ UnverifiedSymbolTable(
                     identifier='List',
                     subscripts=[
                       AtomicTypeAnnotation(
-                        identifier='Reference',
+                        identifier='Embedded_data_specification',
                         node=...)],
                     node=...)],
                 node=...),
@@ -5183,7 +5141,7 @@ UnverifiedSymbolTable(
                 node=...),
               node=...),
             Argument(
-              name='data_specifications',
+              name='embedded_data_specifications',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
                 subscripts=[
@@ -5191,7 +5149,7 @@ UnverifiedSymbolTable(
                     identifier='List',
                     subscripts=[
                       AtomicTypeAnnotation(
-                        identifier='Reference',
+                        identifier='Embedded_data_specification',
                         node=...)],
                     node=...)],
                 node=...),
@@ -5469,7 +5427,7 @@ UnverifiedSymbolTable(
                 node=...),
               node=...),
             Argument(
-              name='data_specifications',
+              name='embedded_data_specifications',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
                 subscripts=[
@@ -5477,7 +5435,7 @@ UnverifiedSymbolTable(
                     identifier='List',
                     subscripts=[
                       AtomicTypeAnnotation(
-                        identifier='Reference',
+                        identifier='Embedded_data_specification',
                         node=...)],
                     node=...)],
                 node=...),
@@ -5699,7 +5657,7 @@ UnverifiedSymbolTable(
                 node=...),
               node=...),
             Argument(
-              name='data_specifications',
+              name='embedded_data_specifications',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
                 subscripts=[
@@ -5707,7 +5665,7 @@ UnverifiedSymbolTable(
                     identifier='List',
                     subscripts=[
                       AtomicTypeAnnotation(
-                        identifier='Reference',
+                        identifier='Embedded_data_specification',
                         node=...)],
                     node=...)],
                 node=...),
@@ -5929,7 +5887,7 @@ UnverifiedSymbolTable(
                 node=...),
               node=...),
             Argument(
-              name='data_specifications',
+              name='embedded_data_specifications',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
                 subscripts=[
@@ -5937,7 +5895,7 @@ UnverifiedSymbolTable(
                     identifier='List',
                     subscripts=[
                       AtomicTypeAnnotation(
-                        identifier='Reference',
+                        identifier='Embedded_data_specification',
                         node=...)],
                     node=...)],
                 node=...),
@@ -6161,7 +6119,7 @@ UnverifiedSymbolTable(
                 node=...),
               node=...),
             Argument(
-              name='data_specifications',
+              name='embedded_data_specifications',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
                 subscripts=[
@@ -6169,7 +6127,7 @@ UnverifiedSymbolTable(
                     identifier='List',
                     subscripts=[
                       AtomicTypeAnnotation(
-                        identifier='Reference',
+                        identifier='Embedded_data_specification',
                         node=...)],
                     node=...)],
                 node=...),
@@ -6455,7 +6413,7 @@ UnverifiedSymbolTable(
                 node=...),
               node=...),
             Argument(
-              name='data_specifications',
+              name='embedded_data_specifications',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
                 subscripts=[
@@ -6463,7 +6421,7 @@ UnverifiedSymbolTable(
                     identifier='List',
                     subscripts=[
                       AtomicTypeAnnotation(
-                        identifier='Reference',
+                        identifier='Embedded_data_specification',
                         node=...)],
                     node=...)],
                 node=...),
@@ -7070,7 +7028,7 @@ UnverifiedSymbolTable(
                 node=...),
               node=...),
             Argument(
-              name='data_specifications',
+              name='embedded_data_specifications',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
                 subscripts=[
@@ -7078,7 +7036,7 @@ UnverifiedSymbolTable(
                     identifier='List',
                     subscripts=[
                       AtomicTypeAnnotation(
-                        identifier='Reference',
+                        identifier='Embedded_data_specification',
                         node=...)],
                     node=...)],
                 node=...),
@@ -7372,7 +7330,7 @@ UnverifiedSymbolTable(
                 node=...),
               node=...),
             Argument(
-              name='data_specifications',
+              name='embedded_data_specifications',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
                 subscripts=[
@@ -7380,7 +7338,7 @@ UnverifiedSymbolTable(
                     identifier='List',
                     subscripts=[
                       AtomicTypeAnnotation(
-                        identifier='Reference',
+                        identifier='Embedded_data_specification',
                         node=...)],
                     node=...)],
                 node=...),
@@ -7739,7 +7697,7 @@ UnverifiedSymbolTable(
                 node=...),
               node=...),
             Argument(
-              name='data_specifications',
+              name='embedded_data_specifications',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
                 subscripts=[
@@ -7747,7 +7705,7 @@ UnverifiedSymbolTable(
                     identifier='List',
                     subscripts=[
                       AtomicTypeAnnotation(
-                        identifier='Reference',
+                        identifier='Embedded_data_specification',
                         node=...)],
                     node=...)],
                 node=...),
@@ -8032,7 +7990,7 @@ UnverifiedSymbolTable(
                 node=...),
               node=...),
             Argument(
-              name='data_specifications',
+              name='embedded_data_specifications',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
                 subscripts=[
@@ -8040,7 +7998,7 @@ UnverifiedSymbolTable(
                     identifier='List',
                     subscripts=[
                       AtomicTypeAnnotation(
-                        identifier='Reference',
+                        identifier='Embedded_data_specification',
                         node=...)],
                     node=...)],
                 node=...),
@@ -8227,7 +8185,7 @@ UnverifiedSymbolTable(
                 node=...),
               node=...),
             Argument(
-              name='data_specifications',
+              name='embedded_data_specifications',
               type_annotation=SubscriptedTypeAnnotation(
                 identifier='Optional',
                 subscripts=[
@@ -8235,7 +8193,7 @@ UnverifiedSymbolTable(
                     identifier='List',
                     subscripts=[
                       AtomicTypeAnnotation(
-                        identifier='Reference',
+                        identifier='Embedded_data_specification',
                         node=...)],
                     node=...)],
                 node=...),
@@ -9674,148 +9632,6 @@ UnverifiedSymbolTable(
       properties_by_name=...,
       methods_by_name=...),
     ConcreteClass(
-      name='Data_specification_content',
-      is_implementation_specific=False,
-      inheritances=[],
-      properties=[],
-      methods=[],
-      invariants=[],
-      serialization=None,
-      reference_in_the_book=ReferenceInTheBook(
-        section=[
-          6,
-          2,
-          1,
-          1],
-        index=1,
-        fragment=None),
-      description=Description(
-        document=...,
-        node=...),
-      node=...,
-      properties_by_name=...,
-      methods_by_name=...),
-    ConcreteClass(
-      name='Data_specification',
-      is_implementation_specific=False,
-      inheritances=[],
-      properties=[
-        Property(
-          name='id',
-          type_annotation=AtomicTypeAnnotation(
-            identifier='Identifier',
-            node=...),
-          description=Description(
-            document=...,
-            node=...),
-          node=...),
-        Property(
-          name='data_specification_content',
-          type_annotation=AtomicTypeAnnotation(
-            identifier='Data_specification_content',
-            node=...),
-          description=Description(
-            document=...,
-            node=...),
-          node=...),
-        Property(
-          name='administration',
-          type_annotation=SubscriptedTypeAnnotation(
-            identifier='Optional',
-            subscripts=[
-              AtomicTypeAnnotation(
-                identifier='Administrative_information',
-                node=...)],
-            node=...),
-          description=Description(
-            document=...,
-            node=...),
-          node=...),
-        Property(
-          name='description',
-          type_annotation=SubscriptedTypeAnnotation(
-            identifier='Optional',
-            subscripts=[
-              AtomicTypeAnnotation(
-                identifier='Lang_string_set',
-                node=...)],
-            node=...),
-          description=Description(
-            document=...,
-            node=...),
-          node=...)],
-      methods=[
-        ConstructorToBeUnderstood(
-          name='__init__',
-          verification=False,
-          arguments=[
-            Argument(
-              name='self',
-              type_annotation=SelfTypeAnnotation(),
-              default=None,
-              node=...),
-            Argument(
-              name='id',
-              type_annotation=AtomicTypeAnnotation(
-                identifier='Identifier',
-                node=...),
-              default=None,
-              node=...),
-            Argument(
-              name='data_specification_content',
-              type_annotation=AtomicTypeAnnotation(
-                identifier='Data_specification_content',
-                node=...),
-              default=None,
-              node=...),
-            Argument(
-              name='administration',
-              type_annotation=SubscriptedTypeAnnotation(
-                identifier='Optional',
-                subscripts=[
-                  AtomicTypeAnnotation(
-                    identifier='Administrative_information',
-                    node=...)],
-                node=...),
-              default=None,
-              node=...),
-            Argument(
-              name='description',
-              type_annotation=SubscriptedTypeAnnotation(
-                identifier='Optional',
-                subscripts=[
-                  AtomicTypeAnnotation(
-                    identifier='Lang_string_set',
-                    node=...)],
-                node=...),
-              default=None,
-              node=...)],
-          returns=None,
-          description=None,
-          contracts=Contracts(
-            preconditions=[],
-            snapshots=[],
-            postconditions=[]),
-          node=...,
-          arguments_by_name=...,
-          body=...)],
-      invariants=[],
-      serialization=None,
-      reference_in_the_book=ReferenceInTheBook(
-        section=[
-          6,
-          2,
-          1,
-          1],
-        index=0,
-        fragment=None),
-      description=Description(
-        document=...,
-        node=...),
-      node=...,
-      properties_by_name=...,
-      methods_by_name=...),
-    ConcreteClass(
       name='Environment',
       is_implementation_specific=False,
       inheritances=[],
@@ -9950,6 +9766,1186 @@ UnverifiedSymbolTable(
       description=Description(
         document=...,
         node=...),
+      node=...,
+      properties_by_name=...,
+      methods_by_name=...),
+    AbstractClass(
+      name='Data_specification_content',
+      is_implementation_specific=False,
+      inheritances=[],
+      properties=[],
+      methods=[],
+      invariants=[],
+      serialization=Serialization(
+        with_model_type=True),
+      reference_in_the_book=ReferenceInTheBook(
+        section=[
+          6,
+          2,
+          1,
+          1],
+        index=1,
+        fragment='6.2.1.1 Data Specification Template Attributes'),
+      description=Description(
+        document=...,
+        node=...),
+      node=...,
+      properties_by_name=...,
+      methods_by_name=...),
+    ConcreteClass(
+      name='Embedded_data_specification',
+      is_implementation_specific=False,
+      inheritances=[],
+      properties=[
+        Property(
+          name='data_specification',
+          type_annotation=AtomicTypeAnnotation(
+            identifier='Reference',
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        Property(
+          name='data_specification_content',
+          type_annotation=AtomicTypeAnnotation(
+            identifier='Data_specification_content',
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...)],
+      methods=[
+        ConstructorToBeUnderstood(
+          name='__init__',
+          verification=False,
+          arguments=[
+            Argument(
+              name='self',
+              type_annotation=SelfTypeAnnotation(),
+              default=None,
+              node=...),
+            Argument(
+              name='data_specification',
+              type_annotation=AtomicTypeAnnotation(
+                identifier='Reference',
+                node=...),
+              default=None,
+              node=...),
+            Argument(
+              name='data_specification_content',
+              type_annotation=AtomicTypeAnnotation(
+                identifier='Data_specification_content',
+                node=...),
+              default=None,
+              node=...)],
+          returns=None,
+          description=None,
+          contracts=Contracts(
+            preconditions=[],
+            snapshots=[],
+            postconditions=[]),
+          node=...,
+          arguments_by_name=...,
+          body=...)],
+      invariants=[],
+      serialization=None,
+      reference_in_the_book=ReferenceInTheBook(
+        section=[
+          9,
+          2,
+          5],
+        index=0,
+        fragment='9.2.5 Embedded Data Specifications'),
+      description=Description(
+        document=...,
+        node=...),
+      node=...,
+      properties_by_name=...,
+      methods_by_name=...),
+    Enumeration(
+      name='Data_type_IEC_61360',
+      literals=[
+        EnumerationLiteral(
+          name='Date',
+          value='DATE',
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        EnumerationLiteral(
+          name='String',
+          value='STRING',
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        EnumerationLiteral(
+          name='String_translatable',
+          value='STRING_TRANSLATABLE',
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        EnumerationLiteral(
+          name='Integer_measure',
+          value='INTEGER_MEASURE',
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        EnumerationLiteral(
+          name='Integer_count',
+          value='INTEGER_COUNT',
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        EnumerationLiteral(
+          name='Integer_currency',
+          value='INTEGER_CURRENCY',
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        EnumerationLiteral(
+          name='Real_measure',
+          value='REAL_MEASURE',
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        EnumerationLiteral(
+          name='Real_count',
+          value='REAL_COUNT',
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        EnumerationLiteral(
+          name='Real_currency',
+          value='REAL_CURRENCY',
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        EnumerationLiteral(
+          name='Boolean',
+          value='BOOLEAN',
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        EnumerationLiteral(
+          name='IRI',
+          value='IRI',
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        EnumerationLiteral(
+          name='IRDI',
+          value='IRDI',
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        EnumerationLiteral(
+          name='Rational',
+          value='RATIONAL',
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        EnumerationLiteral(
+          name='Rational_measure',
+          value='RATIONAL_MEASURE',
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        EnumerationLiteral(
+          name='Time',
+          value='TIME',
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        EnumerationLiteral(
+          name='Timestamp',
+          value='TIMESTAMP',
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        EnumerationLiteral(
+          name='File',
+          value='FILE',
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        EnumerationLiteral(
+          name='HTML',
+          value='HTML',
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        EnumerationLiteral(
+          name='Blob',
+          value='BLOB',
+          description=Description(
+            document=...,
+            node=...),
+          node=...)],
+      reference_in_the_book=ReferenceInTheBook(
+        section=[
+          6,
+          3,
+          3,
+          1],
+        index=1,
+        fragment='6.3.3.1 Data Specification IEC61360 Template Attributes'),
+      description=None,
+      node=...,
+      literals_by_name=...),
+    Enumeration(
+      name='Concept_descriptions_categories',
+      literals=[
+        EnumerationLiteral(
+          name='Application_class',
+          value='APPLICATION_CLASS',
+          description=None,
+          node=...),
+        EnumerationLiteral(
+          name='Capability',
+          value='CAPABILITY',
+          description=None,
+          node=...),
+        EnumerationLiteral(
+          name='Collections',
+          value='COLLECTIONS',
+          description=None,
+          node=...),
+        EnumerationLiteral(
+          name='Documentation',
+          value='DOCUMENTATION',
+          description=None,
+          node=...),
+        EnumerationLiteral(
+          name='Entity',
+          value='ENTITY',
+          description=None,
+          node=...),
+        EnumerationLiteral(
+          name='Event',
+          value='EVENT',
+          description=None,
+          node=...),
+        EnumerationLiteral(
+          name='Function',
+          value='FUNCTION',
+          description=None,
+          node=...),
+        EnumerationLiteral(
+          name='Property',
+          value='PROPERTY',
+          description=None,
+          node=...),
+        EnumerationLiteral(
+          name='Value',
+          value='VALUE',
+          description=None,
+          node=...),
+        EnumerationLiteral(
+          name='Range',
+          value='RANGE',
+          description=None,
+          node=...),
+        EnumerationLiteral(
+          name='Qualifier_type',
+          value='QUALIFIER_TYPE',
+          description=None,
+          node=...),
+        EnumerationLiteral(
+          name='Referencing',
+          value='REFERENCING',
+          description=None,
+          node=...),
+        EnumerationLiteral(
+          name='Relationship',
+          value='RELATIONSHIP',
+          description=None,
+          node=...)],
+      reference_in_the_book=ReferenceInTheBook(
+        section=[
+          6,
+          3,
+          4],
+        index=0,
+        fragment='6.3.4 Category of Concept Descriptions'),
+      description=None,
+      node=...,
+      literals_by_name=...),
+    Enumeration(
+      name='Level_type',
+      literals=[
+        EnumerationLiteral(
+          name='Min',
+          value='Min',
+          description=None,
+          node=...),
+        EnumerationLiteral(
+          name='Max',
+          value='Max',
+          description=None,
+          node=...),
+        EnumerationLiteral(
+          name='Nom',
+          value='Nom',
+          description=None,
+          node=...),
+        EnumerationLiteral(
+          name='Typ',
+          value='Typ',
+          description=None,
+          node=...)],
+      reference_in_the_book=ReferenceInTheBook(
+        section=[
+          6,
+          3,
+          3,
+          1],
+        index=4,
+        fragment='6.3.3.1 Data Specification IEC61360 Template Attributes'),
+      description=None,
+      node=...,
+      literals_by_name=...),
+    ConcreteClass(
+      name='Value_reference_pair',
+      is_implementation_specific=False,
+      inheritances=[],
+      properties=[
+        Property(
+          name='value',
+          type_annotation=AtomicTypeAnnotation(
+            identifier='str',
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        Property(
+          name='value_id',
+          type_annotation=AtomicTypeAnnotation(
+            identifier='Reference',
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...)],
+      methods=[
+        ConstructorToBeUnderstood(
+          name='__init__',
+          verification=False,
+          arguments=[
+            Argument(
+              name='self',
+              type_annotation=SelfTypeAnnotation(),
+              default=None,
+              node=...),
+            Argument(
+              name='value',
+              type_annotation=AtomicTypeAnnotation(
+                identifier='str',
+                node=...),
+              default=None,
+              node=...),
+            Argument(
+              name='value_id',
+              type_annotation=AtomicTypeAnnotation(
+                identifier='Reference',
+                node=...),
+              default=None,
+              node=...)],
+          returns=None,
+          description=None,
+          contracts=Contracts(
+            preconditions=[],
+            snapshots=[],
+            postconditions=[]),
+          node=...,
+          arguments_by_name=...,
+          body=...)],
+      invariants=[],
+      serialization=None,
+      reference_in_the_book=ReferenceInTheBook(
+        section=[
+          6,
+          3,
+          3,
+          1],
+        index=3,
+        fragment='4.8.2 Predefined Templates for Property and Value Descriptions'),
+      description=Description(
+        document=...,
+        node=...),
+      node=...,
+      properties_by_name=...,
+      methods_by_name=...),
+    ConcreteClass(
+      name='Value_list',
+      is_implementation_specific=False,
+      inheritances=[],
+      properties=[
+        Property(
+          name='value_reference_pair_types',
+          type_annotation=SubscriptedTypeAnnotation(
+            identifier='List',
+            subscripts=[
+              AtomicTypeAnnotation(
+                identifier='Value_reference_pair',
+                node=...)],
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...)],
+      methods=[
+        ConstructorToBeUnderstood(
+          name='__init__',
+          verification=False,
+          arguments=[
+            Argument(
+              name='self',
+              type_annotation=SelfTypeAnnotation(),
+              default=None,
+              node=...),
+            Argument(
+              name='value_reference_pair_types',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='List',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Value_reference_pair',
+                    node=...)],
+                node=...),
+              default=None,
+              node=...)],
+          returns=None,
+          description=None,
+          contracts=Contracts(
+            preconditions=[],
+            snapshots=[],
+            postconditions=[]),
+          node=...,
+          arguments_by_name=...,
+          body=...)],
+      invariants=[
+        Invariant(
+          description=None,
+          body=textwrap.dedent("""\
+            Comparison(
+              left=FunctionCall(
+                name='len',
+                args=[
+                  Member(
+                    instance=Name(
+                      identifier='self',
+                      original_node=...),
+                    name='value_reference_pair_types',
+                    original_node=...)],
+                original_node=...),
+              op='GE',
+              right=Constant(
+                value=1,
+                original_node=...),
+              original_node=...)"""),
+          node=...)],
+      serialization=None,
+      reference_in_the_book=ReferenceInTheBook(
+        section=[
+          6,
+          3,
+          3,
+          1],
+        index=2,
+        fragment='6.3.3.1 Data Specification IEC61360 Template Attributes'),
+      description=Description(
+        document=...,
+        node=...),
+      node=...,
+      properties_by_name=...,
+      methods_by_name=...),
+    ConcreteClass(
+      name='Data_specification_IEC_61360',
+      is_implementation_specific=False,
+      inheritances=[
+        'Data_specification_content'],
+      properties=[
+        Property(
+          name='preferred_name',
+          type_annotation=AtomicTypeAnnotation(
+            identifier='Lang_string_set',
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        Property(
+          name='short_name',
+          type_annotation=SubscriptedTypeAnnotation(
+            identifier='Optional',
+            subscripts=[
+              AtomicTypeAnnotation(
+                identifier='Lang_string_set',
+                node=...)],
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        Property(
+          name='unit',
+          type_annotation=SubscriptedTypeAnnotation(
+            identifier='Optional',
+            subscripts=[
+              AtomicTypeAnnotation(
+                identifier='Non_empty_string',
+                node=...)],
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        Property(
+          name='unit_id',
+          type_annotation=SubscriptedTypeAnnotation(
+            identifier='Optional',
+            subscripts=[
+              AtomicTypeAnnotation(
+                identifier='Reference',
+                node=...)],
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        Property(
+          name='source_of_definition',
+          type_annotation=SubscriptedTypeAnnotation(
+            identifier='Optional',
+            subscripts=[
+              AtomicTypeAnnotation(
+                identifier='Non_empty_string',
+                node=...)],
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        Property(
+          name='symbol',
+          type_annotation=SubscriptedTypeAnnotation(
+            identifier='Optional',
+            subscripts=[
+              AtomicTypeAnnotation(
+                identifier='Non_empty_string',
+                node=...)],
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        Property(
+          name='data_type',
+          type_annotation=SubscriptedTypeAnnotation(
+            identifier='Optional',
+            subscripts=[
+              AtomicTypeAnnotation(
+                identifier='Data_type_IEC_61360',
+                node=...)],
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        Property(
+          name='definition',
+          type_annotation=SubscriptedTypeAnnotation(
+            identifier='Optional',
+            subscripts=[
+              AtomicTypeAnnotation(
+                identifier='Lang_string_set',
+                node=...)],
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        Property(
+          name='value_format',
+          type_annotation=SubscriptedTypeAnnotation(
+            identifier='Optional',
+            subscripts=[
+              AtomicTypeAnnotation(
+                identifier='Non_empty_string',
+                node=...)],
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        Property(
+          name='value_list',
+          type_annotation=SubscriptedTypeAnnotation(
+            identifier='Optional',
+            subscripts=[
+              AtomicTypeAnnotation(
+                identifier='Value_list',
+                node=...)],
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        Property(
+          name='value',
+          type_annotation=SubscriptedTypeAnnotation(
+            identifier='Optional',
+            subscripts=[
+              AtomicTypeAnnotation(
+                identifier='str',
+                node=...)],
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        Property(
+          name='level_type',
+          type_annotation=SubscriptedTypeAnnotation(
+            identifier='Optional',
+            subscripts=[
+              AtomicTypeAnnotation(
+                identifier='Level_type',
+                node=...)],
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...)],
+      methods=[
+        ConstructorToBeUnderstood(
+          name='__init__',
+          verification=False,
+          arguments=[
+            Argument(
+              name='self',
+              type_annotation=SelfTypeAnnotation(),
+              default=None,
+              node=...),
+            Argument(
+              name='preferred_name',
+              type_annotation=AtomicTypeAnnotation(
+                identifier='Lang_string_set',
+                node=...),
+              default=None,
+              node=...),
+            Argument(
+              name='short_name',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Lang_string_set',
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='unit',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Non_empty_string',
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='unit_id',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Reference',
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='source_of_definition',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Non_empty_string',
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='symbol',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Non_empty_string',
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='data_type',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Data_type_IEC_61360',
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='definition',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Lang_string_set',
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='value_format',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Non_empty_string',
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='value_list',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Value_list',
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='value',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='str',
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='level_type',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Level_type',
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...)],
+          returns=None,
+          description=None,
+          contracts=Contracts(
+            preconditions=[],
+            snapshots=[],
+            postconditions=[]),
+          node=...,
+          arguments_by_name=...,
+          body=...)],
+      invariants=[],
+      serialization=Serialization(
+        with_model_type=True),
+      reference_in_the_book=ReferenceInTheBook(
+        section=[
+          6,
+          3,
+          3,
+          1],
+        index=0,
+        fragment='6.3.3.1 Data Specification IEC61360 Template Attributes'),
+      description=Description(
+        document=...,
+        node=...),
+      node=...,
+      properties_by_name=...,
+      methods_by_name=...),
+    ConcreteClass(
+      name='Data_specification_physical_unit',
+      is_implementation_specific=False,
+      inheritances=[
+        'Data_specification_content'],
+      properties=[
+        Property(
+          name='unit_name',
+          type_annotation=AtomicTypeAnnotation(
+            identifier='Non_empty_string',
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        Property(
+          name='unit_symbol',
+          type_annotation=AtomicTypeAnnotation(
+            identifier='Non_empty_string',
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        Property(
+          name='definition',
+          type_annotation=AtomicTypeAnnotation(
+            identifier='Lang_string_set',
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        Property(
+          name='SI_notation',
+          type_annotation=SubscriptedTypeAnnotation(
+            identifier='Optional',
+            subscripts=[
+              AtomicTypeAnnotation(
+                identifier='Non_empty_string',
+                node=...)],
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        Property(
+          name='SI_name',
+          type_annotation=SubscriptedTypeAnnotation(
+            identifier='Optional',
+            subscripts=[
+              AtomicTypeAnnotation(
+                identifier='Non_empty_string',
+                node=...)],
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        Property(
+          name='DIN_notation',
+          type_annotation=SubscriptedTypeAnnotation(
+            identifier='Optional',
+            subscripts=[
+              AtomicTypeAnnotation(
+                identifier='Non_empty_string',
+                node=...)],
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        Property(
+          name='ECE_name',
+          type_annotation=SubscriptedTypeAnnotation(
+            identifier='Optional',
+            subscripts=[
+              AtomicTypeAnnotation(
+                identifier='Non_empty_string',
+                node=...)],
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        Property(
+          name='ECE_code',
+          type_annotation=SubscriptedTypeAnnotation(
+            identifier='Optional',
+            subscripts=[
+              AtomicTypeAnnotation(
+                identifier='Non_empty_string',
+                node=...)],
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        Property(
+          name='NIST_name',
+          type_annotation=SubscriptedTypeAnnotation(
+            identifier='Optional',
+            subscripts=[
+              AtomicTypeAnnotation(
+                identifier='Non_empty_string',
+                node=...)],
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        Property(
+          name='source_of_definition',
+          type_annotation=SubscriptedTypeAnnotation(
+            identifier='Optional',
+            subscripts=[
+              AtomicTypeAnnotation(
+                identifier='Non_empty_string',
+                node=...)],
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        Property(
+          name='conversion_factor',
+          type_annotation=SubscriptedTypeAnnotation(
+            identifier='Optional',
+            subscripts=[
+              AtomicTypeAnnotation(
+                identifier='Non_empty_string',
+                node=...)],
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        Property(
+          name='registration_authority_id',
+          type_annotation=SubscriptedTypeAnnotation(
+            identifier='Optional',
+            subscripts=[
+              AtomicTypeAnnotation(
+                identifier='Non_empty_string',
+                node=...)],
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...),
+        Property(
+          name='supplier',
+          type_annotation=SubscriptedTypeAnnotation(
+            identifier='Optional',
+            subscripts=[
+              AtomicTypeAnnotation(
+                identifier='Non_empty_string',
+                node=...)],
+            node=...),
+          description=Description(
+            document=...,
+            node=...),
+          node=...)],
+      methods=[
+        ConstructorToBeUnderstood(
+          name='__init__',
+          verification=False,
+          arguments=[
+            Argument(
+              name='self',
+              type_annotation=SelfTypeAnnotation(),
+              default=None,
+              node=...),
+            Argument(
+              name='unit_name',
+              type_annotation=AtomicTypeAnnotation(
+                identifier='Non_empty_string',
+                node=...),
+              default=None,
+              node=...),
+            Argument(
+              name='unit_symbol',
+              type_annotation=AtomicTypeAnnotation(
+                identifier='Non_empty_string',
+                node=...),
+              default=None,
+              node=...),
+            Argument(
+              name='definition',
+              type_annotation=AtomicTypeAnnotation(
+                identifier='Lang_string_set',
+                node=...),
+              default=None,
+              node=...),
+            Argument(
+              name='SI_notation',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Non_empty_string',
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='SI_name',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Non_empty_string',
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='DIN_notation',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Non_empty_string',
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='ECE_name',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Non_empty_string',
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='ECE_code',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Non_empty_string',
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='NIST_name',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Non_empty_string',
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='source_of_definition',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Non_empty_string',
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='conversion_factor',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Non_empty_string',
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='registration_authority_id',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Non_empty_string',
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...),
+            Argument(
+              name='supplier',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Non_empty_string',
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
+              node=...)],
+          returns=None,
+          description=None,
+          contracts=Contracts(
+            preconditions=[],
+            snapshots=[],
+            postconditions=[]),
+          node=...,
+          arguments_by_name=...,
+          body=...)],
+      invariants=[],
+      serialization=Serialization(
+        with_model_type=True),
+      reference_in_the_book=ReferenceInTheBook(
+        section=[
+          6,
+          4,
+          2,
+          1],
+        index=0,
+        fragment='6.4.2.1 Data Specification Template Physical Unit Attributes'),
+      description=None,
       node=...,
       properties_by_name=...,
       methods_by_name=...)],
@@ -16107,4 +17103,5 @@ UnverifiedSymbolTable(
       document=...,
       node=...),
     book_url='https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/Details_of_the_Asset_Administration_Shell_Part1_V3.pdf?__blob=publicationFile&v=10',
-    book_version='V3.0RC02'))
+    book_version='V3.0RC02',
+    xml_namespace='http://www.admin-shell.io/aas/3/0/RC02'))

--- a/test_data/parse/unexpected/class_decorators/non_name_decorator/meta_model.py
+++ b/test_data/parse/unexpected/class_decorators/non_name_decorator/meta_model.py
@@ -5,3 +5,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/class_decorators/unknown_decorator/meta_model.py
+++ b/test_data/parse/unexpected/class_decorators/unknown_decorator/meta_model.py
@@ -5,3 +5,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/class_definitions/is_abstract_and_implementation_specific/meta_model.py
+++ b/test_data/parse/unexpected/class_definitions/is_abstract_and_implementation_specific/meta_model.py
@@ -6,3 +6,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/class_definitions/unexpected_docstring_before_a_method/meta_model.py
+++ b/test_data/parse/unexpected/class_definitions/unexpected_docstring_before_a_method/meta_model.py
@@ -9,3 +9,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/class_definitions/unexpected_docstring_for_a_pass/meta_model.py
+++ b/test_data/parse/unexpected/class_definitions/unexpected_docstring_for_a_pass/meta_model.py
@@ -7,3 +7,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/class_definitions/unexpected_double_description_for_a_property/meta_model.py
+++ b/test_data/parse/unexpected/class_definitions/unexpected_double_description_for_a_property/meta_model.py
@@ -8,3 +8,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/class_inheritances/inheriting_from_implementation_specific_parent/meta_model.py
+++ b/test_data/parse/unexpected/class_inheritances/inheriting_from_implementation_specific_parent/meta_model.py
@@ -18,3 +18,4 @@ class Something(Parent):
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/class_inheritances/non_name_super_class/meta_model.py
+++ b/test_data/parse/unexpected/class_inheritances/non_name_super_class/meta_model.py
@@ -4,3 +4,4 @@ class Something(some_module.SomeOtherClass):
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/enum/expression_as_assignment_value/meta_model.py
+++ b/test_data/parse/unexpected/enum/expression_as_assignment_value/meta_model.py
@@ -4,3 +4,4 @@ class Some_enum(Enum):
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/enum/non_assignment/meta_model.py
+++ b/test_data/parse/unexpected/enum/non_assignment/meta_model.py
@@ -6,3 +6,4 @@ class Some_enum(Enum):
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/enum/non_string_literal/meta_model.py
+++ b/test_data/parse/unexpected/enum/non_string_literal/meta_model.py
@@ -4,3 +4,4 @@ class Some_enum(Enum):
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/enum/unexpected_inheritance/meta_model.py
+++ b/test_data/parse/unexpected/enum/unexpected_inheritance/meta_model.py
@@ -4,3 +4,4 @@ class Some_enum(Enum, SomeUnexpectedClass):
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/method_contracts/contract/non_lambda_condition/meta_model.py
+++ b/test_data/parse/unexpected/method_contracts/contract/non_lambda_condition/meta_model.py
@@ -6,3 +6,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/method_contracts/contract/non_string_literal_description/meta_model.py
+++ b/test_data/parse/unexpected/method_contracts/contract/non_string_literal_description/meta_model.py
@@ -6,3 +6,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/method_contracts/contract/without_any_arguments/meta_model.py
+++ b/test_data/parse/unexpected/method_contracts/contract/without_any_arguments/meta_model.py
@@ -6,3 +6,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/method_contracts/contract/without_condition/meta_model.py
+++ b/test_data/parse/unexpected/method_contracts/contract/without_condition/meta_model.py
@@ -6,3 +6,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/method_contracts/postcondition/OLD_in_postcondition_without_snapshot/meta_model.py
+++ b/test_data/parse/unexpected/method_contracts/postcondition/OLD_in_postcondition_without_snapshot/meta_model.py
@@ -6,3 +6,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/method_contracts/postcondition/argument_missing_in_function/meta_model.py
+++ b/test_data/parse/unexpected/method_contracts/postcondition/argument_missing_in_function/meta_model.py
@@ -6,3 +6,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/method_contracts/precondition/argument_missing_in_function/meta_model.py
+++ b/test_data/parse/unexpected/method_contracts/precondition/argument_missing_in_function/meta_model.py
@@ -6,3 +6,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/method_contracts/snapshot/argument_missing_in_function/meta_model.py
+++ b/test_data/parse/unexpected/method_contracts/snapshot/argument_missing_in_function/meta_model.py
@@ -6,3 +6,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/method_contracts/snapshot/capture_not_a_lambda/meta_model.py
+++ b/test_data/parse/unexpected/method_contracts/snapshot/capture_not_a_lambda/meta_model.py
@@ -6,3 +6,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/method_contracts/snapshot/invalid_name/meta_model.py
+++ b/test_data/parse/unexpected/method_contracts/snapshot/invalid_name/meta_model.py
@@ -6,3 +6,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/method_contracts/snapshot/name_not_a_string_literal/meta_model.py
+++ b/test_data/parse/unexpected/method_contracts/snapshot/name_not_a_string_literal/meta_model.py
@@ -6,3 +6,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/method_contracts/snapshot/without_a_capture/meta_model.py
+++ b/test_data/parse/unexpected/method_contracts/snapshot/without_a_capture/meta_model.py
@@ -6,3 +6,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/method_contracts/snapshot/without_a_name/meta_model.py
+++ b/test_data/parse/unexpected/method_contracts/snapshot/without_a_name/meta_model.py
@@ -6,3 +6,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/method_decorators/non_name_decorator/meta_model.py
+++ b/test_data/parse/unexpected/method_decorators/non_name_decorator/meta_model.py
@@ -6,3 +6,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/method_decorators/unknown_call_decorator/meta_model.py
+++ b/test_data/parse/unexpected/method_decorators/unknown_call_decorator/meta_model.py
@@ -6,3 +6,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/method_decorators/unknown_name_decorator/meta_model.py
+++ b/test_data/parse/unexpected/method_decorators/unknown_name_decorator/meta_model.py
@@ -6,3 +6,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/method_definitions/argument_with_final/meta_model.py
+++ b/test_data/parse/unexpected/method_definitions/argument_with_final/meta_model.py
@@ -5,3 +5,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/method_definitions/argument_without_a_type_annotation/meta_model.py
+++ b/test_data/parse/unexpected/method_definitions/argument_without_a_type_annotation/meta_model.py
@@ -5,3 +5,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/method_definitions/default_for_self/meta_model.py
+++ b/test_data/parse/unexpected/method_definitions/default_for_self/meta_model.py
@@ -5,3 +5,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/method_definitions/dunder/meta_model.py
+++ b/test_data/parse/unexpected/method_definitions/dunder/meta_model.py
@@ -5,3 +5,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/method_definitions/init_with_return_type/meta_model.py
+++ b/test_data/parse/unexpected/method_definitions/init_with_return_type/meta_model.py
@@ -5,3 +5,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/method_definitions/with_keyword_only_arguments/meta_model.py
+++ b/test_data/parse/unexpected/method_definitions/with_keyword_only_arguments/meta_model.py
@@ -5,3 +5,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/method_definitions/with_positional_arguments/meta_model.py
+++ b/test_data/parse/unexpected/method_definitions/with_positional_arguments/meta_model.py
@@ -5,3 +5,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/method_definitions/with_type_annotation_for_self/meta_model.py
+++ b/test_data/parse/unexpected/method_definitions/with_type_annotation_for_self/meta_model.py
@@ -5,3 +5,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/method_definitions/with_variable_arguments/meta_model.py
+++ b/test_data/parse/unexpected/method_definitions/with_variable_arguments/meta_model.py
@@ -5,3 +5,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/method_definitions/with_variable_keyword_arguments/meta_model.py
+++ b/test_data/parse/unexpected/method_definitions/with_variable_keyword_arguments/meta_model.py
@@ -5,3 +5,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/method_definitions/without_arguments/meta_model.py
+++ b/test_data/parse/unexpected/method_definitions/without_arguments/meta_model.py
@@ -5,3 +5,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/method_definitions/without_self/meta_model.py
+++ b/test_data/parse/unexpected/method_definitions/without_self/meta_model.py
@@ -5,3 +5,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/method_definitions/without_type_annotation_for_result/meta_model.py
+++ b/test_data/parse/unexpected/method_definitions/without_type_annotation_for_result/meta_model.py
@@ -5,3 +5,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/property_definitions/final_without_subscript/meta_model.py
+++ b/test_data/parse/unexpected/property_definitions/final_without_subscript/meta_model.py
@@ -4,3 +4,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/property_definitions/nested_final/meta_model.py
+++ b/test_data/parse/unexpected/property_definitions/nested_final/meta_model.py
@@ -4,3 +4,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/property_definitions/non_simple/meta_model.py
+++ b/test_data/parse/unexpected/property_definitions/non_simple/meta_model.py
@@ -4,3 +4,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/property_definitions/unexpected_assignment/meta_model.py
+++ b/test_data/parse/unexpected/property_definitions/unexpected_assignment/meta_model.py
@@ -4,3 +4,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/property_definitions/unexpected_non_name_property/meta_model.py
+++ b/test_data/parse/unexpected/property_definitions/unexpected_non_name_property/meta_model.py
@@ -4,3 +4,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/property_definitions/without_type_annotation/meta_model.py
+++ b/test_data/parse/unexpected/property_definitions/without_type_annotation/meta_model.py
@@ -4,3 +4,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/symbol_table/constant_set_with_a_non_set_subset/meta_model.py
+++ b/test_data/parse/unexpected/symbol_table/constant_set_with_a_non_set_subset/meta_model.py
@@ -4,3 +4,4 @@ Something: Set[str] = constant_set(values=[], subsets=[Some_string])
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/symbol_table/dangling_inheritance/meta_model.py
+++ b/test_data/parse/unexpected/symbol_table/dangling_inheritance/meta_model.py
@@ -4,3 +4,4 @@ class Something(Dangling):
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/symbol_table/dangling_reference_in_type_annotation_of_a_property/meta_model.py
+++ b/test_data/parse/unexpected/symbol_table/dangling_reference_in_type_annotation_of_a_property/meta_model.py
@@ -4,3 +4,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/symbol_table/dangling_reference_in_type_annotation_of_an_argument/meta_model.py
+++ b/test_data/parse/unexpected/symbol_table/dangling_reference_in_type_annotation_of_an_argument/meta_model.py
@@ -5,3 +5,4 @@ class Something:
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/symbol_table/dangling_reference_in_type_annotation_of_constant_set/meta_model.py
+++ b/test_data/parse/unexpected/symbol_table/dangling_reference_in_type_annotation_of_constant_set/meta_model.py
@@ -4,3 +4,4 @@ Something: Set["Some_dangling_enum"] = constant_set(
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/symbol_table/dangling_subset_in_constant_set/meta_model.py
+++ b/test_data/parse/unexpected/symbol_table/dangling_subset_in_constant_set/meta_model.py
@@ -2,3 +2,4 @@ Something: Set[str] = constant_set(values=[], subsets=[Dangling_subset])
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/parse/unexpected/symbol_table/inheritance_from_non_class/meta_model.py
+++ b/test_data/parse/unexpected/symbol_table/inheritance_from_non_class/meta_model.py
@@ -8,3 +8,4 @@ class Something(Some_enum):
 
 __book_url__ = "dummy"
 __book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/expected_output/rdf-ontology.ttl
+++ b/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/expected_output/rdf-ontology.ttl
@@ -371,6 +371,91 @@ aas:ConceptDescription rdf:type owl:Class ;
     rdfs:comment "Reference to an external definition the concept is compatible to or was derived from."@en ;
 .
 
+###  https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories
+aas:ConceptDescriptionsCategories rdf:type owl:Class ;
+    rdfs:label "Concept Descriptions Categories"^^xsd:string ;
+    owl:oneOf (
+        <https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/ApplicationClass>
+        <https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Capability>
+        <https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Collections>
+        <https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Documentation>
+        <https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Entity>
+        <https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Event>
+        <https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Function>
+        <https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Property>
+        <https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/QualifierType>
+        <https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Range>
+        <https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Referencing>
+        <https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Relationship>
+        <https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Value>
+    ) ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/ApplicationClass
+<https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/ApplicationClass> rdf:type aas:ConceptDescriptionsCategories ;
+    rdfs:label "Application Class"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Capability
+<https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Capability> rdf:type aas:ConceptDescriptionsCategories ;
+    rdfs:label "Capability"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Collections
+<https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Collections> rdf:type aas:ConceptDescriptionsCategories ;
+    rdfs:label "Collections"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Documentation
+<https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Documentation> rdf:type aas:ConceptDescriptionsCategories ;
+    rdfs:label "Documentation"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Entity
+<https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Entity> rdf:type aas:ConceptDescriptionsCategories ;
+    rdfs:label "Entity"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Event
+<https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Event> rdf:type aas:ConceptDescriptionsCategories ;
+    rdfs:label "Event"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Function
+<https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Function> rdf:type aas:ConceptDescriptionsCategories ;
+    rdfs:label "Function"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Property
+<https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Property> rdf:type aas:ConceptDescriptionsCategories ;
+    rdfs:label "Property"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/QualifierType
+<https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/QualifierType> rdf:type aas:ConceptDescriptionsCategories ;
+    rdfs:label "Qualifier Type"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Range
+<https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Range> rdf:type aas:ConceptDescriptionsCategories ;
+    rdfs:label "Range"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Referencing
+<https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Referencing> rdf:type aas:ConceptDescriptionsCategories ;
+    rdfs:label "Referencing"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Relationship
+<https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Relationship> rdf:type aas:ConceptDescriptionsCategories ;
+    rdfs:label "Relationship"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Value
+<https://admin-shell.io/aas/3/0/RC02/ConceptDescriptionsCategories/Value> rdf:type aas:ConceptDescriptionsCategories ;
+    rdfs:label "Value"^^xsd:string ;
+.
+
 ###  https://admin-shell.io/aas/3/0/RC02/DataElement
 aas:DataElement rdf:type owl:Class ;
     rdfs:subClassOf aas:SubmodelElement ;
@@ -378,48 +463,223 @@ aas:DataElement rdf:type owl:Class ;
     rdfs:comment "A data element is a submodel element that is not further composed out of other submodel elements."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC02/DataSpecification
-aas:DataSpecification rdf:type owl:Class ;
-    rdfs:label "Data Specification"^^xsd:string ;
-    rdfs:comment "Data Specification Template"@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC02/DataSpecification/administration
-<https://admin-shell.io/aas/3/0/RC02/DataSpecification/administration> rdf:type owl:ObjectProperty ;
-    rdfs:label "has administration"^^xsd:string ;
-    rdfs:domain aas:DataSpecification ;
-    rdfs:range aas:AdministrativeInformation ;
-    rdfs:comment "Administrative information of an identifiable element."@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC02/DataSpecification/dataSpecificationContent
-<https://admin-shell.io/aas/3/0/RC02/DataSpecification/dataSpecificationContent> rdf:type owl:ObjectProperty ;
-    rdfs:label "has data specification content"^^xsd:string ;
-    rdfs:domain aas:DataSpecification ;
-    rdfs:range aas:DataSpecificationContent ;
-    rdfs:comment "The content of the template without meta data"@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC02/DataSpecification/description
-<https://admin-shell.io/aas/3/0/RC02/DataSpecification/description> rdf:type owl:ObjectProperty ;
-    rdfs:label "has description"^^xsd:string ;
-    rdfs:domain aas:DataSpecification ;
-    rdfs:range aas:LangStringSet ;
-    rdfs:comment "Description how and in which context the data specification template is applicable. The description can be provided in several languages."@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC02/DataSpecification/id
-<https://admin-shell.io/aas/3/0/RC02/DataSpecification/id> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has id"^^xsd:string ;
-    rdfs:domain aas:DataSpecification ;
-    rdfs:range xsd:string ;
-    rdfs:comment "The globally unique identification of the element."@en ;
-.
-
 ###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationContent
 aas:DataSpecificationContent rdf:type owl:Class ;
     rdfs:label "Data Specification Content"^^xsd:string ;
     rdfs:comment "Data specification content is part of a data specification template and defines which additional attributes shall be added to the element instance that references the data specification template and meta information about the template itself."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360
+aas:DataSpecificationIEC61360 rdf:type owl:Class ;
+    rdfs:subClassOf aas:DataSpecificationContent ;
+    rdfs:label "Data Specification IEC 61360"^^xsd:string ;
+    rdfs:comment "Content of data specification template for concept descriptions for properties, values and value lists conformant to IEC 61360."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/dataType
+<https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/dataType> rdf:type owl:ObjectProperty ;
+    rdfs:label "has data type"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationIEC61360 ;
+    rdfs:range aas:DataTypeIEC61360 ;
+    rdfs:comment "Data Type"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/definition
+<https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/definition> rdf:type owl:ObjectProperty ;
+    rdfs:label "has definition"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationIEC61360 ;
+    rdfs:range aas:LangStringSet ;
+    rdfs:comment "Definition in different languages"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/levelType
+<https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/levelType> rdf:type owl:ObjectProperty ;
+    rdfs:label "has level type"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationIEC61360 ;
+    rdfs:range aas:LevelType ;
+    rdfs:comment "Set of levels."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/preferredName
+<https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/preferredName> rdf:type owl:ObjectProperty ;
+    rdfs:label "has preferred name"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationIEC61360 ;
+    rdfs:range aas:LangStringSet ;
+    rdfs:comment "Preferred name"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/shortName
+<https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/shortName> rdf:type owl:ObjectProperty ;
+    rdfs:label "has short name"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationIEC61360 ;
+    rdfs:range aas:LangStringSet ;
+    rdfs:comment "Short name"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/sourceOfDefinition
+<https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/sourceOfDefinition> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has source of definition"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationIEC61360 ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Source of definition"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/symbol
+<https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/symbol> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has symbol"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationIEC61360 ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Symbol"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/unit
+<https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/unit> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has unit"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationIEC61360 ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Unit"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/unitId
+<https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/unitId> rdf:type owl:ObjectProperty ;
+    rdfs:label "has unit id"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationIEC61360 ;
+    rdfs:range aas:Reference ;
+    rdfs:comment "Unique unit id"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/value
+<https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/value> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has value"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationIEC61360 ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Value"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/valueFormat
+<https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/valueFormat> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has value format"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationIEC61360 ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Value Format"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/valueList
+<https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/valueList> rdf:type owl:ObjectProperty ;
+    rdfs:label "has value list"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationIEC61360 ;
+    rdfs:range aas:ValueList ;
+    rdfs:comment "List of allowed values"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit
+aas:DataSpecificationPhysicalUnit rdf:type owl:Class ;
+    rdfs:subClassOf aas:DataSpecificationContent ;
+    rdfs:label "Data Specification Physical Unit"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/conversionFactor
+<https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/conversionFactor> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has conversion factor"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationPhysicalUnit ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Conversion factor"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/definition
+<https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/definition> rdf:type owl:ObjectProperty ;
+    rdfs:label "has definition"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationPhysicalUnit ;
+    rdfs:range aas:LangStringSet ;
+    rdfs:comment "Definition in different languages"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/dinNotation
+<https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/dinNotation> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has din notation"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationPhysicalUnit ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Notation of physical unit conformant to DIN"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/eceCode
+<https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/eceCode> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has ece code"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationPhysicalUnit ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Code of physical unit conformant to ECE"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/eceName
+<https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/eceName> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has ece name"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationPhysicalUnit ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Name of physical unit conformant to ECE"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/nistName
+<https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/nistName> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has nist name"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationPhysicalUnit ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Name of NIST physical unit"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/registrationAuthorityId
+<https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/registrationAuthorityId> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has registration authority id"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationPhysicalUnit ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Registration authority ID"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/siName
+<https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/siName> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has si name"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationPhysicalUnit ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Name of SI physical unit"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/siNotation
+<https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/siNotation> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has si notation"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationPhysicalUnit ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Notation of SI physical unit"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/sourceOfDefinition
+<https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/sourceOfDefinition> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has source of definition"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationPhysicalUnit ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Source of definition"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/supplier
+<https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/supplier> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has supplier"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationPhysicalUnit ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Supplier"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/unitName
+<https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/unitName> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has unit name"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationPhysicalUnit ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Name of the physical unit"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/unitSymbol
+<https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/unitSymbol> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has unit symbol"^^xsd:string ;
+    rdfs:domain aas:DataSpecificationPhysicalUnit ;
+    rdfs:range xsd:string ;
+    rdfs:comment "Symbol for the physical unit"@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC02/DataTypeDefXsd
@@ -628,6 +888,146 @@ aas:DataTypeDefXsd rdf:type owl:Class ;
     rdfs:label "Year Month Duration"^^xsd:string ;
 .
 
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360
+aas:DataTypeIEC61360 rdf:type owl:Class ;
+    rdfs:label "Data Type IEC 61360"^^xsd:string ;
+    owl:oneOf (
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Blob>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Boolean>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Date>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/File>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Html>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/IntegerCount>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/IntegerCurrency>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/IntegerMeasure>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Irdi>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Iri>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Rational>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/RationalMeasure>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/RealCount>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/RealCurrency>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/RealMeasure>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/String>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/StringTranslatable>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Time>
+        <https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Timestamp>
+    ) ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Blob
+<https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Blob> rdf:type aas:DataTypeIEC61360 ;
+    rdfs:label "Blob"^^xsd:string ;
+    rdfs:comment "values containing the content of a file. Values may be binaries."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Boolean
+<https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Boolean> rdf:type aas:DataTypeIEC61360 ;
+    rdfs:label "Boolean"^^xsd:string ;
+    rdfs:comment "values representing truth of logic or Boolean algebra (TRUE, FALSE)"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Date
+<https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Date> rdf:type aas:DataTypeIEC61360 ;
+    rdfs:label "Date"^^xsd:string ;
+    rdfs:comment "values containing a calendar date, conformant to ISO 8601:2004 Format yyyy-mm-dd Example from IEC 61360-1:2017: \"1999-05-31\" is the [DATE] representation of: \"31 May 1999\"."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/File
+<https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/File> rdf:type aas:DataTypeIEC61360 ;
+    rdfs:label "File"^^xsd:string ;
+    rdfs:comment "values containing an address to a file. The values are of type URI and can represent an absolute or relative path."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Html
+<https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Html> rdf:type aas:DataTypeIEC61360 ;
+    rdfs:label "Html"^^xsd:string ;
+    rdfs:comment "Values containing string with any sequence of characters, using the syntax of HTML5 (see W3C Recommendation 28:2014)"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/IntegerCount
+<https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/IntegerCount> rdf:type aas:DataTypeIEC61360 ;
+    rdfs:label "Integer Count"^^xsd:string ;
+    rdfs:comment "values containing values of type INTEGER but are no currencies or measures"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/IntegerCurrency
+<https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/IntegerCurrency> rdf:type aas:DataTypeIEC61360 ;
+    rdfs:label "Integer Currency"^^xsd:string ;
+    rdfs:comment "values containing values of type INTEGER that are currencies"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/IntegerMeasure
+<https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/IntegerMeasure> rdf:type aas:DataTypeIEC61360 ;
+    rdfs:label "Integer Measure"^^xsd:string ;
+    rdfs:comment "values containing values that are measure of type INTEGER. In addition such a value comes with a physical unit."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Irdi
+<https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Irdi> rdf:type aas:DataTypeIEC61360 ;
+    rdfs:label "IRDI"^^xsd:string ;
+    rdfs:comment "values conforming to ISO/IEC 11179 series global identifier sequences"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Iri
+<https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Iri> rdf:type aas:DataTypeIEC61360 ;
+    rdfs:label "IRI"^^xsd:string ;
+    rdfs:comment "values containing values of type STRING conformant to Rfc 3987"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Rational
+<https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Rational> rdf:type aas:DataTypeIEC61360 ;
+    rdfs:label "Rational"^^xsd:string ;
+    rdfs:comment "values containing values of type rational"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/RationalMeasure
+<https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/RationalMeasure> rdf:type aas:DataTypeIEC61360 ;
+    rdfs:label "Rational Measure"^^xsd:string ;
+    rdfs:comment "values containing values of type rational. In addition such a value comes with a physical unit."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/RealCount
+<https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/RealCount> rdf:type aas:DataTypeIEC61360 ;
+    rdfs:label "Real Count"^^xsd:string ;
+    rdfs:comment "values containing numbers that can be written as a terminating or non-terminating decimal; a rational or irrational number but are no currencies or measures"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/RealCurrency
+<https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/RealCurrency> rdf:type aas:DataTypeIEC61360 ;
+    rdfs:label "Real Currency"^^xsd:string ;
+    rdfs:comment "values containing values of type REAL that are currencies"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/RealMeasure
+<https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/RealMeasure> rdf:type aas:DataTypeIEC61360 ;
+    rdfs:label "Real Measure"^^xsd:string ;
+    rdfs:comment "values containing values that are measures of type REAL. In addition such a value comes with a physical unit."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/String
+<https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/String> rdf:type aas:DataTypeIEC61360 ;
+    rdfs:label "String"^^xsd:string ;
+    rdfs:comment "values consisting of sequence of characters but cannot be translated into other languages"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/StringTranslatable
+<https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/StringTranslatable> rdf:type aas:DataTypeIEC61360 ;
+    rdfs:label "String Translatable"^^xsd:string ;
+    rdfs:comment "values containing string but shall be represented as different string in different languages"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Time
+<https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Time> rdf:type aas:DataTypeIEC61360 ;
+    rdfs:label "Time"^^xsd:string ;
+    rdfs:comment "values containing a time, conformant to ISO 8601:2004 but restricted to what is allowed in the corresponding type in xml."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Timestamp
+<https://admin-shell.io/aas/3/0/RC02/DataTypeIEC61360/Timestamp> rdf:type aas:DataTypeIEC61360 ;
+    rdfs:label "Timestamp"^^xsd:string ;
+    rdfs:comment "values containing a time, conformant to ISO 8601:2004 but restricted to what is allowed in the corresponding type in xml."@en ;
+.
+
 ###  https://admin-shell.io/aas/3/0/RC02/Direction
 aas:Direction rdf:type owl:Class ;
     rdfs:label "Direction"^^xsd:string ;
@@ -648,6 +1048,28 @@ aas:Direction rdf:type owl:Class ;
 <https://admin-shell.io/aas/3/0/RC02/Direction/Output> rdf:type aas:Direction ;
     rdfs:label "Output"^^xsd:string ;
     rdfs:comment "Output direction"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/EmbeddedDataSpecification
+aas:EmbeddedDataSpecification rdf:type owl:Class ;
+    rdfs:label "Embedded Data Specification"^^xsd:string ;
+    rdfs:comment "Embed the content of a data specification."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/EmbeddedDataSpecification/dataSpecification
+<https://admin-shell.io/aas/3/0/RC02/EmbeddedDataSpecification/dataSpecification> rdf:type owl:ObjectProperty ;
+    rdfs:label "has data specification"^^xsd:string ;
+    rdfs:domain aas:EmbeddedDataSpecification ;
+    rdfs:range aas:Reference ;
+    rdfs:comment "Reference to the data specification"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/EmbeddedDataSpecification/dataSpecificationContent
+<https://admin-shell.io/aas/3/0/RC02/EmbeddedDataSpecification/dataSpecificationContent> rdf:type owl:ObjectProperty ;
+    rdfs:label "has data specification content"^^xsd:string ;
+    rdfs:domain aas:EmbeddedDataSpecification ;
+    rdfs:range aas:DataSpecificationContent ;
+    rdfs:comment "Actual content of the data specification"@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC02/Entity
@@ -886,12 +1308,12 @@ aas:HasDataSpecification rdf:type owl:Class ;
     rdfs:comment "Element that can be extended by using data specification templates."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC02/HasDataSpecification/dataSpecifications
-<https://admin-shell.io/aas/3/0/RC02/HasDataSpecification/dataSpecifications> rdf:type owl:ObjectProperty ;
-    rdfs:label "has data specifications"^^xsd:string ;
+###  https://admin-shell.io/aas/3/0/RC02/HasDataSpecification/embeddedDataSpecifications
+<https://admin-shell.io/aas/3/0/RC02/HasDataSpecification/embeddedDataSpecifications> rdf:type owl:ObjectProperty ;
+    rdfs:label "has embedded data specifications"^^xsd:string ;
     rdfs:domain aas:HasDataSpecification ;
-    rdfs:range aas:Reference ;
-    rdfs:comment "Global reference to the data specification template used by the element."@en ;
+    rdfs:range aas:EmbeddedDataSpecification ;
+    rdfs:comment "Embedded data specification."@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC02/HasExtensions
@@ -1186,6 +1608,37 @@ aas:LangStringSet rdf:type owl:Class ;
     rdfs:domain aas:LangStringSet ;
     rdfs:range aas:LangString ;
     rdfs:comment "Strings in different languages"@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/LevelType
+aas:LevelType rdf:type owl:Class ;
+    rdfs:label "Level Type"^^xsd:string ;
+    owl:oneOf (
+        <https://admin-shell.io/aas/3/0/RC02/LevelType/Max>
+        <https://admin-shell.io/aas/3/0/RC02/LevelType/Min>
+        <https://admin-shell.io/aas/3/0/RC02/LevelType/Nom>
+        <https://admin-shell.io/aas/3/0/RC02/LevelType/Typ>
+    ) ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/LevelType/Max
+<https://admin-shell.io/aas/3/0/RC02/LevelType/Max> rdf:type aas:LevelType ;
+    rdfs:label "Max"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/LevelType/Min
+<https://admin-shell.io/aas/3/0/RC02/LevelType/Min> rdf:type aas:LevelType ;
+    rdfs:label "Min"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/LevelType/Nom
+<https://admin-shell.io/aas/3/0/RC02/LevelType/Nom> rdf:type aas:LevelType ;
+    rdfs:label "Nom"^^xsd:string ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/LevelType/Typ
+<https://admin-shell.io/aas/3/0/RC02/LevelType/Typ> rdf:type aas:LevelType ;
+    rdfs:label "Typ"^^xsd:string ;
 .
 
 ###  https://admin-shell.io/aas/3/0/RC02/ModelingKind
@@ -1732,4 +2185,40 @@ aas:SubmodelElementList rdf:type owl:Class ;
     rdfs:domain aas:SubmodelElementList ;
     rdfs:range aas:DataTypeDefXsd ;
     rdfs:comment "The value type of the submodel element contained in the list."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ValueList
+aas:ValueList rdf:type owl:Class ;
+    rdfs:label "Value List"^^xsd:string ;
+    rdfs:comment "A set of value reference pairs."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ValueList/valueReferencePairTypes
+<https://admin-shell.io/aas/3/0/RC02/ValueList/valueReferencePairTypes> rdf:type owl:ObjectProperty ;
+    rdfs:label "has value reference pair types"^^xsd:string ;
+    rdfs:domain aas:ValueList ;
+    rdfs:range aas:ValueReferencePair ;
+    rdfs:comment "A pair of a value together with its global unique id."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ValueReferencePair
+aas:ValueReferencePair rdf:type owl:Class ;
+    rdfs:label "Value Reference Pair"^^xsd:string ;
+    rdfs:comment "A value reference pair within a value list. Each value has a global unique id defining its semantic."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ValueReferencePair/value
+<https://admin-shell.io/aas/3/0/RC02/ValueReferencePair/value> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has value"^^xsd:string ;
+    rdfs:domain aas:ValueReferencePair ;
+    rdfs:range xsd:string ;
+    rdfs:comment "The value of the referenced concept definition of the value in valueId."@en ;
+.
+
+###  https://admin-shell.io/aas/3/0/RC02/ValueReferencePair/valueId
+<https://admin-shell.io/aas/3/0/RC02/ValueReferencePair/valueId> rdf:type owl:ObjectProperty ;
+    rdfs:label "has value id"^^xsd:string ;
+    rdfs:domain aas:ValueReferencePair ;
+    rdfs:range aas:Reference ;
+    rdfs:comment "Global unique id of the value."@en ;
 .

--- a/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/expected_output/shacl-schema.ttl
+++ b/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/expected_output/shacl-schema.ttl
@@ -227,11 +227,121 @@ aas:DataElementShape a sh:NodeShape ;
     ] ;
 .
 
-aas:DataSpecificationShape a sh:NodeShape ;
-    sh:targetClass aas:DataSpecification ;
+aas:DataSpecificationContentShape a sh:NodeShape ;
+    sh:targetClass aas:DataSpecificationContent ;
+    sh:sparql [
+        a sh:SPARQLConstraint ;
+        sh:message "(DataSpecificationContentShape): An aas:DataSpecificationContent is an abstract class. Please use one of the subclasses for the generation of instances."@en ;
+        sh:prefixes aas: ;
+        sh:select """
+            SELECT ?this ?type
+            WHERE {
+                ?this rdf:type ?type .
+                FILTER (?type = aas:DataSpecificationContent)
+            }
+        """ ;
+    ] ;
+.
+
+aas:DataSpecificationIEC61360Shape a sh:NodeShape ;
+    sh:targetClass aas:DataSpecificationIEC61360 ;
+    rdfs:subClassOf aas:DataSpecificationContentShape ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecification/id> ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/preferredName> ;
+        sh:class aas:LangStringSet ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/shortName> ;
+        sh:class aas:LangStringSet ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/unit> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/unitId> ;
+        sh:class aas:Reference ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/sourceOfDefinition> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/symbol> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/dataType> ;
+        sh:class aas:DataTypeIEC61360 ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/definition> ;
+        sh:class aas:LangStringSet ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/valueFormat> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/valueList> ;
+        sh:class aas:ValueList ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/value> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/levelType> ;
+        sh:class aas:LevelType ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+.
+
+aas:DataSpecificationPhysicalUnitShape a sh:NodeShape ;
+    sh:targetClass aas:DataSpecificationPhysicalUnit ;
+    rdfs:subClassOf aas:DataSpecificationContentShape ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/unitName> ;
         sh:datatype xsd:string ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
@@ -239,29 +349,117 @@ aas:DataSpecificationShape a sh:NodeShape ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecification/dataSpecificationContent> ;
-        sh:class aas:DataSpecificationContent ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/unitSymbol> ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/definition> ;
+        sh:class aas:LangStringSet ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecification/administration> ;
-        sh:class aas:AdministrativeInformation ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/siNotation> ;
+        sh:datatype xsd:string ;
         sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/siName> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/dinNotation> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/eceName> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/eceCode> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/nistName> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/sourceOfDefinition> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/conversionFactor> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/registrationAuthorityId> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/supplier> ;
+        sh:datatype xsd:string ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:minLength 1 ;
+    ] ;
+.
+
+aas:EmbeddedDataSpecificationShape a sh:NodeShape ;
+    sh:targetClass aas:EmbeddedDataSpecification ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/EmbeddedDataSpecification/dataSpecification> ;
+        sh:class aas:Reference ;
+        sh:minCount 1 ;
         sh:maxCount 1 ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecification/description> ;
-        sh:class aas:LangStringSet ;
-        sh:minCount 0 ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/EmbeddedDataSpecification/dataSpecificationContent> ;
+        sh:class aas:DataSpecificationContent ;
+        sh:minCount 1 ;
         sh:maxCount 1 ;
     ] ;
-.
-
-aas:DataSpecificationContentShape a sh:NodeShape ;
-    sh:targetClass aas:DataSpecificationContent ;
 .
 
 aas:EntityShape a sh:NodeShape ;
@@ -471,8 +669,8 @@ aas:HasDataSpecificationShape a sh:NodeShape ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/RC02/HasDataSpecification/dataSpecifications> ;
-        sh:class aas:Reference ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/HasDataSpecification/embeddedDataSpecifications> ;
+        sh:class aas:EmbeddedDataSpecification ;
         sh:minCount 0 ;
     ] ;
 .
@@ -1042,6 +1240,34 @@ aas:SubmodelElementListShape a sh:NodeShape ;
         sh:path <https://admin-shell.io/aas/3/0/RC02/SubmodelElementList/valueTypeListElement> ;
         sh:class aas:DataTypeDefXsd ;
         sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+.
+
+aas:ValueListShape a sh:NodeShape ;
+    sh:targetClass aas:ValueList ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/ValueList/valueReferencePairTypes> ;
+        sh:class aas:ValueReferencePair ;
+        sh:minCount 1 ;
+    ] ;
+.
+
+aas:ValueReferencePairShape a sh:NodeShape ;
+    sh:targetClass aas:ValueReferencePair ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/ValueReferencePair/value> ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://admin-shell.io/aas/3/0/RC02/ValueReferencePair/valueId> ;
+        sh:class aas:Reference ;
+        sh:minCount 1 ;
         sh:maxCount 1 ;
     ] ;
 .

--- a/test_data/smoke/test_main/unexpected/infer_for_schema_error/meta_model.py
+++ b/test_data/smoke/test_main/unexpected/infer_for_schema_error/meta_model.py
@@ -10,3 +10,4 @@ class Something:
 
 __book_version__ = "dummy"
 __book_url__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/smoke/test_main/unexpected/intermediate_error/meta_model.py
+++ b/test_data/smoke/test_main/unexpected/intermediate_error/meta_model.py
@@ -16,3 +16,4 @@ class Bundle:
 
 __book_version__ = "dummy"
 __book_url__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/smoke/test_main/unexpected/parse_error/expected_stderr.txt
+++ b/test_data/smoke/test_main/unexpected/parse_error/expected_stderr.txt
@@ -2,3 +2,4 @@ Failed to construct the symbol table from <meta_model.py>:
 * Failed to parse the meta-model
     The book URL (given as assignment to ``__book_url__``) is missing
     The book version (given as assignment to ``__book_version__``) is missing
+    The XML namespace (given as assignment to ``__xml_namespace__``) is missing

--- a/test_data/smoke/test_main/unexpected/pattern_verification_unparsable_regex/direct_match/meta_model.py
+++ b/test_data/smoke/test_main/unexpected/pattern_verification_unparsable_regex/direct_match/meta_model.py
@@ -6,3 +6,4 @@ def match_something(text: str) -> None:
 
 __book_version__ = "dummy"
 __book_url__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/xsd/test_main/aas_core_meta.v3rc2/expected_output/schema.xsd
+++ b/test_data/xsd/test_main/aas_core_meta.v3rc2/expected_output/schema.xsd
@@ -144,22 +144,157 @@
       <xs:element name="referenceElement" type="referenceElement_t"/>
     </xs:choice>
   </xs:group>
-  <xs:group name="dataSpecification">
+  <xs:group name="dataSpecificationContent">
+    <xs:sequence/>
+  </xs:group>
+  <xs:group name="dataSpecificationContent_choice">
+    <xs:choice>
+      <xs:element name="dataSpecificationIec61360" type="dataSpecificationIec61360_t"/>
+      <xs:element name="dataSpecificationPhysicalUnit" type="dataSpecificationPhysicalUnit_t"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="dataSpecificationIec61360">
     <xs:sequence>
-      <xs:element name="id">
+      <xs:group ref="dataSpecificationContent"/>
+      <xs:element name="preferredName" type="langStringSet_t"/>
+      <xs:element name="shortName" type="langStringSet_t" minOccurs="0"/>
+      <xs:element name="unit" minOccurs="0">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="dataSpecificationContent" type="dataSpecificationContent_t"/>
-      <xs:element name="administration" type="administrativeInformation_t" minOccurs="0"/>
-      <xs:element name="description" type="langStringSet_t" minOccurs="0"/>
+      <xs:element name="unitId" type="reference_t" minOccurs="0"/>
+      <xs:element name="sourceOfDefinition" minOccurs="0">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="symbol" minOccurs="0">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="dataType" type="dataTypeIec61360_t" minOccurs="0"/>
+      <xs:element name="definition" type="langStringSet_t" minOccurs="0"/>
+      <xs:element name="valueFormat" minOccurs="0">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="valueList" type="valueList_t" minOccurs="0"/>
+      <xs:element name="value" type="xs:string" minOccurs="0"/>
+      <xs:element name="levelType" type="levelType_t" minOccurs="0"/>
     </xs:sequence>
   </xs:group>
-  <xs:group name="dataSpecificationContent">
-    <xs:sequence/>
+  <xs:group name="dataSpecificationPhysicalUnit">
+    <xs:sequence>
+      <xs:group ref="dataSpecificationContent"/>
+      <xs:element name="unitName">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="unitSymbol">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="definition" type="langStringSet_t"/>
+      <xs:element name="siNotation" minOccurs="0">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="siName" minOccurs="0">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="dinNotation" minOccurs="0">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="eceName" minOccurs="0">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="eceCode" minOccurs="0">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="nistName" minOccurs="0">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="sourceOfDefinition" minOccurs="0">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="conversionFactor" minOccurs="0">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="registrationAuthorityId" minOccurs="0">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="supplier" minOccurs="0">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="embeddedDataSpecification">
+    <xs:sequence>
+      <xs:element name="dataSpecification" type="reference_t"/>
+      <xs:element name="dataSpecificationContent">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="dataSpecificationContent_choice"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
   </xs:group>
   <xs:group name="entity">
     <xs:sequence>
@@ -279,10 +414,10 @@
   </xs:group>
   <xs:group name="hasDataSpecification">
     <xs:sequence>
-      <xs:element name="dataSpecifications" minOccurs="0">
+      <xs:element name="embeddedDataSpecifications" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="reference" type="reference_t" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="embeddedDataSpecification" type="embeddedDataSpecification_t" minOccurs="0" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
@@ -754,6 +889,23 @@
       <xs:element name="submodelElementList" type="submodelElementList_t"/>
     </xs:choice>
   </xs:group>
+  <xs:group name="valueList">
+    <xs:sequence>
+      <xs:element name="valueReferencePairTypes">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="valueReferencePair" type="valueReferencePair_t" minOccurs="1" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="valueReferencePair">
+    <xs:sequence>
+      <xs:element name="value" type="xs:string"/>
+      <xs:element name="valueId" type="reference_t"/>
+    </xs:sequence>
+  </xs:group>
   <xs:simpleType name="aasSubmodelElements_t">
     <xs:restriction base="xs:string">
       <xs:enumeration value="AnnotatedRelationshipElement"/>
@@ -818,6 +970,29 @@
       <xs:enumeration value="xs:negativeInteger"/>
     </xs:restriction>
   </xs:simpleType>
+  <xs:simpleType name="dataTypeIec61360_t">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="DATE"/>
+      <xs:enumeration value="STRING"/>
+      <xs:enumeration value="STRING_TRANSLATABLE"/>
+      <xs:enumeration value="INTEGER_MEASURE"/>
+      <xs:enumeration value="INTEGER_COUNT"/>
+      <xs:enumeration value="INTEGER_CURRENCY"/>
+      <xs:enumeration value="REAL_MEASURE"/>
+      <xs:enumeration value="REAL_COUNT"/>
+      <xs:enumeration value="REAL_CURRENCY"/>
+      <xs:enumeration value="BOOLEAN"/>
+      <xs:enumeration value="IRI"/>
+      <xs:enumeration value="IRDI"/>
+      <xs:enumeration value="RATIONAL"/>
+      <xs:enumeration value="RATIONAL_MEASURE"/>
+      <xs:enumeration value="TIME"/>
+      <xs:enumeration value="TIMESTAMP"/>
+      <xs:enumeration value="FILE"/>
+      <xs:enumeration value="HTML"/>
+      <xs:enumeration value="BLOB"/>
+    </xs:restriction>
+  </xs:simpleType>
   <xs:simpleType name="direction_t">
     <xs:restriction base="xs:string">
       <xs:enumeration value="INPUT"/>
@@ -856,6 +1031,14 @@
       <xs:enumeration value="SubmodelElement"/>
       <xs:enumeration value="SubmodelElementList"/>
       <xs:enumeration value="SubmodelElementCollection"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="levelType_t">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Min"/>
+      <xs:enumeration value="Max"/>
+      <xs:enumeration value="Nom"/>
+      <xs:enumeration value="Typ"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="modelingKind_t">
@@ -933,9 +1116,19 @@
       <xs:group ref="dataSpecificationContent"/>
     </xs:sequence>
   </xs:complexType>
-  <xs:complexType name="dataSpecification_t">
+  <xs:complexType name="dataSpecificationIec61360_t">
     <xs:sequence>
-      <xs:group ref="dataSpecification"/>
+      <xs:group ref="dataSpecificationIec61360"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="dataSpecificationPhysicalUnit_t">
+    <xs:sequence>
+      <xs:group ref="dataSpecificationPhysicalUnit"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="embeddedDataSpecification_t">
+    <xs:sequence>
+      <xs:group ref="embeddedDataSpecification"/>
     </xs:sequence>
   </xs:complexType>
   <xs:complexType name="entity_t">
@@ -1091,6 +1284,16 @@
   <xs:complexType name="submodel_t">
     <xs:sequence>
       <xs:group ref="submodel"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="valueList_t">
+    <xs:sequence>
+      <xs:group ref="valueList"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="valueReferencePair_t">
+    <xs:sequence>
+      <xs:group ref="valueReferencePair"/>
     </xs:sequence>
   </xs:complexType>
   <xs:element name="environment" type="environment_t"/>

--- a/tests/csharp/test_description.py
+++ b/tests/csharp/test_description.py
@@ -39,6 +39,7 @@ class Test_to_render_description_of_meta_model(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             '''
         )
 
@@ -56,6 +57,7 @@ class Test_to_render_description_of_meta_model(unittest.TestCase):
 
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
+                __xml_namespace__ = "https://dummy.com"
                 '''
             )
         )
@@ -106,6 +108,7 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             '''
         )
 
@@ -127,6 +130,7 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             '''
         )
 
@@ -158,6 +162,7 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             '''
         )
 
@@ -180,6 +185,7 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
 
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
+                __xml_namespace__ = "https://dummy.com"
                 '''
             )
         )
@@ -203,6 +209,7 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
 
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
+                __xml_namespace__ = "https://dummy.com"
                 '''
             )
         )
@@ -225,6 +232,7 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
 
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
+                __xml_namespace__ = "https://dummy.com"
                 '''
             )
         )
@@ -248,6 +256,7 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
 
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
+                __xml_namespace__ = "https://dummy.com"
                 '''
             )
         )
@@ -277,6 +286,7 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
 
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
+                __xml_namespace__ = "https://dummy.com"
                 '''
             )
         )
@@ -329,6 +339,7 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
 
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
+                __xml_namespace__ = "https://dummy.com"
                 '''
             )
         )
@@ -397,6 +408,7 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
 
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
+                __xml_namespace__ = "https://dummy.com"
                 '''
             )
         )
@@ -454,6 +466,7 @@ class Test_to_render_description_of_signature(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             '''
         )
 
@@ -475,6 +488,7 @@ class Test_to_render_description_of_signature(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             '''
         )
 
@@ -516,6 +530,7 @@ class Test_to_render_description_of_signature(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             '''
         )
 
@@ -581,6 +596,7 @@ class Test_to_render_paragraphs(unittest.TestCase):
 
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
+                __xml_namespace__ = "https://dummy.com"
                 '''
             )
         )
@@ -609,6 +625,7 @@ class Test_to_render_paragraphs(unittest.TestCase):
 
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
+                __xml_namespace__ = "https://dummy.com"
                 '''
             )
         )
@@ -648,6 +665,7 @@ class Test_to_render_paragraphs(unittest.TestCase):
 
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
+                __xml_namespace__ = "https://dummy.com"
                 '''
             )
         )

--- a/tests/infer_for_schema/test_len_on_properties.py
+++ b/tests/infer_for_schema/test_len_on_properties.py
@@ -21,6 +21,7 @@ class Test_expected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -65,6 +66,7 @@ class Test_expected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -112,6 +114,7 @@ class Test_expected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -159,6 +162,7 @@ class Test_expected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -206,6 +210,7 @@ class Test_expected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -257,6 +262,7 @@ class Test_expected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -304,6 +310,7 @@ class Test_expected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -351,6 +358,7 @@ class Test_expected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -402,6 +410,7 @@ class Test_expected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -458,6 +467,7 @@ class Test_expected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -516,6 +526,7 @@ class Test_unexpected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -551,6 +562,7 @@ class Test_unexpected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -586,6 +598,7 @@ class Test_unexpected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -622,6 +635,7 @@ class Test_stacking(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -692,6 +706,7 @@ class Test_stacking(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -763,6 +778,7 @@ class Test_stacking(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 

--- a/tests/infer_for_schema/test_len_on_self.py
+++ b/tests/infer_for_schema/test_len_on_self.py
@@ -25,6 +25,7 @@ class Test_expected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -72,6 +73,7 @@ class Test_expected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -122,6 +124,7 @@ class Test_expected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -172,6 +175,7 @@ class Test_expected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -222,6 +226,7 @@ class Test_expected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -272,6 +277,7 @@ class Test_expected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -322,6 +328,7 @@ class Test_expected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -377,6 +384,7 @@ class Test_expected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -434,6 +442,7 @@ class Test_unexpected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -473,6 +482,7 @@ class Test_unexpected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -512,6 +522,7 @@ class Test_unexpected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 

--- a/tests/infer_for_schema/test_patterns_on_properties.py
+++ b/tests/infer_for_schema/test_patterns_on_properties.py
@@ -22,6 +22,7 @@ class Test_expected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -71,6 +72,7 @@ class Test_expected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -127,6 +129,7 @@ class Test_expected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -183,6 +186,7 @@ class Test_expected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -248,6 +252,7 @@ class Test_expected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -310,6 +315,7 @@ class Test_stacking(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -377,6 +383,7 @@ class Test_stacking(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -452,6 +459,7 @@ class Test_stacking(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -527,6 +535,7 @@ class Test_stacking(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -599,6 +608,7 @@ class Test_stacking(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 

--- a/tests/infer_for_schema/test_patterns_on_self.py
+++ b/tests/infer_for_schema/test_patterns_on_self.py
@@ -25,6 +25,7 @@ class Test_expected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -77,6 +78,7 @@ class Test_expected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -136,6 +138,7 @@ class Test_expected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -199,6 +202,7 @@ class Test_expected(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 

--- a/tests/infer_for_schema/test_property_in_set_of_enumeration_literals.py
+++ b/tests/infer_for_schema/test_property_in_set_of_enumeration_literals.py
@@ -26,6 +26,7 @@ class Test_property_in_set(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -80,6 +81,7 @@ class Test_property_in_set(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -148,6 +150,7 @@ ConstraintsByProperty(
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -208,6 +211,7 @@ ConstraintsByProperty(
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -278,6 +282,7 @@ ConstraintsByProperty(
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -344,6 +349,7 @@ class Test_stacking(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -431,6 +437,7 @@ ConstraintsByProperty(
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -537,6 +544,7 @@ ConstraintsByProperty(
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 

--- a/tests/infer_for_schema/test_property_in_set_of_primitives.py
+++ b/tests/infer_for_schema/test_property_in_set_of_primitives.py
@@ -22,6 +22,7 @@ class Test_property_in_set(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -68,6 +69,7 @@ class Test_property_in_set(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -130,6 +132,7 @@ ConstraintsByProperty(
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -185,6 +188,7 @@ ConstraintsByProperty(
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -250,6 +254,7 @@ ConstraintsByProperty(
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -310,6 +315,7 @@ class Test_stacking(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -392,6 +398,7 @@ ConstraintsByProperty(
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -482,6 +489,7 @@ ConstraintsByProperty(
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 

--- a/tests/intermediate/test_constructor.py
+++ b/tests/intermediate/test_constructor.py
@@ -62,6 +62,7 @@ class Test_empty_ok(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -84,6 +85,7 @@ class Test_empty_ok(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -112,6 +114,7 @@ class Test_call_to_super_constructor_ok(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -146,6 +149,7 @@ class Test_call_to_super_constructor_ok(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -175,6 +179,7 @@ class Test_assign_property_ok(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -203,6 +208,7 @@ class Test_assign_fail(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -226,6 +232,7 @@ class Test_assign_fail(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -250,6 +257,7 @@ class Test_assign_fail(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -270,6 +278,7 @@ class Test_assign_fail(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -292,6 +301,7 @@ class Test_assign_fail(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -319,6 +329,7 @@ class Test_assign_fail(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -356,6 +367,7 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             '''
         )
 
@@ -391,6 +403,7 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             '''
         )
 
@@ -420,6 +433,7 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -446,6 +460,7 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -473,6 +488,7 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -501,6 +517,7 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -531,6 +548,7 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -561,6 +579,7 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -592,6 +611,7 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             '''
         )
 
@@ -623,6 +643,7 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -655,6 +676,7 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -679,6 +701,7 @@ class Test_unexpected_statements(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -702,6 +725,7 @@ class Test_unexpected_statements(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 

--- a/tests/intermediate/test_hierarchy.py
+++ b/tests/intermediate/test_hierarchy.py
@@ -19,6 +19,7 @@ class Test_ontology_ok(unittest.TestCase):
 
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
+                __xml_namespace__ = "https://dummy.com"
                 """
             )
         )
@@ -64,6 +65,7 @@ class Test_ontology_ok(unittest.TestCase):
 
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
+                __xml_namespace__ = "https://dummy.com"
                 """
             )
         )
@@ -111,6 +113,7 @@ class Test_ontology_fail(unittest.TestCase):
 
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
+                __xml_namespace__ = "https://dummy.com"
                 """
             )
         )
@@ -142,6 +145,7 @@ class Test_ontology_fail(unittest.TestCase):
 
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
+                __xml_namespace__ = "https://dummy.com"
                 """
             )
         )
@@ -171,6 +175,7 @@ class Test_ontology_fail(unittest.TestCase):
 
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
+                __xml_namespace__ = "https://dummy.com"
                 """
             )
         )
@@ -201,6 +206,7 @@ class Test_ontology_fail(unittest.TestCase):
 
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
+                __xml_namespace__ = "https://dummy.com"
                 """
             )
         )

--- a/tests/intermediate/test_translate.py
+++ b/tests/intermediate/test_translate.py
@@ -53,6 +53,7 @@ class Test_in_lining_of_constructor_statements(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -84,6 +85,7 @@ class Test_parsing_docstrings(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             '''
         )
 
@@ -123,6 +125,7 @@ class Test_parsing_docstrings(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             '''
         )
 

--- a/tests/intermediate/test_type_inference.py
+++ b/tests/intermediate/test_type_inference.py
@@ -74,6 +74,7 @@ class Test_with_smoke(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -95,6 +96,7 @@ class Test_with_smoke(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -127,6 +129,7 @@ class Test_with_smoke(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -156,6 +159,7 @@ class Test_with_smoke(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 

--- a/tests/intermediate/test_types.py
+++ b/tests/intermediate/test_types.py
@@ -22,6 +22,7 @@ class TestIsSubclassOf(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -58,6 +59,7 @@ class TestIsSubclassOf(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -101,6 +103,7 @@ class TestIsSubclassOf(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 
@@ -143,6 +146,7 @@ class TestIsSubclassOf(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             """
         )
 

--- a/tests/parse/test_parse.py
+++ b/tests/parse/test_parse.py
@@ -167,6 +167,7 @@ class Test_parsing_docstring(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             '''
         )
 
@@ -182,6 +183,7 @@ class Test_parsing_docstring(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             '''
         )
 
@@ -202,6 +204,7 @@ class Test_parsing_docstring(unittest.TestCase):
 
             __book_url__ = "dummy"
             __book_version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
             '''
         )
 


### PR DESCRIPTION
We expected the XML namespace to be specified in the meta-model (as
`__xml_namespace__`), and propagate it to code generation.