### PR TITLE
Restrict value data types in XML

### DIFF
--- a/test_data/xsd/test_main/aas_core_meta.v3rc2/expected_output/schema.xsd
+++ b/test_data/xsd/test_main/aas_core_meta.v3rc2/expected_output/schema.xsd
@@ -411,7 +411,7 @@
         </xs:simpleType>
       </xs:element>
       <xs:element name="valueType" type="dataTypeDefXsd_t" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="value" type="xs:anySimpleType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="value" type="valueDataType" minOccurs="0" maxOccurs="1"/>
       <xs:element name="refersTo" type="reference_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
@@ -657,7 +657,7 @@
     <xs:sequence>
       <xs:group ref="dataElement"/>
       <xs:element name="valueType" type="dataTypeDefXsd_t"/>
-      <xs:element name="value" type="xs:anySimpleType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="value" type="valueDataType" minOccurs="0" maxOccurs="1"/>
       <xs:element name="valueId" type="reference_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
@@ -703,7 +703,7 @@
         </xs:simpleType>
       </xs:element>
       <xs:element name="valueType" type="dataTypeDefXsd_t"/>
-      <xs:element name="value" type="xs:anySimpleType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="value" type="valueDataType" minOccurs="0" maxOccurs="1"/>
       <xs:element name="valueId" type="reference_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
@@ -711,8 +711,8 @@
     <xs:sequence>
       <xs:group ref="dataElement"/>
       <xs:element name="valueType" type="dataTypeDefXsd_t"/>
-      <xs:element name="min" type="xs:anySimpleType" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="max" type="xs:anySimpleType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="min" type="valueDataType" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="max" type="valueDataType" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="referable">
@@ -1096,6 +1096,9 @@
       <xs:enumeration value="on"/>
       <xs:enumeration value="off"/>
     </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="valueDataType">
+    <xs:union memberTypes="xs:anyURI xs:base64Binary xs:boolean xs:date xs:dateTime xs:dateTimeStamp xs:decimal xs:double xs:duration xs:float xs:gDay xs:gMonth xs:gMonthDay xs:gYear xs:gYearMonth xs:hexBinary xs:string xs:time xs:dayTimeDuration xs:yearMonthDuration xs:integer xs:long xs:int xs:short xs:byte xs:nonNegativeInteger xs:positiveInteger xs:unsignedLong xs:unsignedInt xs:unsignedShort xs:unsignedByte xs:nonPositiveInteger xs:negativeInteger"/>
   </xs:simpleType>
   <xs:complexType name="administrativeInformation_t">
     <xs:sequence>

--- a/tests/xsd/test_main.py
+++ b/tests/xsd/test_main.py
@@ -199,7 +199,7 @@ class Test_against_recorded(unittest.TestCase):
 
             schema_pth = case_dir / "expected_output" / "schema.xsd"
 
-            schema = xmlschema.XMLSchema(str(schema_pth))
+            schema = xmlschema.XMLSchema11(str(schema_pth))
 
             for data_pth in sorted(
                 (case_dir / "examples" / "expected").glob("**/*.xml")


### PR DESCRIPTION
We hard-code the member types which are allowed as `Value_data_type`.
This is really hacky -- as we iterate over concrete enumeration from the
model. If the model changes, and provides no ``Data_type_def_XSD`` or
``Value_data_type`` changes the semantics *etc.*, the generator for XML
schema is messed up.

Yet, we deliberately decided to keep other generators simple, and make
XML generator hacky for this particular pain point.

If in the future, for whatever reason, the semantic of
``Value_data_type`` changes (or the type is renamed), be careful to
maintain backwards compatibility here! You probably want to
distinguish different versions of the meta-model and act accordingly.
At that point, it might also make sense to refactor this schema
generator to a separate repository, and fix it to a particular range of
meta-model versions.