### PR TITLE
Fix escaping in XML serialization in Python

### DIFF
--- a/aas_core_codegen/python/xmlization/_generate.py
+++ b/aas_core_codegen/python/xmlization/_generate.py
@@ -1656,7 +1656,7 @@ def _escape_and_write_text(
 {I}# a dictionary, and on another snippet which called three ``.replace()``.
 {I}# The code with ``.replace()`` was an order of magnitude faster on our computers.
 {I}self.stream.write(
-{II}text.replace('&', '&amp').replace('<', '&lt;').replace('>', '&gt;')
+{II}text.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
 {I})"""
         ),
         Stripped(

--- a/test_data/python/test_main/aas_core_meta.v3rc2/expected_output/xmlization.py
+++ b/test_data/python/test_main/aas_core_meta.v3rc2/expected_output/xmlization.py
@@ -26200,7 +26200,7 @@ class _Serializer(aas_types.AbstractVisitor):
         # a dictionary, and on another snippet which called three ``.replace()``.
         # The code with ``.replace()`` was an order of magnitude faster on our computers.
         self.stream.write(
-            text.replace('&', '&amp').replace('<', '&lt;').replace('>', '&gt;')
+            text.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
         )
 
     def _write_end_element(


### PR DESCRIPTION
We mistakenly escape an ampersand to ``&amp`` instead of ``&amp;`` (mind the semi-colon), which causes XML errors in de-serialization.

The mistake went unnoticed due to a bug in the unit test code where the examples were not globbed recursively, but only at the top-level example directory.