### PR TITLE
Restrict `Value_data_type` to `xs:string` in XSD

### DIFF
--- a/aas_core_codegen/xsd/main.py
+++ b/aas_core_codegen/xsd/main.py
@@ -927,10 +927,6 @@ def _generate(
     # sense to refactor this schema generator to a separate repository, and
     # fix it to a particular range of meta-model versions.
 
-    data_type_def_xsd_enum = symbol_table.must_find_enumeration(
-        Identifier("Data_type_def_XSD")
-    )
-
     # NOTE (mristin, 2022-09-02):
     # We assert here to put some guard rails in case the meta-model diverges
     # unexpectedly.
@@ -945,12 +941,8 @@ def _generate(
 
     value_data_type_element.append(
         ET.Element(
-            "xs:union",
-            attrib={
-                "memberTypes": " ".join(
-                    literal.value for literal in data_type_def_xsd_enum.literals
-                )
-            },
+            "xs:restriction",
+            attrib={"base": "xs:string"},
         )
     )
 

--- a/test_data/xsd/test_main/aas_core_meta.v3rc2/expected_output/schema.xsd
+++ b/test_data/xsd/test_main/aas_core_meta.v3rc2/expected_output/schema.xsd
@@ -1098,7 +1098,7 @@
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="valueDataType">
-    <xs:union memberTypes="xs:anyURI xs:base64Binary xs:boolean xs:date xs:dateTime xs:dateTimeStamp xs:decimal xs:double xs:duration xs:float xs:gDay xs:gMonth xs:gMonthDay xs:gYear xs:gYearMonth xs:hexBinary xs:string xs:time xs:dayTimeDuration xs:yearMonthDuration xs:integer xs:long xs:int xs:short xs:byte xs:nonNegativeInteger xs:positiveInteger xs:unsignedLong xs:unsignedInt xs:unsignedShort xs:unsignedByte xs:nonPositiveInteger xs:negativeInteger"/>
+    <xs:restriction base="xs:string"/>
   </xs:simpleType>
   <xs:complexType name="administrativeInformation_t">
     <xs:sequence>

--- a/tests/xsd/test_main.py
+++ b/tests/xsd/test_main.py
@@ -199,7 +199,7 @@ class Test_against_recorded(unittest.TestCase):
 
             schema_pth = case_dir / "expected_output" / "schema.xsd"
 
-            schema = xmlschema.XMLSchema11(str(schema_pth))
+            schema = xmlschema.XMLSchema(str(schema_pth))
 
             for data_pth in sorted(
                 (case_dir / "examples" / "expected").glob("**/*.xml")


### PR DESCRIPTION
We hard-wire the constrained primitive `Value_data_type` to a simple type with `xs:string` restriction in the XSD generator.

Previously, we hard-wired it to a list corresponding to `Data_type_def_XSD`. This list, however, is only compatible with XSD 1.1 and breaks XSD 1.0. Since the effect of the restriction is identical, we opt for compatibility with XSD 1.0.

See also the important note in the commit [5ae9681] regarding how hacky this whole hard-wiring is. In the near future, you should re-consider to refactor the XSD generator out of this repository and pin it to a range of AAS meta-model versions.

[5ae9681]: https://github.com/aas-core-works/aas-core-codegen/commit/5ae9681632477852bda9b7ced18730a22b6492bd