### PR TITLE
Undo `anySimpleType` in RDF

### DIFF
--- a/aas_core_codegen/rdf_shacl/common.py
+++ b/aas_core_codegen/rdf_shacl/common.py
@@ -58,27 +58,6 @@ def map_our_type_to_rdfs_range(
             # and make this schema generator a bit hacky in return.
             our_type_to_rdfs_range[our_type] = Stripped("rdf:langString")
 
-        elif our_type.name == "Value_data_type":
-            # NOTE (mristin, 2022-09-01):
-            # We hard-wire the ``Value_data_type`` to xs:anySimpleType. Similar to
-            # ``Lang_string``, this hard-wiring is hacky. We could have made
-            # the class ``Value_data_type`` implementation-specific and defined its
-            # ``rdfs:range`` manually as
-            # a snippet.
-            #
-            # However, we decided against that. This would be a major hurdle for
-            # other code and test data generators (which can treat ``Value_data_type``
-            # simply as string). Therefore, we make the RDF+SHACL schema generator
-            # a bit more hacky instead of complicating the other generators.
-            #
-            # If in the future, for whatever reason, the semantic of ``Value_data_type``
-            # changes (or the type is renamed), be careful to maintain backwards
-            # compatibility here! You probably want to distinguish different versions
-            # of the meta-model and act accordingly. At that point, it might also make
-            # sense to refactor this schema generator to a separate repository, and
-            # fix it to a particular range of meta-model versions.
-            our_type_to_rdfs_range[our_type] = Stripped("xs:anySimpleType")
-
         elif isinstance(
             our_type, (intermediate.AbstractClass, intermediate.ConcreteClass)
         ):

--- a/aas_core_codegen/rdf_shacl/rdf.py
+++ b/aas_core_codegen/rdf_shacl/rdf.py
@@ -377,27 +377,6 @@ def generate(
             # and make this code generator a bit hacky in return.
             continue
 
-        if our_type.name == "Value_data_type":
-            # NOTE (mristin, 2022-09-01):
-            # We hard-wire the ``Value_data_type`` to xs:anySimpleType. Similar to
-            # ``Lang_string``, this hard-wiring is hacky. We could have made
-            # the class ``Value_data_type`` implementation-specific and defined its
-            # ``rdfs:range`` manually as
-            # a snippet.
-            #
-            # However, we decided against that. This would be a major hurdle for
-            # other code and test data generators (which can treat ``Value_data_type``
-            # simply as string). Therefore, we make the RDF+SHACL schema generator
-            # a bit more hacky instead of complicating the other generators.
-            #
-            # If in the future, for whatever reason, the semantic of ``Value_data_type``
-            # changes (or the type is renamed), be careful to maintain backwards
-            # compatibility here! You probably want to distinguish different versions
-            # of the meta-model and act accordingly. At that point, it might also make
-            # sense to refactor this schema generator to a separate repository, and
-            # fix it to a particular range of meta-model versions.
-            continue
-
         if isinstance(our_type, intermediate.Enumeration):
             block, error = _define_for_enumeration(
                 enumeration=our_type, xml_namespace=xml_namespace

--- a/aas_core_codegen/rdf_shacl/shacl.py
+++ b/aas_core_codegen/rdf_shacl/shacl.py
@@ -349,27 +349,6 @@ def generate(
             # and make this code generator a bit hacky in return.
             continue
 
-        if our_type.name == "Value_data_type":
-            # NOTE (mristin, 2022-09-01):
-            # We hard-wire the ``Value_data_type`` to xs:anySimpleType. Similar to
-            # ``Lang_string``, this hard-wiring is hacky. We could have made
-            # the class ``Value_data_type`` implementation-specific and defined its
-            # ``rdfs:range`` manually as
-            # a snippet.
-            #
-            # However, we decided against that. This would be a major hurdle for
-            # other code and test data generators (which can treat ``Value_data_type``
-            # simply as string). Therefore, we make the RDF+SHACL schema generator
-            # a bit more hacky instead of complicating the other generators.
-            #
-            # If in the future, for whatever reason, the semantic of ``Value_data_type``
-            # changes (or the type is renamed), be careful to maintain backwards
-            # compatibility here! You probably want to distinguish different versions
-            # of the meta-model and act accordingly. At that point, it might also make
-            # sense to refactor this schema generator to a separate repository, and
-            # fix it to a particular range of meta-model versions.
-            continue
-
         # noinspection PyUnusedLocal
         block = None  # type: Optional[Stripped]
 

--- a/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/expected_output/rdf-ontology.ttl
+++ b/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/expected_output/rdf-ontology.ttl
@@ -1179,7 +1179,7 @@ aas:Extension rdf:type owl:Class ;
 <https://admin-shell.io/aas/3/0/RC02/Extension/value> rdf:type owl:DatatypeProperty ;
     rdfs:label "has value"^^xs:string ;
     rdfs:domain aas:Extension ;
-    rdfs:range xs:anySimpleType ;
+    rdfs:range xs:string ;
     rdfs:comment "Value of the extension"@en ;
 .
 
@@ -1618,7 +1618,7 @@ aas:Property rdf:type owl:Class ;
 <https://admin-shell.io/aas/3/0/RC02/Property/value> rdf:type owl:DatatypeProperty ;
     rdfs:label "has value"^^xs:string ;
     rdfs:domain aas:Property ;
-    rdfs:range xs:anySimpleType ;
+    rdfs:range xs:string ;
     rdfs:comment "The value of the property instance."@en ;
 .
 
@@ -1679,7 +1679,7 @@ aas:Qualifier rdf:type owl:Class ;
 <https://admin-shell.io/aas/3/0/RC02/Qualifier/value> rdf:type owl:DatatypeProperty ;
     rdfs:label "has value"^^xs:string ;
     rdfs:domain aas:Qualifier ;
-    rdfs:range xs:anySimpleType ;
+    rdfs:range xs:string ;
     rdfs:comment "The qualifier value is the value of the qualifier."@en ;
 .
 
@@ -1739,7 +1739,7 @@ aas:Range rdf:type owl:Class ;
 <https://admin-shell.io/aas/3/0/RC02/Range/max> rdf:type owl:DatatypeProperty ;
     rdfs:label "has max"^^xs:string ;
     rdfs:domain aas:Range ;
-    rdfs:range xs:anySimpleType ;
+    rdfs:range xs:string ;
     rdfs:comment "The maximum value of the range."@en ;
 .
 
@@ -1747,7 +1747,7 @@ aas:Range rdf:type owl:Class ;
 <https://admin-shell.io/aas/3/0/RC02/Range/min> rdf:type owl:DatatypeProperty ;
     rdfs:label "has min"^^xs:string ;
     rdfs:domain aas:Range ;
-    rdfs:range xs:anySimpleType ;
+    rdfs:range xs:string ;
     rdfs:comment "The minimum value of the range."@en ;
 .
 

--- a/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/expected_output/shacl-schema.ttl
+++ b/test_data/rdf_shacl/test_main/aas_core_meta.v3rc2/expected_output/shacl-schema.ttl
@@ -611,7 +611,7 @@ aas:ExtensionShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <https://admin-shell.io/aas/3/0/RC02/Extension/value> ;
-        sh:datatype xs:anySimpleType ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
     ] ;
@@ -859,7 +859,7 @@ aas:PropertyShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <https://admin-shell.io/aas/3/0/RC02/Property/value> ;
-        sh:datatype xs:anySimpleType ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
     ] ;
@@ -922,7 +922,7 @@ aas:QualifierShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <https://admin-shell.io/aas/3/0/RC02/Qualifier/value> ;
-        sh:datatype xs:anySimpleType ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
     ] ;
@@ -948,14 +948,14 @@ aas:RangeShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <https://admin-shell.io/aas/3/0/RC02/Range/min> ;
-        sh:datatype xs:anySimpleType ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <https://admin-shell.io/aas/3/0/RC02/Range/max> ;
-        sh:datatype xs:anySimpleType ;
+        sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
     ] ;


### PR DESCRIPTION
We undo the pull request #265 since RDF and SHACL can not deal with
`xs:anySimpleType`.

Please see this comment on [issue 210 of admin-shell-io/aas-specs].

[issue 210 of admin-shell-io/aas-specs]: https://github.com/admin-shell-io/aas-specs/issues/210#issuecomment-1234331148