### PR TITLE
Ignore hidden files in snippets

### DIFF
--- a/aas_core_codegen/specific_implementations.py
+++ b/aas_core_codegen/specific_implementations.py
@@ -36,6 +36,12 @@ def read_from_directory(
 
     errors = []  # type: List[str]
     for pth in snippets_dir.glob("**/*"):
+        # NOTE (mristin, 2022-08-25):
+        # Ignore hidden or special files. In particular, we do not want Git-related
+        # files such as ``.gitignore`` to be included as snippets.
+        if pth.name.startswith("."):
+            continue
+
         if pth.is_dir():
             continue
 


### PR DESCRIPTION
We ignore files starting with a dot (".") when listing the snippets.
This is important, so that special files such as ``.gitignore`` are not
included in the snippets.