### PR TITLE
Update test data to aas-core-meta 1df1729

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
             "twine",
             "jsonschema==3.2.0",
             "xmlschema==1.10.0",
-            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@8d909e9#egg=aas-core-meta",
+            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@1df1729#egg=aas-core-meta",
         ]
     },
     # fmt: on

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/types.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/types.cs
@@ -2932,18 +2932,18 @@ namespace AasCore.Aas3_0_RC02
     ///   <li>
     ///     Constraint AASd-107:
     ///     If a first level child element in a <see cref="Aas.SubmodelElementList" /> has
-    ///     a <see cref="Aas.ISubmodelElement.SemanticId" /> it
+    ///     a <see cref="Aas.IHasSemantics.SemanticId" /> it
     ///     shall be identical to <see cref="Aas.SubmodelElementList.SemanticIdListElement" />.
     ///   </li>
     ///   <li>
     ///     Constraint AASd-114:
     ///     If two first level child elements in a <see cref="Aas.SubmodelElementList" /> have
-    ///     a <see cref="Aas.ISubmodelElement.SemanticId" /> then they shall be identical.
+    ///     a <see cref="Aas.IHasSemantics.SemanticId" /> then they shall be identical.
     ///   </li>
     ///   <li>
     ///     Constraint AASd-115:
     ///     If a first level child element in a <see cref="Aas.SubmodelElementList" /> does not
-    ///     specify a <see cref="Aas.ISubmodelElement.SemanticId" /> then the value is assumed to be
+    ///     specify a <see cref="Aas.IHasSemantics.SemanticId" /> then the value is assumed to be
     ///     identical to <see cref="Aas.SubmodelElementList.SemanticIdListElement" />.
     ///   </li>
     ///   <li>
@@ -3993,8 +3993,8 @@ namespace AasCore.Aas3_0_RC02
     ///   <li>
     ///     <para>
     ///     Constraint AASd-090:
-    ///     For data elements <see cref="Aas.IDataElement.Category" /> (inherited by <see cref="Aas.IReferable" />) shall be
-    ///     one of the following values: <c>CONSTANT</c>, <c>PARAMETER</c> or <c>VARIABLE</c>.
+    ///     For data elements <see cref="Aas.IDataElement.Category" /> shall be one of the following
+    ///     values: <c>CONSTANT</c>, <c>PARAMETER</c> or <c>VARIABLE</c>.
     ///     </para>
     ///     <para>
     ///     Default: <c>VARIABLE</c>
@@ -4274,7 +4274,7 @@ namespace AasCore.Aas3_0_RC02
         }
 
         /// <summary>
-        /// Return the <see cref="IDataElement.Category" /> or the default value
+        /// Return the <see cref="IReferable.Category" /> or the default value
         /// if it has not been set.
         /// </summary>
         public string CategoryOrDefault()
@@ -4791,7 +4791,7 @@ namespace AasCore.Aas3_0_RC02
         }
 
         /// <summary>
-        /// Return the <see cref="IDataElement.Category" /> or the default value
+        /// Return the <see cref="IReferable.Category" /> or the default value
         /// if it has not been set.
         /// </summary>
         public string CategoryOrDefault()
@@ -5314,7 +5314,7 @@ namespace AasCore.Aas3_0_RC02
         }
 
         /// <summary>
-        /// Return the <see cref="IDataElement.Category" /> or the default value
+        /// Return the <see cref="IReferable.Category" /> or the default value
         /// if it has not been set.
         /// </summary>
         public string CategoryOrDefault()
@@ -5789,7 +5789,7 @@ namespace AasCore.Aas3_0_RC02
         }
 
         /// <summary>
-        /// Return the <see cref="IDataElement.Category" /> or the default value
+        /// Return the <see cref="IReferable.Category" /> or the default value
         /// if it has not been set.
         /// </summary>
         public string CategoryOrDefault()
@@ -6294,7 +6294,7 @@ namespace AasCore.Aas3_0_RC02
         }
 
         /// <summary>
-        /// Return the <see cref="IDataElement.Category" /> or the default value
+        /// Return the <see cref="IReferable.Category" /> or the default value
         /// if it has not been set.
         /// </summary>
         public string CategoryOrDefault()
@@ -6777,7 +6777,7 @@ namespace AasCore.Aas3_0_RC02
         }
 
         /// <summary>
-        /// Return the <see cref="IDataElement.Category" /> or the default value
+        /// Return the <see cref="IReferable.Category" /> or the default value
         /// if it has not been set.
         /// </summary>
         public string CategoryOrDefault()

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/input/snippets/Types/Data_element/category_or_default.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/input/snippets/Types/Data_element/category_or_default.cs
@@ -1,5 +1,5 @@
 /// <summary>
-/// Return the <see cref="IDataElement.Category" /> or the default value
+/// Return the <see cref="IReferable.Category" /> or the default value
 /// if it has not been set.
 /// </summary>
 public string CategoryOrDefault()

--- a/test_data/intermediate/real_meta_models/aas_core_meta.v3rc2/expected_symbol_table.txt
+++ b/test_data/intermediate/real_meta_models/aas_core_meta.v3rc2/expected_symbol_table.txt
@@ -9806,18 +9806,18 @@ SymbolTable(
             'AASd-107',
             textwrap.dedent("""\
               <field_body><paragraph>If a first level child element in a <ReferenceToOurType refuri=".Submodel_element_list">.Submodel_element_list</ReferenceToOurType> has
-              a <ReferenceToAttribute refuri="~Submodel_element.semantic_id">~Submodel_element.semantic_id</ReferenceToAttribute> it
+              a <ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute> it
               shall be identical to <ReferenceToAttribute refuri="~Submodel_element_list.semantic_id_list_element">~Submodel_element_list.semantic_id_list_element</ReferenceToAttribute>.</paragraph></field_body>""")],
           [
             'AASd-114',
             textwrap.dedent("""\
               <field_body><paragraph>If two first level child elements in a <ReferenceToOurType refuri=".Submodel_element_list">.Submodel_element_list</ReferenceToOurType> have
-              a <ReferenceToAttribute refuri="~Submodel_element.semantic_id">~Submodel_element.semantic_id</ReferenceToAttribute> then they shall be identical.</paragraph></field_body>""")],
+              a <ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute> then they shall be identical.</paragraph></field_body>""")],
           [
             'AASd-115',
             textwrap.dedent("""\
               <field_body><paragraph>If a first level child element in a <ReferenceToOurType refuri=".Submodel_element_list">.Submodel_element_list</ReferenceToOurType> does not
-              specify a <ReferenceToAttribute refuri="~Submodel_element.semantic_id">~Submodel_element.semantic_id</ReferenceToAttribute> then the value is assumed to be
+              specify a <ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute> then the value is assumed to be
               identical to <ReferenceToAttribute refuri="~Submodel_element_list.semantic_id_list_element">~Submodel_element_list.semantic_id_list_element</ReferenceToAttribute>.</paragraph></field_body>""")],
           [
             'AASd-108',
@@ -11083,8 +11083,8 @@ SymbolTable(
             [
               'AASd-090',
               textwrap.dedent("""\
-                <field_body><paragraph>For data elements <ReferenceToAttribute refuri="~category">~category</ReferenceToAttribute> (inherited by <ReferenceToOurType refuri=".Referable">.Referable</ReferenceToOurType>) shall be
-                one of the following values: <literal>CONSTANT</literal>, <literal>PARAMETER</literal> or <literal>VARIABLE</literal>.</paragraph><paragraph>Default: <literal>VARIABLE</literal></paragraph></field_body>""")]],
+                <field_body><paragraph>For data elements <ReferenceToAttribute refuri="~category">~category</ReferenceToAttribute> shall be one of the following
+                values: <literal>CONSTANT</literal>, <literal>PARAMETER</literal> or <literal>VARIABLE</literal>.</paragraph><paragraph>Default: <literal>VARIABLE</literal></paragraph></field_body>""")]],
           parsed=...),
         parsed=...,
         properties_by_name=...,
@@ -11982,8 +11982,8 @@ SymbolTable(
           [
             'AASd-090',
             textwrap.dedent("""\
-              <field_body><paragraph>For data elements <ReferenceToAttribute refuri="~category">~category</ReferenceToAttribute> (inherited by <ReferenceToOurType refuri=".Referable">.Referable</ReferenceToOurType>) shall be
-              one of the following values: <literal>CONSTANT</literal>, <literal>PARAMETER</literal> or <literal>VARIABLE</literal>.</paragraph><paragraph>Default: <literal>VARIABLE</literal></paragraph></field_body>""")]],
+              <field_body><paragraph>For data elements <ReferenceToAttribute refuri="~category">~category</ReferenceToAttribute> shall be one of the following
+              values: <literal>CONSTANT</literal>, <literal>PARAMETER</literal> or <literal>VARIABLE</literal>.</paragraph><paragraph>Default: <literal>VARIABLE</literal></paragraph></field_body>""")]],
         parsed=...),
       parsed=...,
       properties_by_name=...,


### PR DESCRIPTION
We update the development requirements to and re-record the test data
for [aas-core-meta 1df1729].

So far, we referenced the properties as properties of a concrete class
in the documentation instead of referencing them to the most abstract
class which defines them.

This creates problems with [docfx] in C# so we reference the
properties as properties of the abstract class.

We also update the implementation-specific snippets for C# which also
referenced the properties in the concrete class instead of the abstract
one.

[aas-core-meta 1df1729]: https://github.com/aas-core-works/aas-core-meta/commit/1df1729
[docfx]: https://dotnet.github.io/docfx/