### PR TITLE
Make remote CI work again

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -152,7 +152,7 @@ Call the generator with the appropriate target:
 
     usage: aas-core-codegen [-h] --model_path MODEL_PATH --snippets_dir
                             SNIPPETS_DIR --output_dir OUTPUT_DIR --target
-                            {csharp,jsonschema,rdf_shacl,xsd} [--version]
+                            {csharp,jsonschema,python,rdf_shacl,xsd} [--version]
 
     Generate implementations and schemas based on an AAS meta-model.
 
@@ -165,7 +165,7 @@ Call the generator with the appropriate target:
                             specific code snippets
       --output_dir OUTPUT_DIR
                             path to the generated code
-      --target {csharp,jsonschema,rdf_shacl,xsd}
+      --target {csharp,jsonschema,python,rdf_shacl,xsd}
                             target language or schema
       --version             show the current version and exit
 

--- a/aas_core_codegen/rdf_shacl/main.py
+++ b/aas_core_codegen/rdf_shacl/main.py
@@ -6,7 +6,7 @@ from typing import TextIO
 import aas_core_codegen
 import aas_core_codegen.rdf_shacl.rdf
 import aas_core_codegen.rdf_shacl.shacl
-from aas_core_codegen import specific_implementations, run
+from aas_core_codegen import run
 from aas_core_codegen.rdf_shacl import common as rdf_shacl_common
 
 

--- a/continuous_integration/precommit.py
+++ b/continuous_integration/precommit.py
@@ -130,7 +130,7 @@ def main() -> int:
         else:
             exit_code = call_and_report(
                 verb="check with black",
-                cmd=["black", "--check"] + reformat_targets,
+                cmd=["black", "--check"] + reformat_targets + ["--exclude"] + exclude,
                 cwd=repo_root,
             )
             if exit_code != 0:

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
             "twine",
             "jsonschema==3.2.0",
             "xmlschema==1.10.0",
-            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@e63c0c9#egg=aas-core-meta",
+            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@3ffe727#egg=aas-core-meta",
         ]
     },
     # fmt: on


### PR DESCRIPTION
We only considered excludes in the ``--overwrite`` mode of the pre-commit checks, but forgot to include them also in the non-invasive checks as well. This patch fixes the issue, and the CI runs again.