### PR TITLE
Fix C# snippets after working on Python SDK

### DIFF
--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/input/snippets/Verification/data_specification_IEC_61360s_have_definition_at_least_in_english.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/input/snippets/Verification/data_specification_IEC_61360s_have_definition_at_least_in_english.cs
@@ -20,15 +20,20 @@ public static bool DataSpecificationIec61360sHaveDefinitionAtLeastInEnglish(
                 return false;
             }
 
+            var noDefinitionInEnglish = true;
             foreach (var langString in iec61360.Definition)
             {
                 if (IsBcp47ForEnglish(langString.Language))
                 {
-                    return true;
+                    noDefinitionInEnglish = false;
+                    break;
                 }
             }
 
-            return false;
+            if (noDefinitionInEnglish)
+            {
+                return false;
+            }
         }
     }
 

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/input/snippets/Verification/is_xs_date_time_stamp_utc.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/input/snippets/Verification/is_xs_date_time_stamp_utc.cs
@@ -12,7 +12,8 @@ private static readonly string[] XsDateFormats = {
 /// exactly four digits.
 ///
 /// We strip the negative sign and assume astronomical years.
-/// See: https://en.wikipedia.org/wiki/Leap_year#Algorithm
+/// See: https://en.wikipedia.org/wiki/Leap_year#Algorithm and
+/// the note at: https://www.w3.org/TR/xmlschema-2/#dateTime
 ///
 /// Furthermore, we always assume that <paramref name="value" /> has been
 /// already validated with the corresponding regular expression.
@@ -44,10 +45,6 @@ private static string ClipToDate(string value)
 /// Check that <paramref name="value" /> is a <c>xs:dateTimeStamp</c> with
 /// the time zone set to UTC.
 /// </summary>
-/// <remarks>
-/// The <paramref name="value" /> is assumed to be already checked with
-/// <see cref="MatchesXsDateTimeStampUtc" />.
-/// </remarks>
 public static bool IsXsDateTimeStampUtc(
     string value
 )

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/input/snippets/Verification/submodel_element_is_of_type.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/input/snippets/Verification/submodel_element_is_of_type.cs
@@ -1,9 +1,9 @@
 public static bool SubmodelElementIsOfType(
     Aas.ISubmodelElement element,
-    Aas.AasSubmodelElements elementType
+    Aas.AasSubmodelElements expectedType
 )
 {
-    switch (elementType)
+    switch (expectedType)
     {
         case Aas.AasSubmodelElements.AnnotatedRelationshipElement:
             return element is Aas.AnnotatedRelationshipElement;
@@ -60,7 +60,7 @@ public static bool SubmodelElementIsOfType(
 
         default:
             throw new System.ArgumentException(
-                $"elementType is not a valid AasSubmodelElements: {elementType}"
+                $"expectedType is not a valid AasSubmodelElements: {expectedType}"
             );
     }
 }


### PR DESCRIPTION
We discovered a couple of (minor) bugs in the code while we were working on the generator for Python SDK. This patch includes the fixes, and also harmonizes the names with the (future) Python SDK for clarity.