### PR TITLE
Sort out handling of reference paths

### DIFF
--- a/test_data/intermediate/real_meta_models/aas_core_meta.v3rc2/expected_symbol_table.txt
+++ b/test_data/intermediate/real_meta_models/aas_core_meta.v3rc2/expected_symbol_table.txt
@@ -346,7 +346,7 @@ SymbolTable(
       invariant_id_set=...,
       reference_in_the_book=None,
       description=DescriptionOfOurType(
-        summary='<paragraph>any xsd atomic type as specified via <ReferenceToOurType refuri=".Data_type_def_XSD">.Data_type_def_XSD</ReferenceToOurType></paragraph>',
+        summary='<paragraph>any xsd atomic type as specified via <ReferenceToOurType refuri="Data_type_def_XSD">Data_type_def_XSD</ReferenceToOurType></paragraph>',
         remarks=[],
         constraints_by_identifier=[],
         parsed=...),
@@ -392,19 +392,19 @@ SymbolTable(
       invariant_id_set=...,
       reference_in_the_book=None,
       description=DescriptionOfOurType(
-        summary='<paragraph>Represent a short ID of an <ReferenceToOurType refuri=".Referable">.Referable</ReferenceToOurType>.</paragraph>',
+        summary='<paragraph>Represent a short ID of an <ReferenceToOurType refuri="Referable">Referable</ReferenceToOurType>.</paragraph>',
         remarks=[],
         constraints_by_identifier=[
           [
             'AASd-002',
             textwrap.dedent("""\
-              <field_body><paragraph>ID-short of <ReferenceToOurType refuri=".Referable">.Referable</ReferenceToOurType>'s shall only feature letters, digits,
+              <field_body><paragraph>ID-short of <ReferenceToOurType refuri="Referable">Referable</ReferenceToOurType>'s shall only feature letters, digits,
               underscore (<literal>_</literal>); starting mandatory with a letter.
               <emphasis>I.e.</emphasis> <literal>[a-zA-Z][a-zA-Z0-9_]+</literal>.</paragraph></field_body>""")],
           [
             'AASd-027',
             textwrap.dedent("""\
-              <field_body><paragraph>ID-short of <ReferenceToOurType refuri=".Referable">.Referable</ReferenceToOurType>'s shall have a maximum length
+              <field_body><paragraph>ID-short of <ReferenceToOurType refuri="Referable">Referable</ReferenceToOurType>'s shall have a maximum length
               of 128 characters.</paragraph></field_body>""")]],
         parsed=...),
       parsed=...),
@@ -483,8 +483,8 @@ SymbolTable(
             [
               'AASd-118',
               textwrap.dedent("""\
-                <field_body><paragraph>If there are ID <ReferenceToAttribute refuri="~Has_semantics.supplemental_semantic_ids">~Has_semantics.supplemental_semantic_ids</ReferenceToAttribute> defined
-                then there shall be also a main semantic ID <ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>.</paragraph></field_body>""")]],
+                <field_body><paragraph>If there are ID <ReferenceToAttribute refuri="Has_semantics.supplemental_semantic_ids">Has_semantics.supplemental_semantic_ids</ReferenceToAttribute> defined
+                then there shall be also a main semantic ID <ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>.</paragraph></field_body>""")]],
           parsed=...),
         parsed=...,
         properties_by_name=...,
@@ -679,8 +679,8 @@ SymbolTable(
           [
             'AASd-118',
             textwrap.dedent("""\
-              <field_body><paragraph>If there are ID <ReferenceToAttribute refuri="~Has_semantics.supplemental_semantic_ids">~Has_semantics.supplemental_semantic_ids</ReferenceToAttribute> defined
-              then there shall be also a main semantic ID <ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>.</paragraph></field_body>""")]],
+              <field_body><paragraph>If there are ID <ReferenceToAttribute refuri="Has_semantics.supplemental_semantic_ids">Has_semantics.supplemental_semantic_ids</ReferenceToAttribute> defined
+              then there shall be also a main semantic ID <ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>.</paragraph></field_body>""")]],
         parsed=...),
       parsed=...,
       properties_by_name=...,
@@ -744,7 +744,7 @@ SymbolTable(
             constraints_by_identifier=[
               [
                 'AASd-077',
-                '<field_body><paragraph>The name of an extension within <ReferenceToOurType refuri=".Has_extensions">.Has_extensions</ReferenceToOurType> needs to be unique.</paragraph></field_body>']],
+                '<field_body><paragraph>The name of an extension within <ReferenceToOurType refuri="Has_extensions">Has_extensions</ReferenceToOurType> needs to be unique.</paragraph></field_body>']],
             parsed=...),
           specified_for='Reference to ConcreteClass Extension',
           parsed=...),
@@ -758,7 +758,7 @@ SymbolTable(
           description=DescriptionOfProperty(
             summary='<paragraph>Type of the value of the extension.</paragraph>',
             remarks=[
-              '<paragraph>Default: <ReferenceToAttribute refuri="~Data_type_def_XSD.String">~Data_type_def_XSD.String</ReferenceToAttribute></paragraph>'],
+              '<paragraph>Default: <ReferenceToAttribute refuri="Data_type_def_XSD.String">Data_type_def_XSD.String</ReferenceToAttribute></paragraph>'],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to ConcreteClass Extension',
@@ -1314,7 +1314,7 @@ SymbolTable(
               remarks=[
                 textwrap.dedent("""\
                   <note><paragraph>The category is not identical to the semantic definition
-                  (<ReferenceToOurType refuri=".Has_semantics">.Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
+                  (<ReferenceToOurType refuri="Has_semantics">Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
                   the element is a measurement value whereas the semantic definition of
                   the element would denote that it is the measured temperature.</paragraph></note>""")],
               constraints_by_identifier=[],
@@ -1336,8 +1336,8 @@ SymbolTable(
               remarks=[
                 textwrap.dedent("""\
                   <note><paragraph>In case the element is a property and the property has a semantic definition
-                  (<ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
-                  the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
+                  (<ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
+                  the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -1362,7 +1362,7 @@ SymbolTable(
                   the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
                   then the corresponding preferred name in the language is chosen
                   according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
-                  the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
+                  the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -1415,7 +1415,7 @@ SymbolTable(
             parsed=...)],
         signatures=[],
         description=DescriptionOfOurType(
-          summary='<paragraph>An element that is referable by its <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute>.</paragraph>',
+          summary='<paragraph>An element that is referable by its <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute>.</paragraph>',
           remarks=[
             textwrap.dedent("""\
               <paragraph>This ID is not globally unique.
@@ -1477,7 +1477,7 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>The category is not identical to the semantic definition
-                (<ReferenceToOurType refuri=".Has_semantics">.Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
+                (<ReferenceToOurType refuri="Has_semantics">Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
                 the element is a measurement value whereas the semantic definition of
                 the element would denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
@@ -1499,8 +1499,8 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>In case the element is a property and the property has a semantic definition
-                (<ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
-                the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
+                (<ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
+                the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -1525,7 +1525,7 @@ SymbolTable(
                 the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
                 then the corresponding preferred name in the language is chosen
                 according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
-                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -1901,7 +1901,7 @@ SymbolTable(
         index=0,
         fragment=None),
       description=DescriptionOfOurType(
-        summary='<paragraph>An element that is referable by its <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute>.</paragraph>',
+        summary='<paragraph>An element that is referable by its <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute>.</paragraph>',
         remarks=[
           textwrap.dedent("""\
             <paragraph>This ID is not globally unique.
@@ -1961,7 +1961,7 @@ SymbolTable(
               remarks=[
                 textwrap.dedent("""\
                   <note><paragraph>The category is not identical to the semantic definition
-                  (<ReferenceToOurType refuri=".Has_semantics">.Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
+                  (<ReferenceToOurType refuri="Has_semantics">Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
                   the element is a measurement value whereas the semantic definition of
                   the element would denote that it is the measured temperature.</paragraph></note>""")],
               constraints_by_identifier=[],
@@ -1983,8 +1983,8 @@ SymbolTable(
               remarks=[
                 textwrap.dedent("""\
                   <note><paragraph>In case the element is a property and the property has a semantic definition
-                  (<ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
-                  the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
+                  (<ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
+                  the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -2009,7 +2009,7 @@ SymbolTable(
                   the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
                   then the corresponding preferred name in the language is chosen
                   according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
-                  the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
+                  the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -2136,7 +2136,7 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>The category is not identical to the semantic definition
-                (<ReferenceToOurType refuri=".Has_semantics">.Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
+                (<ReferenceToOurType refuri="Has_semantics">Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
                 the element is a measurement value whereas the semantic definition of
                 the element would denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
@@ -2158,8 +2158,8 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>In case the element is a property and the property has a semantic definition
-                (<ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
-                the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
+                (<ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
+                the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -2184,7 +2184,7 @@ SymbolTable(
                 the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
                 then the corresponding preferred name in the language is chosen
                 according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
-                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -2693,7 +2693,7 @@ SymbolTable(
             description=DescriptionOfProperty(
               summary='<paragraph>Kind of the element: either type or instance.</paragraph>',
               remarks=[
-                '<paragraph>Default: <ReferenceToAttribute refuri="~Modeling_kind.Instance">~Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
+                '<paragraph>Default: <ReferenceToAttribute refuri="Modeling_kind.Instance">Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Has_kind',
@@ -2751,7 +2751,7 @@ SymbolTable(
           description=DescriptionOfProperty(
             summary='<paragraph>Kind of the element: either type or instance.</paragraph>',
             remarks=[
-              '<paragraph>Default: <ReferenceToAttribute refuri="~Modeling_kind.Instance">~Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
+              '<paragraph>Default: <ReferenceToAttribute refuri="Modeling_kind.Instance">Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_kind',
@@ -3225,7 +3225,7 @@ SymbolTable(
           [
             'AASd-005',
             textwrap.dedent("""\
-              <field_body><paragraph>If <ReferenceToAttribute refuri="~version">~version</ReferenceToAttribute> is not specified then also <ReferenceToAttribute refuri="~revision">~revision</ReferenceToAttribute> shall be
+              <field_body><paragraph>If <ReferenceToAttribute refuri="version">version</ReferenceToAttribute> is not specified then also <ReferenceToAttribute refuri="revision">revision</ReferenceToAttribute> shall be
               unspecified. This means, a revision requires a version. If there is no version
               there is no revision neither. Revision is optional.</paragraph></field_body>""")]],
         parsed=...),
@@ -3277,7 +3277,7 @@ SymbolTable(
                   'AASd-021',
                   textwrap.dedent("""\
                     <field_body><paragraph>Every qualifiable can only have one qualifier with the same
-                    <ReferenceToAttribute refuri="~Qualifier.type">~Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
+                    <ReferenceToAttribute refuri="Qualifier.type">Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
               parsed=...),
             specified_for='Reference to AbstractClass Qualifiable',
             parsed=...)],
@@ -3291,9 +3291,9 @@ SymbolTable(
             [
               'AASd-119',
               textwrap.dedent("""\
-                <field_body><paragraph>If any <ReferenceToAttribute refuri="~Qualifier.kind">~Qualifier.kind</ReferenceToAttribute> value of <ReferenceToAttribute refuri="~Qualifiable.qualifiers">~Qualifiable.qualifiers</ReferenceToAttribute> is
-                equal to <ReferenceToAttribute refuri="~Qualifier_kind.Template_qualifier">~Qualifier_kind.Template_qualifier</ReferenceToAttribute> and the qualified element
-                inherits from <ReferenceToOurType refuri=".Has_kind">.Has_kind</ReferenceToOurType> then the qualified element shall be of
+                <field_body><paragraph>If any <ReferenceToAttribute refuri="Qualifier.kind">Qualifier.kind</ReferenceToAttribute> value of <ReferenceToAttribute refuri="Qualifiable.qualifiers">Qualifiable.qualifiers</ReferenceToAttribute> is
+                equal to <ReferenceToAttribute refuri="Qualifier_kind.Template_qualifier">Qualifier_kind.Template_qualifier</ReferenceToAttribute> and the qualified element
+                inherits from <ReferenceToOurType refuri="Has_kind">Has_kind</ReferenceToOurType> then the qualified element shall be of
                 kind Template (<ReferenceToAttribute refuri="Has_kind.kind">Has_kind.kind</ReferenceToAttribute> = <ReferenceToAttribute refuri="Modeling_kind.Template">Modeling_kind.Template</ReferenceToAttribute>).</paragraph></field_body>""")]],
           parsed=...),
         parsed=...,
@@ -3334,7 +3334,7 @@ SymbolTable(
                 'AASd-021',
                 textwrap.dedent("""\
                   <field_body><paragraph>Every qualifiable can only have one qualifier with the same
-                  <ReferenceToAttribute refuri="~Qualifier.type">~Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
+                  <ReferenceToAttribute refuri="Qualifier.type">Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...)],
@@ -3452,9 +3452,9 @@ SymbolTable(
           [
             'AASd-119',
             textwrap.dedent("""\
-              <field_body><paragraph>If any <ReferenceToAttribute refuri="~Qualifier.kind">~Qualifier.kind</ReferenceToAttribute> value of <ReferenceToAttribute refuri="~Qualifiable.qualifiers">~Qualifiable.qualifiers</ReferenceToAttribute> is
-              equal to <ReferenceToAttribute refuri="~Qualifier_kind.Template_qualifier">~Qualifier_kind.Template_qualifier</ReferenceToAttribute> and the qualified element
-              inherits from <ReferenceToOurType refuri=".Has_kind">.Has_kind</ReferenceToOurType> then the qualified element shall be of
+              <field_body><paragraph>If any <ReferenceToAttribute refuri="Qualifier.kind">Qualifier.kind</ReferenceToAttribute> value of <ReferenceToAttribute refuri="Qualifiable.qualifiers">Qualifiable.qualifiers</ReferenceToAttribute> is
+              equal to <ReferenceToAttribute refuri="Qualifier_kind.Template_qualifier">Qualifier_kind.Template_qualifier</ReferenceToAttribute> and the qualified element
+              inherits from <ReferenceToOurType refuri="Has_kind">Has_kind</ReferenceToOurType> then the qualified element shall be of
               kind Template (<ReferenceToAttribute refuri="Has_kind.kind">Has_kind.kind</ReferenceToAttribute> = <ReferenceToAttribute refuri="Modeling_kind.Template">Modeling_kind.Template</ReferenceToAttribute>).</paragraph></field_body>""")]],
         parsed=...),
       parsed=...,
@@ -3473,7 +3473,7 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <paragraph>Value qualifiers are only applicable to elements with kind
-                <ReferenceToAttribute refuri="~Modeling_kind.Instance">~Modeling_kind.Instance</ReferenceToAttribute>.</paragraph>""")],
+                <ReferenceToAttribute refuri="Modeling_kind.Instance">Modeling_kind.Instance</ReferenceToAttribute>.</paragraph>""")],
             parsed=...),
           parsed=...),
         EnumerationLiteral(
@@ -3482,7 +3482,7 @@ SymbolTable(
           description=DescriptionOfEnumerationLiteral(
             summary=textwrap.dedent("""\
               <paragraph>qualifies the semantic definition the element is referring to
-              (<ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>)</paragraph>"""),
+              (<ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>)</paragraph>"""),
             remarks=[],
             parsed=...),
           parsed=...),
@@ -3494,7 +3494,7 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <paragraph>Template qualifiers are only applicable to elements with kind
-                <ReferenceToAttribute refuri="~Modeling_kind.Template">~Modeling_kind.Template</ReferenceToAttribute>.</paragraph>""")],
+                <ReferenceToAttribute refuri="Modeling_kind.Template">Modeling_kind.Template</ReferenceToAttribute>.</paragraph>""")],
             parsed=...),
           parsed=...)],
       reference_in_the_book=ReferenceInTheBook(
@@ -3572,7 +3572,7 @@ SymbolTable(
               <paragraph>The qualifier kind describes the kind of the qualifier that is applied to the
               element.</paragraph>"""),
             remarks=[
-              '<paragraph>Default: <ReferenceToAttribute refuri="~Qualifier_kind.Concept_qualifier">~Qualifier_kind.Concept_qualifier</ReferenceToAttribute></paragraph>'],
+              '<paragraph>Default: <ReferenceToAttribute refuri="Qualifier_kind.Concept_qualifier">Qualifier_kind.Concept_qualifier</ReferenceToAttribute></paragraph>'],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to ConcreteClass Qualifier',
@@ -3900,15 +3900,15 @@ SymbolTable(
           [
             'AASd-006',
             textwrap.dedent("""\
-              <field_body><paragraph>If both the <ReferenceToAttribute refuri="~value">~value</ReferenceToAttribute> and the <ReferenceToAttribute refuri="~value_id">~value_id</ReferenceToAttribute> of
-              a <ReferenceToOurType refuri=".Qualifier">.Qualifier</ReferenceToOurType> are present then the <ReferenceToAttribute refuri="~value">~value</ReferenceToAttribute> needs
+              <field_body><paragraph>If both the <ReferenceToAttribute refuri="value">value</ReferenceToAttribute> and the <ReferenceToAttribute refuri="value_id">value_id</ReferenceToAttribute> of
+              a <ReferenceToOurType refuri="Qualifier">Qualifier</ReferenceToOurType> are present then the <ReferenceToAttribute refuri="value">value</ReferenceToAttribute> needs
               to be identical to the value of the referenced coded value
-              in <ReferenceToAttribute refuri="~value_id">~value_id</ReferenceToAttribute>.</paragraph></field_body>""")],
+              in <ReferenceToAttribute refuri="value_id">value_id</ReferenceToAttribute>.</paragraph></field_body>""")],
           [
             'AASd-020',
             textwrap.dedent("""\
-              <field_body><paragraph>The value of <ReferenceToAttribute refuri="~value">~value</ReferenceToAttribute> shall be consistent to the data type as
-              defined in <ReferenceToAttribute refuri="~value_type">~value_type</ReferenceToAttribute>.</paragraph></field_body>""")]],
+              <field_body><paragraph>The value of <ReferenceToAttribute refuri="value">value</ReferenceToAttribute> shall be consistent to the data type as
+              defined in <ReferenceToAttribute refuri="value_type">value_type</ReferenceToAttribute>.</paragraph></field_body>""")]],
         parsed=...),
       parsed=...,
       properties_by_name=...,
@@ -3958,7 +3958,7 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>The category is not identical to the semantic definition
-                (<ReferenceToOurType refuri=".Has_semantics">.Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
+                (<ReferenceToOurType refuri="Has_semantics">Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
                 the element is a measurement value whereas the semantic definition of
                 the element would denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
@@ -3980,8 +3980,8 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>In case the element is a property and the property has a semantic definition
-                (<ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
-                the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
+                (<ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
+                the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -4006,7 +4006,7 @@ SymbolTable(
                 the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
                 then the corresponding preferred name in the language is chosen
                 according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
-                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -4715,8 +4715,8 @@ SymbolTable(
             parsed=...),
           description=DescriptionOfProperty(
             summary=textwrap.dedent("""\
-              <paragraph>Denotes whether the Asset is of kind <ReferenceToAttribute refuri="~Asset_kind.Type">~Asset_kind.Type</ReferenceToAttribute> or
-              <ReferenceToAttribute refuri="~Asset_kind.Instance">~Asset_kind.Instance</ReferenceToAttribute>.</paragraph>"""),
+              <paragraph>Denotes whether the Asset is of kind <ReferenceToAttribute refuri="Asset_kind.Type">Asset_kind.Type</ReferenceToAttribute> or
+              <ReferenceToAttribute refuri="Asset_kind.Instance">Asset_kind.Instance</ReferenceToAttribute>.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -4736,7 +4736,7 @@ SymbolTable(
                 <paragraph>This attribute is required as soon as the AAS is exchanged via partners in the life
                 cycle of the asset. In a first phase of the life cycle the asset might not yet have
                 a global ID but already an internal identifier. The internal identifier would be
-                modelled via <ReferenceToAttribute refuri="~specific_asset_ids">~specific_asset_ids</ReferenceToAttribute>.</paragraph>"""),
+                modelled via <ReferenceToAttribute refuri="specific_asset_ids">specific_asset_ids</ReferenceToAttribute>.</paragraph>"""),
               '<note><paragraph>This is a global reference.</paragraph></note>'],
             constraints_by_identifier=[],
             parsed=...),
@@ -4915,7 +4915,7 @@ SymbolTable(
         fragment=None),
       description=DescriptionOfOurType(
         summary=textwrap.dedent("""\
-          <paragraph>In <ReferenceToOurType refuri=".Asset_information">.Asset_information</ReferenceToOurType> identifying meta data of the asset that is
+          <paragraph>In <ReferenceToOurType refuri="Asset_information">Asset_information</ReferenceToOurType> identifying meta data of the asset that is
           represented by an AAS is defined.</paragraph>"""),
         remarks=[
           '<paragraph>The asset may either represent an asset type or an asset instance.</paragraph>',
@@ -4923,14 +4923,14 @@ SymbolTable(
             <paragraph>The asset has a globally unique identifier plus – if needed – additional domain
             specific (proprietary) identifiers. However, to support the corner case of very
             first phase of lifecycle where a stabilised/constant_set global asset identifier does
-            not already exist, the corresponding attribute <ReferenceToAttribute refuri="~global_asset_id">~global_asset_id</ReferenceToAttribute> is optional.</paragraph>""")],
+            not already exist, the corresponding attribute <ReferenceToAttribute refuri="global_asset_id">global_asset_id</ReferenceToAttribute> is optional.</paragraph>""")],
         constraints_by_identifier=[
           [
             'AASd-116',
             textwrap.dedent("""\
               <field_body><paragraph><literal>globalAssetId</literal> (case-insensitive) is a reserved key. If used as value for
-              <ReferenceToAttribute refuri="~Specific_asset_id.name">~Specific_asset_id.name</ReferenceToAttribute> then <ReferenceToAttribute refuri="~Specific_asset_id.value">~Specific_asset_id.value</ReferenceToAttribute> shall be
-              identical to <ReferenceToAttribute refuri="~global_asset_id">~global_asset_id</ReferenceToAttribute>.</paragraph></field_body>""")]],
+              <ReferenceToAttribute refuri="Specific_asset_id.name">Specific_asset_id.name</ReferenceToAttribute> then <ReferenceToAttribute refuri="Specific_asset_id.value">Specific_asset_id.value</ReferenceToAttribute> shall be
+              identical to <ReferenceToAttribute refuri="global_asset_id">global_asset_id</ReferenceToAttribute>.</paragraph></field_body>""")]],
         parsed=...),
       parsed=...,
       properties_by_name=...,
@@ -5403,7 +5403,7 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>The category is not identical to the semantic definition
-                (<ReferenceToOurType refuri=".Has_semantics">.Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
+                (<ReferenceToOurType refuri="Has_semantics">Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
                 the element is a measurement value whereas the semantic definition of
                 the element would denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
@@ -5425,8 +5425,8 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>In case the element is a property and the property has a semantic definition
-                (<ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
-                the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
+                (<ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
+                the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -5451,7 +5451,7 @@ SymbolTable(
                 the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
                 then the corresponding preferred name in the language is chosen
                 according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
-                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -5541,7 +5541,7 @@ SymbolTable(
           description=DescriptionOfProperty(
             summary='<paragraph>Kind of the element: either type or instance.</paragraph>',
             remarks=[
-              '<paragraph>Default: <ReferenceToAttribute refuri="~Modeling_kind.Instance">~Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
+              '<paragraph>Default: <ReferenceToAttribute refuri="Modeling_kind.Instance">Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_kind',
@@ -5599,7 +5599,7 @@ SymbolTable(
                 'AASd-021',
                 textwrap.dedent("""\
                   <field_body><paragraph>Every qualifiable can only have one qualifier with the same
-                  <ReferenceToAttribute refuri="~Qualifier.type">~Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
+                  <ReferenceToAttribute refuri="Qualifier.type">Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -6474,7 +6474,7 @@ SymbolTable(
               remarks=[
                 textwrap.dedent("""\
                   <note><paragraph>The category is not identical to the semantic definition
-                  (<ReferenceToOurType refuri=".Has_semantics">.Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
+                  (<ReferenceToOurType refuri="Has_semantics">Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
                   the element is a measurement value whereas the semantic definition of
                   the element would denote that it is the measured temperature.</paragraph></note>""")],
               constraints_by_identifier=[],
@@ -6496,8 +6496,8 @@ SymbolTable(
               remarks=[
                 textwrap.dedent("""\
                   <note><paragraph>In case the element is a property and the property has a semantic definition
-                  (<ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
-                  the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
+                  (<ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
+                  the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -6522,7 +6522,7 @@ SymbolTable(
                   the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
                   then the corresponding preferred name in the language is chosen
                   according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
-                  the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
+                  the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -6583,7 +6583,7 @@ SymbolTable(
             description=DescriptionOfProperty(
               summary='<paragraph>Kind of the element: either type or instance.</paragraph>',
               remarks=[
-                '<paragraph>Default: <ReferenceToAttribute refuri="~Modeling_kind.Instance">~Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
+                '<paragraph>Default: <ReferenceToAttribute refuri="Modeling_kind.Instance">Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Has_kind',
@@ -6641,7 +6641,7 @@ SymbolTable(
                   'AASd-021',
                   textwrap.dedent("""\
                     <field_body><paragraph>Every qualifiable can only have one qualifier with the same
-                    <ReferenceToAttribute refuri="~Qualifier.type">~Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
+                    <ReferenceToAttribute refuri="Qualifier.type">Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
               parsed=...),
             specified_for='Reference to AbstractClass Qualifiable',
             parsed=...),
@@ -6667,7 +6667,7 @@ SymbolTable(
             <paragraph>A submodel element is an element suitable for the description and differentiation of
             assets.</paragraph>"""),
           remarks=[
-            '<paragraph>It is recommended to add a <ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute> to a submodel element.</paragraph>'],
+            '<paragraph>It is recommended to add a <ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute> to a submodel element.</paragraph>'],
           constraints_by_identifier=[],
           parsed=...),
         parsed=...,
@@ -6722,7 +6722,7 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>The category is not identical to the semantic definition
-                (<ReferenceToOurType refuri=".Has_semantics">.Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
+                (<ReferenceToOurType refuri="Has_semantics">Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
                 the element is a measurement value whereas the semantic definition of
                 the element would denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
@@ -6744,8 +6744,8 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>In case the element is a property and the property has a semantic definition
-                (<ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
-                the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
+                (<ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
+                the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -6770,7 +6770,7 @@ SymbolTable(
                 the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
                 then the corresponding preferred name in the language is chosen
                 according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
-                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -6831,7 +6831,7 @@ SymbolTable(
           description=DescriptionOfProperty(
             summary='<paragraph>Kind of the element: either type or instance.</paragraph>',
             remarks=[
-              '<paragraph>Default: <ReferenceToAttribute refuri="~Modeling_kind.Instance">~Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
+              '<paragraph>Default: <ReferenceToAttribute refuri="Modeling_kind.Instance">Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_kind',
@@ -6889,7 +6889,7 @@ SymbolTable(
                 'AASd-021',
                 textwrap.dedent("""\
                   <field_body><paragraph>Every qualifiable can only have one qualifier with the same
-                  <ReferenceToAttribute refuri="~Qualifier.type">~Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
+                  <ReferenceToAttribute refuri="Qualifier.type">Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -7528,7 +7528,7 @@ SymbolTable(
           <paragraph>A submodel element is an element suitable for the description and differentiation of
           assets.</paragraph>"""),
         remarks=[
-          '<paragraph>It is recommended to add a <ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute> to a submodel element.</paragraph>'],
+          '<paragraph>It is recommended to add a <ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute> to a submodel element.</paragraph>'],
         constraints_by_identifier=[],
         parsed=...),
       parsed=...,
@@ -7583,7 +7583,7 @@ SymbolTable(
               remarks=[
                 textwrap.dedent("""\
                   <note><paragraph>The category is not identical to the semantic definition
-                  (<ReferenceToOurType refuri=".Has_semantics">.Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
+                  (<ReferenceToOurType refuri="Has_semantics">Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
                   the element is a measurement value whereas the semantic definition of
                   the element would denote that it is the measured temperature.</paragraph></note>""")],
               constraints_by_identifier=[],
@@ -7605,8 +7605,8 @@ SymbolTable(
               remarks=[
                 textwrap.dedent("""\
                   <note><paragraph>In case the element is a property and the property has a semantic definition
-                  (<ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
-                  the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
+                  (<ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
+                  the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -7631,7 +7631,7 @@ SymbolTable(
                   the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
                   then the corresponding preferred name in the language is chosen
                   according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
-                  the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
+                  the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -7692,7 +7692,7 @@ SymbolTable(
             description=DescriptionOfProperty(
               summary='<paragraph>Kind of the element: either type or instance.</paragraph>',
               remarks=[
-                '<paragraph>Default: <ReferenceToAttribute refuri="~Modeling_kind.Instance">~Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
+                '<paragraph>Default: <ReferenceToAttribute refuri="Modeling_kind.Instance">Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Has_kind',
@@ -7750,7 +7750,7 @@ SymbolTable(
                   'AASd-021',
                   textwrap.dedent("""\
                     <field_body><paragraph>Every qualifiable can only have one qualifier with the same
-                    <ReferenceToAttribute refuri="~Qualifier.type">~Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
+                    <ReferenceToAttribute refuri="Qualifier.type">Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
               parsed=...),
             specified_for='Reference to AbstractClass Qualifiable',
             parsed=...),
@@ -7841,7 +7841,7 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>The category is not identical to the semantic definition
-                (<ReferenceToOurType refuri=".Has_semantics">.Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
+                (<ReferenceToOurType refuri="Has_semantics">Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
                 the element is a measurement value whereas the semantic definition of
                 the element would denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
@@ -7863,8 +7863,8 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>In case the element is a property and the property has a semantic definition
-                (<ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
-                the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
+                (<ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
+                the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -7889,7 +7889,7 @@ SymbolTable(
                 the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
                 then the corresponding preferred name in the language is chosen
                 according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
-                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -7950,7 +7950,7 @@ SymbolTable(
           description=DescriptionOfProperty(
             summary='<paragraph>Kind of the element: either type or instance.</paragraph>',
             remarks=[
-              '<paragraph>Default: <ReferenceToAttribute refuri="~Modeling_kind.Instance">~Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
+              '<paragraph>Default: <ReferenceToAttribute refuri="Modeling_kind.Instance">Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_kind',
@@ -8008,7 +8008,7 @@ SymbolTable(
                 'AASd-021',
                 textwrap.dedent("""\
                   <field_body><paragraph>Every qualifiable can only have one qualifier with the same
-                  <ReferenceToAttribute refuri="~Qualifier.type">~Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
+                  <ReferenceToAttribute refuri="Qualifier.type">Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -8791,7 +8791,7 @@ SymbolTable(
           parsed=...)],
       reference_in_the_book=None,
       description=DescriptionOfOurType(
-        summary='<paragraph>Enumeration of all possible elements of a <ReferenceToOurType refuri=".Submodel_element_list">.Submodel_element_list</ReferenceToOurType>.</paragraph>',
+        summary='<paragraph>Enumeration of all possible elements of a <ReferenceToOurType refuri="Submodel_element_list">Submodel_element_list</ReferenceToOurType>.</paragraph>',
         remarks=[],
         constraints_by_identifier=[],
         parsed=...),
@@ -8841,7 +8841,7 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>The category is not identical to the semantic definition
-                (<ReferenceToOurType refuri=".Has_semantics">.Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
+                (<ReferenceToOurType refuri="Has_semantics">Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
                 the element is a measurement value whereas the semantic definition of
                 the element would denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
@@ -8863,8 +8863,8 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>In case the element is a property and the property has a semantic definition
-                (<ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
-                the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
+                (<ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
+                the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -8889,7 +8889,7 @@ SymbolTable(
                 the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
                 then the corresponding preferred name in the language is chosen
                 according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
-                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -8950,7 +8950,7 @@ SymbolTable(
           description=DescriptionOfProperty(
             summary='<paragraph>Kind of the element: either type or instance.</paragraph>',
             remarks=[
-              '<paragraph>Default: <ReferenceToAttribute refuri="~Modeling_kind.Instance">~Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
+              '<paragraph>Default: <ReferenceToAttribute refuri="Modeling_kind.Instance">Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_kind',
@@ -9008,7 +9008,7 @@ SymbolTable(
                 'AASd-021',
                 textwrap.dedent("""\
                   <field_body><paragraph>Every qualifiable can only have one qualifier with the same
-                  <ReferenceToAttribute refuri="~Qualifier.type">~Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
+                  <ReferenceToAttribute refuri="Qualifier.type">Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -9037,7 +9037,7 @@ SymbolTable(
             parsed=...),
           description=DescriptionOfProperty(
             summary=textwrap.dedent("""\
-              <paragraph>Defines whether order in list is relevant. If <ReferenceToAttribute refuri="~order_relevant">~order_relevant</ReferenceToAttribute> = <literal>False</literal>
+              <paragraph>Defines whether order in list is relevant. If <ReferenceToAttribute refuri="order_relevant">order_relevant</ReferenceToAttribute> = <literal>False</literal>
               then the list is representing a set or a bag.</paragraph>"""),
             remarks=[
               '<paragraph>Default: <literal>True</literal></paragraph>'],
@@ -10107,34 +10107,34 @@ SymbolTable(
           [
             'AASd-107',
             textwrap.dedent("""\
-              <field_body><paragraph>If a first level child element in a <ReferenceToOurType refuri=".Submodel_element_list">.Submodel_element_list</ReferenceToOurType> has
-              a <ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute> it
-              shall be identical to <ReferenceToAttribute refuri="~Submodel_element_list.semantic_id_list_element">~Submodel_element_list.semantic_id_list_element</ReferenceToAttribute>.</paragraph></field_body>""")],
+              <field_body><paragraph>If a first level child element in a <ReferenceToOurType refuri="Submodel_element_list">Submodel_element_list</ReferenceToOurType> has
+              a <ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute> it
+              shall be identical to <ReferenceToAttribute refuri="Submodel_element_list.semantic_id_list_element">Submodel_element_list.semantic_id_list_element</ReferenceToAttribute>.</paragraph></field_body>""")],
           [
             'AASd-114',
             textwrap.dedent("""\
-              <field_body><paragraph>If two first level child elements in a <ReferenceToOurType refuri=".Submodel_element_list">.Submodel_element_list</ReferenceToOurType> have
-              a <ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute> then they shall be identical.</paragraph></field_body>""")],
+              <field_body><paragraph>If two first level child elements in a <ReferenceToOurType refuri="Submodel_element_list">Submodel_element_list</ReferenceToOurType> have
+              a <ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute> then they shall be identical.</paragraph></field_body>""")],
           [
             'AASd-115',
             textwrap.dedent("""\
-              <field_body><paragraph>If a first level child element in a <ReferenceToOurType refuri=".Submodel_element_list">.Submodel_element_list</ReferenceToOurType> does not
-              specify a <ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute> then the value is assumed to be
-              identical to <ReferenceToAttribute refuri="~Submodel_element_list.semantic_id_list_element">~Submodel_element_list.semantic_id_list_element</ReferenceToAttribute>.</paragraph></field_body>""")],
+              <field_body><paragraph>If a first level child element in a <ReferenceToOurType refuri="Submodel_element_list">Submodel_element_list</ReferenceToOurType> does not
+              specify a <ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute> then the value is assumed to be
+              identical to <ReferenceToAttribute refuri="Submodel_element_list.semantic_id_list_element">Submodel_element_list.semantic_id_list_element</ReferenceToAttribute>.</paragraph></field_body>""")],
           [
             'AASd-108',
             textwrap.dedent("""\
-              <field_body><paragraph>All first level child elements in a <ReferenceToOurType refuri=".Submodel_element_list">.Submodel_element_list</ReferenceToOurType> shall have
-              the same submodel element type as specified in <ReferenceToAttribute refuri="~type_value_list_element">~type_value_list_element</ReferenceToAttribute>.</paragraph></field_body>""")],
+              <field_body><paragraph>All first level child elements in a <ReferenceToOurType refuri="Submodel_element_list">Submodel_element_list</ReferenceToOurType> shall have
+              the same submodel element type as specified in <ReferenceToAttribute refuri="type_value_list_element">type_value_list_element</ReferenceToAttribute>.</paragraph></field_body>""")],
           [
             'AASd-109',
             textwrap.dedent("""\
-              <field_body><paragraph>If <ReferenceToAttribute refuri="~type_value_list_element">~type_value_list_element</ReferenceToAttribute> is equal to
+              <field_body><paragraph>If <ReferenceToAttribute refuri="type_value_list_element">type_value_list_element</ReferenceToAttribute> is equal to
               <ReferenceToAttribute refuri="AAS_submodel_elements.Property">AAS_submodel_elements.Property</ReferenceToAttribute> or
               <ReferenceToAttribute refuri="AAS_submodel_elements.Range">AAS_submodel_elements.Range</ReferenceToAttribute>
-              <ReferenceToAttribute refuri="~value_type_list_element">~value_type_list_element</ReferenceToAttribute> shall be set and all first
-              level child elements in the <ReferenceToOurType refuri=".Submodel_element_list">.Submodel_element_list</ReferenceToOurType> shall have
-              the value type as specified in <ReferenceToAttribute refuri="~value_type_list_element">~value_type_list_element</ReferenceToAttribute>.</paragraph></field_body>""")]],
+              <ReferenceToAttribute refuri="value_type_list_element">value_type_list_element</ReferenceToAttribute> shall be set and all first
+              level child elements in the <ReferenceToOurType refuri="Submodel_element_list">Submodel_element_list</ReferenceToOurType> shall have
+              the value type as specified in <ReferenceToAttribute refuri="value_type_list_element">value_type_list_element</ReferenceToAttribute>.</paragraph></field_body>""")]],
         parsed=...),
       parsed=...,
       properties_by_name=...,
@@ -10183,7 +10183,7 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>The category is not identical to the semantic definition
-                (<ReferenceToOurType refuri=".Has_semantics">.Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
+                (<ReferenceToOurType refuri="Has_semantics">Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
                 the element is a measurement value whereas the semantic definition of
                 the element would denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
@@ -10205,8 +10205,8 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>In case the element is a property and the property has a semantic definition
-                (<ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
-                the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
+                (<ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
+                the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -10231,7 +10231,7 @@ SymbolTable(
                 the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
                 then the corresponding preferred name in the language is chosen
                 according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
-                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -10292,7 +10292,7 @@ SymbolTable(
           description=DescriptionOfProperty(
             summary='<paragraph>Kind of the element: either type or instance.</paragraph>',
             remarks=[
-              '<paragraph>Default: <ReferenceToAttribute refuri="~Modeling_kind.Instance">~Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
+              '<paragraph>Default: <ReferenceToAttribute refuri="Modeling_kind.Instance">Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_kind',
@@ -10350,7 +10350,7 @@ SymbolTable(
                 'AASd-021',
                 textwrap.dedent("""\
                   <field_body><paragraph>Every qualifiable can only have one qualifier with the same
-                  <ReferenceToAttribute refuri="~Qualifier.type">~Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
+                  <ReferenceToAttribute refuri="Qualifier.type">Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -11167,7 +11167,7 @@ SymbolTable(
               remarks=[
                 textwrap.dedent("""\
                   <note><paragraph>The category is not identical to the semantic definition
-                  (<ReferenceToOurType refuri=".Has_semantics">.Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
+                  (<ReferenceToOurType refuri="Has_semantics">Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
                   the element is a measurement value whereas the semantic definition of
                   the element would denote that it is the measured temperature.</paragraph></note>""")],
               constraints_by_identifier=[],
@@ -11189,8 +11189,8 @@ SymbolTable(
               remarks=[
                 textwrap.dedent("""\
                   <note><paragraph>In case the element is a property and the property has a semantic definition
-                  (<ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
-                  the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
+                  (<ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
+                  the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -11215,7 +11215,7 @@ SymbolTable(
                   the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
                   then the corresponding preferred name in the language is chosen
                   according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
-                  the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
+                  the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -11276,7 +11276,7 @@ SymbolTable(
             description=DescriptionOfProperty(
               summary='<paragraph>Kind of the element: either type or instance.</paragraph>',
               remarks=[
-                '<paragraph>Default: <ReferenceToAttribute refuri="~Modeling_kind.Instance">~Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
+                '<paragraph>Default: <ReferenceToAttribute refuri="Modeling_kind.Instance">Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Has_kind',
@@ -11334,7 +11334,7 @@ SymbolTable(
                   'AASd-021',
                   textwrap.dedent("""\
                     <field_body><paragraph>Every qualifiable can only have one qualifier with the same
-                    <ReferenceToAttribute refuri="~Qualifier.type">~Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
+                    <ReferenceToAttribute refuri="Qualifier.type">Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
               parsed=...),
             specified_for='Reference to AbstractClass Qualifiable',
             parsed=...),
@@ -11394,7 +11394,7 @@ SymbolTable(
             [
               'AASd-090',
               textwrap.dedent("""\
-                <field_body><paragraph>For data elements <ReferenceToAttribute refuri="~category">~category</ReferenceToAttribute> shall be one of the following
+                <field_body><paragraph>For data elements <ReferenceToAttribute refuri="category">category</ReferenceToAttribute> shall be one of the following
                 values: <literal>CONSTANT</literal>, <literal>PARAMETER</literal> or <literal>VARIABLE</literal>.</paragraph><paragraph>Default: <literal>VARIABLE</literal></paragraph></field_body>""")]],
           parsed=...),
         parsed=...,
@@ -11441,7 +11441,7 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>The category is not identical to the semantic definition
-                (<ReferenceToOurType refuri=".Has_semantics">.Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
+                (<ReferenceToOurType refuri="Has_semantics">Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
                 the element is a measurement value whereas the semantic definition of
                 the element would denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
@@ -11463,8 +11463,8 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>In case the element is a property and the property has a semantic definition
-                (<ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
-                the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
+                (<ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
+                the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -11489,7 +11489,7 @@ SymbolTable(
                 the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
                 then the corresponding preferred name in the language is chosen
                 according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
-                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -11550,7 +11550,7 @@ SymbolTable(
           description=DescriptionOfProperty(
             summary='<paragraph>Kind of the element: either type or instance.</paragraph>',
             remarks=[
-              '<paragraph>Default: <ReferenceToAttribute refuri="~Modeling_kind.Instance">~Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
+              '<paragraph>Default: <ReferenceToAttribute refuri="Modeling_kind.Instance">Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_kind',
@@ -11608,7 +11608,7 @@ SymbolTable(
                 'AASd-021',
                 textwrap.dedent("""\
                   <field_body><paragraph>Every qualifiable can only have one qualifier with the same
-                  <ReferenceToAttribute refuri="~Qualifier.type">~Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
+                  <ReferenceToAttribute refuri="Qualifier.type">Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -12297,7 +12297,7 @@ SymbolTable(
           [
             'AASd-090',
             textwrap.dedent("""\
-              <field_body><paragraph>For data elements <ReferenceToAttribute refuri="~category">~category</ReferenceToAttribute> shall be one of the following
+              <field_body><paragraph>For data elements <ReferenceToAttribute refuri="category">category</ReferenceToAttribute> shall be one of the following
               values: <literal>CONSTANT</literal>, <literal>PARAMETER</literal> or <literal>VARIABLE</literal>.</paragraph><paragraph>Default: <literal>VARIABLE</literal></paragraph></field_body>""")]],
         parsed=...),
       parsed=...,
@@ -12347,7 +12347,7 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>The category is not identical to the semantic definition
-                (<ReferenceToOurType refuri=".Has_semantics">.Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
+                (<ReferenceToOurType refuri="Has_semantics">Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
                 the element is a measurement value whereas the semantic definition of
                 the element would denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
@@ -12369,8 +12369,8 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>In case the element is a property and the property has a semantic definition
-                (<ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
-                the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
+                (<ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
+                the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -12395,7 +12395,7 @@ SymbolTable(
                 the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
                 then the corresponding preferred name in the language is chosen
                 according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
-                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -12456,7 +12456,7 @@ SymbolTable(
           description=DescriptionOfProperty(
             summary='<paragraph>Kind of the element: either type or instance.</paragraph>',
             remarks=[
-              '<paragraph>Default: <ReferenceToAttribute refuri="~Modeling_kind.Instance">~Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
+              '<paragraph>Default: <ReferenceToAttribute refuri="Modeling_kind.Instance">Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_kind',
@@ -12514,7 +12514,7 @@ SymbolTable(
                 'AASd-021',
                 textwrap.dedent("""\
                   <field_body><paragraph>Every qualifiable can only have one qualifier with the same
-                  <ReferenceToAttribute refuri="~Qualifier.type">~Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
+                  <ReferenceToAttribute refuri="Qualifier.type">Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -13329,9 +13329,9 @@ SymbolTable(
           [
             'AASd-007',
             textwrap.dedent("""\
-              <field_body><paragraph>If both, the <ReferenceToAttribute refuri="~value">~value</ReferenceToAttribute> and the <ReferenceToAttribute refuri="~value_id">~value_id</ReferenceToAttribute> are
-              present then the value of <ReferenceToAttribute refuri="~value">~value</ReferenceToAttribute> needs to be identical to
-              the value of the referenced coded value in <ReferenceToAttribute refuri="~value_id">~value_id</ReferenceToAttribute>.</paragraph></field_body>""")]],
+              <field_body><paragraph>If both, the <ReferenceToAttribute refuri="value">value</ReferenceToAttribute> and the <ReferenceToAttribute refuri="value_id">value_id</ReferenceToAttribute> are
+              present then the value of <ReferenceToAttribute refuri="value">value</ReferenceToAttribute> needs to be identical to
+              the value of the referenced coded value in <ReferenceToAttribute refuri="value_id">value_id</ReferenceToAttribute>.</paragraph></field_body>""")]],
         parsed=...),
       parsed=...,
       properties_by_name=...,
@@ -13380,7 +13380,7 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>The category is not identical to the semantic definition
-                (<ReferenceToOurType refuri=".Has_semantics">.Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
+                (<ReferenceToOurType refuri="Has_semantics">Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
                 the element is a measurement value whereas the semantic definition of
                 the element would denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
@@ -13402,8 +13402,8 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>In case the element is a property and the property has a semantic definition
-                (<ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
-                the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
+                (<ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
+                the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -13428,7 +13428,7 @@ SymbolTable(
                 the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
                 then the corresponding preferred name in the language is chosen
                 according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
-                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -13489,7 +13489,7 @@ SymbolTable(
           description=DescriptionOfProperty(
             summary='<paragraph>Kind of the element: either type or instance.</paragraph>',
             remarks=[
-              '<paragraph>Default: <ReferenceToAttribute refuri="~Modeling_kind.Instance">~Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
+              '<paragraph>Default: <ReferenceToAttribute refuri="Modeling_kind.Instance">Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_kind',
@@ -13547,7 +13547,7 @@ SymbolTable(
                 'AASd-021',
                 textwrap.dedent("""\
                   <field_body><paragraph>Every qualifiable can only have one qualifier with the same
-                  <ReferenceToAttribute refuri="~Qualifier.type">~Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
+                  <ReferenceToAttribute refuri="Qualifier.type">Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -14362,9 +14362,9 @@ SymbolTable(
           [
             'AASd-012',
             textwrap.dedent("""\
-              <field_body><paragraph>If both the <ReferenceToAttribute refuri="~value">~value</ReferenceToAttribute> and the <ReferenceToAttribute refuri="~value_id">~value_id</ReferenceToAttribute> are present then for each
+              <field_body><paragraph>If both the <ReferenceToAttribute refuri="value">value</ReferenceToAttribute> and the <ReferenceToAttribute refuri="value_id">value_id</ReferenceToAttribute> are present then for each
               string in a specific language the meaning must be the same as specified in
-              <ReferenceToAttribute refuri="~value_id">~value_id</ReferenceToAttribute>.</paragraph></field_body>""")]],
+              <ReferenceToAttribute refuri="value_id">value_id</ReferenceToAttribute>.</paragraph></field_body>""")]],
         parsed=...),
       parsed=...,
       properties_by_name=...,
@@ -14413,7 +14413,7 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>The category is not identical to the semantic definition
-                (<ReferenceToOurType refuri=".Has_semantics">.Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
+                (<ReferenceToOurType refuri="Has_semantics">Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
                 the element is a measurement value whereas the semantic definition of
                 the element would denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
@@ -14435,8 +14435,8 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>In case the element is a property and the property has a semantic definition
-                (<ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
-                the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
+                (<ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
+                the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -14461,7 +14461,7 @@ SymbolTable(
                 the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
                 then the corresponding preferred name in the language is chosen
                 according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
-                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -14522,7 +14522,7 @@ SymbolTable(
           description=DescriptionOfProperty(
             summary='<paragraph>Kind of the element: either type or instance.</paragraph>',
             remarks=[
-              '<paragraph>Default: <ReferenceToAttribute refuri="~Modeling_kind.Instance">~Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
+              '<paragraph>Default: <ReferenceToAttribute refuri="Modeling_kind.Instance">Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_kind',
@@ -14580,7 +14580,7 @@ SymbolTable(
                 'AASd-021',
                 textwrap.dedent("""\
                   <field_body><paragraph>Every qualifiable can only have one qualifier with the same
-                  <ReferenceToAttribute refuri="~Qualifier.type">~Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
+                  <ReferenceToAttribute refuri="Qualifier.type">Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -15472,7 +15472,7 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>The category is not identical to the semantic definition
-                (<ReferenceToOurType refuri=".Has_semantics">.Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
+                (<ReferenceToOurType refuri="Has_semantics">Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
                 the element is a measurement value whereas the semantic definition of
                 the element would denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
@@ -15494,8 +15494,8 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>In case the element is a property and the property has a semantic definition
-                (<ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
-                the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
+                (<ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
+                the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -15520,7 +15520,7 @@ SymbolTable(
                 the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
                 then the corresponding preferred name in the language is chosen
                 according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
-                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -15581,7 +15581,7 @@ SymbolTable(
           description=DescriptionOfProperty(
             summary='<paragraph>Kind of the element: either type or instance.</paragraph>',
             remarks=[
-              '<paragraph>Default: <ReferenceToAttribute refuri="~Modeling_kind.Instance">~Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
+              '<paragraph>Default: <ReferenceToAttribute refuri="Modeling_kind.Instance">Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_kind',
@@ -15639,7 +15639,7 @@ SymbolTable(
                 'AASd-021',
                 textwrap.dedent("""\
                   <field_body><paragraph>Every qualifiable can only have one qualifier with the same
-                  <ReferenceToAttribute refuri="~Qualifier.type">~Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
+                  <ReferenceToAttribute refuri="Qualifier.type">Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -16409,7 +16409,7 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>The category is not identical to the semantic definition
-                (<ReferenceToOurType refuri=".Has_semantics">.Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
+                (<ReferenceToOurType refuri="Has_semantics">Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
                 the element is a measurement value whereas the semantic definition of
                 the element would denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
@@ -16431,8 +16431,8 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>In case the element is a property and the property has a semantic definition
-                (<ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
-                the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
+                (<ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
+                the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -16457,7 +16457,7 @@ SymbolTable(
                 the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
                 then the corresponding preferred name in the language is chosen
                 according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
-                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -16518,7 +16518,7 @@ SymbolTable(
           description=DescriptionOfProperty(
             summary='<paragraph>Kind of the element: either type or instance.</paragraph>',
             remarks=[
-              '<paragraph>Default: <ReferenceToAttribute refuri="~Modeling_kind.Instance">~Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
+              '<paragraph>Default: <ReferenceToAttribute refuri="Modeling_kind.Instance">Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_kind',
@@ -16576,7 +16576,7 @@ SymbolTable(
                 'AASd-021',
                 textwrap.dedent("""\
                   <field_body><paragraph>Every qualifiable can only have one qualifier with the same
-                  <ReferenceToAttribute refuri="~Qualifier.type">~Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
+                  <ReferenceToAttribute refuri="Qualifier.type">Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -16604,11 +16604,11 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=DescriptionOfProperty(
-            summary='<paragraph>The value of the <ReferenceToOurType refuri=".Blob">.Blob</ReferenceToOurType> instance of a blob data element.</paragraph>',
+            summary='<paragraph>The value of the <ReferenceToOurType refuri="Blob">Blob</ReferenceToOurType> instance of a blob data element.</paragraph>',
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>In contrast to the file property the file content is stored directly as value
-                in the <ReferenceToOurType refuri=".Blob">.Blob</ReferenceToOurType> data element.</paragraph></note>""")],
+                in the <ReferenceToOurType refuri="Blob">Blob</ReferenceToOurType> data element.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to ConcreteClass Blob',
@@ -16619,7 +16619,7 @@ SymbolTable(
             our_type='Reference to our type Content_type',
             parsed=...),
           description=DescriptionOfProperty(
-            summary='<paragraph>Content type of the content of the <ReferenceToOurType refuri=".Blob">.Blob</ReferenceToOurType>.</paragraph>',
+            summary='<paragraph>Content type of the content of the <ReferenceToOurType refuri="Blob">Blob</ReferenceToOurType>.</paragraph>',
             remarks=[
               '<paragraph>The content type (MIME type) states which file extensions the file can have.</paragraph>',
               textwrap.dedent("""\
@@ -17327,7 +17327,7 @@ SymbolTable(
         fragment=None),
       description=DescriptionOfOurType(
         summary=textwrap.dedent("""\
-          <paragraph>A <ReferenceToOurType refuri=".Blob">.Blob</ReferenceToOurType> is a data element that represents a file that is contained with its
+          <paragraph>A <ReferenceToOurType refuri="Blob">Blob</ReferenceToOurType> is a data element that represents a file that is contained with its
           source code in the value attribute.</paragraph>"""),
         remarks=[],
         constraints_by_identifier=[],
@@ -17379,7 +17379,7 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>The category is not identical to the semantic definition
-                (<ReferenceToOurType refuri=".Has_semantics">.Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
+                (<ReferenceToOurType refuri="Has_semantics">Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
                 the element is a measurement value whereas the semantic definition of
                 the element would denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
@@ -17401,8 +17401,8 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>In case the element is a property and the property has a semantic definition
-                (<ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
-                the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
+                (<ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
+                the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -17427,7 +17427,7 @@ SymbolTable(
                 the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
                 then the corresponding preferred name in the language is chosen
                 according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
-                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -17488,7 +17488,7 @@ SymbolTable(
           description=DescriptionOfProperty(
             summary='<paragraph>Kind of the element: either type or instance.</paragraph>',
             remarks=[
-              '<paragraph>Default: <ReferenceToAttribute refuri="~Modeling_kind.Instance">~Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
+              '<paragraph>Default: <ReferenceToAttribute refuri="Modeling_kind.Instance">Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_kind',
@@ -17546,7 +17546,7 @@ SymbolTable(
                 'AASd-021',
                 textwrap.dedent("""\
                   <field_body><paragraph>Every qualifiable can only have one qualifier with the same
-                  <ReferenceToAttribute refuri="~Qualifier.type">~Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
+                  <ReferenceToAttribute refuri="Qualifier.type">Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -18342,7 +18342,7 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>The category is not identical to the semantic definition
-                (<ReferenceToOurType refuri=".Has_semantics">.Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
+                (<ReferenceToOurType refuri="Has_semantics">Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
                 the element is a measurement value whereas the semantic definition of
                 the element would denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
@@ -18364,8 +18364,8 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>In case the element is a property and the property has a semantic definition
-                (<ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
-                the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
+                (<ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
+                the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -18390,7 +18390,7 @@ SymbolTable(
                 the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
                 then the corresponding preferred name in the language is chosen
                 according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
-                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -18451,7 +18451,7 @@ SymbolTable(
           description=DescriptionOfProperty(
             summary='<paragraph>Kind of the element: either type or instance.</paragraph>',
             remarks=[
-              '<paragraph>Default: <ReferenceToAttribute refuri="~Modeling_kind.Instance">~Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
+              '<paragraph>Default: <ReferenceToAttribute refuri="Modeling_kind.Instance">Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_kind',
@@ -18509,7 +18509,7 @@ SymbolTable(
                 'AASd-021',
                 textwrap.dedent("""\
                   <field_body><paragraph>Every qualifiable can only have one qualifier with the same
-                  <ReferenceToAttribute refuri="~Qualifier.type">~Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
+                  <ReferenceToAttribute refuri="Qualifier.type">Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -19349,7 +19349,7 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>The category is not identical to the semantic definition
-                (<ReferenceToOurType refuri=".Has_semantics">.Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
+                (<ReferenceToOurType refuri="Has_semantics">Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
                 the element is a measurement value whereas the semantic definition of
                 the element would denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
@@ -19371,8 +19371,8 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>In case the element is a property and the property has a semantic definition
-                (<ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
-                the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
+                (<ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
+                the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -19397,7 +19397,7 @@ SymbolTable(
                 the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
                 then the corresponding preferred name in the language is chosen
                 according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
-                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -19458,7 +19458,7 @@ SymbolTable(
           description=DescriptionOfProperty(
             summary='<paragraph>Kind of the element: either type or instance.</paragraph>',
             remarks=[
-              '<paragraph>Default: <ReferenceToAttribute refuri="~Modeling_kind.Instance">~Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
+              '<paragraph>Default: <ReferenceToAttribute refuri="Modeling_kind.Instance">Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_kind',
@@ -19516,7 +19516,7 @@ SymbolTable(
                 'AASd-021',
                 textwrap.dedent("""\
                   <field_body><paragraph>Every qualifiable can only have one qualifier with the same
-                  <ReferenceToAttribute refuri="~Qualifier.type">~Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
+                  <ReferenceToAttribute refuri="Qualifier.type">Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -20406,9 +20406,9 @@ SymbolTable(
           [
             'AASd-014',
             textwrap.dedent("""\
-              <field_body><paragraph>Either the attribute <ReferenceToAttribute refuri="~global_asset_id">~global_asset_id</ReferenceToAttribute> or <ReferenceToAttribute refuri="~specific_asset_id">~specific_asset_id</ReferenceToAttribute>
-              of an <ReferenceToOurType refuri=".Entity">.Entity</ReferenceToOurType> must be set if <ReferenceToAttribute refuri="~entity_type">~entity_type</ReferenceToAttribute> is set to
-              <ReferenceToAttribute refuri="~Entity_type.Self_managed_entity">~Entity_type.Self_managed_entity</ReferenceToAttribute>. They are not existing otherwise.</paragraph></field_body>""")]],
+              <field_body><paragraph>Either the attribute <ReferenceToAttribute refuri="global_asset_id">global_asset_id</ReferenceToAttribute> or <ReferenceToAttribute refuri="specific_asset_id">specific_asset_id</ReferenceToAttribute>
+              of an <ReferenceToOurType refuri="Entity">Entity</ReferenceToOurType> must be set if <ReferenceToAttribute refuri="entity_type">entity_type</ReferenceToAttribute> is set to
+              <ReferenceToAttribute refuri="Entity_type.Self_managed_entity">Entity_type.Self_managed_entity</ReferenceToAttribute>. They are not existing otherwise.</paragraph></field_body>""")]],
         parsed=...),
       parsed=...,
       properties_by_name=...,
@@ -20504,8 +20504,8 @@ SymbolTable(
           description=DescriptionOfProperty(
             summary=textwrap.dedent("""\
               <paragraph>Reference to the source event element, including identification of
-              <ReferenceToOurType refuri=".Asset_administration_shell">.Asset_administration_shell</ReferenceToOurType>, <ReferenceToOurType refuri=".Submodel">.Submodel</ReferenceToOurType>,
-              <ReferenceToOurType refuri=".Submodel_element">.Submodel_element</ReferenceToOurType>'s.</paragraph>"""),
+              <ReferenceToOurType refuri="Asset_administration_shell">Asset_administration_shell</ReferenceToOurType>, <ReferenceToOurType refuri="Submodel">Submodel</ReferenceToOurType>,
+              <ReferenceToOurType refuri="Submodel_element">Submodel_element</ReferenceToOurType>'s.</paragraph>"""),
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -20519,7 +20519,7 @@ SymbolTable(
               parsed=...),
             parsed=...),
           description=DescriptionOfProperty(
-            summary='<paragraph><ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute> of the source event element, if available</paragraph>',
+            summary='<paragraph><ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute> of the source event element, if available</paragraph>',
             remarks=[
               '<note><paragraph>It is recommended to use a global reference.</paragraph></note>'],
             constraints_by_identifier=[],
@@ -20535,8 +20535,8 @@ SymbolTable(
             summary='<paragraph>Reference to the referable, which defines the scope of the event.</paragraph>',
             remarks=[
               textwrap.dedent("""\
-                <paragraph>Can be <ReferenceToOurType refuri=".Asset_administration_shell">.Asset_administration_shell</ReferenceToOurType>, <ReferenceToOurType refuri=".Submodel">.Submodel</ReferenceToOurType> or
-                <ReferenceToOurType refuri=".Submodel_element">.Submodel_element</ReferenceToOurType>.</paragraph>""")],
+                <paragraph>Can be <ReferenceToOurType refuri="Asset_administration_shell">Asset_administration_shell</ReferenceToOurType>, <ReferenceToOurType refuri="Submodel">Submodel</ReferenceToOurType> or
+                <ReferenceToOurType refuri="Submodel_element">Submodel_element</ReferenceToOurType>.</paragraph>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to ConcreteClass Event_payload',
@@ -20550,7 +20550,7 @@ SymbolTable(
             parsed=...),
           description=DescriptionOfProperty(
             summary=textwrap.dedent("""\
-              <paragraph><ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute> of the referable which defines the scope of
+              <paragraph><ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute> of the referable which defines the scope of
               the event, if available.</paragraph>"""),
             remarks=[
               '<note><paragraph>It is recommended to use a global reference.</paragraph></note>'],
@@ -20883,7 +20883,7 @@ SymbolTable(
               remarks=[
                 textwrap.dedent("""\
                   <note><paragraph>The category is not identical to the semantic definition
-                  (<ReferenceToOurType refuri=".Has_semantics">.Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
+                  (<ReferenceToOurType refuri="Has_semantics">Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
                   the element is a measurement value whereas the semantic definition of
                   the element would denote that it is the measured temperature.</paragraph></note>""")],
               constraints_by_identifier=[],
@@ -20905,8 +20905,8 @@ SymbolTable(
               remarks=[
                 textwrap.dedent("""\
                   <note><paragraph>In case the element is a property and the property has a semantic definition
-                  (<ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
-                  the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
+                  (<ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
+                  the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -20931,7 +20931,7 @@ SymbolTable(
                   the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
                   then the corresponding preferred name in the language is chosen
                   according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
-                  the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
+                  the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Referable',
@@ -20992,7 +20992,7 @@ SymbolTable(
             description=DescriptionOfProperty(
               summary='<paragraph>Kind of the element: either type or instance.</paragraph>',
               remarks=[
-                '<paragraph>Default: <ReferenceToAttribute refuri="~Modeling_kind.Instance">~Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
+                '<paragraph>Default: <ReferenceToAttribute refuri="Modeling_kind.Instance">Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
               constraints_by_identifier=[],
               parsed=...),
             specified_for='Reference to AbstractClass Has_kind',
@@ -21050,7 +21050,7 @@ SymbolTable(
                   'AASd-021',
                   textwrap.dedent("""\
                     <field_body><paragraph>Every qualifiable can only have one qualifier with the same
-                    <ReferenceToAttribute refuri="~Qualifier.type">~Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
+                    <ReferenceToAttribute refuri="Qualifier.type">Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
               parsed=...),
             specified_for='Reference to AbstractClass Qualifiable',
             parsed=...),
@@ -21115,7 +21115,7 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>The category is not identical to the semantic definition
-                (<ReferenceToOurType refuri=".Has_semantics">.Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
+                (<ReferenceToOurType refuri="Has_semantics">Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
                 the element is a measurement value whereas the semantic definition of
                 the element would denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
@@ -21137,8 +21137,8 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>In case the element is a property and the property has a semantic definition
-                (<ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
-                the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
+                (<ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
+                the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -21163,7 +21163,7 @@ SymbolTable(
                 the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
                 then the corresponding preferred name in the language is chosen
                 according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
-                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -21224,7 +21224,7 @@ SymbolTable(
           description=DescriptionOfProperty(
             summary='<paragraph>Kind of the element: either type or instance.</paragraph>',
             remarks=[
-              '<paragraph>Default: <ReferenceToAttribute refuri="~Modeling_kind.Instance">~Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
+              '<paragraph>Default: <ReferenceToAttribute refuri="Modeling_kind.Instance">Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_kind',
@@ -21282,7 +21282,7 @@ SymbolTable(
                 'AASd-021',
                 textwrap.dedent("""\
                   <field_body><paragraph>Every qualifiable can only have one qualifier with the same
-                  <ReferenceToAttribute refuri="~Qualifier.type">~Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
+                  <ReferenceToAttribute refuri="Qualifier.type">Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -21957,7 +21957,7 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>The category is not identical to the semantic definition
-                (<ReferenceToOurType refuri=".Has_semantics">.Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
+                (<ReferenceToOurType refuri="Has_semantics">Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
                 the element is a measurement value whereas the semantic definition of
                 the element would denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
@@ -21979,8 +21979,8 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>In case the element is a property and the property has a semantic definition
-                (<ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
-                the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
+                (<ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
+                the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -22005,7 +22005,7 @@ SymbolTable(
                 the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
                 then the corresponding preferred name in the language is chosen
                 according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
-                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -22066,7 +22066,7 @@ SymbolTable(
           description=DescriptionOfProperty(
             summary='<paragraph>Kind of the element: either type or instance.</paragraph>',
             remarks=[
-              '<paragraph>Default: <ReferenceToAttribute refuri="~Modeling_kind.Instance">~Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
+              '<paragraph>Default: <ReferenceToAttribute refuri="Modeling_kind.Instance">Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_kind',
@@ -22124,7 +22124,7 @@ SymbolTable(
                 'AASd-021',
                 textwrap.dedent("""\
                   <field_body><paragraph>Every qualifiable can only have one qualifier with the same
-                  <ReferenceToAttribute refuri="~Qualifier.type">~Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
+                  <ReferenceToAttribute refuri="Qualifier.type">Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -22151,9 +22151,9 @@ SymbolTable(
             parsed=...),
           description=DescriptionOfProperty(
             summary=textwrap.dedent("""\
-              <paragraph>Reference to the <ReferenceToOurType refuri=".Referable">.Referable</ReferenceToOurType>, which defines the scope of the event.
-              Can be <ReferenceToOurType refuri=".Asset_administration_shell">.Asset_administration_shell</ReferenceToOurType>, <ReferenceToOurType refuri=".Submodel">.Submodel</ReferenceToOurType>, or
-              <ReferenceToOurType refuri=".Submodel_element">.Submodel_element</ReferenceToOurType>.</paragraph>"""),
+              <paragraph>Reference to the <ReferenceToOurType refuri="Referable">Referable</ReferenceToOurType>, which defines the scope of the event.
+              Can be <ReferenceToOurType refuri="Asset_administration_shell">Asset_administration_shell</ReferenceToOurType>, <ReferenceToOurType refuri="Submodel">Submodel</ReferenceToOurType>, or
+              <ReferenceToOurType refuri="Submodel_element">Submodel_element</ReferenceToOurType>.</paragraph>"""),
             remarks=[
               textwrap.dedent("""\
                 <paragraph>Reference to a referable, e.g., a data element or
@@ -22214,9 +22214,9 @@ SymbolTable(
           description=DescriptionOfProperty(
             summary=textwrap.dedent("""\
               <paragraph>Information, which outer message infrastructure shall handle messages for
-              the <ReferenceToOurType refuri=".Event_element">.Event_element</ReferenceToOurType>. Refers to a <ReferenceToOurType refuri=".Submodel">.Submodel</ReferenceToOurType>,
-              <ReferenceToOurType refuri=".Submodel_element_list">.Submodel_element_list</ReferenceToOurType>, <ReferenceToOurType refuri=".Submodel_element_collection">.Submodel_element_collection</ReferenceToOurType> or
-              <ReferenceToOurType refuri=".Entity">.Entity</ReferenceToOurType>, which contains <ReferenceToOurType refuri=".Data_element">.Data_element</ReferenceToOurType>'s describing
+              the <ReferenceToOurType refuri="Event_element">Event_element</ReferenceToOurType>. Refers to a <ReferenceToOurType refuri="Submodel">Submodel</ReferenceToOurType>,
+              <ReferenceToOurType refuri="Submodel_element_list">Submodel_element_list</ReferenceToOurType>, <ReferenceToOurType refuri="Submodel_element_collection">Submodel_element_collection</ReferenceToOurType> or
+              <ReferenceToOurType refuri="Entity">Entity</ReferenceToOurType>, which contains <ReferenceToOurType refuri="Data_element">Data_element</ReferenceToOurType>'s describing
               the proprietary specification for the message broker.</paragraph>"""),
             remarks=[
               textwrap.dedent("""\
@@ -23162,7 +23162,7 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>The category is not identical to the semantic definition
-                (<ReferenceToOurType refuri=".Has_semantics">.Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
+                (<ReferenceToOurType refuri="Has_semantics">Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
                 the element is a measurement value whereas the semantic definition of
                 the element would denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
@@ -23184,8 +23184,8 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>In case the element is a property and the property has a semantic definition
-                (<ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
-                the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
+                (<ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
+                the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -23210,7 +23210,7 @@ SymbolTable(
                 the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
                 then the corresponding preferred name in the language is chosen
                 according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
-                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -23271,7 +23271,7 @@ SymbolTable(
           description=DescriptionOfProperty(
             summary='<paragraph>Kind of the element: either type or instance.</paragraph>',
             remarks=[
-              '<paragraph>Default: <ReferenceToAttribute refuri="~Modeling_kind.Instance">~Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
+              '<paragraph>Default: <ReferenceToAttribute refuri="Modeling_kind.Instance">Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_kind',
@@ -23329,7 +23329,7 @@ SymbolTable(
                 'AASd-021',
                 textwrap.dedent("""\
                   <field_body><paragraph>Every qualifiable can only have one qualifier with the same
-                  <ReferenceToAttribute refuri="~Qualifier.type">~Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
+                  <ReferenceToAttribute refuri="Qualifier.type">Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -24290,7 +24290,7 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>The category is not identical to the semantic definition
-                (<ReferenceToOurType refuri=".Has_semantics">.Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
+                (<ReferenceToOurType refuri="Has_semantics">Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
                 the element is a measurement value whereas the semantic definition of
                 the element would denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
@@ -24312,8 +24312,8 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>In case the element is a property and the property has a semantic definition
-                (<ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
-                the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
+                (<ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
+                the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -24338,7 +24338,7 @@ SymbolTable(
                 the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
                 then the corresponding preferred name in the language is chosen
                 according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
-                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -24399,7 +24399,7 @@ SymbolTable(
           description=DescriptionOfProperty(
             summary='<paragraph>Kind of the element: either type or instance.</paragraph>',
             remarks=[
-              '<paragraph>Default: <ReferenceToAttribute refuri="~Modeling_kind.Instance">~Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
+              '<paragraph>Default: <ReferenceToAttribute refuri="Modeling_kind.Instance">Modeling_kind.Instance</ReferenceToAttribute></paragraph>'],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Has_kind',
@@ -24457,7 +24457,7 @@ SymbolTable(
                 'AASd-021',
                 textwrap.dedent("""\
                   <field_body><paragraph>Every qualifiable can only have one qualifier with the same
-                  <ReferenceToAttribute refuri="~Qualifier.type">~Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
+                  <ReferenceToAttribute refuri="Qualifier.type">Qualifier.type</ReferenceToAttribute>.</paragraph></field_body>""")]],
             parsed=...),
           specified_for='Reference to AbstractClass Qualifiable',
           parsed=...),
@@ -25086,7 +25086,7 @@ SymbolTable(
           asset to achieve a certain effect in the physical or virtual world.</paragraph>"""),
         remarks=[
           textwrap.dedent("""\
-            <note><paragraph>The <ReferenceToAttribute refuri="~semantic_id">~semantic_id</ReferenceToAttribute> of a capability is typically an ontology.
+            <note><paragraph>The <ReferenceToAttribute refuri="semantic_id">semantic_id</ReferenceToAttribute> of a capability is typically an ontology.
             Thus, reasoning on capabilities is enabled.</paragraph></note>""")],
         constraints_by_identifier=[],
         parsed=...),
@@ -25138,7 +25138,7 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>The category is not identical to the semantic definition
-                (<ReferenceToOurType refuri=".Has_semantics">.Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
+                (<ReferenceToOurType refuri="Has_semantics">Has_semantics</ReferenceToOurType>) of an element. The category e.g. could denote that
                 the element is a measurement value whereas the semantic definition of
                 the element would denote that it is the measured temperature.</paragraph></note>""")],
             constraints_by_identifier=[],
@@ -25160,8 +25160,8 @@ SymbolTable(
             remarks=[
               textwrap.dedent("""\
                 <note><paragraph>In case the element is a property and the property has a semantic definition
-                (<ReferenceToAttribute refuri="~Has_semantics.semantic_id">~Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
-                the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
+                (<ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute>) conformant to IEC61360
+                the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> is typically identical to the short name in English.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -25186,7 +25186,7 @@ SymbolTable(
                 the semantics of the element</paragraph></list_item><list_item><paragraph>If there is a default language list defined in the application,
                 then the corresponding preferred name in the language is chosen
                 according to this order.</paragraph></list_item><list_item><paragraph>the English preferred name of the concept description defining
-                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="~id_short">~id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
+                the semantics of the element</paragraph></list_item><list_item><paragraph>the short name of the concept description</paragraph></list_item><list_item><paragraph>the <ReferenceToAttribute refuri="id_short">id_short</ReferenceToAttribute> of the element</paragraph></list_item></bullet_list>""")],
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to AbstractClass Referable',
@@ -26103,16 +26103,16 @@ SymbolTable(
           [
             'AASd-051',
             textwrap.dedent("""\
-              <field_body><paragraph>A <ReferenceToOurType refuri=".Concept_description">.Concept_description</ReferenceToOurType> shall have one of the following categories
+              <field_body><paragraph>A <ReferenceToOurType refuri="Concept_description">Concept_description</ReferenceToOurType> shall have one of the following categories
               <literal>VALUE</literal>, <literal>PROPERTY</literal>, <literal>REFERENCE</literal>, <literal>DOCUMENT</literal>, <literal>CAPABILITY</literal>,
               <literal>RELATIONSHIP</literal>, <literal>COLLECTION</literal>, <literal>FUNCTION</literal>, <literal>EVENT</literal>, <literal>ENTITY</literal>,
               <literal>APPLICATION_CLASS</literal>, <literal>QUALIFIER</literal>, <literal>VIEW</literal>.</paragraph><paragraph>Default: <literal>PROPERTY</literal>.</paragraph></field_body>""")],
           [
             'AASc-004',
             textwrap.dedent("""\
-              <field_body><paragraph>For a <ReferenceToOurType refuri=".Concept_description">.Concept_description</ReferenceToOurType> with <ReferenceToAttribute refuri="~category">~category</ReferenceToAttribute> <literal>PROPERTY</literal> or
+              <field_body><paragraph>For a <ReferenceToOurType refuri="Concept_description">Concept_description</ReferenceToOurType> with <ReferenceToAttribute refuri="category">category</ReferenceToAttribute> <literal>PROPERTY</literal> or
               <literal>VALUE</literal> using data specification IEC61360,
-              the <ReferenceToAttribute refuri="~Data_specification_IEC_61360.data_type">~Data_specification_IEC_61360.data_type</ReferenceToAttribute> is mandatory and shall be
+              the <ReferenceToAttribute refuri="Data_specification_IEC_61360.data_type">Data_specification_IEC_61360.data_type</ReferenceToAttribute> is mandatory and shall be
               one of: <literal>DATE</literal>, <literal>STRING</literal>, <literal>STRING_TRANSLATABLE</literal>, <literal>INTEGER_MEASURE</literal>,
               <literal>INTEGER_COUNT</literal>, <literal>INTEGER_CURRENCY</literal>, <literal>REAL_MEASURE</literal>, <literal>REAL_COUNT</literal>,
               <literal>REAL_CURRENCY</literal>, <literal>BOOLEAN</literal>, <literal>RATIONAL</literal>, <literal>RATIONAL_MEASURE</literal>,
@@ -26120,36 +26120,36 @@ SymbolTable(
           [
             'AASc-005',
             textwrap.dedent("""\
-              <field_body><paragraph>For a <ReferenceToOurType refuri=".Concept_description">.Concept_description</ReferenceToOurType> with <ReferenceToAttribute refuri="~category">~category</ReferenceToAttribute> <literal>REFERENCE</literal>
+              <field_body><paragraph>For a <ReferenceToOurType refuri="Concept_description">Concept_description</ReferenceToOurType> with <ReferenceToAttribute refuri="category">category</ReferenceToAttribute> <literal>REFERENCE</literal>
               using data specification IEC61360,
-              the <ReferenceToAttribute refuri="~Data_specification_IEC_61360.data_type">~Data_specification_IEC_61360.data_type</ReferenceToAttribute> is mandatory and shall be
+              the <ReferenceToAttribute refuri="Data_specification_IEC_61360.data_type">Data_specification_IEC_61360.data_type</ReferenceToAttribute> is mandatory and shall be
               one of: <literal>STRING</literal>, <literal>IRI</literal>, <literal>IRDI</literal>.</paragraph></field_body>""")],
           [
             'AASc-006',
             textwrap.dedent("""\
-              <field_body><paragraph>For a <ReferenceToOurType refuri=".Concept_description">.Concept_description</ReferenceToOurType> with <ReferenceToAttribute refuri="~category">~category</ReferenceToAttribute> <literal>DOCUMENT</literal>
+              <field_body><paragraph>For a <ReferenceToOurType refuri="Concept_description">Concept_description</ReferenceToOurType> with <ReferenceToAttribute refuri="category">category</ReferenceToAttribute> <literal>DOCUMENT</literal>
               using data specification IEC61360,
-              the <ReferenceToAttribute refuri="~Data_specification_IEC_61360.data_type">~Data_specification_IEC_61360.data_type</ReferenceToAttribute> is mandatory and shall be
+              the <ReferenceToAttribute refuri="Data_specification_IEC_61360.data_type">Data_specification_IEC_61360.data_type</ReferenceToAttribute> is mandatory and shall be
               defined.</paragraph></field_body>""")],
           [
             'AASc-007',
             textwrap.dedent("""\
-              <field_body><paragraph>For a <ReferenceToOurType refuri=".Concept_description">.Concept_description</ReferenceToOurType> with <ReferenceToAttribute refuri="~category">~category</ReferenceToAttribute> <literal>QUALIFIER_TYPE</literal>
+              <field_body><paragraph>For a <ReferenceToOurType refuri="Concept_description">Concept_description</ReferenceToOurType> with <ReferenceToAttribute refuri="category">category</ReferenceToAttribute> <literal>QUALIFIER_TYPE</literal>
               using data specification IEC61360,
-              the <ReferenceToAttribute refuri="~Data_specification_IEC_61360.data_type">~Data_specification_IEC_61360.data_type</ReferenceToAttribute> is mandatory and shall be</paragraph></field_body>""")],
+              the <ReferenceToAttribute refuri="Data_specification_IEC_61360.data_type">Data_specification_IEC_61360.data_type</ReferenceToAttribute> is mandatory and shall be</paragraph></field_body>""")],
           [
             'AASc-008',
             textwrap.dedent("""\
-              <field_body><paragraph>For all <ReferenceToOurType refuri=".Concept_description">.Concept_description</ReferenceToOurType>'s with a category except
-              <ReferenceToAttribute refuri="~category">~category</ReferenceToAttribute> <literal>VALUE</literal> using data specification IEC61360,
-              <ReferenceToAttribute refuri="~Data_specification_IEC_61360.definition">~Data_specification_IEC_61360.definition</ReferenceToAttribute> is mandatory and shall be
+              <field_body><paragraph>For all <ReferenceToOurType refuri="Concept_description">Concept_description</ReferenceToOurType>'s with a category except
+              <ReferenceToAttribute refuri="category">category</ReferenceToAttribute> <literal>VALUE</literal> using data specification IEC61360,
+              <ReferenceToAttribute refuri="Data_specification_IEC_61360.definition">Data_specification_IEC_61360.definition</ReferenceToAttribute> is mandatory and shall be
               defined at least in English.</paragraph></field_body>""")],
           [
             'AASc-003',
             textwrap.dedent("""\
-              <field_body><paragraph>For a <ReferenceToOurType refuri=".Concept_description">.Concept_description</ReferenceToOurType> with <ReferenceToAttribute refuri="~category">~category</ReferenceToAttribute> <literal>VALUE</literal>
+              <field_body><paragraph>For a <ReferenceToOurType refuri="Concept_description">Concept_description</ReferenceToOurType> with <ReferenceToAttribute refuri="category">category</ReferenceToAttribute> <literal>VALUE</literal>
               using data specification IEC61360,
-              the <ReferenceToAttribute refuri="~Data_specification_IEC_61360.value">~Data_specification_IEC_61360.value</ReferenceToAttribute> shall be set.</paragraph></field_body>""")]],
+              the <ReferenceToAttribute refuri="Data_specification_IEC_61360.value">Data_specification_IEC_61360.value</ReferenceToAttribute> shall be set.</paragraph></field_body>""")]],
         parsed=...),
       parsed=...,
       properties_by_name=...,
@@ -26224,7 +26224,7 @@ SymbolTable(
           description=DescriptionOfProperty(
             summary=textwrap.dedent("""\
               <paragraph><ReferenceToAttribute refuri="Has_semantics.semantic_id">Has_semantics.semantic_id</ReferenceToAttribute> of the referenced model element
-              (<ReferenceToAttribute refuri="~Reference.type">~Reference.type</ReferenceToAttribute> = <ReferenceToAttribute refuri="~Reference_types.Model_reference">~Reference_types.Model_reference</ReferenceToAttribute>).</paragraph>"""),
+              (<ReferenceToAttribute refuri="Reference.type">Reference.type</ReferenceToAttribute> = <ReferenceToAttribute refuri="Reference_types.Model_reference">Reference_types.Model_reference</ReferenceToAttribute>).</paragraph>"""),
             remarks=[
               '<paragraph>For global references there typically is no semantic ID.</paragraph>',
               '<note><paragraph>It is recommended to use a global reference.</paragraph></note>'],
@@ -27003,64 +27003,64 @@ SymbolTable(
           [
             'AASd-121',
             textwrap.dedent("""\
-              <field_body><paragraph>For <ReferenceToOurType refuri=".Reference">.Reference</ReferenceToOurType>'s the <ReferenceToAttribute refuri="~Key.type">~Key.type</ReferenceToAttribute> of the first key of
-              <ReferenceToAttribute refuri="~keys">~keys</ReferenceToAttribute> shall be one of <ReferenceToConstant refuri=".Globally_identifiables">.Globally_identifiables</ReferenceToConstant>.</paragraph></field_body>""")],
+              <field_body><paragraph>For <ReferenceToOurType refuri="Reference">Reference</ReferenceToOurType>'s the <ReferenceToAttribute refuri="Key.type">Key.type</ReferenceToAttribute> of the first key of
+              <ReferenceToAttribute refuri="keys">keys</ReferenceToAttribute> shall be one of <ReferenceToConstant refuri="Globally_identifiables">Globally_identifiables</ReferenceToConstant>.</paragraph></field_body>""")],
           [
             'AASd-122',
             textwrap.dedent("""\
-              <field_body><paragraph>For global references, i.e. <ReferenceToOurType refuri=".Reference">.Reference</ReferenceToOurType>'s with
-              <ReferenceToAttribute refuri="~Reference.type">~Reference.type</ReferenceToAttribute> = <ReferenceToAttribute refuri="~Reference_types.Global_reference">~Reference_types.Global_reference</ReferenceToAttribute>, the type
-              of the first key of <ReferenceToAttribute refuri="~Reference.keys">~Reference.keys</ReferenceToAttribute> shall be one of
-              <ReferenceToConstant refuri=".Generic_globally_identifiables">.Generic_globally_identifiables</ReferenceToConstant>.</paragraph></field_body>""")],
+              <field_body><paragraph>For global references, i.e. <ReferenceToOurType refuri="Reference">Reference</ReferenceToOurType>'s with
+              <ReferenceToAttribute refuri="Reference.type">Reference.type</ReferenceToAttribute> = <ReferenceToAttribute refuri="Reference_types.Global_reference">Reference_types.Global_reference</ReferenceToAttribute>, the type
+              of the first key of <ReferenceToAttribute refuri="Reference.keys">Reference.keys</ReferenceToAttribute> shall be one of
+              <ReferenceToConstant refuri="Generic_globally_identifiables">Generic_globally_identifiables</ReferenceToConstant>.</paragraph></field_body>""")],
           [
             'AASd-123',
             textwrap.dedent("""\
-              <field_body><paragraph>For model references, i.e. <ReferenceToOurType refuri=".Reference">.Reference</ReferenceToOurType>'s with
-              <ReferenceToAttribute refuri="~Reference.type">~Reference.type</ReferenceToAttribute> = <ReferenceToAttribute refuri="~Reference_types.Model_reference">~Reference_types.Model_reference</ReferenceToAttribute>, the type
-              of the first key of <ReferenceToAttribute refuri="~Reference.keys">~Reference.keys</ReferenceToAttribute> shall be one of
-              <ReferenceToConstant refuri=".AAS_identifiables">.AAS_identifiables</ReferenceToConstant>.</paragraph></field_body>""")],
+              <field_body><paragraph>For model references, i.e. <ReferenceToOurType refuri="Reference">Reference</ReferenceToOurType>'s with
+              <ReferenceToAttribute refuri="Reference.type">Reference.type</ReferenceToAttribute> = <ReferenceToAttribute refuri="Reference_types.Model_reference">Reference_types.Model_reference</ReferenceToAttribute>, the type
+              of the first key of <ReferenceToAttribute refuri="Reference.keys">Reference.keys</ReferenceToAttribute> shall be one of
+              <ReferenceToConstant refuri="AAS_identifiables">AAS_identifiables</ReferenceToConstant>.</paragraph></field_body>""")],
           [
             'AASd-124',
             textwrap.dedent("""\
-              <field_body><paragraph>For global references, i.e. <ReferenceToOurType refuri=".Reference">.Reference</ReferenceToOurType>'s with
-              <ReferenceToAttribute refuri="~Reference.type">~Reference.type</ReferenceToAttribute> = <ReferenceToAttribute refuri="~Reference_types.Global_reference">~Reference_types.Global_reference</ReferenceToAttribute>, the last
-              key of <ReferenceToAttribute refuri="~Reference.keys">~Reference.keys</ReferenceToAttribute> shall be either one of
-              <ReferenceToConstant refuri=".Generic_globally_identifiables">.Generic_globally_identifiables</ReferenceToConstant> or one of
-              <ReferenceToConstant refuri=".Generic_fragment_keys">.Generic_fragment_keys</ReferenceToConstant>.</paragraph></field_body>""")],
+              <field_body><paragraph>For global references, i.e. <ReferenceToOurType refuri="Reference">Reference</ReferenceToOurType>'s with
+              <ReferenceToAttribute refuri="Reference.type">Reference.type</ReferenceToAttribute> = <ReferenceToAttribute refuri="Reference_types.Global_reference">Reference_types.Global_reference</ReferenceToAttribute>, the last
+              key of <ReferenceToAttribute refuri="Reference.keys">Reference.keys</ReferenceToAttribute> shall be either one of
+              <ReferenceToConstant refuri="Generic_globally_identifiables">Generic_globally_identifiables</ReferenceToConstant> or one of
+              <ReferenceToConstant refuri="Generic_fragment_keys">Generic_fragment_keys</ReferenceToConstant>.</paragraph></field_body>""")],
           [
             'AASd-125',
             textwrap.dedent("""\
-              <field_body><paragraph>For model references, i.e. <ReferenceToOurType refuri=".Reference">.Reference</ReferenceToOurType>'s with
-              <ReferenceToAttribute refuri="~Reference.type">~Reference.type</ReferenceToAttribute> = <ReferenceToAttribute refuri="~Reference_types.Model_reference">~Reference_types.Model_reference</ReferenceToAttribute>, with more
-              than one key in <ReferenceToAttribute refuri="~Reference.keys">~Reference.keys</ReferenceToAttribute> the type of the keys following the first
-              key of  <ReferenceToAttribute refuri="~Reference.keys">~Reference.keys</ReferenceToAttribute> shall be one of <ReferenceToConstant refuri=".Fragment_keys">.Fragment_keys</ReferenceToConstant>.</paragraph><note><paragraph><ReferenceToConstraint refuri="AASd-125">AASd-125</ReferenceToConstraint> ensures that the shortest path is used.</paragraph></note></field_body>""")],
+              <field_body><paragraph>For model references, i.e. <ReferenceToOurType refuri="Reference">Reference</ReferenceToOurType>'s with
+              <ReferenceToAttribute refuri="Reference.type">Reference.type</ReferenceToAttribute> = <ReferenceToAttribute refuri="Reference_types.Model_reference">Reference_types.Model_reference</ReferenceToAttribute>, with more
+              than one key in <ReferenceToAttribute refuri="Reference.keys">Reference.keys</ReferenceToAttribute> the type of the keys following the first
+              key of  <ReferenceToAttribute refuri="Reference.keys">Reference.keys</ReferenceToAttribute> shall be one of <ReferenceToConstant refuri="Fragment_keys">Fragment_keys</ReferenceToConstant>.</paragraph><note><paragraph><ReferenceToConstraint refuri="AASd-125">AASd-125</ReferenceToConstraint> ensures that the shortest path is used.</paragraph></note></field_body>""")],
           [
             'AASd-126',
             textwrap.dedent("""\
-              <field_body><paragraph>For model references, i.e. <ReferenceToOurType refuri=".Reference">.Reference</ReferenceToOurType>'s with
-              <ReferenceToAttribute refuri="~Reference.type">~Reference.type</ReferenceToAttribute> = <ReferenceToAttribute refuri="~Reference_types.Model_reference">~Reference_types.Model_reference</ReferenceToAttribute>, with more
-              than one key in <ReferenceToAttribute refuri="~Reference.keys">~Reference.keys</ReferenceToAttribute> the type of the last key in the
-              reference key chain may be one of <ReferenceToConstant refuri=".Generic_fragment_keys">.Generic_fragment_keys</ReferenceToConstant> or no key
-              at all shall have a value out of <ReferenceToConstant refuri=".Generic_fragment_keys">.Generic_fragment_keys</ReferenceToConstant>.</paragraph></field_body>""")],
+              <field_body><paragraph>For model references, i.e. <ReferenceToOurType refuri="Reference">Reference</ReferenceToOurType>'s with
+              <ReferenceToAttribute refuri="Reference.type">Reference.type</ReferenceToAttribute> = <ReferenceToAttribute refuri="Reference_types.Model_reference">Reference_types.Model_reference</ReferenceToAttribute>, with more
+              than one key in <ReferenceToAttribute refuri="Reference.keys">Reference.keys</ReferenceToAttribute> the type of the last key in the
+              reference key chain may be one of <ReferenceToConstant refuri="Generic_fragment_keys">Generic_fragment_keys</ReferenceToConstant> or no key
+              at all shall have a value out of <ReferenceToConstant refuri="Generic_fragment_keys">Generic_fragment_keys</ReferenceToConstant>.</paragraph></field_body>""")],
           [
             'AASd-127',
             textwrap.dedent("""\
-              <field_body><paragraph>For model references, i.e. <ReferenceToOurType refuri=".Reference">.Reference</ReferenceToOurType>'s with
-              <ReferenceToAttribute refuri="~Reference.type">~Reference.type</ReferenceToAttribute> = <ReferenceToAttribute refuri="~Reference_types.Model_reference">~Reference_types.Model_reference</ReferenceToAttribute>, with more
-              than one key in <ReferenceToAttribute refuri="~Reference.keys">~Reference.keys</ReferenceToAttribute> a key with <ReferenceToAttribute refuri="~Key.type">~Key.type</ReferenceToAttribute>
-              <ReferenceToAttribute refuri="~Key_types.Fragment_reference">~Key_types.Fragment_reference</ReferenceToAttribute> shall be preceded by a key with
-              <ReferenceToAttribute refuri="~Key.type">~Key.type</ReferenceToAttribute> <ReferenceToAttribute refuri="~Key_types.File">~Key_types.File</ReferenceToAttribute> or <ReferenceToAttribute refuri="~Key_types.Blob">~Key_types.Blob</ReferenceToAttribute>. All other
-              AAS fragments, i.e. type values out of <ReferenceToConstant refuri=".AAS_submodel_elements_as_keys">.AAS_submodel_elements_as_keys</ReferenceToConstant>,
+              <field_body><paragraph>For model references, i.e. <ReferenceToOurType refuri="Reference">Reference</ReferenceToOurType>'s with
+              <ReferenceToAttribute refuri="Reference.type">Reference.type</ReferenceToAttribute> = <ReferenceToAttribute refuri="Reference_types.Model_reference">Reference_types.Model_reference</ReferenceToAttribute>, with more
+              than one key in <ReferenceToAttribute refuri="Reference.keys">Reference.keys</ReferenceToAttribute> a key with <ReferenceToAttribute refuri="Key.type">Key.type</ReferenceToAttribute>
+              <ReferenceToAttribute refuri="Key_types.Fragment_reference">Key_types.Fragment_reference</ReferenceToAttribute> shall be preceded by a key with
+              <ReferenceToAttribute refuri="Key.type">Key.type</ReferenceToAttribute> <ReferenceToAttribute refuri="Key_types.File">Key_types.File</ReferenceToAttribute> or <ReferenceToAttribute refuri="Key_types.Blob">Key_types.Blob</ReferenceToAttribute>. All other
+              AAS fragments, i.e. type values out of <ReferenceToConstant refuri="AAS_submodel_elements_as_keys">AAS_submodel_elements_as_keys</ReferenceToConstant>,
               do not support fragments.</paragraph><note><paragraph>Which kind of fragments are supported depends on the content type and the
               specification of allowed fragment identifiers for the corresponding resource
               being referenced via the reference.</paragraph></note></field_body>""")],
           [
             'AASd-128',
             textwrap.dedent("""\
-              <field_body><paragraph>For model references, i.e. <ReferenceToOurType refuri=".Reference">.Reference</ReferenceToOurType>'s with
-              <ReferenceToAttribute refuri="~Reference.type">~Reference.type</ReferenceToAttribute> = <ReferenceToAttribute refuri="~Reference_types.Model_reference">~Reference_types.Model_reference</ReferenceToAttribute>, the
-              <ReferenceToAttribute refuri="~Key.value">~Key.value</ReferenceToAttribute> of a <ReferenceToOurType refuri=".Key">.Key</ReferenceToOurType> preceded by a <ReferenceToOurType refuri=".Key">.Key</ReferenceToOurType> with
-              <ReferenceToAttribute refuri="~Key.type">~Key.type</ReferenceToAttribute> = <ReferenceToAttribute refuri="~Key_types.Submodel_element_list">~Key_types.Submodel_element_list</ReferenceToAttribute> is an integer
+              <field_body><paragraph>For model references, i.e. <ReferenceToOurType refuri="Reference">Reference</ReferenceToOurType>'s with
+              <ReferenceToAttribute refuri="Reference.type">Reference.type</ReferenceToAttribute> = <ReferenceToAttribute refuri="Reference_types.Model_reference">Reference_types.Model_reference</ReferenceToAttribute>, the
+              <ReferenceToAttribute refuri="Key.value">Key.value</ReferenceToAttribute> of a <ReferenceToOurType refuri="Key">Key</ReferenceToOurType> preceded by a <ReferenceToOurType refuri="Key">Key</ReferenceToOurType> with
+              <ReferenceToAttribute refuri="Key.type">Key.type</ReferenceToAttribute> = <ReferenceToAttribute refuri="Key_types.Submodel_element_list">Key_types.Submodel_element_list</ReferenceToAttribute> is an integer
               number denoting the position in the array of the submodel element list.</paragraph></field_body>""")]],
         parsed=...),
       parsed=...,
@@ -27086,7 +27086,7 @@ SymbolTable(
             summary='<paragraph>Denotes which kind of entity is referenced.</paragraph>',
             remarks=[
               textwrap.dedent("""\
-                <paragraph>In case <ReferenceToAttribute refuri="~type">~type</ReferenceToAttribute> = <ReferenceToAttribute refuri="~Key_types.Fragment_reference">~Key_types.Fragment_reference</ReferenceToAttribute> the key represents
+                <paragraph>In case <ReferenceToAttribute refuri="type">type</ReferenceToAttribute> = <ReferenceToAttribute refuri="Key_types.Fragment_reference">Key_types.Fragment_reference</ReferenceToAttribute> the key represents
                 a bookmark or a similar local identifier within its parent element as specified
                 by the key that precedes this key.</paragraph>"""),
               textwrap.dedent("""\
@@ -27244,7 +27244,7 @@ SymbolTable(
             summary='<paragraph>Data element.</paragraph>',
             remarks=[
               textwrap.dedent("""\
-                <note><paragraph>Data Element is abstract, <emphasis>i.e.</emphasis> if a key uses <ReferenceToAttribute refuri="~Data_element">~Data_element</ReferenceToAttribute>
+                <note><paragraph>Data Element is abstract, <emphasis>i.e.</emphasis> if a key uses <ReferenceToAttribute refuri="Data_element">Data_element</ReferenceToAttribute>
                 the reference may be a Property, a File etc.</paragraph></note>""")],
             parsed=...),
           parsed=...),
@@ -27259,7 +27259,7 @@ SymbolTable(
           description=DescriptionOfEnumerationLiteral(
             summary='<paragraph>Event.</paragraph>',
             remarks=[
-              '<note><paragraph><ReferenceToOurType refuri=".Event_element">.Event_element</ReferenceToOurType> is abstract.</paragraph></note>'],
+              '<note><paragraph><ReferenceToOurType refuri="Event_element">Event_element</ReferenceToOurType> is abstract.</paragraph></note>'],
             parsed=...),
           parsed=...),
         EnumerationLiteral(
@@ -27326,8 +27326,8 @@ SymbolTable(
             summary='<paragraph>Submodel Element</paragraph>',
             remarks=[
               textwrap.dedent("""\
-                <note><paragraph>Submodel Element is abstract, <emphasis>i.e.</emphasis> if a key uses <ReferenceToAttribute refuri="~Submodel_element">~Submodel_element</ReferenceToAttribute>
-                the reference may be a <ReferenceToOurType refuri=".Property">.Property</ReferenceToOurType>, an <ReferenceToOurType refuri=".Operation">.Operation</ReferenceToOurType> etc.</paragraph></note>""")],
+                <note><paragraph>Submodel Element is abstract, <emphasis>i.e.</emphasis> if a key uses <ReferenceToAttribute refuri="Submodel_element">Submodel_element</ReferenceToAttribute>
+                the reference may be a <ReferenceToOurType refuri="Property">Property</ReferenceToOurType>, an <ReferenceToOurType refuri="Operation">Operation</ReferenceToOurType> etc.</paragraph></note>""")],
             parsed=...),
           parsed=...),
         EnumerationLiteral(
@@ -27575,7 +27575,7 @@ SymbolTable(
             a_type='STR',
             parsed=...),
           description=DescriptionOfProperty(
-            summary='<paragraph>Text in the <ReferenceToAttribute refuri="~language">~language</ReferenceToAttribute></paragraph>',
+            summary='<paragraph>Text in the <ReferenceToAttribute refuri="language">language</ReferenceToAttribute></paragraph>',
             remarks=[],
             constraints_by_identifier=[],
             parsed=...),
@@ -28559,7 +28559,7 @@ SymbolTable(
             constraints_by_identifier=[
               [
                 'AASc-002',
-                '<field_body><paragraph><ReferenceToAttribute refuri="~preferred_name">~preferred_name</ReferenceToAttribute> shall be provided at least in English.</paragraph></field_body>']],
+                '<field_body><paragraph><ReferenceToAttribute refuri="preferred_name">preferred_name</ReferenceToAttribute> shall be provided at least in English.</paragraph></field_body>']],
             parsed=...),
           specified_for='Reference to ConcreteClass Data_specification_IEC_61360',
           parsed=...),
@@ -28604,13 +28604,13 @@ SymbolTable(
             summary='<paragraph>Unique unit id</paragraph>',
             remarks=[
               textwrap.dedent("""\
-                <paragraph><ReferenceToAttribute refuri="~unit">~unit</ReferenceToAttribute> and <ReferenceToAttribute refuri="~unit_id">~unit_id</ReferenceToAttribute> need to be consistent if both attributes
+                <paragraph><ReferenceToAttribute refuri="unit">unit</ReferenceToAttribute> and <ReferenceToAttribute refuri="unit_id">unit_id</ReferenceToAttribute> need to be consistent if both attributes
                 are set</paragraph>"""),
               '<note><paragraph>It is recommended to use a global reference.</paragraph></note>',
               textwrap.dedent("""\
-                <note><paragraph>Although the <ReferenceToAttribute refuri="~unit_id">~unit_id</ReferenceToAttribute> is a global reference there might exist a
-                <ReferenceToOurType refuri=".Concept_description">.Concept_description</ReferenceToOurType>
-                with data specification <ReferenceToOurType refuri=".Data_specification_physical_unit">.Data_specification_physical_unit</ReferenceToOurType> with
+                <note><paragraph>Although the <ReferenceToAttribute refuri="unit_id">unit_id</ReferenceToAttribute> is a global reference there might exist a
+                <ReferenceToOurType refuri="Concept_description">Concept_description</ReferenceToOurType>
+                with data specification <ReferenceToOurType refuri="Data_specification_physical_unit">Data_specification_physical_unit</ReferenceToOurType> with
                 the same ID.</paragraph></note>""")],
             constraints_by_identifier=[],
             parsed=...),
@@ -29307,32 +29307,32 @@ SymbolTable(
           textwrap.dedent("""\
             <note><paragraph>IEC61360 requires also a globally unique identifier for a concept
             description. This ID is not part of the data specification template.
-            Instead the <ReferenceToAttribute refuri="~Concept_description.id">~Concept_description.id</ReferenceToAttribute> as inherited via
-            <ReferenceToOurType refuri=".Identifiable">.Identifiable</ReferenceToOurType> is used. Same holds for administrative
+            Instead the <ReferenceToAttribute refuri="Concept_description.id">Concept_description.id</ReferenceToAttribute> as inherited via
+            <ReferenceToOurType refuri="Identifiable">Identifiable</ReferenceToOurType> is used. Same holds for administrative
             information like the version and revision.</paragraph></note>"""),
           textwrap.dedent("""\
-            <note><paragraph><ReferenceToAttribute refuri="Concept_description.id_short">Concept_description.id_short</ReferenceToAttribute> and <ReferenceToAttribute refuri="~short_name">~short_name</ReferenceToAttribute> are very
+            <note><paragraph><ReferenceToAttribute refuri="Concept_description.id_short">Concept_description.id_short</ReferenceToAttribute> and <ReferenceToAttribute refuri="short_name">short_name</ReferenceToAttribute> are very
             similar. However, in this case the decision was to add
-            <ReferenceToAttribute refuri="~short_name">~short_name</ReferenceToAttribute> explicitly to the data specification. Same holds for
-            <ReferenceToAttribute refuri="~Concept_description.display_name">~Concept_description.display_name</ReferenceToAttribute> and
-            <ReferenceToAttribute refuri="~preferred_name">~preferred_name</ReferenceToAttribute>. Same holds for
-            <ReferenceToAttribute refuri="Concept_description.description">Concept_description.description</ReferenceToAttribute> and <ReferenceToAttribute refuri="~definition">~definition</ReferenceToAttribute>.</paragraph></note>""")],
+            <ReferenceToAttribute refuri="short_name">short_name</ReferenceToAttribute> explicitly to the data specification. Same holds for
+            <ReferenceToAttribute refuri="Concept_description.display_name">Concept_description.display_name</ReferenceToAttribute> and
+            <ReferenceToAttribute refuri="preferred_name">preferred_name</ReferenceToAttribute>. Same holds for
+            <ReferenceToAttribute refuri="Concept_description.description">Concept_description.description</ReferenceToAttribute> and <ReferenceToAttribute refuri="definition">definition</ReferenceToAttribute>.</paragraph></note>""")],
         constraints_by_identifier=[
           [
             'AASc-010',
             textwrap.dedent("""\
-              <field_body><paragraph>If <ReferenceToAttribute refuri="~value">~value</ReferenceToAttribute> is not empty then <ReferenceToAttribute refuri="~value_list">~value_list</ReferenceToAttribute> shall be empty
+              <field_body><paragraph>If <ReferenceToAttribute refuri="value">value</ReferenceToAttribute> is not empty then <ReferenceToAttribute refuri="value_list">value_list</ReferenceToAttribute> shall be empty
               and vice versa.</paragraph></field_body>""")],
           [
             'AASc-009',
             textwrap.dedent("""\
-              <field_body><paragraph>If <ReferenceToAttribute refuri="~data_type">~data_type</ReferenceToAttribute> one of:
-              <ReferenceToAttribute refuri="~Data_type_IEC_61360.Integer_measure">~Data_type_IEC_61360.Integer_measure</ReferenceToAttribute>,
-              <ReferenceToAttribute refuri="~Data_type_IEC_61360.Real_measure">~Data_type_IEC_61360.Real_measure</ReferenceToAttribute>,
-              <ReferenceToAttribute refuri="~Data_type_IEC_61360.Rational_measure">~Data_type_IEC_61360.Rational_measure</ReferenceToAttribute>,
-              <ReferenceToAttribute refuri="~Data_type_IEC_61360.Integer_currency">~Data_type_IEC_61360.Integer_currency</ReferenceToAttribute>,
-              <ReferenceToAttribute refuri="~Data_type_IEC_61360.Real_currency">~Data_type_IEC_61360.Real_currency</ReferenceToAttribute>, then <ReferenceToAttribute refuri="~unit">~unit</ReferenceToAttribute> or
-              <ReferenceToAttribute refuri="~unit_id">~unit_id</ReferenceToAttribute> shall be defined.</paragraph></field_body>""")]],
+              <field_body><paragraph>If <ReferenceToAttribute refuri="data_type">data_type</ReferenceToAttribute> one of:
+              <ReferenceToAttribute refuri="Data_type_IEC_61360.Integer_measure">Data_type_IEC_61360.Integer_measure</ReferenceToAttribute>,
+              <ReferenceToAttribute refuri="Data_type_IEC_61360.Real_measure">Data_type_IEC_61360.Real_measure</ReferenceToAttribute>,
+              <ReferenceToAttribute refuri="Data_type_IEC_61360.Rational_measure">Data_type_IEC_61360.Rational_measure</ReferenceToAttribute>,
+              <ReferenceToAttribute refuri="Data_type_IEC_61360.Integer_currency">Data_type_IEC_61360.Integer_currency</ReferenceToAttribute>,
+              <ReferenceToAttribute refuri="Data_type_IEC_61360.Real_currency">Data_type_IEC_61360.Real_currency</ReferenceToAttribute>, then <ReferenceToAttribute refuri="unit">unit</ReferenceToAttribute> or
+              <ReferenceToAttribute refuri="unit_id">unit_id</ReferenceToAttribute> shall be defined.</paragraph></field_body>""")]],
         parsed=...),
       parsed=...,
       properties_by_name=...,
@@ -29935,7 +29935,7 @@ SymbolTable(
       subsets=[],
       reference_in_the_book=None,
       description=DescriptionOfConstant(
-        summary='<paragraph>Categories for <ReferenceToOurType refuri=".Data_element">.Data_element</ReferenceToOurType> as defined in <ReferenceToConstraint refuri="AASd-090">AASd-090</ReferenceToConstraint></paragraph>',
+        summary='<paragraph>Categories for <ReferenceToOurType refuri="Data_element">Data_element</ReferenceToOurType> as defined in <ReferenceToConstraint refuri="AASd-090">AASd-090</ReferenceToConstraint></paragraph>',
         remarks=[],
         parsed=...),
       parsed=...),
@@ -29999,7 +29999,7 @@ SymbolTable(
       subsets=[],
       reference_in_the_book=None,
       description=DescriptionOfConstant(
-        summary='<paragraph>Categories for <ReferenceToOurType refuri=".Concept_description">.Concept_description</ReferenceToOurType> as defined in <ReferenceToConstraint refuri="AASd-051">AASd-051</ReferenceToConstraint></paragraph>',
+        summary='<paragraph>Categories for <ReferenceToOurType refuri="Concept_description">Concept_description</ReferenceToOurType> as defined in <ReferenceToConstraint refuri="AASd-051">AASd-051</ReferenceToConstraint></paragraph>',
         remarks=[],
         parsed=...),
       parsed=...),
@@ -30533,7 +30533,7 @@ SymbolTable(
       description=DescriptionOfSignature(
         summary=textwrap.dedent("""\
           <paragraph>Check that the <ReferenceToArgument refuri="lang_strings">lang_strings</ReferenceToArgument> do not have overlapping
-          <ReferenceToAttribute refuri="~Lang_string.language">~Lang_string.language</ReferenceToAttribute>'s</paragraph>"""),
+          <ReferenceToAttribute refuri="Lang_string.language">Lang_string.language</ReferenceToAttribute>'s</paragraph>"""),
         remarks=[],
         arguments_by_name=[],
         returns=None,
@@ -30560,13 +30560,13 @@ SymbolTable(
         a_type='BOOL',
         parsed=...),
       description=DescriptionOfSignature(
-        summary='<paragraph>Check that <ReferenceToAttribute refuri="~Qualifier.type">~Qualifier.type</ReferenceToAttribute>\'s of <ReferenceToArgument refuri="qualifiers">qualifiers</ReferenceToArgument> are unique.</paragraph>',
+        summary='<paragraph>Check that <ReferenceToAttribute refuri="Qualifier.type">Qualifier.type</ReferenceToAttribute>\'s of <ReferenceToArgument refuri="qualifiers">qualifiers</ReferenceToArgument> are unique.</paragraph>',
         remarks=[],
         arguments_by_name=[
           [
             'qualifiers',
             '<field_body><paragraph>to be checked</paragraph></field_body>']],
-        returns='<field_body><paragraph>True if all <ReferenceToAttribute refuri="~Qualifier.type">~Qualifier.type</ReferenceToAttribute>\'s are unique</paragraph></field_body>',
+        returns='<field_body><paragraph>True if all <ReferenceToAttribute refuri="Qualifier.type">Qualifier.type</ReferenceToAttribute>\'s are unique</paragraph></field_body>',
         parsed=...),
       contracts=Contracts(
         preconditions=[],
@@ -31683,7 +31683,7 @@ SymbolTable(
         a_type='BOOL',
         parsed=...),
       description=DescriptionOfSignature(
-        summary='<paragraph>Check that the target of the reference matches a <ReferenceToConstant refuri=".AAS_referables">.AAS_referables</ReferenceToConstant>.</paragraph>',
+        summary='<paragraph>Check that the target of the reference matches a <ReferenceToConstant refuri="AAS_referables">AAS_referables</ReferenceToConstant>.</paragraph>',
         remarks=[],
         arguments_by_name=[],
         returns=None,
@@ -31711,7 +31711,7 @@ SymbolTable(
         parsed=...),
       description=DescriptionOfSignature(
         summary=textwrap.dedent("""\
-          <paragraph>Check that the <ReferenceToAttribute refuri="~Referable.id_short">~Referable.id_short</ReferenceToAttribute>'s among the <ReferenceToArgument refuri="referables">referables</ReferenceToArgument> are
+          <paragraph>Check that the <ReferenceToAttribute refuri="Referable.id_short">Referable.id_short</ReferenceToAttribute>'s among the <ReferenceToArgument refuri="referables">referables</ReferenceToArgument> are
           unique.</paragraph>"""),
         remarks=[],
         arguments_by_name=[],
@@ -31894,7 +31894,7 @@ SymbolTable(
         parsed=...),
       description=DescriptionOfSignature(
         summary=textwrap.dedent("""\
-          <paragraph>Check that the <ReferenceToAttribute refuri="~Data_specification_IEC_61360.data_type">~Data_specification_IEC_61360.data_type</ReferenceToAttribute> is defined
+          <paragraph>Check that the <ReferenceToAttribute refuri="Data_specification_IEC_61360.data_type">Data_specification_IEC_61360.data_type</ReferenceToAttribute> is defined
           appropriately for all data specifications whose content is given as IEC 61360.</paragraph>"""),
         remarks=[],
         arguments_by_name=[],
@@ -31923,7 +31923,7 @@ SymbolTable(
         parsed=...),
       description=DescriptionOfSignature(
         summary=textwrap.dedent("""\
-          <paragraph>Check that the <ReferenceToAttribute refuri="~Data_specification_IEC_61360.data_type">~Data_specification_IEC_61360.data_type</ReferenceToAttribute> is defined
+          <paragraph>Check that the <ReferenceToAttribute refuri="Data_specification_IEC_61360.data_type">Data_specification_IEC_61360.data_type</ReferenceToAttribute> is defined
           appropriately for all data specifications whose content is given as IEC 61360.</paragraph>"""),
         remarks=[],
         arguments_by_name=[],
@@ -31952,7 +31952,7 @@ SymbolTable(
         parsed=...),
       description=DescriptionOfSignature(
         summary=textwrap.dedent("""\
-          <paragraph>Check that the <ReferenceToAttribute refuri="~Data_specification_IEC_61360.data_type">~Data_specification_IEC_61360.data_type</ReferenceToAttribute> is defined
+          <paragraph>Check that the <ReferenceToAttribute refuri="Data_specification_IEC_61360.data_type">Data_specification_IEC_61360.data_type</ReferenceToAttribute> is defined
           appropriately for all data specifications whose content is given as IEC 61360.</paragraph>"""),
         remarks=[],
         arguments_by_name=[],
@@ -31981,7 +31981,7 @@ SymbolTable(
         parsed=...),
       description=DescriptionOfSignature(
         summary=textwrap.dedent("""\
-          <paragraph>Check that the <ReferenceToAttribute refuri="~Data_specification_IEC_61360.data_type">~Data_specification_IEC_61360.data_type</ReferenceToAttribute> is defined for all
+          <paragraph>Check that the <ReferenceToAttribute refuri="Data_specification_IEC_61360.data_type">Data_specification_IEC_61360.data_type</ReferenceToAttribute> is defined for all
           data specifications whose content is given as IEC 61360.</paragraph>"""),
         remarks=[],
         arguments_by_name=[],
@@ -32010,7 +32010,7 @@ SymbolTable(
         parsed=...),
       description=DescriptionOfSignature(
         summary=textwrap.dedent("""\
-          <paragraph>Check that the <ReferenceToAttribute refuri="~Data_specification_IEC_61360.value">~Data_specification_IEC_61360.value</ReferenceToAttribute> is defined
+          <paragraph>Check that the <ReferenceToAttribute refuri="Data_specification_IEC_61360.value">Data_specification_IEC_61360.value</ReferenceToAttribute> is defined
           for all data specifications whose content is given as IEC 61360.</paragraph>"""),
         remarks=[],
         arguments_by_name=[],
@@ -32039,7 +32039,7 @@ SymbolTable(
         parsed=...),
       description=DescriptionOfSignature(
         summary=textwrap.dedent("""\
-          <paragraph>Check that the <ReferenceToAttribute refuri="~Data_specification_IEC_61360.definition">~Data_specification_IEC_61360.definition</ReferenceToAttribute> is defined
+          <paragraph>Check that the <ReferenceToAttribute refuri="Data_specification_IEC_61360.definition">Data_specification_IEC_61360.definition</ReferenceToAttribute> is defined
           for all data specifications whose content is given as IEC 61360 at least in English.</paragraph>"""),
         remarks=[],
         arguments_by_name=[],
@@ -32098,8 +32098,8 @@ SymbolTable(
         '<bullet_list bullet="*"><list_item><paragraph><ReferenceToConstraint refuri="AASd-012">AASd-012</ReferenceToConstraint></paragraph></list_item></bullet_list>',
         textwrap.dedent("""\
           <paragraph><ReferenceToConstraint refuri="AASd-116">AASd-116</ReferenceToConstraint> is ill-defined. The type of the
-          <ReferenceToAttribute refuri="~Specific_asset_id.value">~Specific_asset_id.value</ReferenceToAttribute> is a string, but the type of
-          <ReferenceToAttribute refuri="~Asset_information.global_asset_id">~Asset_information.global_asset_id</ReferenceToAttribute> is a <ReferenceToOurType refuri=".Reference">.Reference</ReferenceToOurType>. The comparison
+          <ReferenceToAttribute refuri="Specific_asset_id.value">Specific_asset_id.value</ReferenceToAttribute> is a string, but the type of
+          <ReferenceToAttribute refuri="Asset_information.global_asset_id">Asset_information.global_asset_id</ReferenceToAttribute> is a <ReferenceToOurType refuri="Reference">Reference</ReferenceToOurType>. The comparison
           between a string and a reference is not defined, so we can not implement
           this constraint.</paragraph>"""),
         textwrap.dedent("""\
@@ -32110,21 +32110,21 @@ SymbolTable(
           the following divergences:</paragraph>"""),
         textwrap.dedent("""\
           <bullet_list bullet="*"><list_item><paragraph>We decided therefore to remove the enumerations <literal>DataTypeDef</literal> and <literal>DataTypeDefRDF</literal>
-          and keep only <ReferenceToOurType refuri=".Data_type_def_XSD">.Data_type_def_XSD</ReferenceToOurType> as enumeration. Otherwise, we would have
+          and keep only <ReferenceToOurType refuri="Data_type_def_XSD">Data_type_def_XSD</ReferenceToOurType> as enumeration. Otherwise, we would have
           to write redundant invariants all over the meta-model because <literal>DataTypeDef</literal> and
-          <literal>DataTypeDefRDF</literal> are actually never used in any type definition.</paragraph></list_item><list_item><paragraph>The enumeration <ReferenceToOurType refuri=".AAS_submodel_elements">.AAS_submodel_elements</ReferenceToOurType> is used in two different contexts.
+          <literal>DataTypeDefRDF</literal> are actually never used in any type definition.</paragraph></list_item><list_item><paragraph>The enumeration <ReferenceToOurType refuri="AAS_submodel_elements">AAS_submodel_elements</ReferenceToOurType> is used in two different contexts.
           One context is the definition of key types in a reference. Another context is
-          the definition of element types in a <ReferenceToOurType refuri=".Submodel_element_list">.Submodel_element_list</ReferenceToOurType>. It is very
+          the definition of element types in a <ReferenceToOurType refuri="Submodel_element_list">Submodel_element_list</ReferenceToOurType>. It is very
           counter-intuitive to see the type of
-          <ReferenceToAttribute refuri="~Submodel_element_list.type_value_list_element">~Submodel_element_list.type_value_list_element</ReferenceToAttribute> as
-          <ReferenceToOurType refuri=".Key_types">.Key_types</ReferenceToOurType> even though an invariant might specify that it is an element of
-          <ReferenceToOurType refuri=".AAS_submodel_elements">.AAS_submodel_elements</ReferenceToOurType>.</paragraph><paragraph>To avoid confusion, we introduce a set of <ReferenceToOurType refuri=".Key_types">.Key_types</ReferenceToOurType>,
-          <ReferenceToConstant refuri=".AAS_submodel_elements_as_keys">.AAS_submodel_elements_as_keys</ReferenceToConstant> to represent the first context (key type
-          in a reference). The enumeration <ReferenceToOurType refuri=".AAS_submodel_elements">.AAS_submodel_elements</ReferenceToOurType> is kept as designator
-          for <ReferenceToAttribute refuri="~Submodel_element_list.type_value_list_element">~Submodel_element_list.type_value_list_element</ReferenceToAttribute>.</paragraph></list_item></bullet_list>"""),
+          <ReferenceToAttribute refuri="Submodel_element_list.type_value_list_element">Submodel_element_list.type_value_list_element</ReferenceToAttribute> as
+          <ReferenceToOurType refuri="Key_types">Key_types</ReferenceToOurType> even though an invariant might specify that it is an element of
+          <ReferenceToOurType refuri="AAS_submodel_elements">AAS_submodel_elements</ReferenceToOurType>.</paragraph><paragraph>To avoid confusion, we introduce a set of <ReferenceToOurType refuri="Key_types">Key_types</ReferenceToOurType>,
+          <ReferenceToConstant refuri="AAS_submodel_elements_as_keys">AAS_submodel_elements_as_keys</ReferenceToConstant> to represent the first context (key type
+          in a reference). The enumeration <ReferenceToOurType refuri="AAS_submodel_elements">AAS_submodel_elements</ReferenceToOurType> is kept as designator
+          for <ReferenceToAttribute refuri="Submodel_element_list.type_value_list_element">Submodel_element_list.type_value_list_element</ReferenceToAttribute>.</paragraph></list_item></bullet_list>"""),
         textwrap.dedent("""\
           <paragraph>Concerning the data specifications, we embed them within
-          <ReferenceToOurType refuri=".Has_data_specification">.Has_data_specification</ReferenceToOurType> instead of referencing them <emphasis>via</emphasis> a global reference.
+          <ReferenceToOurType refuri="Has_data_specification">Has_data_specification</ReferenceToOurType> instead of referencing them <emphasis>via</emphasis> a global reference.
           The working group decided to change the rules for serialization <emphasis>after</emphasis> the book was
           published. The data specifications are critical in applications, but there is no
           possibility to access them through a data channel as they are not part of
@@ -32139,7 +32139,7 @@ SymbolTable(
             namespace.</paragraph></field_body>""")],
         [
           'AASd-003',
-          '<field_body><paragraph><ReferenceToAttribute refuri="Referable.id_short">Referable.id_short</ReferenceToAttribute> of <ReferenceToOurType refuri=".Referable">.Referable</ReferenceToOurType>\'s shall be matched case-sensitive.</paragraph></field_body>']],
+          '<field_body><paragraph><ReferenceToAttribute refuri="Referable.id_short">Referable.id_short</ReferenceToAttribute> of <ReferenceToOurType refuri="Referable">Referable</ReferenceToOurType>\'s shall be matched case-sensitive.</paragraph></field_body>']],
       parsed=...),
     book_url='https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/Details_of_the_Asset_Administration_Shell_Part1_V3.pdf?__blob=publicationFile&v=10',
     book_version='V3.0RC02',

--- a/tests/csharp/test_description.py
+++ b/tests/csharp/test_description.py
@@ -205,7 +205,7 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
             textwrap.dedent(
                 '''\
                 class Something:
-                    """Do & drink :class:`.Something`."""
+                    """Do & drink :class:`Something`."""
 
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
@@ -228,7 +228,7 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
                 '''\
                 @abstract
                 class Something:
-                    """Do & drink :class:`.Something`."""
+                    """Do & drink :class:`Something`."""
 
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"
@@ -252,7 +252,7 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
             textwrap.dedent(
                 '''\
                 class Something(Enum):
-                    """Do & drink :class:`.Something`."""
+                    """Do & drink :class:`Something`."""
 
                 __book_url__ = "dummy"
                 __book_version__ = "dummy"

--- a/tests/intermediate/test_translate.py
+++ b/tests/intermediate/test_translate.py
@@ -80,7 +80,7 @@ class Test_parsing_docstrings(unittest.TestCase):
                 """
                 This is some documentation.
 
-                Nested reference :class:`.Some_class`
+                Nested reference :class:`Some_class`
                 """
 
             __book_url__ = "dummy"


### PR DESCRIPTION
Previously, due to ignorance, we annotated references with different prefixes (attributes with ``~`` and classes and constants with ``.``). Eventually, we learned more about Sphinx and how it deals with references (see [1]).

In this change, we sort out the referencing and make it a bit clearer:

* attributes, classes and constants must be references as-are,
* appearance prefixes ``!`` and ``~`` are ignored (as target languages usually do not work like Sphinx), and
* relaxed qualified names (references prefixed with a ``.``) are disallowed as we can only resolve references *within* the meta-model and not outside it.

The unit tests are expected to fail as we have to update aas-core-meta after this change to avoid aas-core-meta's unit tests to fail.

[1]: https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#xref-syntax