### PR TITLE
Create test empty snippets for RDF+SHACL

### DIFF
--- a/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/input/snippets/.gitignore
+++ b/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/input/snippets/.gitignore
@@ -1,0 +1,2 @@
+# This file is empty on purpose so that we keep the directory in the Git.
+


### PR DESCRIPTION
Currently, RDF+SHACL generation does not depend on any snippets, which
will probably change in the near future. Therefore, we keep the logic
for reading the snippets from a directory, and create an empty snippets
directory in the test data.

We mistakenly broke the tests since Git automatically removed empty
directories.