### PR TITLE
Fix undone line-breaks in interpolated strings

### DIFF
--- a/aas_core_codegen/csharp/structure/_generate.py
+++ b/aas_core_codegen/csharp/structure/_generate.py
@@ -166,7 +166,7 @@ def _verify_intra_structure_collisions(
         errors.append(
             Error(
                 our_type.parsed.node,
-                f"Naming collision(s) in C# code " f"for our type {our_type.name!r}",
+                f"Naming collision(s) in C# code for our type {our_type.name!r}",
                 underlying=errors,
             )
         )

--- a/aas_core_codegen/csharp/visitation/_generate.py
+++ b/aas_core_codegen/csharp/visitation/_generate.py
@@ -542,7 +542,12 @@ def generate(
 
     writer = io.StringIO()
     writer.write(f"namespace {namespace}\n{{\n")
-    writer.write(f"{I}public static class Visitation\n" f"{I}{{\n")
+    writer.write(
+        f"""\
+{I}public static class Visitation
+{I}{{
+"""
+    )
 
     visitation_blocks = [
         _generate_ivisitor(symbol_table=symbol_table),

--- a/aas_core_codegen/infer_for_schema/_stringify.py
+++ b/aas_core_codegen/infer_for_schema/_stringify.py
@@ -69,7 +69,7 @@ def _stringify_set_of_enumeration_literals_constraint(
             stringify.Property(
                 "literals",
                 [
-                    f"Reference to {literal.__class__.__name__} " f"{literal.name}"
+                    f"Reference to {literal.__class__.__name__} {literal.name}"
                     for literal in that.literals
                 ],
             ),

--- a/aas_core_codegen/intermediate/_stringify.py
+++ b/aas_core_codegen/intermediate/_stringify.py
@@ -773,7 +773,7 @@ def _stringify_interface(
         properties=[
             stringify_mod.Property(
                 "base",
-                f"Reference to {that.base.__class__.__name__} " f"{that.base.name}",
+                f"Reference to {that.base.__class__.__name__} {that.base.name}",
             ),
             stringify_mod.Property("name", that.name),
             stringify_mod.Property(

--- a/aas_core_codegen/intermediate/_translate.py
+++ b/aas_core_codegen/intermediate/_translate.py
@@ -2192,7 +2192,7 @@ def _to_constant(
             return None, [
                 Error(
                     parsed.items_type_annotation.node,
-                    f"The constant set refers to " f"an invalid type: {our_type_name}",
+                    f"The constant set refers to an invalid type: {our_type_name}",
                 )
             ]
 
@@ -2284,7 +2284,7 @@ def _second_pass_to_resolve_our_types_in_atomic_type_annotations_in_place(
             errors.append(
                 Error(
                     our_type_annotation.parsed.node,
-                    f"Our type is invalid: " f"{our_type_annotation.our_type.name!r}",
+                    f"Our type is invalid: {our_type_annotation.our_type.name!r}",
                 )
             )
             continue

--- a/aas_core_codegen/intermediate/construction.py
+++ b/aas_core_codegen/intermediate/construction.py
@@ -667,7 +667,7 @@ def _stringify_default_enum_literal(
             stringify.PropertyEllipsis("node", that.node),
             stringify.Property(
                 "enum",
-                f"Reference to {that.enum.__class__.__name__} " f"{that.enum.name}",
+                f"Reference to {that.enum.__class__.__name__} {that.enum.name}",
             ),
             stringify.Property(
                 "literal",

--- a/aas_core_codegen/parse/retree/_parse.py
+++ b/aas_core_codegen/parse/retree/_parse.py
@@ -494,7 +494,7 @@ def _parse_range_char(cursor: Cursor) -> Tuple[Optional[Char], Optional[Error]]:
         # noinspection RegExpSimplifiable
         if not re.fullmatch(r"[a-fA-F0-9]{2}", substring):
             return None, Error(
-                f"Expected two hexadecimal digits after \\x, " f"but got {substring!r}",
+                f"Expected two hexadecimal digits after \\x, but got {substring!r}",
                 cursor,
             )
 
@@ -674,7 +674,7 @@ def _parse_char_literal(cursor: Cursor) -> Tuple[Optional[Char], Optional[Error]
 
         if not re.fullmatch(r"[a-fA-F0-9]{2}", substring):
             return None, Error(
-                f"Expected two hexadecimal digits after \\x, " f"but got {substring!r}",
+                f"Expected two hexadecimal digits after \\x, but got {substring!r}",
                 cursor,
             )
 

--- a/aas_core_codegen/smoke/main.py
+++ b/aas_core_codegen/smoke/main.py
@@ -72,7 +72,7 @@ def execute(model_path: pathlib.Path, stderr: TextIO) -> int:
             )
         else:
             stderr.write(
-                f"Failed to parse the meta-model {model_path}: " f"{parse_exception}\n"
+                f"Failed to parse the meta-model {model_path}: {parse_exception}\n"
             )
 
         return 1

--- a/tests/csharp/test_structure.py
+++ b/tests/csharp/test_structure.py
@@ -83,7 +83,7 @@ class Test_generation_against_recorded(unittest.TestCase):
                     expected_code = expected_pth.read_text(encoding="utf-8")
                 except Exception as exception:
                     raise RuntimeError(
-                        f"Failed to read the expected code " f"from {expected_pth}"
+                        f"Failed to read the expected code from {expected_pth}"
                     ) from exception
 
                 self.assertEqual(expected_code, code)

--- a/tests/csharp/test_verification.py
+++ b/tests/csharp/test_verification.py
@@ -159,7 +159,7 @@ class Test_against_recorded(unittest.TestCase):
                     expected_code = expected_pth.read_text(encoding="utf-8")
                 except Exception as exception:
                     raise RuntimeError(
-                        f"Failed to read the expected code " f"from {expected_pth}"
+                        f"Failed to read the expected code from {expected_pth}"
                     ) from exception
 
                 self.assertEqual(expected_code, code)

--- a/tests/intermediate/test_translate.py
+++ b/tests/intermediate/test_translate.py
@@ -281,7 +281,7 @@ class Test_against_recorded(unittest.TestCase):
                 source = meta_model_pth.read_text(encoding="utf-8")
             except Exception as exception:
                 raise AssertionError(
-                    f"Unexpected exception when reading " f"from {meta_model_pth}"
+                    f"Unexpected exception when reading from {meta_model_pth}"
                 ) from exception
 
             try:

--- a/tests/parse/test_retree.py
+++ b/tests/parse/test_retree.py
@@ -214,7 +214,7 @@ class Test_against_recorded(unittest.TestCase):
                 assert error is not None
 
                 regex_line, pointer_line = parse_retree.render_pointer(error.cursor)
-                error_str = f"{error.message}\n" f"{regex_line}\n" f"{pointer_line}\n"
+                error_str = f"{error.message}\n{regex_line}\n{pointer_line}\n"
 
                 if tests.common.RERECORD:
                     expected_error_pth.write_text(error_str, encoding="utf-8")


### PR DESCRIPTION
Black reformatted back a lot of line breaks in interpolated strings. This makes the string literals barely readable, so we join the adjacent string literals for better readability.