### PR TITLE
Consider ``object`` a reserved keyword

### DIFF
--- a/aas_core_codegen/parse/_translate.py
+++ b/aas_core_codegen/parse/_translate.py
@@ -2534,6 +2534,7 @@ def _verify_symbol_table(
         "boolean",
         "bytes",
         "bytearray",
+        "object",
     }
 
     reserved_type_names = builtin_types_in_many_implementations.union(


### PR DESCRIPTION
We add the word ``object`` to a list of reserved keywords in the parse
stage since a conflict already happened with the security part of the
meta-model.