### PR TITLE
Sort all enumeration literals in JSON schema

### DIFF
--- a/aas_core_codegen/jsonschema/main.py
+++ b/aas_core_codegen/jsonschema/main.py
@@ -37,7 +37,7 @@ def _define_for_enumeration(
     """
     definition = collections.OrderedDict()  # type: MutableMapping[str, Any]
     definition["type"] = "string"
-    definition["enum"] = [literal.value for literal in enumeration.literals]
+    definition["enum"] = sorted(literal.value for literal in enumeration.literals)
 
     model_type = naming.json_model_type(enumeration.name)
 
@@ -390,7 +390,7 @@ def _generate(
             Error(
                 None,
                 f"Unexpected property '$id' in the base JSON schema "
-                f"from: {schema_base_key}"
+                f"from: {schema_base_key}",
             )
         ]
 
@@ -403,7 +403,7 @@ def _generate(
             Error(
                 None,
                 f"The property ``definitions`` unexpected in the base JSON schema "
-                f"from: {schema_base_key}"
+                f"from: {schema_base_key}",
             )
         ]
 
@@ -525,14 +525,14 @@ def _generate(
     if len(errors) > 0:
         return None, errors
 
-    model_types = [
+    model_types = sorted(
         naming.json_model_type(our_type.name)
         for our_type in symbol_table.our_types
         if (
             isinstance(our_type, intermediate.ConcreteClass)
             and our_type.serialization.with_model_type
         )
-    ]  # type: List[Identifier]
+    )  # type: List[Identifier]
 
     definitions["ModelType"] = collections.OrderedDict(
         [("type", "string"), ("enum", model_types)]

--- a/test_data/jsonschema/test_main/aas_core_meta.v3rc2/expected_output/schema.json
+++ b/test_data/jsonschema/test_main/aas_core_meta.v3rc2/expected_output/schema.json
@@ -27,8 +27,8 @@
         "ReferenceElement",
         "RelationshipElement",
         "SubmodelElement",
-        "SubmodelElementList",
-        "SubmodelElementCollection"
+        "SubmodelElementCollection",
+        "SubmodelElementList"
       ]
     },
     "AdministrativeInformation": {
@@ -125,8 +125,8 @@
     "AssetKind": {
       "type": "string",
       "enum": [
-        "Type",
-        "Instance"
+        "Instance",
+        "Type"
       ]
     },
     "BasicEventElement": {
@@ -374,12 +374,15 @@
     "DataTypeDefXsd": {
       "type": "string",
       "enum": [
+        "xs:NonNegativeInteger",
         "xs:anyURI",
         "xs:base64Binary",
         "xs:boolean",
+        "xs:byte",
         "xs:date",
         "xs:dateTime",
         "xs:dateTimeStamp",
+        "xs:dayTimeDuration",
         "xs:decimal",
         "xs:double",
         "xs:duration",
@@ -390,47 +393,44 @@
         "xs:gYear",
         "xs:gYearMonth",
         "xs:hexBinary",
-        "xs:string",
-        "xs:time",
-        "xs:dayTimeDuration",
-        "xs:yearMonthDuration",
+        "xs:int",
         "xs:integer",
         "xs:long",
-        "xs:int",
-        "xs:short",
-        "xs:byte",
-        "xs:NonNegativeInteger",
-        "xs:positiveInteger",
-        "xs:unsignedLong",
-        "xs:unsignedInt",
-        "xs:unsignedShort",
-        "xs:unsignedByte",
+        "xs:negativeInteger",
         "xs:nonPositiveInteger",
-        "xs:negativeInteger"
+        "xs:positiveInteger",
+        "xs:short",
+        "xs:string",
+        "xs:time",
+        "xs:unsignedByte",
+        "xs:unsignedInt",
+        "xs:unsignedLong",
+        "xs:unsignedShort",
+        "xs:yearMonthDuration"
       ]
     },
     "DataTypeIEC61360": {
       "type": "string",
       "enum": [
-        "DATE",
-        "STRING",
-        "STRING_TRANSLATABLE",
-        "INTEGER_MEASURE",
-        "INTEGER_COUNT",
-        "INTEGER_CURRENCY",
-        "REAL_MEASURE",
-        "REAL_COUNT",
-        "REAL_CURRENCY",
+        "BLOB",
         "BOOLEAN",
-        "IRI",
-        "IRDI",
-        "RATIONAL",
-        "RATIONAL_MEASURE",
-        "TIME",
-        "TIMESTAMP",
+        "DATE",
         "FILE",
         "HTML",
-        "BLOB"
+        "INTEGER_COUNT",
+        "INTEGER_CURRENCY",
+        "INTEGER_MEASURE",
+        "IRDI",
+        "IRI",
+        "RATIONAL",
+        "RATIONAL_MEASURE",
+        "REAL_COUNT",
+        "REAL_CURRENCY",
+        "REAL_MEASURE",
+        "STRING",
+        "STRING_TRANSLATABLE",
+        "TIME",
+        "TIMESTAMP"
       ]
     },
     "Direction": {
@@ -696,30 +696,30 @@
     "KeyTypes": {
       "type": "string",
       "enum": [
-        "FragmentReference",
-        "GlobalReference",
         "AnnotatedRelationshipElement",
         "AssetAdministrationShell",
         "BasicEventElement",
         "Blob",
         "Capability",
         "ConceptDescription",
-        "Identifiable",
         "DataElement",
         "Entity",
         "EventElement",
         "File",
+        "FragmentReference",
+        "GlobalReference",
+        "Identifiable",
         "MultiLanguageProperty",
         "Operation",
         "Property",
         "Range",
-        "ReferenceElement",
         "Referable",
+        "ReferenceElement",
         "RelationshipElement",
         "Submodel",
         "SubmodelElement",
-        "SubmodelElementList",
-        "SubmodelElementCollection"
+        "SubmodelElementCollection",
+        "SubmodelElementList"
       ]
     },
     "LangString": {
@@ -741,8 +741,8 @@
     "LevelType": {
       "type": "string",
       "enum": [
-        "Min",
         "Max",
+        "Min",
         "Nom",
         "Typ"
       ]
@@ -750,32 +750,32 @@
     "ModelType": {
       "type": "string",
       "enum": [
-        "AssetAdministrationShell",
-        "Submodel",
-        "RelationshipElement",
-        "SubmodelElementList",
-        "SubmodelElementCollection",
-        "Property",
-        "MultiLanguageProperty",
-        "Range",
-        "ReferenceElement",
-        "Blob",
-        "File",
         "AnnotatedRelationshipElement",
-        "Entity",
+        "AssetAdministrationShell",
         "BasicEventElement",
-        "Operation",
+        "Blob",
         "Capability",
         "ConceptDescription",
         "DataSpecificationIEC61360",
-        "DataSpecificationPhysicalUnit"
+        "DataSpecificationPhysicalUnit",
+        "Entity",
+        "File",
+        "MultiLanguageProperty",
+        "Operation",
+        "Property",
+        "Range",
+        "ReferenceElement",
+        "RelationshipElement",
+        "Submodel",
+        "SubmodelElementCollection",
+        "SubmodelElementList"
       ]
     },
     "ModelingKind": {
       "type": "string",
       "enum": [
-        "Template",
-        "Instance"
+        "Instance",
+        "Template"
       ]
     },
     "MultiLanguageProperty": {
@@ -917,9 +917,9 @@
     "QualifierKind": {
       "type": "string",
       "enum": [
-        "ValueQualifier",
         "ConceptQualifier",
-        "TemplateQualifier"
+        "TemplateQualifier",
+        "ValueQualifier"
       ]
     },
     "Range": {
@@ -1101,8 +1101,8 @@
     "StateOfEvent": {
       "type": "string",
       "enum": [
-        "ON",
-        "OFF"
+        "OFF",
+        "ON"
       ]
     },
     "Submodel": {


### PR DESCRIPTION
We sort all the enumeration literals in JSON schema so that it is easier
to diff two versions of the schema.