### PR TITLE
Expose ``infer_for_schema._common`` as ``match``

### DIFF
--- a/aas_core_codegen/infer_for_schema/__init__.py
+++ b/aas_core_codegen/infer_for_schema/__init__.py
@@ -1,6 +1,7 @@
 """Infer constraints representable in common schemas such as JSON Schema or XSD."""
 
 from aas_core_codegen.infer_for_schema import (
+    match,
     _len,
     _pattern,
     _inline,

--- a/aas_core_codegen/infer_for_schema/_len.py
+++ b/aas_core_codegen/infer_for_schema/_len.py
@@ -10,7 +10,7 @@ from aas_core_codegen.common import (
     Identifier,
     assert_union_of_descendants_exhaustive,
 )
-from aas_core_codegen.infer_for_schema import _common as infer_for_schema_common
+from aas_core_codegen.infer_for_schema import match as infer_for_schema_match
 from aas_core_codegen.infer_for_schema._types import LenConstraint
 from aas_core_codegen.parse import tree as parse_tree
 
@@ -69,7 +69,7 @@ def _match_len_on_member_or_name(node: parse_tree.Node) -> Optional[_LenOnMember
 
     Return the name of the property, or None, if not matched.
     """
-    mtch = infer_for_schema_common.match_single_arg_function_on_member_or_name(node)
+    mtch = infer_for_schema_match.try_single_arg_function_on_member_or_name(node)
 
     if mtch is None:
         return None
@@ -258,7 +258,7 @@ def _match_len_constraint_on_property(
     """Match a len constraint on a property such as ``len(self.something) < 42``."""
     len_constraint_on_member_or_name = _match_len_constraint_on_member_or_name(node)
     if len_constraint_on_member_or_name:
-        prop_name = infer_for_schema_common.match_property(
+        prop_name = infer_for_schema_match.try_property(
             len_constraint_on_member_or_name.member_or_name
         )
 
@@ -372,7 +372,7 @@ def len_constraints_from_invariants(
         len_constraint_on_prop = None  # type: Optional[_LenConstraintOnProperty]
 
         # Match ``self.something is None or len(self.something) < X``
-        conditional_on_prop = infer_for_schema_common.match_conditional_on_prop(
+        conditional_on_prop = infer_for_schema_match.try_conditional_on_prop(
             invariant.body
         )
         if conditional_on_prop is not None:

--- a/aas_core_codegen/infer_for_schema/_pattern.py
+++ b/aas_core_codegen/infer_for_schema/_pattern.py
@@ -13,7 +13,7 @@ from icontract import require
 
 from aas_core_codegen import intermediate
 from aas_core_codegen.common import Identifier
-from aas_core_codegen.infer_for_schema import _common as infer_for_schema_common
+from aas_core_codegen.infer_for_schema import match as infer_for_schema_match
 from aas_core_codegen.infer_for_schema._types import PatternConstraint
 from aas_core_codegen.parse import tree as parse_tree
 
@@ -91,7 +91,7 @@ def _match_constraint_on_property(
     if len(node.args) != 1:
         return None
 
-    prop_name = infer_for_schema_common.match_property(node.args[0])
+    prop_name = infer_for_schema_match.try_property(node.args[0])
     if prop_name is None:
         return None
 
@@ -137,7 +137,7 @@ def patterns_from_invariants(
             continue
 
         # Match something like ``self.something is None or is_ID_short(self.something)``
-        conditional_on_prop = infer_for_schema_common.match_conditional_on_prop(
+        conditional_on_prop = infer_for_schema_match.try_conditional_on_prop(
             invariant.body
         )
 

--- a/aas_core_codegen/infer_for_schema/_set.py
+++ b/aas_core_codegen/infer_for_schema/_set.py
@@ -11,7 +11,7 @@ from aas_core_codegen.infer_for_schema._types import (
 )
 from aas_core_codegen.parse import tree as parse_tree
 from aas_core_codegen import intermediate
-from aas_core_codegen.infer_for_schema import _common as infer_for_schema_common
+from aas_core_codegen.infer_for_schema import match as infer_for_schema_match
 
 
 class _PropNameInNamedContainer:
@@ -33,7 +33,7 @@ def _match_prop_in_named_container(
     if not isinstance(node, parse_tree.IsIn):
         return None
 
-    prop_name = infer_for_schema_common.match_property(node.member)
+    prop_name = infer_for_schema_match.try_property(node.member)
     if prop_name is None:
         return None
 
@@ -262,7 +262,7 @@ def infer_set_constraints_by_property_from_invariants(
             continue
 
         # Match ``not (self.something is not None) or self.something in X``
-        conditional_on_prop = infer_for_schema_common.match_conditional_on_prop(
+        conditional_on_prop = infer_for_schema_match.try_conditional_on_prop(
             invariant.body
         )
         if conditional_on_prop is not None:

--- a/aas_core_codegen/infer_for_schema/match.py
+++ b/aas_core_codegen/infer_for_schema/match.py
@@ -1,8 +1,13 @@
 """
-Provide common functions for different algorithms for inference of the constraints.
+Provide matching functions for different algorithms for inference of the constraints.
 
 The constraints are inferred based on the invariants, so the properties in this context
 refer to member access in form of ``self.some_property``.
+
+.. note::
+
+    This module is not only used by aas-core-codegen, but also by downstream clients
+    or continuous integrations of other packages, *e.g.*, aas-core-meta.
 """
 from typing import Optional, Union
 
@@ -11,7 +16,7 @@ from aas_core_codegen.common import Identifier
 from aas_core_codegen.parse import tree as parse_tree
 
 
-def match_property(node: parse_tree.Node) -> Optional[Identifier]:
+def try_property(node: parse_tree.Node) -> Optional[Identifier]:
     """
     Match access to a property.
 
@@ -45,7 +50,7 @@ class SingleArgFunctionOnMemberOrName:
         self.member_or_name = member_or_name
 
 
-def match_single_arg_function_on_member_or_name(
+def try_single_arg_function_on_member_or_name(
     node: parse_tree.Node,
 ) -> Optional[SingleArgFunctionOnMemberOrName]:
     """
@@ -82,7 +87,7 @@ class ConditionalOnProp:
         self.consequent = consequent
 
 
-def match_conditional_on_prop(node: parse_tree.Node) -> Optional[ConditionalOnProp]:
+def try_conditional_on_prop(node: parse_tree.Node) -> Optional[ConditionalOnProp]:
     """
     Match an invariant conditioned on an optional property.
 
@@ -93,7 +98,7 @@ def match_conditional_on_prop(node: parse_tree.Node) -> Optional[ConditionalOnPr
         if not isinstance(node.antecedent, parse_tree.IsNotNone):
             return None
 
-        prop_name = match_property(node.antecedent.value)
+        prop_name = try_property(node.antecedent.value)
         if prop_name is None:
             return None
 
@@ -107,7 +112,7 @@ def match_conditional_on_prop(node: parse_tree.Node) -> Optional[ConditionalOnPr
             return None
 
         # noinspection PyUnresolvedReferences
-        prop_name = match_property(node.values[0].value)
+        prop_name = try_property(node.values[0].value)
         if prop_name is None:
             return None
 


### PR DESCRIPTION
Downstream clients, such as aas-core-meta, need to also match
invariants. Therefore, we expose ``infer_for_schema._common`` as a
public module ``infer_for_schema.match`` so that this logic can be used
by clients as well.