### PR TITLE
Hard-wire ``Lang_string`` in RDF+SHACL

### DIFF
--- a/aas_core_codegen/rdf_shacl/common.py
+++ b/aas_core_codegen/rdf_shacl/common.py
@@ -62,6 +62,20 @@ def map_class_to_rdfs_range(
                     )
                 else:
                     class_to_rdfs_range[our_type] = implementation
+            elif our_type.name == "Lang_string":
+                # NOTE (mristin, 2022-09-01):
+                # We hard-wire the langString's to rdf:langString. Admittedly, this is
+                # hacky. We could have made the class ``Lang_string``
+                # implementation-specific and defined its ``rdfs:range`` manually as
+                # a snippet.
+                #
+                # However, we decided against that as such a design would force us to
+                # define langString for every language and schema which do not natively
+                # support it, write custom data generation methods *etc.* Given that
+                # RDF+SHACL codegen is one out of many code generators we leave the
+                # other code generators and test data generators as simple as possible,
+                # and make this code generator a bit hacky in return.
+                class_to_rdfs_range[our_type] = Stripped("rdf:langString")
             else:
                 class_to_rdfs_range[our_type] = Stripped(
                     f"aas:{rdf_shacl_naming.class_name(our_type.name)}"

--- a/aas_core_codegen/rdf_shacl/rdf.py
+++ b/aas_core_codegen/rdf_shacl/rdf.py
@@ -362,6 +362,21 @@ def generate(
         symbol_table.our_types,
         key=lambda another_our_type: rdf_shacl_naming.class_name(another_our_type.name),
     ):
+        if our_type.name == "Lang_string":
+            # NOTE (mristin, 2022-09-01):
+            # We hard-wire the langString's to rdf:langString. Admittedly, this is
+            # hacky. We could have made the class ``Lang_string``
+            # implementation-specific and defined its ``rdfs:range`` manually as
+            # a snippet.
+            #
+            # However, we decided against that as such a design would force us to
+            # define langString for every language and schema which do not natively
+            # support it, write custom data generation methods *etc.* Given that
+            # RDF+SHACL codegen is one out of many code generators we leave the
+            # other code generators and test data generators as simple as possible,
+            # and make this code generator a bit hacky in return.
+            continue
+
         if isinstance(our_type, intermediate.Enumeration):
             block, error = _define_for_enumeration(
                 enumeration=our_type, xml_namespace=xml_namespace

--- a/aas_core_codegen/rdf_shacl/shacl.py
+++ b/aas_core_codegen/rdf_shacl/shacl.py
@@ -334,6 +334,21 @@ def generate(
         symbol_table.our_types,
         key=lambda another_our_type: rdf_shacl_naming.class_name(another_our_type.name),
     ):
+        if our_type.name == "Lang_string":
+            # NOTE (mristin, 2022-09-01):
+            # We hard-wire the langString's to rdf:langString. Admittedly, this is
+            # hacky. We could have made the class ``Lang_string``
+            # implementation-specific and defined its ``rdfs:range`` manually as
+            # a snippet.
+            #
+            # However, we decided against that as such a design would force us to
+            # define langString for every language and schema which do not natively
+            # support it, write custom data generation methods *etc.* Given that
+            # RDF+SHACL codegen is one out of many code generators we leave the
+            # other code generators and test data generators as simple as possible,
+            # and make this code generator a bit hacky in return.
+            continue
+
         # noinspection PyUnusedLocal
         block = None  # type: Optional[Stripped]
 

--- a/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/expected_output/rdf-ontology.ttl
+++ b/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/expected_output/rdf-ontology.ttl
@@ -400,7 +400,7 @@ aas:DataSpecificationIEC61360 rdf:type owl:Class ;
 <https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/definition> rdf:type owl:ObjectProperty ;
     rdfs:label "has definition"^^xs:string ;
     rdfs:domain aas:DataSpecificationIEC61360 ;
-    rdfs:range aas:LangString ;
+    rdfs:range rdf:langString ;
     rdfs:comment "Definition in different languages"@en ;
 .
 
@@ -416,7 +416,7 @@ aas:DataSpecificationIEC61360 rdf:type owl:Class ;
 <https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/preferredName> rdf:type owl:ObjectProperty ;
     rdfs:label "has preferred name"^^xs:string ;
     rdfs:domain aas:DataSpecificationIEC61360 ;
-    rdfs:range aas:LangString ;
+    rdfs:range rdf:langString ;
     rdfs:comment "Preferred name"@en ;
 .
 
@@ -424,7 +424,7 @@ aas:DataSpecificationIEC61360 rdf:type owl:Class ;
 <https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/shortName> rdf:type owl:ObjectProperty ;
     rdfs:label "has short name"^^xs:string ;
     rdfs:domain aas:DataSpecificationIEC61360 ;
-    rdfs:range aas:LangString ;
+    rdfs:range rdf:langString ;
     rdfs:comment "Short name"@en ;
 .
 
@@ -502,7 +502,7 @@ aas:DataSpecificationPhysicalUnit rdf:type owl:Class ;
 <https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/definition> rdf:type owl:ObjectProperty ;
     rdfs:label "has definition"^^xs:string ;
     rdfs:domain aas:DataSpecificationPhysicalUnit ;
-    rdfs:range aas:LangString ;
+    rdfs:range rdf:langString ;
     rdfs:comment "Definition in different languages"@en ;
 .
 
@@ -1486,28 +1486,6 @@ aas:KeyTypes rdf:type owl:Class ;
     rdfs:comment "List of Submodel Elements"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/RC02/LangString
-aas:LangString rdf:type owl:Class ;
-    rdfs:label "Lang String"^^xs:string ;
-    rdfs:comment "Strings with language tags"@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC02/LangString/language
-<https://admin-shell.io/aas/3/0/RC02/LangString/language> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has language"^^xs:string ;
-    rdfs:domain aas:LangString ;
-    rdfs:range xs:string ;
-    rdfs:comment "Language tag conforming to BCP 47"@en ;
-.
-
-###  https://admin-shell.io/aas/3/0/RC02/LangString/text
-<https://admin-shell.io/aas/3/0/RC02/LangString/text> rdf:type owl:DatatypeProperty ;
-    rdfs:label "has text"^^xs:string ;
-    rdfs:domain aas:LangString ;
-    rdfs:range xs:string ;
-    rdfs:comment "Text in the 'language'"@en ;
-.
-
 ###  https://admin-shell.io/aas/3/0/RC02/LevelType
 aas:LevelType rdf:type owl:Class ;
     rdfs:label "Level Type"^^xs:string ;
@@ -1572,7 +1550,7 @@ aas:MultiLanguageProperty rdf:type owl:Class ;
 <https://admin-shell.io/aas/3/0/RC02/MultiLanguageProperty/value> rdf:type owl:ObjectProperty ;
     rdfs:label "has value"^^xs:string ;
     rdfs:domain aas:MultiLanguageProperty ;
-    rdfs:range aas:LangString ;
+    rdfs:range rdf:langString ;
     rdfs:comment "The value of the property instance."@en ;
 .
 
@@ -1808,7 +1786,7 @@ aas:Referable rdf:type owl:Class ;
 <https://admin-shell.io/aas/3/0/RC02/Referable/description> rdf:type owl:ObjectProperty ;
     rdfs:label "has description"^^xs:string ;
     rdfs:domain aas:Referable ;
-    rdfs:range aas:LangString ;
+    rdfs:range rdf:langString ;
     rdfs:comment "Description or comments on the element."@en ;
 .
 
@@ -1816,7 +1794,7 @@ aas:Referable rdf:type owl:Class ;
 <https://admin-shell.io/aas/3/0/RC02/Referable/displayName> rdf:type owl:ObjectProperty ;
     rdfs:label "has display name"^^xs:string ;
     rdfs:domain aas:Referable ;
-    rdfs:range aas:LangString ;
+    rdfs:range rdf:langString ;
     rdfs:comment "Display name. Can be provided in several languages."@en ;
 .
 

--- a/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/expected_output/shacl-schema.ttl
+++ b/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/expected_output/shacl-schema.ttl
@@ -247,13 +247,13 @@ aas:DataSpecificationIEC61360Shape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/preferredName> ;
-        sh:class aas:LangString ;
+        sh:datatype rdf:langString ;
         sh:minCount 1 ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/shortName> ;
-        sh:class aas:LangString ;
+        sh:datatype rdf:langString ;
         sh:minCount 0 ;
     ] ;
     sh:property [
@@ -297,7 +297,7 @@ aas:DataSpecificationIEC61360Shape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecificationIEC61360/definition> ;
-        sh:class aas:LangString ;
+        sh:datatype rdf:langString ;
         sh:minCount 0 ;
     ] ;
     sh:property [
@@ -353,7 +353,7 @@ aas:DataSpecificationPhysicalUnitShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <https://admin-shell.io/aas/3/0/RC02/DataSpecificationPhysicalUnit/definition> ;
-        sh:class aas:LangString ;
+        sh:datatype rdf:langString ;
         sh:minCount 1 ;
     ] ;
     sh:property [
@@ -794,32 +794,13 @@ aas:KeyShape a sh:NodeShape ;
     ] ;
 .
 
-aas:LangStringShape a sh:NodeShape ;
-    sh:targetClass aas:LangString ;
-    sh:property [
-        a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/RC02/LangString/language> ;
-        sh:datatype xs:string ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
-        sh:pattern "^(([a-zA-Z]{2,3}(-[a-zA-Z]{3}(-[a-zA-Z]{3}){2})?|[a-zA-Z]{4}|[a-zA-Z]{5,8})(-[a-zA-Z]{4})?(-([a-zA-Z]{2}|[0-9]{3}))?(-(([a-zA-Z0-9]){5,8}|[0-9]([a-zA-Z0-9]){3}))*(-[0-9A-WY-Za-wy-z](-([a-zA-Z0-9]){2,8})+)*(-[xX](-([a-zA-Z0-9]){1,8})+)?|[xX](-([a-zA-Z0-9]){1,8})+|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$" ;
-    ] ;
-    sh:property [
-        a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/RC02/LangString/text> ;
-        sh:datatype xs:string ;
-        sh:minCount 1 ;
-        sh:maxCount 1 ;
-    ] ;
-.
-
 aas:MultiLanguagePropertyShape a sh:NodeShape ;
     sh:targetClass aas:MultiLanguageProperty ;
     rdfs:subClassOf aas:DataElementShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <https://admin-shell.io/aas/3/0/RC02/MultiLanguageProperty/value> ;
-        sh:class aas:LangString ;
+        sh:datatype rdf:langString ;
         sh:minCount 0 ;
     ] ;
     sh:property [
@@ -1015,13 +996,13 @@ aas:ReferableShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <https://admin-shell.io/aas/3/0/RC02/Referable/displayName> ;
-        sh:class aas:LangString ;
+        sh:datatype rdf:langString ;
         sh:minCount 0 ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <https://admin-shell.io/aas/3/0/RC02/Referable/description> ;
-        sh:class aas:LangString ;
+        sh:datatype rdf:langString ;
         sh:minCount 0 ;
     ] ;
     sh:property [


### PR DESCRIPTION
We hard-wire the handling of the class ``Lang_string`` in RDF+SHACL, and
represent it as the native ``rdf:langString``.

Admittedly, this is hacky. We could have made the class ``Lang_string``
implementation-specific and defined its ``rdfs:range`` manually as
a snippet.

However, we decided against that as such a design would force us to
define ``langString`` for every language and schema which do not
natively support it, write custom data generation methods *etc.* Given
that RDF+SHACL codegen is one out of many code generators we leave the
other code generators and test data generators as simple as possible,
and make the RDF+SHACL code generator a bit hacky in return.