### PR TITLE
Hard-wirte `Value_data_type` to `xs:anySimpleType`

### DIFF
--- a/aas_core_codegen/rdf_shacl/main.py
+++ b/aas_core_codegen/rdf_shacl/main.py
@@ -29,7 +29,7 @@ def execute(context: run.Context, stdout: TextIO, stderr: TextIO) -> int:
     """Generate the code."""
     # region Dependencies
 
-    class_to_rdfs_range, error = rdf_shacl_common.map_class_to_rdfs_range(
+    our_type_to_rdfs_range, error = rdf_shacl_common.map_our_type_to_rdfs_range(
         symbol_table=context.symbol_table, spec_impls=context.spec_impls
     )
     if error:
@@ -42,7 +42,7 @@ def execute(context: run.Context, stdout: TextIO, stderr: TextIO) -> int:
 
         return 1
 
-    assert class_to_rdfs_range is not None
+    assert our_type_to_rdfs_range is not None
 
     # endregion
 
@@ -50,7 +50,7 @@ def execute(context: run.Context, stdout: TextIO, stderr: TextIO) -> int:
 
     rdf_code, errors = aas_core_codegen.rdf_shacl.rdf.generate(
         symbol_table=context.symbol_table,
-        class_to_rdfs_range=class_to_rdfs_range,
+        our_type_to_rdfs_range=our_type_to_rdfs_range,
         spec_impls=context.spec_impls,
     )
 
@@ -82,7 +82,7 @@ def execute(context: run.Context, stdout: TextIO, stderr: TextIO) -> int:
 
     shacl_code, errors = aas_core_codegen.rdf_shacl.shacl.generate(
         symbol_table=context.symbol_table,
-        class_to_rdfs_range=class_to_rdfs_range,
+        our_type_to_rdfs_range=our_type_to_rdfs_range,
         spec_impls=context.spec_impls,
     )
 

--- a/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/expected_output/rdf-ontology.ttl
+++ b/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/expected_output/rdf-ontology.ttl
@@ -1179,7 +1179,7 @@ aas:Extension rdf:type owl:Class ;
 <https://admin-shell.io/aas/3/0/RC02/Extension/value> rdf:type owl:DatatypeProperty ;
     rdfs:label "has value"^^xs:string ;
     rdfs:domain aas:Extension ;
-    rdfs:range xs:string ;
+    rdfs:range xs:anySimpleType ;
     rdfs:comment "Value of the extension"@en ;
 .
 
@@ -1618,7 +1618,7 @@ aas:Property rdf:type owl:Class ;
 <https://admin-shell.io/aas/3/0/RC02/Property/value> rdf:type owl:DatatypeProperty ;
     rdfs:label "has value"^^xs:string ;
     rdfs:domain aas:Property ;
-    rdfs:range xs:string ;
+    rdfs:range xs:anySimpleType ;
     rdfs:comment "The value of the property instance."@en ;
 .
 
@@ -1679,7 +1679,7 @@ aas:Qualifier rdf:type owl:Class ;
 <https://admin-shell.io/aas/3/0/RC02/Qualifier/value> rdf:type owl:DatatypeProperty ;
     rdfs:label "has value"^^xs:string ;
     rdfs:domain aas:Qualifier ;
-    rdfs:range xs:string ;
+    rdfs:range xs:anySimpleType ;
     rdfs:comment "The qualifier value is the value of the qualifier."@en ;
 .
 
@@ -1739,7 +1739,7 @@ aas:Range rdf:type owl:Class ;
 <https://admin-shell.io/aas/3/0/RC02/Range/max> rdf:type owl:DatatypeProperty ;
     rdfs:label "has max"^^xs:string ;
     rdfs:domain aas:Range ;
-    rdfs:range xs:string ;
+    rdfs:range xs:anySimpleType ;
     rdfs:comment "The maximum value of the range."@en ;
 .
 
@@ -1747,7 +1747,7 @@ aas:Range rdf:type owl:Class ;
 <https://admin-shell.io/aas/3/0/RC02/Range/min> rdf:type owl:DatatypeProperty ;
     rdfs:label "has min"^^xs:string ;
     rdfs:domain aas:Range ;
-    rdfs:range xs:string ;
+    rdfs:range xs:anySimpleType ;
     rdfs:comment "The minimum value of the range."@en ;
 .
 

--- a/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/expected_output/shacl-schema.ttl
+++ b/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/expected_output/shacl-schema.ttl
@@ -611,7 +611,7 @@ aas:ExtensionShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <https://admin-shell.io/aas/3/0/RC02/Extension/value> ;
-        sh:datatype xs:string ;
+        sh:datatype xs:anySimpleType ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
     ] ;
@@ -859,7 +859,7 @@ aas:PropertyShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <https://admin-shell.io/aas/3/0/RC02/Property/value> ;
-        sh:datatype xs:string ;
+        sh:datatype xs:anySimpleType ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
     ] ;
@@ -922,7 +922,7 @@ aas:QualifierShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <https://admin-shell.io/aas/3/0/RC02/Qualifier/value> ;
-        sh:datatype xs:string ;
+        sh:datatype xs:anySimpleType ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
     ] ;
@@ -948,14 +948,14 @@ aas:RangeShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <https://admin-shell.io/aas/3/0/RC02/Range/min> ;
-        sh:datatype xs:string ;
+        sh:datatype xs:anySimpleType ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <https://admin-shell.io/aas/3/0/RC02/Range/max> ;
-        sh:datatype xs:string ;
+        sh:datatype xs:anySimpleType ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
     ] ;

--- a/test_data/xsd/test_main/aas_core_meta.v3rc2/expected_output/schema.xsd
+++ b/test_data/xsd/test_main/aas_core_meta.v3rc2/expected_output/schema.xsd
@@ -411,7 +411,7 @@
         </xs:simpleType>
       </xs:element>
       <xs:element name="valueType" type="dataTypeDefXsd_t" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="value" type="xs:anySimpleType" minOccurs="0" maxOccurs="1"/>
       <xs:element name="refersTo" type="reference_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
@@ -657,7 +657,7 @@
     <xs:sequence>
       <xs:group ref="dataElement"/>
       <xs:element name="valueType" type="dataTypeDefXsd_t"/>
-      <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="value" type="xs:anySimpleType" minOccurs="0" maxOccurs="1"/>
       <xs:element name="valueId" type="reference_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
@@ -703,7 +703,7 @@
         </xs:simpleType>
       </xs:element>
       <xs:element name="valueType" type="dataTypeDefXsd_t"/>
-      <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="value" type="xs:anySimpleType" minOccurs="0" maxOccurs="1"/>
       <xs:element name="valueId" type="reference_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
@@ -711,8 +711,8 @@
     <xs:sequence>
       <xs:group ref="dataElement"/>
       <xs:element name="valueType" type="dataTypeDefXsd_t"/>
-      <xs:element name="min" type="xs:string" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="max" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="min" type="xs:anySimpleType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="max" type="xs:anySimpleType" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="referable">


### PR DESCRIPTION
In XSD, RDF and SHACL, ``Value_data_type`` should be represented as
``xs:anySimpleType`` instead of a string. We hard-wire how we represent it
in XSD and RDF+SHACL schema generators.

Similar to ``Lang_string``, this hard-wiring is hacky. We could have made
the class ``Value_data_type`` implementation-specific and defined it
manually as a snippet.

However, we decided against that. This would be a major hurdle for
other code and test data generators (which can treat ``Value_data_type``
simply as string). Therefore, we make the XML and RDF+SHACL schema
generators a bit more hacky instead of complicating the other
generators.

If in the future, for whatever reason, the semantic of ``Value_data_type``
changes (or the type is renamed), be careful to maintain backwards
compatibility! You probably want to distinguish different versions
of the meta-model and act accordingly. At that point, it might also make
sense to refactor these schema generators to separate repositories, and
fix them to a particular range of meta-model versions.

This change addresses the following issue:
https://github.com/admin-shell-io/aas-specs/issues/210