### PR TITLE
Represent bytes as ``base64Binary`` in RDF+SHACL

### DIFF
--- a/aas_core_codegen/rdf_shacl/common.py
+++ b/aas_core_codegen/rdf_shacl/common.py
@@ -139,6 +139,6 @@ PRIMITIVE_MAP = {
     intermediate.PrimitiveType.INT: "xs:long",
     intermediate.PrimitiveType.FLOAT: "xs:double",
     intermediate.PrimitiveType.STR: "xs:string",
-    intermediate.PrimitiveType.BYTEARRAY: "xs:byte",
+    intermediate.PrimitiveType.BYTEARRAY: "xs:base64Binary",
 }
 assert all(literal in PRIMITIVE_MAP for literal in intermediate.PrimitiveType)

--- a/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/expected_output/rdf-ontology.ttl
+++ b/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/expected_output/rdf-ontology.ttl
@@ -341,7 +341,7 @@ aas:Blob rdf:type owl:Class ;
 <https://admin-shell.io/aas/3/0/RC02/Blob/value> rdf:type owl:DatatypeProperty ;
     rdfs:label "has value"^^xs:string ;
     rdfs:domain aas:Blob ;
-    rdfs:range xs:byte ;
+    rdfs:range xs:base64Binary ;
     rdfs:comment "The value of the 'Blob' instance of a blob data element."@en ;
 .
 

--- a/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/expected_output/shacl-schema.ttl
+++ b/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/expected_output/shacl-schema.ttl
@@ -176,7 +176,7 @@ aas:BlobShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <https://admin-shell.io/aas/3/0/RC02/Blob/value> ;
-        sh:datatype xs:byte ;
+        sh:datatype xs:base64Binary ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
     ] ;


### PR DESCRIPTION
So far, we represented byte arrays as ``xs:byte`` in RDF+SHACL. This is
wrong as RDF follows XML. Hence, we fix the range of byte arrays to
``xs:base64Binary``, just as in XSD.