### PR TITLE
Update logic for min. length of 1 for lists

### DIFF
--- a/aas_core_codegen/rdf_shacl/shacl.py
+++ b/aas_core_codegen/rdf_shacl/shacl.py
@@ -97,22 +97,34 @@ def _define_property_shape(
     if len_constraint is not None:
         if isinstance(type_anno, intermediate.ListTypeAnnotation):
             if len_constraint.min_value is not None:
-                if len_constraint.min_value > 0 and isinstance(
+                if len_constraint.min_value > 1 and isinstance(
                     prop.type_annotation, intermediate.OptionalTypeAnnotation
                 ):
                     return None, Error(
                         prop.parsed.node,
                         f"(mristin, 2022-02-09): "
                         f"The property {prop.name} is optional, but the minCount "
-                        f"is given. If you see this message, it is time to consider "
-                        f"how to implement this logic; please contact the developers.",
+                        f"is larger than 1. If you see this message, it is time to "
+                        f"consider how to implement this logic; please contact "
+                        f"the developers.",
                     )
 
-                min_count = (
-                    max(min_count, len_constraint.min_value)
-                    if min_count is not None
-                    else len_constraint.min_value
-                )
+                # NOTE (mristin, 2022-08-19):
+                # SHACL does not distinguish between optional and mandatory properties
+                # (*i.e.*, nullable and non-nullable properties). Hence, we simply make
+                # the optional properties as minCount 0 even though we inferred that
+                # the minimum length is 1 in case that the property is null.
+                if len_constraint.min_value == 1 and isinstance(
+                    prop.type_annotation, intermediate.OptionalTypeAnnotation
+                ):
+                    min_count = 0
+
+                else:
+                    min_count = (
+                        max(min_count, len_constraint.min_value)
+                        if min_count is not None
+                        else len_constraint.min_value
+                    )
 
             if len_constraint.max_value is not None:
                 max_count = (

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
             "twine",
             "jsonschema==3.2.0",
             "xmlschema==1.10.0",
-            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@c913cb4#egg=aas-core-meta",
+            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@08f5bb1#egg=aas-core-meta",
         ]
     },
     # fmt: on

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/verification.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/verification.cs
@@ -2406,6 +2406,18 @@ namespace AasCore.Aas3_0_RC02
             {
                 if (!(
                     !(that.SupplementalSemanticIds != null)
+                    || (that.SupplementalSemanticIds.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Supplemental semantic IDs must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.SupplementalSemanticIds != null)\n" +
+                        "|| (that.SupplementalSemanticIds.Count > 0)");
+                }
+
+                if (!(
+                    !(that.SupplementalSemanticIds != null)
                     || (that.SemanticId != null)))
                 {
                     yield return new Reporting.Error(
@@ -2506,6 +2518,18 @@ namespace AasCore.Aas3_0_RC02
                 Aas.AdministrativeInformation that)
             {
                 if (!(
+                    !(that.EmbeddedDataSpecifications != null)
+                    || (that.EmbeddedDataSpecifications.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Embedded data specifications must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.EmbeddedDataSpecifications != null)\n" +
+                        "|| (that.EmbeddedDataSpecifications.Count > 0)");
+                }
+
+                if (!(
                     !(that.Revision != null)
                     || (that.Version != null)))
                 {
@@ -2565,6 +2589,18 @@ namespace AasCore.Aas3_0_RC02
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.Qualifier that)
             {
+                if (!(
+                    !(that.SupplementalSemanticIds != null)
+                    || (that.SupplementalSemanticIds.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Supplemental semantic IDs must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.SupplementalSemanticIds != null)\n" +
+                        "|| (that.SupplementalSemanticIds.Count > 0)");
+                }
+
                 if (!(
                     !(that.SupplementalSemanticIds != null)
                     || (that.SemanticId != null)))
@@ -2678,6 +2714,17 @@ namespace AasCore.Aas3_0_RC02
             {
                 if (!(
                     !(that.Extensions != null)
+                    || (that.Extensions.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Extensions must be either null or have at least one item\n" +
+                        "!(that.Extensions != null)\n" +
+                        "|| (that.Extensions.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Extensions != null)
                     || Verification.ExtensionNamesAreUnique(that.Extensions)))
                 {
                     yield return new Reporting.Error(
@@ -2686,6 +2733,29 @@ namespace AasCore.Aas3_0_RC02
                         "Has-Extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
+                }
+
+                if (!(
+                    !(that.EmbeddedDataSpecifications != null)
+                    || (that.EmbeddedDataSpecifications.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Embedded data specifications must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.EmbeddedDataSpecifications != null)\n" +
+                        "|| (that.EmbeddedDataSpecifications.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Submodels != null)
+                    || (that.Submodels.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Submodels must be either null or have at least one item\n" +
+                        "!(that.Submodels != null)\n" +
+                        "|| (that.Submodels.Count > 0)");
                 }
 
                 if (!(
@@ -2873,6 +2943,18 @@ namespace AasCore.Aas3_0_RC02
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.AssetInformation that)
             {
+                if (!(
+                    !(that.SpecificAssetIds != null)
+                    || (that.SpecificAssetIds.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Specific asset IDs must be either null or have at least one " +
+                        "item\n" +
+                        "!(that.SpecificAssetIds != null)\n" +
+                        "|| (that.SpecificAssetIds.Count > 0)");
+                }
+
                 foreach (var error in Verification.VerifyAssetKind(that.AssetKind))
                 {
                     error.PrependSegment(
@@ -2953,6 +3035,18 @@ namespace AasCore.Aas3_0_RC02
             {
                 if (!(
                     !(that.SupplementalSemanticIds != null)
+                    || (that.SupplementalSemanticIds.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Supplemental semantic IDs must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.SupplementalSemanticIds != null)\n" +
+                        "|| (that.SupplementalSemanticIds.Count > 0)");
+                }
+
+                if (!(
+                    !(that.SupplementalSemanticIds != null)
                     || (that.SemanticId != null)))
                 {
                     yield return new Reporting.Error(
@@ -3024,6 +3118,17 @@ namespace AasCore.Aas3_0_RC02
             {
                 if (!(
                     !(that.Extensions != null)
+                    || (that.Extensions.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Extensions must be either null or have at least one item\n" +
+                        "!(that.Extensions != null)\n" +
+                        "|| (that.Extensions.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Extensions != null)
                     || Verification.ExtensionNamesAreUnique(that.Extensions)))
                 {
                     yield return new Reporting.Error(
@@ -3032,6 +3137,18 @@ namespace AasCore.Aas3_0_RC02
                         "Has-Extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
+                }
+
+                if (!(
+                    !(that.SupplementalSemanticIds != null)
+                    || (that.SupplementalSemanticIds.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Supplemental semantic IDs must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.SupplementalSemanticIds != null)\n" +
+                        "|| (that.SupplementalSemanticIds.Count > 0)");
                 }
 
                 if (!(
@@ -3048,6 +3165,17 @@ namespace AasCore.Aas3_0_RC02
 
                 if (!(
                     !(that.Qualifiers != null)
+                    || (that.Qualifiers.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Qualifiers must be either null or have at least one item\n" +
+                        "!(that.Qualifiers != null)\n" +
+                        "|| (that.Qualifiers.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Qualifiers != null)
                     || Verification.QualifierTypesAreUnique(that.Qualifiers)))
                 {
                     yield return new Reporting.Error(
@@ -3056,6 +3184,30 @@ namespace AasCore.Aas3_0_RC02
                         "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
+                }
+
+                if (!(
+                    !(that.EmbeddedDataSpecifications != null)
+                    || (that.EmbeddedDataSpecifications.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Embedded data specifications must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.EmbeddedDataSpecifications != null)\n" +
+                        "|| (that.EmbeddedDataSpecifications.Count > 0)");
+                }
+
+                if (!(
+                    !(that.SubmodelElements != null)
+                    || (that.SubmodelElements.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Submodel elements must be either null or have at least one " +
+                        "item\n" +
+                        "!(that.SubmodelElements != null)\n" +
+                        "|| (that.SubmodelElements.Count > 0)");
                 }
 
                 if (!(
@@ -3314,6 +3466,17 @@ namespace AasCore.Aas3_0_RC02
             {
                 if (!(
                     !(that.Extensions != null)
+                    || (that.Extensions.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Extensions must be either null or have at least one item\n" +
+                        "!(that.Extensions != null)\n" +
+                        "|| (that.Extensions.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Extensions != null)
                     || Verification.ExtensionNamesAreUnique(that.Extensions)))
                 {
                     yield return new Reporting.Error(
@@ -3322,6 +3485,18 @@ namespace AasCore.Aas3_0_RC02
                         "Has-Extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
+                }
+
+                if (!(
+                    !(that.SupplementalSemanticIds != null)
+                    || (that.SupplementalSemanticIds.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Supplemental semantic IDs must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.SupplementalSemanticIds != null)\n" +
+                        "|| (that.SupplementalSemanticIds.Count > 0)");
                 }
 
                 if (!(
@@ -3338,6 +3513,17 @@ namespace AasCore.Aas3_0_RC02
 
                 if (!(
                     !(that.Qualifiers != null)
+                    || (that.Qualifiers.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Qualifiers must be either null or have at least one item\n" +
+                        "!(that.Qualifiers != null)\n" +
+                        "|| (that.Qualifiers.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Qualifiers != null)
                     || Verification.QualifierTypesAreUnique(that.Qualifiers)))
                 {
                     yield return new Reporting.Error(
@@ -3346,6 +3532,18 @@ namespace AasCore.Aas3_0_RC02
                         "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
+                }
+
+                if (!(
+                    !(that.EmbeddedDataSpecifications != null)
+                    || (that.EmbeddedDataSpecifications.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Embedded data specifications must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.EmbeddedDataSpecifications != null)\n" +
+                        "|| (that.EmbeddedDataSpecifications.Count > 0)");
                 }
 
                 if (!(
@@ -3553,6 +3751,17 @@ namespace AasCore.Aas3_0_RC02
             {
                 if (!(
                     !(that.Extensions != null)
+                    || (that.Extensions.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Extensions must be either null or have at least one item\n" +
+                        "!(that.Extensions != null)\n" +
+                        "|| (that.Extensions.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Extensions != null)
                     || Verification.ExtensionNamesAreUnique(that.Extensions)))
                 {
                     yield return new Reporting.Error(
@@ -3561,6 +3770,18 @@ namespace AasCore.Aas3_0_RC02
                         "Has-Extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
+                }
+
+                if (!(
+                    !(that.SupplementalSemanticIds != null)
+                    || (that.SupplementalSemanticIds.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Supplemental semantic IDs must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.SupplementalSemanticIds != null)\n" +
+                        "|| (that.SupplementalSemanticIds.Count > 0)");
                 }
 
                 if (!(
@@ -3577,6 +3798,17 @@ namespace AasCore.Aas3_0_RC02
 
                 if (!(
                     !(that.Qualifiers != null)
+                    || (that.Qualifiers.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Qualifiers must be either null or have at least one item\n" +
+                        "!(that.Qualifiers != null)\n" +
+                        "|| (that.Qualifiers.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Qualifiers != null)
                     || Verification.QualifierTypesAreUnique(that.Qualifiers)))
                 {
                     yield return new Reporting.Error(
@@ -3585,6 +3817,18 @@ namespace AasCore.Aas3_0_RC02
                         "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
+                }
+
+                if (!(
+                    !(that.EmbeddedDataSpecifications != null)
+                    || (that.EmbeddedDataSpecifications.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Embedded data specifications must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.EmbeddedDataSpecifications != null)\n" +
+                        "|| (that.EmbeddedDataSpecifications.Count > 0)");
                 }
 
                 if (!(
@@ -3938,6 +4182,17 @@ namespace AasCore.Aas3_0_RC02
             {
                 if (!(
                     !(that.Extensions != null)
+                    || (that.Extensions.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Extensions must be either null or have at least one item\n" +
+                        "!(that.Extensions != null)\n" +
+                        "|| (that.Extensions.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Extensions != null)
                     || Verification.ExtensionNamesAreUnique(that.Extensions)))
                 {
                     yield return new Reporting.Error(
@@ -3946,6 +4201,18 @@ namespace AasCore.Aas3_0_RC02
                         "Has-Extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
+                }
+
+                if (!(
+                    !(that.SupplementalSemanticIds != null)
+                    || (that.SupplementalSemanticIds.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Supplemental semantic IDs must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.SupplementalSemanticIds != null)\n" +
+                        "|| (that.SupplementalSemanticIds.Count > 0)");
                 }
 
                 if (!(
@@ -3962,6 +4229,17 @@ namespace AasCore.Aas3_0_RC02
 
                 if (!(
                     !(that.Qualifiers != null)
+                    || (that.Qualifiers.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Qualifiers must be either null or have at least one item\n" +
+                        "!(that.Qualifiers != null)\n" +
+                        "|| (that.Qualifiers.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Qualifiers != null)
                     || Verification.QualifierTypesAreUnique(that.Qualifiers)))
                 {
                     yield return new Reporting.Error(
@@ -3970,6 +4248,18 @@ namespace AasCore.Aas3_0_RC02
                         "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
+                }
+
+                if (!(
+                    !(that.EmbeddedDataSpecifications != null)
+                    || (that.EmbeddedDataSpecifications.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Embedded data specifications must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.EmbeddedDataSpecifications != null)\n" +
+                        "|| (that.EmbeddedDataSpecifications.Count > 0)");
                 }
 
                 if (!(
@@ -4207,6 +4497,17 @@ namespace AasCore.Aas3_0_RC02
             {
                 if (!(
                     !(that.Extensions != null)
+                    || (that.Extensions.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Extensions must be either null or have at least one item\n" +
+                        "!(that.Extensions != null)\n" +
+                        "|| (that.Extensions.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Extensions != null)
                     || Verification.ExtensionNamesAreUnique(that.Extensions)))
                 {
                     yield return new Reporting.Error(
@@ -4215,6 +4516,18 @@ namespace AasCore.Aas3_0_RC02
                         "Has-Extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
+                }
+
+                if (!(
+                    !(that.SupplementalSemanticIds != null)
+                    || (that.SupplementalSemanticIds.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Supplemental semantic IDs must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.SupplementalSemanticIds != null)\n" +
+                        "|| (that.SupplementalSemanticIds.Count > 0)");
                 }
 
                 if (!(
@@ -4231,6 +4544,17 @@ namespace AasCore.Aas3_0_RC02
 
                 if (!(
                     !(that.Qualifiers != null)
+                    || (that.Qualifiers.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Qualifiers must be either null or have at least one item\n" +
+                        "!(that.Qualifiers != null)\n" +
+                        "|| (that.Qualifiers.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Qualifiers != null)
                     || Verification.QualifierTypesAreUnique(that.Qualifiers)))
                 {
                     yield return new Reporting.Error(
@@ -4239,6 +4563,18 @@ namespace AasCore.Aas3_0_RC02
                         "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
+                }
+
+                if (!(
+                    !(that.EmbeddedDataSpecifications != null)
+                    || (that.EmbeddedDataSpecifications.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Embedded data specifications must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.EmbeddedDataSpecifications != null)\n" +
+                        "|| (that.EmbeddedDataSpecifications.Count > 0)");
                 }
 
                 if (!(
@@ -4482,6 +4818,17 @@ namespace AasCore.Aas3_0_RC02
             {
                 if (!(
                     !(that.Extensions != null)
+                    || (that.Extensions.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Extensions must be either null or have at least one item\n" +
+                        "!(that.Extensions != null)\n" +
+                        "|| (that.Extensions.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Extensions != null)
                     || Verification.ExtensionNamesAreUnique(that.Extensions)))
                 {
                     yield return new Reporting.Error(
@@ -4490,6 +4837,18 @@ namespace AasCore.Aas3_0_RC02
                         "Has-Extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
+                }
+
+                if (!(
+                    !(that.SupplementalSemanticIds != null)
+                    || (that.SupplementalSemanticIds.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Supplemental semantic IDs must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.SupplementalSemanticIds != null)\n" +
+                        "|| (that.SupplementalSemanticIds.Count > 0)");
                 }
 
                 if (!(
@@ -4506,6 +4865,17 @@ namespace AasCore.Aas3_0_RC02
 
                 if (!(
                     !(that.Qualifiers != null)
+                    || (that.Qualifiers.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Qualifiers must be either null or have at least one item\n" +
+                        "!(that.Qualifiers != null)\n" +
+                        "|| (that.Qualifiers.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Qualifiers != null)
                     || Verification.QualifierTypesAreUnique(that.Qualifiers)))
                 {
                     yield return new Reporting.Error(
@@ -4514,6 +4884,18 @@ namespace AasCore.Aas3_0_RC02
                         "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
+                }
+
+                if (!(
+                    !(that.EmbeddedDataSpecifications != null)
+                    || (that.EmbeddedDataSpecifications.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Embedded data specifications must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.EmbeddedDataSpecifications != null)\n" +
+                        "|| (that.EmbeddedDataSpecifications.Count > 0)");
                 }
 
                 if (!(
@@ -4739,6 +5121,17 @@ namespace AasCore.Aas3_0_RC02
             {
                 if (!(
                     !(that.Extensions != null)
+                    || (that.Extensions.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Extensions must be either null or have at least one item\n" +
+                        "!(that.Extensions != null)\n" +
+                        "|| (that.Extensions.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Extensions != null)
                     || Verification.ExtensionNamesAreUnique(that.Extensions)))
                 {
                     yield return new Reporting.Error(
@@ -4747,6 +5140,18 @@ namespace AasCore.Aas3_0_RC02
                         "Has-Extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
+                }
+
+                if (!(
+                    !(that.SupplementalSemanticIds != null)
+                    || (that.SupplementalSemanticIds.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Supplemental semantic IDs must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.SupplementalSemanticIds != null)\n" +
+                        "|| (that.SupplementalSemanticIds.Count > 0)");
                 }
 
                 if (!(
@@ -4763,6 +5168,17 @@ namespace AasCore.Aas3_0_RC02
 
                 if (!(
                     !(that.Qualifiers != null)
+                    || (that.Qualifiers.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Qualifiers must be either null or have at least one item\n" +
+                        "!(that.Qualifiers != null)\n" +
+                        "|| (that.Qualifiers.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Qualifiers != null)
                     || Verification.QualifierTypesAreUnique(that.Qualifiers)))
                 {
                     yield return new Reporting.Error(
@@ -4771,6 +5187,18 @@ namespace AasCore.Aas3_0_RC02
                         "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
+                }
+
+                if (!(
+                    !(that.EmbeddedDataSpecifications != null)
+                    || (that.EmbeddedDataSpecifications.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Embedded data specifications must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.EmbeddedDataSpecifications != null)\n" +
+                        "|| (that.EmbeddedDataSpecifications.Count > 0)");
                 }
 
                 if (!(
@@ -5024,6 +5452,17 @@ namespace AasCore.Aas3_0_RC02
             {
                 if (!(
                     !(that.Extensions != null)
+                    || (that.Extensions.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Extensions must be either null or have at least one item\n" +
+                        "!(that.Extensions != null)\n" +
+                        "|| (that.Extensions.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Extensions != null)
                     || Verification.ExtensionNamesAreUnique(that.Extensions)))
                 {
                     yield return new Reporting.Error(
@@ -5032,6 +5471,18 @@ namespace AasCore.Aas3_0_RC02
                         "Has-Extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
+                }
+
+                if (!(
+                    !(that.SupplementalSemanticIds != null)
+                    || (that.SupplementalSemanticIds.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Supplemental semantic IDs must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.SupplementalSemanticIds != null)\n" +
+                        "|| (that.SupplementalSemanticIds.Count > 0)");
                 }
 
                 if (!(
@@ -5048,6 +5499,17 @@ namespace AasCore.Aas3_0_RC02
 
                 if (!(
                     !(that.Qualifiers != null)
+                    || (that.Qualifiers.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Qualifiers must be either null or have at least one item\n" +
+                        "!(that.Qualifiers != null)\n" +
+                        "|| (that.Qualifiers.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Qualifiers != null)
                     || Verification.QualifierTypesAreUnique(that.Qualifiers)))
                 {
                     yield return new Reporting.Error(
@@ -5056,6 +5518,18 @@ namespace AasCore.Aas3_0_RC02
                         "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
+                }
+
+                if (!(
+                    !(that.EmbeddedDataSpecifications != null)
+                    || (that.EmbeddedDataSpecifications.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Embedded data specifications must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.EmbeddedDataSpecifications != null)\n" +
+                        "|| (that.EmbeddedDataSpecifications.Count > 0)");
                 }
 
                 if (!(
@@ -5270,6 +5744,17 @@ namespace AasCore.Aas3_0_RC02
             {
                 if (!(
                     !(that.Extensions != null)
+                    || (that.Extensions.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Extensions must be either null or have at least one item\n" +
+                        "!(that.Extensions != null)\n" +
+                        "|| (that.Extensions.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Extensions != null)
                     || Verification.ExtensionNamesAreUnique(that.Extensions)))
                 {
                     yield return new Reporting.Error(
@@ -5278,6 +5763,18 @@ namespace AasCore.Aas3_0_RC02
                         "Has-Extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
+                }
+
+                if (!(
+                    !(that.SupplementalSemanticIds != null)
+                    || (that.SupplementalSemanticIds.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Supplemental semantic IDs must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.SupplementalSemanticIds != null)\n" +
+                        "|| (that.SupplementalSemanticIds.Count > 0)");
                 }
 
                 if (!(
@@ -5294,6 +5791,17 @@ namespace AasCore.Aas3_0_RC02
 
                 if (!(
                     !(that.Qualifiers != null)
+                    || (that.Qualifiers.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Qualifiers must be either null or have at least one item\n" +
+                        "!(that.Qualifiers != null)\n" +
+                        "|| (that.Qualifiers.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Qualifiers != null)
                     || Verification.QualifierTypesAreUnique(that.Qualifiers)))
                 {
                     yield return new Reporting.Error(
@@ -5302,6 +5810,18 @@ namespace AasCore.Aas3_0_RC02
                         "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
+                }
+
+                if (!(
+                    !(that.EmbeddedDataSpecifications != null)
+                    || (that.EmbeddedDataSpecifications.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Embedded data specifications must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.EmbeddedDataSpecifications != null)\n" +
+                        "|| (that.EmbeddedDataSpecifications.Count > 0)");
                 }
 
                 if (!(
@@ -5524,6 +6044,17 @@ namespace AasCore.Aas3_0_RC02
             {
                 if (!(
                     !(that.Extensions != null)
+                    || (that.Extensions.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Extensions must be either null or have at least one item\n" +
+                        "!(that.Extensions != null)\n" +
+                        "|| (that.Extensions.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Extensions != null)
                     || Verification.ExtensionNamesAreUnique(that.Extensions)))
                 {
                     yield return new Reporting.Error(
@@ -5532,6 +6063,18 @@ namespace AasCore.Aas3_0_RC02
                         "Has-Extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
+                }
+
+                if (!(
+                    !(that.SupplementalSemanticIds != null)
+                    || (that.SupplementalSemanticIds.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Supplemental semantic IDs must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.SupplementalSemanticIds != null)\n" +
+                        "|| (that.SupplementalSemanticIds.Count > 0)");
                 }
 
                 if (!(
@@ -5548,6 +6091,17 @@ namespace AasCore.Aas3_0_RC02
 
                 if (!(
                     !(that.Qualifiers != null)
+                    || (that.Qualifiers.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Qualifiers must be either null or have at least one item\n" +
+                        "!(that.Qualifiers != null)\n" +
+                        "|| (that.Qualifiers.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Qualifiers != null)
                     || Verification.QualifierTypesAreUnique(that.Qualifiers)))
                 {
                     yield return new Reporting.Error(
@@ -5556,6 +6110,18 @@ namespace AasCore.Aas3_0_RC02
                         "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
+                }
+
+                if (!(
+                    !(that.EmbeddedDataSpecifications != null)
+                    || (that.EmbeddedDataSpecifications.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Embedded data specifications must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.EmbeddedDataSpecifications != null)\n" +
+                        "|| (that.EmbeddedDataSpecifications.Count > 0)");
                 }
 
                 if (!(
@@ -5778,6 +6344,17 @@ namespace AasCore.Aas3_0_RC02
             {
                 if (!(
                     !(that.Extensions != null)
+                    || (that.Extensions.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Extensions must be either null or have at least one item\n" +
+                        "!(that.Extensions != null)\n" +
+                        "|| (that.Extensions.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Extensions != null)
                     || Verification.ExtensionNamesAreUnique(that.Extensions)))
                 {
                     yield return new Reporting.Error(
@@ -5786,6 +6363,18 @@ namespace AasCore.Aas3_0_RC02
                         "Has-Extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
+                }
+
+                if (!(
+                    !(that.SupplementalSemanticIds != null)
+                    || (that.SupplementalSemanticIds.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Supplemental semantic IDs must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.SupplementalSemanticIds != null)\n" +
+                        "|| (that.SupplementalSemanticIds.Count > 0)");
                 }
 
                 if (!(
@@ -5802,6 +6391,17 @@ namespace AasCore.Aas3_0_RC02
 
                 if (!(
                     !(that.Qualifiers != null)
+                    || (that.Qualifiers.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Qualifiers must be either null or have at least one item\n" +
+                        "!(that.Qualifiers != null)\n" +
+                        "|| (that.Qualifiers.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Qualifiers != null)
                     || Verification.QualifierTypesAreUnique(that.Qualifiers)))
                 {
                     yield return new Reporting.Error(
@@ -5810,6 +6410,18 @@ namespace AasCore.Aas3_0_RC02
                         "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
+                }
+
+                if (!(
+                    !(that.EmbeddedDataSpecifications != null)
+                    || (that.EmbeddedDataSpecifications.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Embedded data specifications must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.EmbeddedDataSpecifications != null)\n" +
+                        "|| (that.EmbeddedDataSpecifications.Count > 0)");
                 }
 
                 if (!(
@@ -5836,6 +6448,17 @@ namespace AasCore.Aas3_0_RC02
                         "    )\n" +
                         "    || (that.KindOrDefault() == ModelingKind.Template)\n" +
                         ")");
+                }
+
+                if (!(
+                    !(that.Annotations != null)
+                    || (that.Annotations.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Annotations must be either null or have at least one item\n" +
+                        "!(that.Annotations != null)\n" +
+                        "|| (that.Annotations.Count > 0)");
                 }
 
                 if (that.Extensions != null)
@@ -6036,6 +6659,17 @@ namespace AasCore.Aas3_0_RC02
             {
                 if (!(
                     !(that.Extensions != null)
+                    || (that.Extensions.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Extensions must be either null or have at least one item\n" +
+                        "!(that.Extensions != null)\n" +
+                        "|| (that.Extensions.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Extensions != null)
                     || Verification.ExtensionNamesAreUnique(that.Extensions)))
                 {
                     yield return new Reporting.Error(
@@ -6044,6 +6678,18 @@ namespace AasCore.Aas3_0_RC02
                         "Has-Extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
+                }
+
+                if (!(
+                    !(that.SupplementalSemanticIds != null)
+                    || (that.SupplementalSemanticIds.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Supplemental semantic IDs must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.SupplementalSemanticIds != null)\n" +
+                        "|| (that.SupplementalSemanticIds.Count > 0)");
                 }
 
                 if (!(
@@ -6060,6 +6706,17 @@ namespace AasCore.Aas3_0_RC02
 
                 if (!(
                     !(that.Qualifiers != null)
+                    || (that.Qualifiers.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Qualifiers must be either null or have at least one item\n" +
+                        "!(that.Qualifiers != null)\n" +
+                        "|| (that.Qualifiers.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Qualifiers != null)
                     || Verification.QualifierTypesAreUnique(that.Qualifiers)))
                 {
                     yield return new Reporting.Error(
@@ -6068,6 +6725,18 @@ namespace AasCore.Aas3_0_RC02
                         "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
+                }
+
+                if (!(
+                    !(that.EmbeddedDataSpecifications != null)
+                    || (that.EmbeddedDataSpecifications.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Embedded data specifications must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.EmbeddedDataSpecifications != null)\n" +
+                        "|| (that.EmbeddedDataSpecifications.Count > 0)");
                 }
 
                 if (!(
@@ -6094,6 +6763,17 @@ namespace AasCore.Aas3_0_RC02
                         "    )\n" +
                         "    || (that.KindOrDefault() == ModelingKind.Template)\n" +
                         ")");
+                }
+
+                if (!(
+                    !(that.Statements != null)
+                    || (that.Statements.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Statements must be either null or have at least one item\n" +
+                        "!(that.Statements != null)\n" +
+                        "|| (that.Statements.Count > 0)");
                 }
 
                 if (!(
@@ -6451,6 +7131,17 @@ namespace AasCore.Aas3_0_RC02
             {
                 if (!(
                     !(that.Extensions != null)
+                    || (that.Extensions.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Extensions must be either null or have at least one item\n" +
+                        "!(that.Extensions != null)\n" +
+                        "|| (that.Extensions.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Extensions != null)
                     || Verification.ExtensionNamesAreUnique(that.Extensions)))
                 {
                     yield return new Reporting.Error(
@@ -6459,6 +7150,18 @@ namespace AasCore.Aas3_0_RC02
                         "Has-Extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
+                }
+
+                if (!(
+                    !(that.SupplementalSemanticIds != null)
+                    || (that.SupplementalSemanticIds.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Supplemental semantic IDs must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.SupplementalSemanticIds != null)\n" +
+                        "|| (that.SupplementalSemanticIds.Count > 0)");
                 }
 
                 if (!(
@@ -6475,6 +7178,17 @@ namespace AasCore.Aas3_0_RC02
 
                 if (!(
                     !(that.Qualifiers != null)
+                    || (that.Qualifiers.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Qualifiers must be either null or have at least one item\n" +
+                        "!(that.Qualifiers != null)\n" +
+                        "|| (that.Qualifiers.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Qualifiers != null)
                     || Verification.QualifierTypesAreUnique(that.Qualifiers)))
                 {
                     yield return new Reporting.Error(
@@ -6483,6 +7197,18 @@ namespace AasCore.Aas3_0_RC02
                         "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
+                }
+
+                if (!(
+                    !(that.EmbeddedDataSpecifications != null)
+                    || (that.EmbeddedDataSpecifications.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Embedded data specifications must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.EmbeddedDataSpecifications != null)\n" +
+                        "|| (that.EmbeddedDataSpecifications.Count > 0)");
                 }
 
                 if (!(
@@ -6782,6 +7508,17 @@ namespace AasCore.Aas3_0_RC02
             {
                 if (!(
                     !(that.Extensions != null)
+                    || (that.Extensions.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Extensions must be either null or have at least one item\n" +
+                        "!(that.Extensions != null)\n" +
+                        "|| (that.Extensions.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Extensions != null)
                     || Verification.ExtensionNamesAreUnique(that.Extensions)))
                 {
                     yield return new Reporting.Error(
@@ -6790,6 +7527,18 @@ namespace AasCore.Aas3_0_RC02
                         "Has-Extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
+                }
+
+                if (!(
+                    !(that.SupplementalSemanticIds != null)
+                    || (that.SupplementalSemanticIds.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Supplemental semantic IDs must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.SupplementalSemanticIds != null)\n" +
+                        "|| (that.SupplementalSemanticIds.Count > 0)");
                 }
 
                 if (!(
@@ -6806,6 +7555,17 @@ namespace AasCore.Aas3_0_RC02
 
                 if (!(
                     !(that.Qualifiers != null)
+                    || (that.Qualifiers.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Qualifiers must be either null or have at least one item\n" +
+                        "!(that.Qualifiers != null)\n" +
+                        "|| (that.Qualifiers.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Qualifiers != null)
                     || Verification.QualifierTypesAreUnique(that.Qualifiers)))
                 {
                     yield return new Reporting.Error(
@@ -6814,6 +7574,18 @@ namespace AasCore.Aas3_0_RC02
                         "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
+                }
+
+                if (!(
+                    !(that.EmbeddedDataSpecifications != null)
+                    || (that.EmbeddedDataSpecifications.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Embedded data specifications must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.EmbeddedDataSpecifications != null)\n" +
+                        "|| (that.EmbeddedDataSpecifications.Count > 0)");
                 }
 
                 if (!(
@@ -6840,6 +7612,42 @@ namespace AasCore.Aas3_0_RC02
                         "    )\n" +
                         "    || (that.KindOrDefault() == ModelingKind.Template)\n" +
                         ")");
+                }
+
+                if (!(
+                    !(that.InputVariables != null)
+                    || (that.InputVariables.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Input variables must be either null or have at least one " +
+                        "item\n" +
+                        "!(that.InputVariables != null)\n" +
+                        "|| (that.InputVariables.Count > 0)");
+                }
+
+                if (!(
+                    !(that.OutputVariables != null)
+                    || (that.OutputVariables.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Output variables must be either null or have at least one " +
+                        "item\n" +
+                        "!(that.OutputVariables != null)\n" +
+                        "|| (that.OutputVariables.Count > 0)");
+                }
+
+                if (!(
+                    !(that.InoutputVariables != null)
+                    || (that.InoutputVariables.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Inoutput variables must be either null or have at least one " +
+                        "item\n" +
+                        "!(that.InoutputVariables != null)\n" +
+                        "|| (that.InoutputVariables.Count > 0)");
                 }
 
                 if (that.Extensions != null)
@@ -7075,6 +7883,17 @@ namespace AasCore.Aas3_0_RC02
             {
                 if (!(
                     !(that.Extensions != null)
+                    || (that.Extensions.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Extensions must be either null or have at least one item\n" +
+                        "!(that.Extensions != null)\n" +
+                        "|| (that.Extensions.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Extensions != null)
                     || Verification.ExtensionNamesAreUnique(that.Extensions)))
                 {
                     yield return new Reporting.Error(
@@ -7083,6 +7902,18 @@ namespace AasCore.Aas3_0_RC02
                         "Has-Extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
+                }
+
+                if (!(
+                    !(that.SupplementalSemanticIds != null)
+                    || (that.SupplementalSemanticIds.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Supplemental semantic IDs must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.SupplementalSemanticIds != null)\n" +
+                        "|| (that.SupplementalSemanticIds.Count > 0)");
                 }
 
                 if (!(
@@ -7099,6 +7930,17 @@ namespace AasCore.Aas3_0_RC02
 
                 if (!(
                     !(that.Qualifiers != null)
+                    || (that.Qualifiers.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Qualifiers must be either null or have at least one item\n" +
+                        "!(that.Qualifiers != null)\n" +
+                        "|| (that.Qualifiers.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Qualifiers != null)
                     || Verification.QualifierTypesAreUnique(that.Qualifiers)))
                 {
                     yield return new Reporting.Error(
@@ -7107,6 +7949,18 @@ namespace AasCore.Aas3_0_RC02
                         "qualifier with the same type.\n" +
                         "!(that.Qualifiers != null)\n" +
                         "|| Verification.QualifierTypesAreUnique(that.Qualifiers)");
+                }
+
+                if (!(
+                    !(that.EmbeddedDataSpecifications != null)
+                    || (that.EmbeddedDataSpecifications.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Embedded data specifications must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.EmbeddedDataSpecifications != null)\n" +
+                        "|| (that.EmbeddedDataSpecifications.Count > 0)");
                 }
 
                 if (!(
@@ -7298,6 +8152,17 @@ namespace AasCore.Aas3_0_RC02
             {
                 if (!(
                     !(that.Extensions != null)
+                    || (that.Extensions.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Extensions must be either null or have at least one item\n" +
+                        "!(that.Extensions != null)\n" +
+                        "|| (that.Extensions.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Extensions != null)
                     || Verification.ExtensionNamesAreUnique(that.Extensions)))
                 {
                     yield return new Reporting.Error(
@@ -7306,6 +8171,29 @@ namespace AasCore.Aas3_0_RC02
                         "Has-Extensions needs to be unique.\n" +
                         "!(that.Extensions != null)\n" +
                         "|| Verification.ExtensionNamesAreUnique(that.Extensions)");
+                }
+
+                if (!(
+                    !(that.EmbeddedDataSpecifications != null)
+                    || (that.EmbeddedDataSpecifications.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Embedded data specifications must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.EmbeddedDataSpecifications != null)\n" +
+                        "|| (that.EmbeddedDataSpecifications.Count > 0)");
+                }
+
+                if (!(
+                    !(that.IsCaseOf != null)
+                    || (that.IsCaseOf.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Is-case-of must be either null or have at least one item\n" +
+                        "!(that.IsCaseOf != null)\n" +
+                        "|| (that.IsCaseOf.Count > 0)");
                 }
 
                 if (!(
@@ -7774,6 +8662,41 @@ namespace AasCore.Aas3_0_RC02
             public override IEnumerable<Reporting.Error> Transform(
                 Aas.Environment that)
             {
+                if (!(
+                    !(that.ConceptDescriptions != null)
+                    || (that.ConceptDescriptions.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Concept descriptions must be either null or have at least " +
+                        "one item\n" +
+                        "!(that.ConceptDescriptions != null)\n" +
+                        "|| (that.ConceptDescriptions.Count > 0)");
+                }
+
+                if (!(
+                    !(that.Submodels != null)
+                    || (that.Submodels.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Submodels must be either null or have at least one item\n" +
+                        "!(that.Submodels != null)\n" +
+                        "|| (that.Submodels.Count > 0)");
+                }
+
+                if (!(
+                    !(that.AssetAdministrationShells != null)
+                    || (that.AssetAdministrationShells.Count > 0)))
+                {
+                    yield return new Reporting.Error(
+                        "Invariant violated:\n" +
+                        "Asset administration shells must be either null or have at " +
+                        "least one item\n" +
+                        "!(that.AssetAdministrationShells != null)\n" +
+                        "|| (that.AssetAdministrationShells.Count > 0)");
+                }
+
                 if (that.AssetAdministrationShells != null)
                 {
                     int indexAssetAdministrationShells = 0;

--- a/test_data/intermediate/real_meta_models/aas_core_meta.v3rc2/expected_symbol_table.txt
+++ b/test_data/intermediate/real_meta_models/aas_core_meta.v3rc2/expected_symbol_table.txt
@@ -592,6 +592,37 @@ SymbolTable(
               default=None)""")]),
       invariants=[
         Invariant(
+          description='Supplemental semantic IDs must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='supplemental_semantic_ids',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='supplemental_semantic_ids',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-118: If there are supplemental semantic IDs defined then there shall be also a main semantic ID.',
           body=textwrap.dedent("""\
             Implication(
@@ -869,6 +900,37 @@ SymbolTable(
               default=None)""")]),
       invariants=[
         Invariant(
+          description='Supplemental semantic IDs must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='supplemental_semantic_ids',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='supplemental_semantic_ids',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-118: If there are supplemental semantic IDs defined then there shall be also a main semantic ID.',
           body=textwrap.dedent("""\
             Implication(
@@ -1068,6 +1130,37 @@ SymbolTable(
               argument='extensions',
               default=None)""")]),
       invariants=[
+        Invariant(
+          description='Extensions must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='extensions',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_extensions',
+          parsed=...),
         Invariant(
           description='Constraint AASd-077: The name of an extension within Has-Extensions needs to be unique.',
           body=textwrap.dedent("""\
@@ -1543,6 +1636,37 @@ SymbolTable(
               argument='checksum',
               default=None)""")]),
       invariants=[
+        Invariant(
+          description='Extensions must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='extensions',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_extensions',
+          parsed=...),
         Invariant(
           description='Constraint AASd-077: The name of an extension within Has-Extensions needs to be unique.',
           body=textwrap.dedent("""\
@@ -2076,6 +2200,37 @@ SymbolTable(
               default=None)""")]),
       invariants=[
         Invariant(
+          description='Extensions must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='extensions',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_extensions',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-077: The name of an extension within Has-Extensions needs to be unique.',
           body=textwrap.dedent("""\
             Implication(
@@ -2459,7 +2614,38 @@ SymbolTable(
               name='embedded_data_specifications',
               argument='embedded_data_specifications',
               default=None)""")]),
-      invariants=[],
+      invariants=[
+        Invariant(
+          description='Embedded data specifications must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='embedded_data_specifications',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='embedded_data_specifications',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_data_specification',
+          parsed=...)],
       serialization=Serialization(
         with_model_type=False),
       reference_in_the_book=ReferenceInTheBook(
@@ -2603,6 +2789,37 @@ SymbolTable(
               argument='revision',
               default=None)""")]),
       invariants=[
+        Invariant(
+          description='Embedded data specifications must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='embedded_data_specifications',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='embedded_data_specifications',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_data_specification',
+          parsed=...),
         Invariant(
           description='Constraint AASd-005: If version is not specified then also revision shall be unspecified. This means, a revision requires a version. If there is no version there is no revision either. Revision is optional.',
           body=textwrap.dedent("""\
@@ -2791,6 +3008,37 @@ SymbolTable(
               argument='qualifiers',
               default=None)""")]),
       invariants=[
+        Invariant(
+          description='Qualifiers must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='qualifiers',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
           body=textwrap.dedent("""\
@@ -3149,6 +3397,37 @@ SymbolTable(
               argument='value_id',
               default=None)""")]),
       invariants=[
+        Invariant(
+          description='Supplemental semantic IDs must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='supplemental_semantic_ids',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='supplemental_semantic_ids',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
         Invariant(
           description='Constraint AASd-118: If there are supplemental semantic IDs defined then there shall be also a main semantic ID.',
           body=textwrap.dedent("""\
@@ -3671,6 +3950,37 @@ SymbolTable(
               default=None)""")]),
       invariants=[
         Invariant(
+          description='Extensions must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='extensions',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_extensions',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-077: The name of an extension within Has-Extensions needs to be unique.',
           body=textwrap.dedent("""\
             Implication(
@@ -3694,6 +4004,68 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Has_extensions',
+          parsed=...),
+        Invariant(
+          description='Embedded data specifications must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='embedded_data_specifications',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='embedded_data_specifications',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_data_specification',
+          parsed=...),
+        Invariant(
+          description='Submodels must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='submodels',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='submodels',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to ConcreteClass Asset_administration_shell',
           parsed=...),
         Invariant(
           description=None,
@@ -3938,7 +4310,38 @@ SymbolTable(
               name='default_thumbnail',
               argument='default_thumbnail',
               default=None)""")]),
-      invariants=[],
+      invariants=[
+        Invariant(
+          description='Specific asset IDs must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='specific_asset_ids',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='specific_asset_ids',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to ConcreteClass Asset_information',
+          parsed=...)],
       serialization=Serialization(
         with_model_type=False),
       reference_in_the_book=ReferenceInTheBook(
@@ -4285,6 +4688,37 @@ SymbolTable(
               argument='external_subject_id',
               default=None)""")]),
       invariants=[
+        Invariant(
+          description='Supplemental semantic IDs must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='supplemental_semantic_ids',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='supplemental_semantic_ids',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
         Invariant(
           description='Constraint AASd-118: If there are supplemental semantic IDs defined then there shall be also a main semantic ID.',
           body=textwrap.dedent("""\
@@ -4864,6 +5298,37 @@ SymbolTable(
               default=None)""")]),
       invariants=[
         Invariant(
+          description='Extensions must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='extensions',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_extensions',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-077: The name of an extension within Has-Extensions needs to be unique.',
           body=textwrap.dedent("""\
             Implication(
@@ -4889,6 +5354,37 @@ SymbolTable(
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
+          description='Supplemental semantic IDs must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='supplemental_semantic_ids',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='supplemental_semantic_ids',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-118: If there are supplemental semantic IDs defined then there shall be also a main semantic ID.',
           body=textwrap.dedent("""\
             Implication(
@@ -4910,6 +5406,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
+          description='Qualifiers must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='qualifiers',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
@@ -4935,6 +5462,68 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Invariant(
+          description='Embedded data specifications must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='embedded_data_specifications',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='embedded_data_specifications',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_data_specification',
+          parsed=...),
+        Invariant(
+          description='Submodel elements must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='submodel_elements',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='submodel_elements',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to ConcreteClass Submodel',
           parsed=...),
         Invariant(
           description='ID-shorts need to be defined for all the submodel elements.',
@@ -5792,6 +6381,37 @@ SymbolTable(
               default=None)""")]),
       invariants=[
         Invariant(
+          description='Extensions must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='extensions',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_extensions',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-077: The name of an extension within Has-Extensions needs to be unique.',
           body=textwrap.dedent("""\
             Implication(
@@ -5817,6 +6437,37 @@ SymbolTable(
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
+          description='Supplemental semantic IDs must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='supplemental_semantic_ids',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='supplemental_semantic_ids',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-118: If there are supplemental semantic IDs defined then there shall be also a main semantic ID.',
           body=textwrap.dedent("""\
             Implication(
@@ -5838,6 +6489,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
+          description='Qualifiers must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='qualifiers',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
@@ -5863,6 +6545,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Invariant(
+          description='Embedded data specifications must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='embedded_data_specifications',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='embedded_data_specifications',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -6695,6 +7408,37 @@ SymbolTable(
               default=None)""")]),
       invariants=[
         Invariant(
+          description='Extensions must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='extensions',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_extensions',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-077: The name of an extension within Has-Extensions needs to be unique.',
           body=textwrap.dedent("""\
             Implication(
@@ -6720,6 +7464,37 @@ SymbolTable(
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
+          description='Supplemental semantic IDs must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='supplemental_semantic_ids',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='supplemental_semantic_ids',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-118: If there are supplemental semantic IDs defined then there shall be also a main semantic ID.',
           body=textwrap.dedent("""\
             Implication(
@@ -6741,6 +7516,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
+          description='Qualifiers must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='qualifiers',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
@@ -6766,6 +7572,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Invariant(
+          description='Embedded data specifications must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='embedded_data_specifications',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='embedded_data_specifications',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -7555,6 +8392,37 @@ SymbolTable(
               default=None)""")]),
       invariants=[
         Invariant(
+          description='Extensions must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='extensions',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_extensions',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-077: The name of an extension within Has-Extensions needs to be unique.',
           body=textwrap.dedent("""\
             Implication(
@@ -7580,6 +8448,37 @@ SymbolTable(
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
+          description='Supplemental semantic IDs must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='supplemental_semantic_ids',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='supplemental_semantic_ids',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-118: If there are supplemental semantic IDs defined then there shall be also a main semantic ID.',
           body=textwrap.dedent("""\
             Implication(
@@ -7601,6 +8500,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
+          description='Qualifiers must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='qualifiers',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
@@ -7626,6 +8556,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Invariant(
+          description='Embedded data specifications must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='embedded_data_specifications',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='embedded_data_specifications',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -8460,6 +9421,37 @@ SymbolTable(
               default=None)""")]),
       invariants=[
         Invariant(
+          description='Extensions must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='extensions',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_extensions',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-077: The name of an extension within Has-Extensions needs to be unique.',
           body=textwrap.dedent("""\
             Implication(
@@ -8485,6 +9477,37 @@ SymbolTable(
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
+          description='Supplemental semantic IDs must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='supplemental_semantic_ids',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='supplemental_semantic_ids',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-118: If there are supplemental semantic IDs defined then there shall be also a main semantic ID.',
           body=textwrap.dedent("""\
             Implication(
@@ -8506,6 +9529,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
+          description='Qualifiers must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='qualifiers',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
@@ -8531,6 +9585,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Invariant(
+          description='Embedded data specifications must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='embedded_data_specifications',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='embedded_data_specifications',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -9424,6 +10509,37 @@ SymbolTable(
               default=None)""")]),
       invariants=[
         Invariant(
+          description='Extensions must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='extensions',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_extensions',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-077: The name of an extension within Has-Extensions needs to be unique.',
           body=textwrap.dedent("""\
             Implication(
@@ -9449,6 +10565,37 @@ SymbolTable(
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
+          description='Supplemental semantic IDs must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='supplemental_semantic_ids',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='supplemental_semantic_ids',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-118: If there are supplemental semantic IDs defined then there shall be also a main semantic ID.',
           body=textwrap.dedent("""\
             Implication(
@@ -9470,6 +10617,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
+          description='Qualifiers must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='qualifiers',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
@@ -9495,6 +10673,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Invariant(
+          description='Embedded data specifications must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='embedded_data_specifications',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='embedded_data_specifications',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -10167,6 +11376,37 @@ SymbolTable(
               default=None)""")]),
       invariants=[
         Invariant(
+          description='Extensions must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='extensions',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_extensions',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-077: The name of an extension within Has-Extensions needs to be unique.',
           body=textwrap.dedent("""\
             Implication(
@@ -10192,6 +11432,37 @@ SymbolTable(
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
+          description='Supplemental semantic IDs must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='supplemental_semantic_ids',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='supplemental_semantic_ids',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-118: If there are supplemental semantic IDs defined then there shall be also a main semantic ID.',
           body=textwrap.dedent("""\
             Implication(
@@ -10213,6 +11484,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
+          description='Qualifiers must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='qualifiers',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
@@ -10238,6 +11540,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Invariant(
+          description='Embedded data specifications must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='embedded_data_specifications',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='embedded_data_specifications',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -10913,6 +12246,37 @@ SymbolTable(
               default=None)""")]),
       invariants=[
         Invariant(
+          description='Extensions must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='extensions',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_extensions',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-077: The name of an extension within Has-Extensions needs to be unique.',
           body=textwrap.dedent("""\
             Implication(
@@ -10938,6 +12302,37 @@ SymbolTable(
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
+          description='Supplemental semantic IDs must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='supplemental_semantic_ids',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='supplemental_semantic_ids',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-118: If there are supplemental semantic IDs defined then there shall be also a main semantic ID.',
           body=textwrap.dedent("""\
             Implication(
@@ -10959,6 +12354,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
+          description='Qualifiers must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='qualifiers',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
@@ -10984,6 +12410,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Invariant(
+          description='Embedded data specifications must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='embedded_data_specifications',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='embedded_data_specifications',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -11653,6 +13110,37 @@ SymbolTable(
               default=None)""")]),
       invariants=[
         Invariant(
+          description='Extensions must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='extensions',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_extensions',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-077: The name of an extension within Has-Extensions needs to be unique.',
           body=textwrap.dedent("""\
             Implication(
@@ -11678,6 +13166,37 @@ SymbolTable(
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
+          description='Supplemental semantic IDs must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='supplemental_semantic_ids',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='supplemental_semantic_ids',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-118: If there are supplemental semantic IDs defined then there shall be also a main semantic ID.',
           body=textwrap.dedent("""\
             Implication(
@@ -11699,6 +13218,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
+          description='Qualifiers must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='qualifiers',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
@@ -11724,6 +13274,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Invariant(
+          description='Embedded data specifications must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='embedded_data_specifications',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='embedded_data_specifications',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -12396,6 +13977,37 @@ SymbolTable(
               default=None)""")]),
       invariants=[
         Invariant(
+          description='Extensions must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='extensions',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_extensions',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-077: The name of an extension within Has-Extensions needs to be unique.',
           body=textwrap.dedent("""\
             Implication(
@@ -12421,6 +14033,37 @@ SymbolTable(
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
+          description='Supplemental semantic IDs must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='supplemental_semantic_ids',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='supplemental_semantic_ids',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-118: If there are supplemental semantic IDs defined then there shall be also a main semantic ID.',
           body=textwrap.dedent("""\
             Implication(
@@ -12442,6 +14085,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
+          description='Qualifiers must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='qualifiers',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
@@ -12467,6 +14141,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Invariant(
+          description='Embedded data specifications must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='embedded_data_specifications',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='embedded_data_specifications',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -13109,6 +14814,37 @@ SymbolTable(
               default=None)""")]),
       invariants=[
         Invariant(
+          description='Extensions must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='extensions',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_extensions',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-077: The name of an extension within Has-Extensions needs to be unique.',
           body=textwrap.dedent("""\
             Implication(
@@ -13134,6 +14870,37 @@ SymbolTable(
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
+          description='Supplemental semantic IDs must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='supplemental_semantic_ids',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='supplemental_semantic_ids',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-118: If there are supplemental semantic IDs defined then there shall be also a main semantic ID.',
           body=textwrap.dedent("""\
             Implication(
@@ -13155,6 +14922,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
+          description='Qualifiers must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='qualifiers',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
@@ -13180,6 +14978,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Invariant(
+          description='Embedded data specifications must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='embedded_data_specifications',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='embedded_data_specifications',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -13815,6 +15644,37 @@ SymbolTable(
               default=None)""")]),
       invariants=[
         Invariant(
+          description='Extensions must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='extensions',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_extensions',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-077: The name of an extension within Has-Extensions needs to be unique.',
           body=textwrap.dedent("""\
             Implication(
@@ -13840,6 +15700,37 @@ SymbolTable(
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
+          description='Supplemental semantic IDs must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='supplemental_semantic_ids',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='supplemental_semantic_ids',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-118: If there are supplemental semantic IDs defined then there shall be also a main semantic ID.',
           body=textwrap.dedent("""\
             Implication(
@@ -13861,6 +15752,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
+          description='Qualifiers must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='qualifiers',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
@@ -13886,6 +15808,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Invariant(
+          description='Embedded data specifications must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='embedded_data_specifications',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='embedded_data_specifications',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -14520,6 +16473,37 @@ SymbolTable(
               default=None)""")]),
       invariants=[
         Invariant(
+          description='Extensions must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='extensions',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_extensions',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-077: The name of an extension within Has-Extensions needs to be unique.',
           body=textwrap.dedent("""\
             Implication(
@@ -14545,6 +16529,37 @@ SymbolTable(
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
+          description='Supplemental semantic IDs must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='supplemental_semantic_ids',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='supplemental_semantic_ids',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-118: If there are supplemental semantic IDs defined then there shall be also a main semantic ID.',
           body=textwrap.dedent("""\
             Implication(
@@ -14566,6 +16581,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
+          description='Qualifiers must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='qualifiers',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
@@ -14591,6 +16637,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Invariant(
+          description='Embedded data specifications must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='embedded_data_specifications',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='embedded_data_specifications',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -14654,6 +16731,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Submodel_element',
+          parsed=...),
+        Invariant(
+          description='Annotations must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='annotations',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='annotations',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to ConcreteClass Annotated_relationship_element',
           parsed=...)],
       serialization=Serialization(
         with_model_type=True),
@@ -15281,6 +17389,37 @@ SymbolTable(
               default=None)""")]),
       invariants=[
         Invariant(
+          description='Extensions must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='extensions',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_extensions',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-077: The name of an extension within Has-Extensions needs to be unique.',
           body=textwrap.dedent("""\
             Implication(
@@ -15306,6 +17445,37 @@ SymbolTable(
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
+          description='Supplemental semantic IDs must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='supplemental_semantic_ids',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='supplemental_semantic_ids',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-118: If there are supplemental semantic IDs defined then there shall be also a main semantic ID.',
           body=textwrap.dedent("""\
             Implication(
@@ -15327,6 +17497,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
+          description='Qualifiers must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='qualifiers',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
@@ -15352,6 +17553,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Invariant(
+          description='Embedded data specifications must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='embedded_data_specifications',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='embedded_data_specifications',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -15415,6 +17647,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Submodel_element',
+          parsed=...),
+        Invariant(
+          description='Statements must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='statements',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='statements',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to ConcreteClass Entity',
           parsed=...),
         Invariant(
           description="Constraint AASd-014: Either the attribute global asset ID or specific asset ID must be set if entity type is set to 'SelfManagedEntity'. They are not existing otherwise.",
@@ -16578,6 +18841,37 @@ SymbolTable(
               default=None)""")]),
       invariants=[
         Invariant(
+          description='Extensions must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='extensions',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_extensions',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-077: The name of an extension within Has-Extensions needs to be unique.',
           body=textwrap.dedent("""\
             Implication(
@@ -16603,6 +18897,37 @@ SymbolTable(
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
+          description='Supplemental semantic IDs must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='supplemental_semantic_ids',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='supplemental_semantic_ids',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-118: If there are supplemental semantic IDs defined then there shall be also a main semantic ID.',
           body=textwrap.dedent("""\
             Implication(
@@ -16624,6 +18949,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
+          description='Qualifiers must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='qualifiers',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
@@ -16649,6 +19005,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Invariant(
+          description='Embedded data specifications must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='embedded_data_specifications',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='embedded_data_specifications',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -17425,6 +19812,37 @@ SymbolTable(
               default=None)""")]),
       invariants=[
         Invariant(
+          description='Extensions must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='extensions',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_extensions',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-077: The name of an extension within Has-Extensions needs to be unique.',
           body=textwrap.dedent("""\
             Implication(
@@ -17450,6 +19868,37 @@ SymbolTable(
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
+          description='Supplemental semantic IDs must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='supplemental_semantic_ids',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='supplemental_semantic_ids',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-118: If there are supplemental semantic IDs defined then there shall be also a main semantic ID.',
           body=textwrap.dedent("""\
             Implication(
@@ -17471,6 +19920,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
+          description='Qualifiers must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='qualifiers',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
@@ -17496,6 +19976,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Invariant(
+          description='Embedded data specifications must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='embedded_data_specifications',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='embedded_data_specifications',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -18191,6 +20702,37 @@ SymbolTable(
               default=None)""")]),
       invariants=[
         Invariant(
+          description='Extensions must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='extensions',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_extensions',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-077: The name of an extension within Has-Extensions needs to be unique.',
           body=textwrap.dedent("""\
             Implication(
@@ -18216,6 +20758,37 @@ SymbolTable(
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
+          description='Supplemental semantic IDs must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='supplemental_semantic_ids',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='supplemental_semantic_ids',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-118: If there are supplemental semantic IDs defined then there shall be also a main semantic ID.',
           body=textwrap.dedent("""\
             Implication(
@@ -18237,6 +20810,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
+          description='Qualifiers must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='qualifiers',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
@@ -18262,6 +20866,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Invariant(
+          description='Embedded data specifications must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='embedded_data_specifications',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='embedded_data_specifications',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -18325,6 +20960,99 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Submodel_element',
+          parsed=...),
+        Invariant(
+          description='Input variables must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='input_variables',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='input_variables',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to ConcreteClass Operation',
+          parsed=...),
+        Invariant(
+          description='Output variables must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='output_variables',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='output_variables',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to ConcreteClass Operation',
+          parsed=...),
+        Invariant(
+          description='Inoutput variables must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='inoutput_variables',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='inoutput_variables',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to ConcreteClass Operation',
           parsed=...)],
       serialization=Serialization(
         with_model_type=True),
@@ -18855,6 +21583,37 @@ SymbolTable(
               default=None)""")]),
       invariants=[
         Invariant(
+          description='Extensions must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='extensions',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_extensions',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-077: The name of an extension within Has-Extensions needs to be unique.',
           body=textwrap.dedent("""\
             Implication(
@@ -18880,6 +21639,37 @@ SymbolTable(
           specified_for='Reference to AbstractClass Has_extensions',
           parsed=...),
         Invariant(
+          description='Supplemental semantic IDs must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='supplemental_semantic_ids',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='supplemental_semantic_ids',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-118: If there are supplemental semantic IDs defined then there shall be also a main semantic ID.',
           body=textwrap.dedent("""\
             Implication(
@@ -18901,6 +21691,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Has_semantics',
+          parsed=...),
+        Invariant(
+          description='Qualifiers must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='qualifiers',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
@@ -18926,6 +21747,37 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Qualifiable',
+          parsed=...),
+        Invariant(
+          description='Embedded data specifications must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='embedded_data_specifications',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='embedded_data_specifications',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_data_specification',
           parsed=...),
         Invariant(
           description='Constraint AASd-119: If any qualifier kind value of a qualifiable qualifier is equal to template qualifier and the qualified element has kind then the qualified element shall be of kind template.',
@@ -19424,6 +22276,37 @@ SymbolTable(
               default=None)""")]),
       invariants=[
         Invariant(
+          description='Extensions must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='extensions',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_extensions',
+          parsed=...),
+        Invariant(
           description='Constraint AASd-077: The name of an extension within Has-Extensions needs to be unique.',
           body=textwrap.dedent("""\
             Implication(
@@ -19447,6 +22330,68 @@ SymbolTable(
                 original_node=...),
               original_node=...)"""),
           specified_for='Reference to AbstractClass Has_extensions',
+          parsed=...),
+        Invariant(
+          description='Embedded data specifications must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='embedded_data_specifications',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='embedded_data_specifications',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to AbstractClass Has_data_specification',
+          parsed=...),
+        Invariant(
+          description='Is-case-of must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='is_case_of',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='is_case_of',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to ConcreteClass Concept_description',
           parsed=...),
         Invariant(
           description="Constraint AASd-051: A concept description shall have one of the following categories: 'VALUE', 'PROPERTY', 'REFERENCE', 'DOCUMENT', 'CAPABILITY',; 'RELATIONSHIP', 'COLLECTION', 'FUNCTION', 'EVENT', 'ENTITY', 'APPLICATION_CLASS', 'QUALIFIER', 'VIEW'.",
@@ -21197,7 +24142,100 @@ SymbolTable(
               name='concept_descriptions',
               argument='concept_descriptions',
               default=None)""")]),
-      invariants=[],
+      invariants=[
+        Invariant(
+          description='Concept descriptions must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='concept_descriptions',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='concept_descriptions',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to ConcreteClass Environment',
+          parsed=...),
+        Invariant(
+          description='Submodels must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='submodels',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='submodels',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to ConcreteClass Environment',
+          parsed=...),
+        Invariant(
+          description='Asset administration shells must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='asset_administration_shells',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='asset_administration_shells',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          specified_for='Reference to ConcreteClass Environment',
+          parsed=...)],
       serialization=Serialization(
         with_model_type=False),
       reference_in_the_book=ReferenceInTheBook(

--- a/test_data/jsonschema/test_main/aas_core_meta.v3rc2/examples/expected/empty/empty_environment_with_optional_properties_empty.json
+++ b/test_data/jsonschema/test_main/aas_core_meta.v3rc2/examples/expected/empty/empty_environment_with_optional_properties_empty.json
@@ -1,5 +1,0 @@
-{
-    "assetAdministrationShells": [],
-    "submodels": [],
-    "conceptDescriptions": []
-}

--- a/test_data/jsonschema/test_main/aas_core_meta.v3rc2/expected_output/schema.json
+++ b/test_data/jsonschema/test_main/aas_core_meta.v3rc2/expected_output/schema.json
@@ -61,7 +61,8 @@
               "type": "array",
               "items": {
                 "$ref": "#/definitions/DataElement"
-              }
+              },
+              "minItems": 1
             }
           }
         }
@@ -87,7 +88,8 @@
               "type": "array",
               "items": {
                 "$ref": "#/definitions/Reference"
-              }
+              },
+              "minItems": 1
             }
           },
           "required": [
@@ -109,7 +111,8 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/SpecificAssetId"
-          }
+          },
+          "minItems": 1
         },
         "defaultThumbnail": {
           "$ref": "#/definitions/Resource"
@@ -210,7 +213,8 @@
               "type": "array",
               "items": {
                 "$ref": "#/definitions/Reference"
-              }
+              },
+              "minItems": 1
             }
           }
         }
@@ -446,7 +450,8 @@
               "type": "array",
               "items": {
                 "$ref": "#/definitions/SubmodelElement"
-              }
+              },
+              "minItems": 1
             },
             "entityType": {
               "$ref": "#/definitions/EntityType"
@@ -478,19 +483,22 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/AssetAdministrationShell"
-          }
+          },
+          "minItems": 1
         },
         "submodels": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/Submodel"
-          }
+          },
+          "minItems": 1
         },
         "conceptDescriptions": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/ConceptDescription"
-          }
+          },
+          "minItems": 1
         }
       }
     },
@@ -592,7 +600,8 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/EmbeddedDataSpecification"
-          }
+          },
+          "minItems": 1
         }
       }
     },
@@ -603,7 +612,8 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/Extension"
-          }
+          },
+          "minItems": 1
         }
       }
     },
@@ -625,7 +635,8 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/Reference"
-          }
+          },
+          "minItems": 1
         }
       }
     },
@@ -794,19 +805,22 @@
               "type": "array",
               "items": {
                 "$ref": "#/definitions/OperationVariable"
-              }
+              },
+              "minItems": 1
             },
             "outputVariables": {
               "type": "array",
               "items": {
                 "$ref": "#/definitions/OperationVariable"
-              }
+              },
+              "minItems": 1
             },
             "inoutputVariables": {
               "type": "array",
               "items": {
                 "$ref": "#/definitions/OperationVariable"
-              }
+              },
+              "minItems": 1
             }
           }
         }
@@ -853,7 +867,8 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/Qualifier"
-          }
+          },
+          "minItems": 1
         },
         "modelType": {
           "$ref": "#/definitions/ModelType"
@@ -1100,7 +1115,8 @@
               "type": "array",
               "items": {
                 "$ref": "#/definitions/SubmodelElement"
-              }
+              },
+              "minItems": 1
             }
           }
         }

--- a/test_data/parse/real_meta_models/aas_core_meta.v3rc2/expected_symbol_table.txt
+++ b/test_data/parse/real_meta_models/aas_core_meta.v3rc2/expected_symbol_table.txt
@@ -379,6 +379,36 @@ UnverifiedSymbolTable(
           body=...)],
       invariants=[
         Invariant(
+          description='Supplemental semantic IDs must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='supplemental_semantic_ids',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='supplemental_semantic_ids',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          node=...),
+        Invariant(
           description='Constraint AASd-118: If there are supplemental semantic IDs defined then there shall be also a main semantic ID.',
           body=textwrap.dedent("""\
             Implication(
@@ -685,6 +715,36 @@ UnverifiedSymbolTable(
           arguments_by_name=...,
           body=...)],
       invariants=[
+        Invariant(
+          description='Extensions must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='extensions',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='extensions',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          node=...),
         Invariant(
           description='Constraint AASd-077: The name of an extension within Has-Extensions needs to be unique.',
           body=textwrap.dedent("""\
@@ -1236,7 +1296,37 @@ UnverifiedSymbolTable(
           node=...,
           arguments_by_name=...,
           body=...)],
-      invariants=[],
+      invariants=[
+        Invariant(
+          description='Embedded data specifications must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='embedded_data_specifications',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='embedded_data_specifications',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          node=...)],
       serialization=None,
       reference_in_the_book=ReferenceInTheBook(
         section=[
@@ -1439,6 +1529,36 @@ UnverifiedSymbolTable(
           arguments_by_name=...,
           body=...)],
       invariants=[
+        Invariant(
+          description='Qualifiers must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='qualifiers',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='qualifiers',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          node=...),
         Invariant(
           description='Constraint AASd-021: Every qualifiable can only have one qualifier with the same type.',
           body=textwrap.dedent("""\
@@ -1954,6 +2074,36 @@ UnverifiedSymbolTable(
           body=...)],
       invariants=[
         Invariant(
+          description='Submodels must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='submodels',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='submodels',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          node=...),
+        Invariant(
           description=None,
           body=textwrap.dedent("""\
             Implication(
@@ -2160,7 +2310,37 @@ UnverifiedSymbolTable(
           node=...,
           arguments_by_name=...,
           body=...)],
-      invariants=[],
+      invariants=[
+        Invariant(
+          description='Specific asset IDs must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='specific_asset_ids',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='specific_asset_ids',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          node=...)],
       serialization=None,
       reference_in_the_book=ReferenceInTheBook(
         section=[
@@ -2630,6 +2810,36 @@ UnverifiedSymbolTable(
           arguments_by_name=...,
           body=...)],
       invariants=[
+        Invariant(
+          description='Submodel elements must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='submodel_elements',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='submodel_elements',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          node=...),
         Invariant(
           description='ID-shorts need to be defined for all the submodel elements.',
           body=textwrap.dedent("""\
@@ -6159,7 +6369,37 @@ UnverifiedSymbolTable(
           node=...,
           arguments_by_name=...,
           body=...)],
-      invariants=[],
+      invariants=[
+        Invariant(
+          description='Annotations must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='annotations',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='annotations',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          node=...)],
       serialization=None,
       reference_in_the_book=ReferenceInTheBook(
         section=[
@@ -6478,6 +6718,36 @@ UnverifiedSymbolTable(
           arguments_by_name=...,
           body=...)],
       invariants=[
+        Invariant(
+          description='Statements must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='statements',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='statements',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          node=...),
         Invariant(
           description="Constraint AASd-014: Either the attribute global asset ID or specific asset ID must be set if entity type is set to 'SelfManagedEntity'. They are not existing otherwise.",
           body=textwrap.dedent("""\
@@ -7769,7 +8039,97 @@ UnverifiedSymbolTable(
           node=...,
           arguments_by_name=...,
           body=...)],
-      invariants=[],
+      invariants=[
+        Invariant(
+          description='Input variables must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='input_variables',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='input_variables',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          node=...),
+        Invariant(
+          description='Output variables must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='output_variables',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='output_variables',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          node=...),
+        Invariant(
+          description='Inoutput variables must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='inoutput_variables',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='inoutput_variables',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          node=...)],
       serialization=None,
       reference_in_the_book=ReferenceInTheBook(
         section=[
@@ -8226,6 +8586,36 @@ UnverifiedSymbolTable(
           arguments_by_name=...,
           body=...)],
       invariants=[
+        Invariant(
+          description='Is-case-of must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='is_case_of',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='is_case_of',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          node=...),
         Invariant(
           description="Constraint AASd-051: A concept description shall have one of the following categories: 'VALUE', 'PROPERTY', 'REFERENCE', 'DOCUMENT', 'CAPABILITY',; 'RELATIONSHIP', 'COLLECTION', 'FUNCTION', 'EVENT', 'ENTITY', 'APPLICATION_CLASS', 'QUALIFIER', 'VIEW'.",
           body=textwrap.dedent("""\
@@ -9754,7 +10144,97 @@ UnverifiedSymbolTable(
           node=...,
           arguments_by_name=...,
           body=...)],
-      invariants=[],
+      invariants=[
+        Invariant(
+          description='Concept descriptions must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='concept_descriptions',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='concept_descriptions',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          node=...),
+        Invariant(
+          description='Submodels must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='submodels',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='submodels',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          node=...),
+        Invariant(
+          description='Asset administration shells must be either null or have at least one item',
+          body=textwrap.dedent("""\
+            Implication(
+              antecedent=IsNotNone(
+                value=Member(
+                  instance=Name(
+                    identifier='self',
+                    original_node=...),
+                  name='asset_administration_shells',
+                  original_node=...),
+                original_node=...),
+              consequent=Comparison(
+                left=FunctionCall(
+                  name='len',
+                  args=[
+                    Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='asset_administration_shells',
+                      original_node=...)],
+                  original_node=...),
+                op='GT',
+                right=Constant(
+                  value=0,
+                  original_node=...),
+                original_node=...),
+              original_node=...)"""),
+          node=...)],
       serialization=None,
       reference_in_the_book=ReferenceInTheBook(
         section=[

--- a/test_data/xsd/test_main/aas_core_meta.v3rc2/examples/expected/empty/empty_environment_with_optional_properties_empty.xml
+++ b/test_data/xsd/test_main/aas_core_meta.v3rc2/examples/expected/empty/empty_environment_with_optional_properties_empty.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" ?>
-<environment xmlns="http://www.admin-shell.io/aas/3/0/RC02">
-    <assetAdministrationShells></assetAdministrationShells>
-    <submodels></submodels>
-    <conceptDescriptions></conceptDescriptions>
-</environment>

--- a/test_data/xsd/test_main/aas_core_meta.v3rc2/expected_output/schema.xsd
+++ b/test_data/xsd/test_main/aas_core_meta.v3rc2/expected_output/schema.xsd
@@ -25,7 +25,7 @@
       <xs:element name="annotations" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:group ref="dataElement_choice" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:group ref="dataElement_choice" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
@@ -40,7 +40,7 @@
       <xs:element name="submodels" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="reference" type="reference_t" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="reference" type="reference_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
@@ -53,7 +53,7 @@
       <xs:element name="specificAssetIds" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="specificAssetId" type="specificAssetId_t" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="specificAssetId" type="specificAssetId_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
@@ -123,7 +123,7 @@
       <xs:element name="isCaseOf" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="reference" type="reference_t" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="reference" type="reference_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
@@ -302,7 +302,7 @@
       <xs:element name="statements" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:group ref="submodelElement_choice" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:group ref="submodelElement_choice" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
@@ -316,21 +316,21 @@
       <xs:element name="assetAdministrationShells" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="assetAdministrationShell" type="assetAdministrationShell_t" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="assetAdministrationShell" type="assetAdministrationShell_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
       <xs:element name="submodels" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="submodel" type="submodel_t" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="submodel" type="submodel_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
       <xs:element name="conceptDescriptions" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="conceptDescription" type="conceptDescription_t" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="conceptDescription" type="conceptDescription_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
@@ -417,7 +417,7 @@
       <xs:element name="embeddedDataSpecifications" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="embeddedDataSpecification" type="embeddedDataSpecification_t" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="embeddedDataSpecification" type="embeddedDataSpecification_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
@@ -450,7 +450,7 @@
       <xs:element name="extensions" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="extension" type="extension_t" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="extension" type="extension_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
@@ -507,7 +507,7 @@
       <xs:element name="supplementalSemanticIds" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="reference" type="reference_t" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="reference" type="reference_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
@@ -603,21 +603,21 @@
       <xs:element name="inputVariables" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="operationVariable" type="operationVariable_t" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="operationVariable" type="operationVariable_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
       <xs:element name="outputVariables" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="operationVariable" type="operationVariable_t" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="operationVariable" type="operationVariable_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
       <xs:element name="inoutputVariables" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="operationVariable" type="operationVariable_t" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="operationVariable" type="operationVariable_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
@@ -647,7 +647,7 @@
       <xs:element name="qualifiers" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="qualifier" type="qualifier_t" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="qualifier" type="qualifier_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
@@ -828,7 +828,7 @@
       <xs:element name="submodelElements" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:group ref="submodelElement_choice" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:group ref="submodelElement_choice" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>


### PR DESCRIPTION
We update for [aas-core-meta 08f5bb1], which requires that
all lists are either null or at least have a length 1 (except for a few
exceptions).

We therefore have to consider a special case in SHACL schema generation
since SHACL does not distinguish between empty and null properties.

Finally, we update the test data to reflect [aas-core-meta 08f5bb1].

[aas-core-meta 08f5bb1]: https://github.com/aas-core-works/aas-core-meta/commit/08f5bb1