### PR TITLE
Specify ``maxOccurs`` for optional elements in XSD

### DIFF
--- a/aas_core_codegen/xsd/main.py
+++ b/aas_core_codegen/xsd/main.py
@@ -491,6 +491,7 @@ def _generate_xs_element_for_a_property(
 
     if isinstance(prop.type_annotation, intermediate.OptionalTypeAnnotation):
         xs_element.attrib["minOccurs"] = "0"
+        xs_element.attrib["maxOccurs"] = "1"
 
     return xs_element, None
 

--- a/test_data/xsd/test_main/aas_core_meta.v3rc2/expected_output/schema.xsd
+++ b/test_data/xsd/test_main/aas_core_meta.v3rc2/expected_output/schema.xsd
@@ -3,14 +3,14 @@
   <xs:group name="administrativeInformation">
     <xs:sequence>
       <xs:group ref="hasDataSpecification"/>
-      <xs:element name="version" minOccurs="0">
+      <xs:element name="version" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="revision" minOccurs="0">
+      <xs:element name="revision" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
@@ -22,7 +22,7 @@
   <xs:group name="annotatedRelationshipElement">
     <xs:sequence>
       <xs:group ref="relationshipElement"/>
-      <xs:element name="annotations" minOccurs="0">
+      <xs:element name="annotations" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:group ref="dataElement_choice" minOccurs="1" maxOccurs="unbounded"/>
@@ -35,9 +35,9 @@
     <xs:sequence>
       <xs:group ref="identifiable"/>
       <xs:group ref="hasDataSpecification"/>
-      <xs:element name="derivedFrom" type="reference_t" minOccurs="0"/>
+      <xs:element name="derivedFrom" type="reference_t" minOccurs="0" maxOccurs="1"/>
       <xs:element name="assetInformation" type="assetInformation_t"/>
-      <xs:element name="submodels" minOccurs="0">
+      <xs:element name="submodels" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="reference" type="reference_t" minOccurs="1" maxOccurs="unbounded"/>
@@ -49,15 +49,15 @@
   <xs:group name="assetInformation">
     <xs:sequence>
       <xs:element name="assetKind" type="assetKind_t"/>
-      <xs:element name="globalAssetId" type="reference_t" minOccurs="0"/>
-      <xs:element name="specificAssetIds" minOccurs="0">
+      <xs:element name="globalAssetId" type="reference_t" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="specificAssetIds" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="specificAssetId" type="specificAssetId_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="defaultThumbnail" type="resource_t" minOccurs="0"/>
+      <xs:element name="defaultThumbnail" type="resource_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="basicEventElement">
@@ -66,23 +66,23 @@
       <xs:element name="observed" type="reference_t"/>
       <xs:element name="direction" type="direction_t"/>
       <xs:element name="state" type="stateOfEvent_t"/>
-      <xs:element name="messageTopic" minOccurs="0">
+      <xs:element name="messageTopic" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="messageBroker" type="reference_t" minOccurs="0"/>
-      <xs:element name="lastUpdate" type="xs:string" minOccurs="0"/>
-      <xs:element name="minInterval" type="xs:string" minOccurs="0"/>
-      <xs:element name="maxInterval" type="xs:string" minOccurs="0"/>
+      <xs:element name="messageBroker" type="reference_t" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="lastUpdate" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="minInterval" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="maxInterval" type="xs:string" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="blob">
     <xs:sequence>
       <xs:group ref="dataElement"/>
-      <xs:element name="value" type="xs:base64Binary" minOccurs="0"/>
+      <xs:element name="value" type="xs:base64Binary" minOccurs="0" maxOccurs="1"/>
       <xs:element name="contentType">
         <xs:simpleType>
           <xs:restriction base="xs:string">
@@ -102,7 +102,7 @@
     <xs:sequence>
       <xs:group ref="identifiable"/>
       <xs:group ref="hasDataSpecification"/>
-      <xs:element name="isCaseOf" minOccurs="0">
+      <xs:element name="isCaseOf" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="reference" type="reference_t" minOccurs="1" maxOccurs="unbounded"/>
@@ -145,53 +145,53 @@
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="shortName" minOccurs="0">
+      <xs:element name="shortName" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="langString" type="langString_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="unit" minOccurs="0">
+      <xs:element name="unit" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="unitId" type="reference_t" minOccurs="0"/>
-      <xs:element name="sourceOfDefinition" minOccurs="0">
+      <xs:element name="unitId" type="reference_t" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="sourceOfDefinition" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="symbol" minOccurs="0">
+      <xs:element name="symbol" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="dataType" type="dataTypeIec61360_t" minOccurs="0"/>
-      <xs:element name="definition" minOccurs="0">
+      <xs:element name="dataType" type="dataTypeIec61360_t" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="definition" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="langString" type="langString_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="valueFormat" minOccurs="0">
+      <xs:element name="valueFormat" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="valueList" type="valueList_t" minOccurs="0"/>
-      <xs:element name="value" type="xs:string" minOccurs="0"/>
-      <xs:element name="levelType" type="levelType_t" minOccurs="0"/>
+      <xs:element name="valueList" type="valueList_t" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="levelType" type="levelType_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="dataSpecificationPhysicalUnit">
@@ -218,70 +218,70 @@
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="siNotation" minOccurs="0">
+      <xs:element name="siNotation" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="siName" minOccurs="0">
+      <xs:element name="siName" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="dinNotation" minOccurs="0">
+      <xs:element name="dinNotation" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="eceName" minOccurs="0">
+      <xs:element name="eceName" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="eceCode" minOccurs="0">
+      <xs:element name="eceCode" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="nistName" minOccurs="0">
+      <xs:element name="nistName" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="sourceOfDefinition" minOccurs="0">
+      <xs:element name="sourceOfDefinition" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="conversionFactor" minOccurs="0">
+      <xs:element name="conversionFactor" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="registrationAuthorityId" minOccurs="0">
+      <xs:element name="registrationAuthorityId" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="supplier" minOccurs="0">
+      <xs:element name="supplier" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
@@ -305,7 +305,7 @@
   <xs:group name="entity">
     <xs:sequence>
       <xs:group ref="submodelElement"/>
-      <xs:element name="statements" minOccurs="0">
+      <xs:element name="statements" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:group ref="submodelElement_choice" minOccurs="1" maxOccurs="unbounded"/>
@@ -313,27 +313,27 @@
         </xs:complexType>
       </xs:element>
       <xs:element name="entityType" type="entityType_t"/>
-      <xs:element name="globalAssetId" type="reference_t" minOccurs="0"/>
-      <xs:element name="specificAssetId" type="specificAssetId_t" minOccurs="0"/>
+      <xs:element name="globalAssetId" type="reference_t" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="specificAssetId" type="specificAssetId_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="environment">
     <xs:sequence>
-      <xs:element name="assetAdministrationShells" minOccurs="0">
+      <xs:element name="assetAdministrationShells" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="assetAdministrationShell" type="assetAdministrationShell_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="submodels" minOccurs="0">
+      <xs:element name="submodels" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="submodel" type="submodel_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="conceptDescriptions" minOccurs="0">
+      <xs:element name="conceptDescriptions" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="conceptDescription" type="conceptDescription_t" minOccurs="1" maxOccurs="unbounded"/>
@@ -355,19 +355,19 @@
   <xs:group name="eventPayload">
     <xs:sequence>
       <xs:element name="source" type="reference_t"/>
-      <xs:element name="sourceSemanticId" type="reference_t" minOccurs="0"/>
+      <xs:element name="sourceSemanticId" type="reference_t" minOccurs="0" maxOccurs="1"/>
       <xs:element name="observableReference" type="reference_t"/>
-      <xs:element name="observableSemanticId" type="reference_t" minOccurs="0"/>
-      <xs:element name="topic" minOccurs="0">
+      <xs:element name="observableSemanticId" type="reference_t" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="topic" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="subjectId" type="reference_t" minOccurs="0"/>
+      <xs:element name="subjectId" type="reference_t" minOccurs="0" maxOccurs="1"/>
       <xs:element name="timeStamp" type="xs:string"/>
-      <xs:element name="payload" minOccurs="0">
+      <xs:element name="payload" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
@@ -386,15 +386,15 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="valueType" type="dataTypeDefXsd_t" minOccurs="0"/>
-      <xs:element name="value" type="xs:string" minOccurs="0"/>
-      <xs:element name="refersTo" type="reference_t" minOccurs="0"/>
+      <xs:element name="valueType" type="dataTypeDefXsd_t" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="refersTo" type="reference_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="file">
     <xs:sequence>
       <xs:group ref="dataElement"/>
-      <xs:element name="value" minOccurs="0">
+      <xs:element name="value" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:pattern value="file:(//((localhost|(\[((([0-9A-Fa-f]{1,4}:){6}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|::([0-9A-Fa-f]{1,4}:){5}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|([0-9A-Fa-f]{1,4})?::([0-9A-Fa-f]{1,4}:){4}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:)?[0-9A-Fa-f]{1,4})?::([0-9A-Fa-f]{1,4}:){3}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:){2}[0-9A-Fa-f]{1,4})?::([0-9A-Fa-f]{1,4}:){2}([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:){3}[0-9A-Fa-f]{1,4})?::[0-9A-Fa-f]{1,4}:([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:){4}[0-9A-Fa-f]{1,4})?::([0-9A-Fa-f]{1,4}:[0-9A-Fa-f]{1,4}|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(([0-9A-Fa-f]{1,4}:){5}[0-9A-Fa-f]{1,4})?::[0-9A-Fa-f]{1,4}|(([0-9A-Fa-f]{1,4}:){6}[0-9A-Fa-f]{1,4})?::)|[vV][0-9A-Fa-f]+\.([a-zA-Z0-9\-._~]|[!$&amp;'()*+,;=]|:)+)\]|([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])|([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=])*)))?/((([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=]|[:@]))+(/(([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=]|[:@]))*)*)?|/((([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=]|[:@]))+(/(([a-zA-Z0-9\-._~]|%[0-9A-Fa-f][0-9A-Fa-f]|[!$&amp;'()*+,;=]|[:@]))*)*)?)"/>
@@ -414,7 +414,7 @@
   </xs:group>
   <xs:group name="hasDataSpecification">
     <xs:sequence>
-      <xs:element name="embeddedDataSpecifications" minOccurs="0">
+      <xs:element name="embeddedDataSpecifications" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="embeddedDataSpecification" type="embeddedDataSpecification_t" minOccurs="1" maxOccurs="unbounded"/>
@@ -447,7 +447,7 @@
   </xs:group>
   <xs:group name="hasExtensions">
     <xs:sequence>
-      <xs:element name="extensions" minOccurs="0">
+      <xs:element name="extensions" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="extension" type="extension_t" minOccurs="1" maxOccurs="unbounded"/>
@@ -479,7 +479,7 @@
   </xs:group>
   <xs:group name="hasKind">
     <xs:sequence>
-      <xs:element name="kind" type="modelingKind_t" minOccurs="0"/>
+      <xs:element name="kind" type="modelingKind_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="hasKind_choice">
@@ -503,8 +503,8 @@
   </xs:group>
   <xs:group name="hasSemantics">
     <xs:sequence>
-      <xs:element name="semanticId" type="reference_t" minOccurs="0"/>
-      <xs:element name="supplementalSemanticIds" minOccurs="0">
+      <xs:element name="semanticId" type="reference_t" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="supplementalSemanticIds" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="reference" type="reference_t" minOccurs="1" maxOccurs="unbounded"/>
@@ -538,7 +538,7 @@
   <xs:group name="identifiable">
     <xs:sequence>
       <xs:group ref="referable"/>
-      <xs:element name="administration" type="administrativeInformation_t" minOccurs="0"/>
+      <xs:element name="administration" type="administrativeInformation_t" minOccurs="0" maxOccurs="1"/>
       <xs:element name="id">
         <xs:simpleType>
           <xs:restriction base="xs:string">
@@ -582,34 +582,34 @@
   <xs:group name="multiLanguageProperty">
     <xs:sequence>
       <xs:group ref="dataElement"/>
-      <xs:element name="value" minOccurs="0">
+      <xs:element name="value" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="langString" type="langString_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="valueId" type="reference_t" minOccurs="0"/>
+      <xs:element name="valueId" type="reference_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="operation">
     <xs:sequence>
       <xs:group ref="submodelElement"/>
-      <xs:element name="inputVariables" minOccurs="0">
+      <xs:element name="inputVariables" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="operationVariable" type="operationVariable_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="outputVariables" minOccurs="0">
+      <xs:element name="outputVariables" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="operationVariable" type="operationVariable_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="inoutputVariables" minOccurs="0">
+      <xs:element name="inoutputVariables" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="operationVariable" type="operationVariable_t" minOccurs="1" maxOccurs="unbounded"/>
@@ -633,13 +633,13 @@
     <xs:sequence>
       <xs:group ref="dataElement"/>
       <xs:element name="valueType" type="dataTypeDefXsd_t"/>
-      <xs:element name="value" type="xs:string" minOccurs="0"/>
-      <xs:element name="valueId" type="reference_t" minOccurs="0"/>
+      <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="valueId" type="reference_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="qualifiable">
     <xs:sequence>
-      <xs:element name="qualifiers" minOccurs="0">
+      <xs:element name="qualifiers" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="qualifier" type="qualifier_t" minOccurs="1" maxOccurs="unbounded"/>
@@ -670,7 +670,7 @@
   <xs:group name="qualifier">
     <xs:sequence>
       <xs:group ref="hasSemantics"/>
-      <xs:element name="kind" type="qualifierKind_t" minOccurs="0"/>
+      <xs:element name="kind" type="qualifierKind_t" minOccurs="0" maxOccurs="1"/>
       <xs:element name="type">
         <xs:simpleType>
           <xs:restriction base="xs:string">
@@ -679,29 +679,29 @@
         </xs:simpleType>
       </xs:element>
       <xs:element name="valueType" type="dataTypeDefXsd_t"/>
-      <xs:element name="value" type="xs:string" minOccurs="0"/>
-      <xs:element name="valueId" type="reference_t" minOccurs="0"/>
+      <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="valueId" type="reference_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="range">
     <xs:sequence>
       <xs:group ref="dataElement"/>
       <xs:element name="valueType" type="dataTypeDefXsd_t"/>
-      <xs:element name="min" type="xs:string" minOccurs="0"/>
-      <xs:element name="max" type="xs:string" minOccurs="0"/>
+      <xs:element name="min" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="max" type="xs:string" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="referable">
     <xs:sequence>
       <xs:group ref="hasExtensions"/>
-      <xs:element name="category" minOccurs="0">
+      <xs:element name="category" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="idShort" minOccurs="0">
+      <xs:element name="idShort" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:pattern value="[a-zA-Z][a-zA-Z0-9_]+"/>
@@ -709,21 +709,21 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="displayName" minOccurs="0">
+      <xs:element name="displayName" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="langString" type="langString_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="description" minOccurs="0">
+      <xs:element name="description" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:element name="langString" type="langString_t" minOccurs="1" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="checksum" minOccurs="0">
+      <xs:element name="checksum" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
@@ -756,7 +756,7 @@
   <xs:group name="reference">
     <xs:sequence>
       <xs:element name="type" type="referenceTypes_t"/>
-      <xs:element name="referredSemanticId" type="reference_t" minOccurs="0"/>
+      <xs:element name="referredSemanticId" type="reference_t" minOccurs="0" maxOccurs="1"/>
       <xs:element name="keys">
         <xs:complexType>
           <xs:sequence>
@@ -769,7 +769,7 @@
   <xs:group name="referenceElement">
     <xs:sequence>
       <xs:group ref="dataElement"/>
-      <xs:element name="value" type="reference_t" minOccurs="0"/>
+      <xs:element name="value" type="reference_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="relationshipElement">
@@ -795,7 +795,7 @@
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="contentType" minOccurs="0">
+      <xs:element name="contentType" minOccurs="0" maxOccurs="1">
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:pattern value="([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+/([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+([ \t]*;[ \t]*([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+=(([!#$%&amp;'*+\-.^_`|~0-9a-zA-Z])+|&quot;(([\t !#-\[\]-~]|[-ÿ])|\\([\t !-~]|[-ÿ]))*&quot;))*"/>
@@ -832,7 +832,7 @@
       <xs:group ref="hasSemantics"/>
       <xs:group ref="qualifiable"/>
       <xs:group ref="hasDataSpecification"/>
-      <xs:element name="submodelElements" minOccurs="0">
+      <xs:element name="submodelElements" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:group ref="submodelElement_choice" minOccurs="1" maxOccurs="unbounded"/>
@@ -853,7 +853,7 @@
   <xs:group name="submodelElementCollection">
     <xs:sequence>
       <xs:group ref="submodelElement"/>
-      <xs:element name="value" minOccurs="0">
+      <xs:element name="value" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:group ref="submodelElement_choice" minOccurs="0" maxOccurs="unbounded"/>
@@ -865,17 +865,17 @@
   <xs:group name="submodelElementList">
     <xs:sequence>
       <xs:group ref="submodelElement"/>
-      <xs:element name="orderRelevant" type="xs:boolean" minOccurs="0"/>
-      <xs:element name="value" minOccurs="0">
+      <xs:element name="orderRelevant" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="value" minOccurs="0" maxOccurs="1">
         <xs:complexType>
           <xs:sequence>
             <xs:group ref="submodelElement_choice" minOccurs="0" maxOccurs="unbounded"/>
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="semanticIdListElement" type="reference_t" minOccurs="0"/>
+      <xs:element name="semanticIdListElement" type="reference_t" minOccurs="0" maxOccurs="1"/>
       <xs:element name="typeValueListElement" type="aasSubmodelElements_t"/>
-      <xs:element name="valueTypeListElement" type="dataTypeDefXsd_t" minOccurs="0"/>
+      <xs:element name="valueTypeListElement" type="dataTypeDefXsd_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="submodelElement_choice">


### PR DESCRIPTION
We specify ``maxOccurs`` of 1 for elements representing optional
properties. Even though the default value for ``maxOccurs`` is 1, this
change in XSD helps to avoid confusion for the less XSD-savvy readers.

Fixes #240.