### PR TITLE
Map literals by value in intermediate layer

### DIFF
--- a/aas_core_codegen/intermediate/_stringify.py
+++ b/aas_core_codegen/intermediate/_stringify.py
@@ -521,6 +521,7 @@ def _stringify_enumeration(
             ),
             stringify_mod.Property("description", stringify(that.description)),
             stringify_mod.PropertyEllipsis("literals_by_name", that.literals_by_name),
+            stringify_mod.PropertyEllipsis("literals_by_value", that.literals_by_value),
             stringify_mod.PropertyEllipsis("literal_id_set", that.literal_id_set),
             stringify_mod.PropertyEllipsis("parsed", that.parsed),
         ],

--- a/aas_core_codegen/intermediate/_types.py
+++ b/aas_core_codegen/intermediate/_types.py
@@ -1008,15 +1008,28 @@ class EnumerationLiteral:
 @invariant(
     lambda self:
     all(
+        literal == self.literals_by_value[literal.value]
+        for literal in self.literals
+    ),
+    "Literal map by value consistent on value"
+)
+@invariant(
+    lambda self:
+    sorted(map(id, self.literals_by_value.values())) == sorted(map(id, self.literals)),
+    "Literal map by value complete"
+)
+@invariant(
+    lambda self:
+    all(
         literal == self.literals_by_name[literal.name]
         for literal in self.literals
     ),
-    "Literal map consistent on name"
+    "Literal map by name consistent on name"
 )
 @invariant(
     lambda self:
     sorted(map(id, self.literals_by_name.values())) == sorted(map(id, self.literals)),
-    "Literal map complete"
+    "Literal map by name complete"
 )
 # fmt: on
 class Enumeration:
@@ -1037,6 +1050,11 @@ class Enumeration:
     #: Map literals by their identifiers
     literals_by_name: Final[Mapping[str, EnumerationLiteral]]
 
+    # NOTE (mristin, 2022-09-01):
+    # This map is used by the downstream code, *e.g.*, aas-core3.0rc02-testgen.
+    #: Map literals by their values
+    literals_by_value: Final[Mapping[str, EnumerationLiteral]]
+
     #: Collect IDs (with :py:func:`id`) of the literal objects in a set
     literal_id_set: Final[FrozenSet[int]]
 
@@ -1056,6 +1074,10 @@ class Enumeration:
 
         self.literals_by_name: Mapping[str, EnumerationLiteral] = {
             literal.name: literal for literal in self.literals
+        }
+
+        self.literals_by_value: Mapping[str, EnumerationLiteral] = {
+            literal.value: literal for literal in self.literals
         }
 
         self.literal_id_set = frozenset(id(literal) for literal in literals)

--- a/test_data/intermediate/expected/constant/constant_set/of_enum/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/constant/constant_set/of_enum/expected_symbol_table.txt
@@ -21,6 +21,7 @@ SymbolTable(
       reference_in_the_book=None,
       description=None,
       literals_by_name=...,
+      literals_by_value=...,
       literal_id_set=...,
       parsed=...)],
   our_types_topologically_sorted=[],

--- a/test_data/intermediate/expected/enumeration/expected_symbol_table.txt
+++ b/test_data/intermediate/expected/enumeration/expected_symbol_table.txt
@@ -18,6 +18,7 @@ SymbolTable(
         constraints_by_identifier=[],
         parsed=...),
       literals_by_name=...,
+      literals_by_value=...,
       literal_id_set=...,
       parsed=...)],
   our_types_topologically_sorted=[],

--- a/test_data/intermediate/real_meta_models/aas_core_meta.v3rc2/expected_symbol_table.txt
+++ b/test_data/intermediate/real_meta_models/aas_core_meta.v3rc2/expected_symbol_table.txt
@@ -2570,6 +2570,7 @@ SymbolTable(
         constraints_by_identifier=[],
         parsed=...),
       literals_by_name=...,
+      literals_by_value=...,
       literal_id_set=...,
       parsed=...),
     AbstractClass(
@@ -3394,6 +3395,7 @@ SymbolTable(
         constraints_by_identifier=[],
         parsed=...),
       literals_by_name=...,
+      literals_by_value=...,
       literal_id_set=...,
       parsed=...),
     ConcreteClass(
@@ -4890,6 +4892,7 @@ SymbolTable(
         constraints_by_identifier=[],
         parsed=...),
       literals_by_name=...,
+      literals_by_value=...,
       literal_id_set=...,
       parsed=...),
     ConcreteClass(
@@ -8524,6 +8527,7 @@ SymbolTable(
         constraints_by_identifier=[],
         parsed=...),
       literals_by_name=...,
+      literals_by_value=...,
       literal_id_set=...,
       parsed=...),
     ConcreteClass(
@@ -18891,6 +18895,7 @@ SymbolTable(
         constraints_by_identifier=[],
         parsed=...),
       literals_by_name=...,
+      literals_by_value=...,
       literal_id_set=...,
       parsed=...),
     ConcreteClass(
@@ -20010,6 +20015,7 @@ SymbolTable(
         constraints_by_identifier=[],
         parsed=...),
       literals_by_name=...,
+      literals_by_value=...,
       literal_id_set=...,
       parsed=...),
     Enumeration(
@@ -20045,6 +20051,7 @@ SymbolTable(
         constraints_by_identifier=[],
         parsed=...),
       literals_by_name=...,
+      literals_by_value=...,
       literal_id_set=...,
       parsed=...),
     ConcreteClass(
@@ -25619,6 +25626,7 @@ SymbolTable(
         constraints_by_identifier=[],
         parsed=...),
       literals_by_name=...,
+      literals_by_value=...,
       literal_id_set=...,
       parsed=...),
     ConcreteClass(
@@ -26762,6 +26770,7 @@ SymbolTable(
         constraints_by_identifier=[],
         parsed=...),
       literals_by_name=...,
+      literals_by_value=...,
       literal_id_set=...,
       parsed=...),
     Enumeration(
@@ -26946,6 +26955,7 @@ SymbolTable(
         constraints_by_identifier=[],
         parsed=...),
       literals_by_name=...,
+      literals_by_value=...,
       literal_id_set=...,
       parsed=...),
     ConcreteClass(
@@ -27653,6 +27663,7 @@ SymbolTable(
         fragment='6.3.3.1 Data Specification IEC61360 Template Attributes'),
       description=None,
       literals_by_name=...,
+      literals_by_value=...,
       literal_id_set=...,
       parsed=...),
     Enumeration(
@@ -27688,6 +27699,7 @@ SymbolTable(
         fragment='6.3.3.1 Data Specification IEC61360 Template Attributes'),
       description=None,
       literals_by_name=...,
+      literals_by_value=...,
       literal_id_set=...,
       parsed=...),
     ConcreteClass(


### PR DESCRIPTION
We map the enumeration literals by their values to allow for quick
lookups. While we do not use this functionality in aas-core-codegen, it
is very useful for the downstream code such as aas-core3.0rc02-testgen.