### PR TITLE
Fix date verification of BCE and zero years in C#

### DIFF
--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/verification.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/verification.cs
@@ -97,47 +97,158 @@ namespace AasCore.Aas3_0_RC02
             return RegexMatchesXsDateTimeStampUtc.IsMatch(text);
         }
 
-        private static readonly string[] XsDateFormats = {
-            "yyyy-MM-dd"
-        };
+        private static Regex RegexDatePrefix = new Regex("^(-?[0-9]+)-([0-9]{2})-([0-9]{2})");
 
         /// <summary>
-        /// Clip the <paramref name="value" /> to the date part.
+        /// Check whether the given year is a leap year.
         /// </summary>
-        /// <remarks>
-        /// We ignore the negative sign prefix and clip years to 4 digits.
-        /// This is necessary as <see cref="System.DateTime" /> can not handle
-        /// dates B.C. and the <see cref="o:System.DateTime.ParseExact" /> expects
-        /// exactly four digits.
-        ///
-        /// We strip the negative sign and assume astronomical years.
-        /// See: https://en.wikipedia.org/wiki/Leap_year#Algorithm and
-        /// the note at: https://www.w3.org/TR/xmlschema-2/#dateTime
-        ///
-        /// Furthermore, we always assume that <paramref name="value" /> has been
-        /// already validated with the corresponding regular expression.
-        /// Hence we can use this function to validate the date-times as the time
-        /// segment and offsets are correctly matched by the regular expression,
-        /// while day/month combinations need to be validated by
-        /// <see cref="o:System.DateTime.ParseExact" />.
-        /// </remarks>
-        private static string ClipToDate(string value)
+        /// <remarks>Year 1 BCE is a leap year.</remarks>
+        /// <param name="year">to be checked</param>
+        /// <returns>True if <paramref name="year"/> is a leap year</returns>
+        public static bool IsLeapYear(System.Numerics.BigInteger year)
         {
-            int start = 0;
-            if (value[0] == '-')
+            // NOTE (mristin, 2022-11-02):
+            // We consider the years B.C. to be one-off.
+            // See the note at: https://www.w3.org/TR/xmlschema-2/#dateTime:
+            // "'-0001' is the lexical representation of the year 1 Before Common Era
+            // (1 BCE, sometimes written "1 BC")."
+            //
+            // Hence, -1 year in XML is 1 BCE, which is 0 year in astronomical years.
+            if (year < 0)
             {
-                start++;
+                year = -year - 1;
             }
 
-            int yearEnd = start;
-            for (; value[yearEnd] != '-'; yearEnd++)
+            // See: See: https://en.wikipedia.org/wiki/Leap_year#Algorithm
+            if (year % 4 > 0)
             {
-                // Intentionally empty.
+                return false;
             }
 
-            return (yearEnd == 4 && value.Length == 10)
-                ? value
-                : value.Substring(yearEnd - 4, 10);
+            if (year % 100 > 0)
+            {
+                return true;
+            }
+
+            if (year % 400 > 0)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Check that the value starts with a valid date.
+        /// </summary>
+        /// <param name="value">
+        ///     an <c>xs:date</c>, an <c>xs:dateTime</c>,
+        ///     or an <c>xs:dateTimeStamp</c></param>
+        /// <returns>
+        ///     <c>true</c> if the value starts with a valid date
+        /// </returns>
+        private static bool IsPrefixedWithValidDate(string value)
+        {
+            // NOTE (mristin, 2022-11-02):
+            // We can not use System.DateTime.ParseExact since it does not handle the zero and
+            // BCE years correctly. Therefore, we have to roll out our own date validator.
+            var match = RegexDatePrefix.Match(value);
+            if (!match.Success)
+            {
+                return false;
+            }
+
+            bool ok = System.Numerics.BigInteger.TryParse(
+                match.Groups[1].Value,
+                out System.Numerics.BigInteger year);
+            if (!ok)
+            {
+                throw new System.InvalidOperationException(
+                    $"Expected to parse the year from {match.Groups[1].Value}, " +
+                    $"but the parsing failed");
+            }
+
+            ok = System.SByte.TryParse(match.Groups[2].Value, out sbyte month);
+            if (!ok)
+            {
+                throw new System.InvalidOperationException(
+                    $"Expected to parse the month from {match.Groups[2].Value}, " +
+                    $"but the parsing failed");
+            }
+
+            ok = System.SByte.TryParse(match.Groups[3].Value, out sbyte day);
+            if (!ok)
+            {
+                throw new System.InvalidOperationException(
+                    $"Expected to parse the day from {match.Groups[3].Value}, " +
+                    $"but the parsing failed");
+            }
+
+            // Year zero does not exist, see: https://www.w3.org/TR/xmlschema-2/#dateTime
+            if (year == 0)
+            {
+                return false;
+            }
+
+            if (day <= 0 || day > 31)
+            {
+                return false;
+            }
+
+            if (month <= 0 || month >= 13)
+            {
+                return false;
+            }
+
+            sbyte maxDaysInMonth;
+            switch (month)
+            {
+                case 1:
+                    maxDaysInMonth = 31;
+                    break;
+                case 2:
+                    maxDaysInMonth = (IsLeapYear(year)) ? (sbyte)29 : (sbyte)28;
+                    break;
+                case 3:
+                    maxDaysInMonth = 31;
+                    break;
+                case 4:
+                    maxDaysInMonth = 30;
+                    break;
+                case 5:
+                    maxDaysInMonth = 31;
+                    break;
+                case 6:
+                    maxDaysInMonth = 30;
+                    break;
+                case 7:
+                    maxDaysInMonth = 31;
+                    break;
+                case 8:
+                    maxDaysInMonth = 31;
+                    break;
+                case 9:
+                    maxDaysInMonth = 30;
+                    break;
+                case 10:
+                    maxDaysInMonth = 31;
+                    break;
+                case 11:
+                    maxDaysInMonth = 30;
+                    break;
+                case 12:
+                    maxDaysInMonth = 31;
+                    break;
+                default:
+                    throw new System.InvalidOperationException($"Unexpected month: {month}");
+            }
+
+            if (day > maxDaysInMonth)
+            {
+                return false;
+            }
+
+            return true;
         }
 
         /// <summary>
@@ -153,20 +264,7 @@ namespace AasCore.Aas3_0_RC02
                 return false;
             }
 
-            try
-            {
-                // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
-                System.DateTime.ParseExact(
-                    ClipToDate(value),
-                    XsDateFormats,
-                    System.Globalization.CultureInfo.InvariantCulture,
-                    System.Globalization.DateTimeStyles.None);
-                return true;
-            }
-            catch (System.FormatException)
-            {
-                return false;
-            }
+            return IsPrefixedWithValidDate(value);
         }
 
         [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
@@ -1434,20 +1532,7 @@ namespace AasCore.Aas3_0_RC02
                         return false;
                     }
 
-                    try
-                    {
-                        // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
-                        System.DateTime.ParseExact(
-                            ClipToDate(value),
-                            XsDateFormats,
-                            System.Globalization.CultureInfo.InvariantCulture,
-                            System.Globalization.DateTimeStyles.None );
-                        return true;
-                    }
-                    catch (System.FormatException)
-                    {
-                        return false;
-                    }
+                    return IsPrefixedWithValidDate(value);
                 }
                 case Aas.DataTypeDefXsd.DateTime:
                 {
@@ -1459,21 +1544,7 @@ namespace AasCore.Aas3_0_RC02
                     // The time part and the time zone part will be checked by
                     // MatchesXsDateTime. We need to check that the date part is
                     // correct in sense of the day/month combination.
-
-                    try
-                    {
-                        // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
-                        System.DateTime.ParseExact(
-                            ClipToDate(value),
-                            XsDateFormats,
-                            System.Globalization.CultureInfo.InvariantCulture,
-                            System.Globalization.DateTimeStyles.None );
-                        return true;
-                    }
-                    catch (System.FormatException)
-                    {
-                        return false;
-                    }
+                    return IsPrefixedWithValidDate(value);
                 }
                 case Aas.DataTypeDefXsd.DateTimeStamp:
                 {
@@ -1485,21 +1556,7 @@ namespace AasCore.Aas3_0_RC02
                     // The time part and the time zone part will be checked by
                     // MatchesXsDateTimeStamp. We need to check that the date part is
                     // correct in sense of the day/month combination.
-
-                    try
-                    {
-                        // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
-                        System.DateTime.ParseExact(
-                            ClipToDate(value),
-                            XsDateFormats,
-                            System.Globalization.CultureInfo.InvariantCulture,
-                            System.Globalization.DateTimeStyles.None );
-                        return true;
-                    }
-                    catch (System.FormatException)
-                    {
-                        return false;
-                    }
+                    return IsPrefixedWithValidDate(value);
                 }
                 case Aas.DataTypeDefXsd.Decimal:
                 {

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/input/snippets/Verification/is_xs_date_time_stamp_UTC.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/input/snippets/Verification/is_xs_date_time_stamp_UTC.cs
@@ -1,44 +1,155 @@
-private static readonly string[] XsDateFormats = {
-    "yyyy-MM-dd"
-};
+private static Regex RegexDatePrefix = new Regex("^(-?[0-9]+)-([0-9]{2})-([0-9]{2})");
 
 /// <summary>
-/// Clip the <paramref name="value" /> to the date part.
+/// Check whether the given year is a leap year.
 /// </summary>
-/// <remarks>
-/// We ignore the negative sign prefix and clip years to 4 digits.
-/// This is necessary as <see cref="System.DateTime" /> can not handle
-/// dates B.C. and the <see cref="o:System.DateTime.ParseExact" /> expects
-/// exactly four digits.
-///
-/// We strip the negative sign and assume astronomical years.
-/// See: https://en.wikipedia.org/wiki/Leap_year#Algorithm and
-/// the note at: https://www.w3.org/TR/xmlschema-2/#dateTime
-///
-/// Furthermore, we always assume that <paramref name="value" /> has been
-/// already validated with the corresponding regular expression.
-/// Hence we can use this function to validate the date-times as the time
-/// segment and offsets are correctly matched by the regular expression,
-/// while day/month combinations need to be validated by
-/// <see cref="o:System.DateTime.ParseExact" />.
-/// </remarks>
-private static string ClipToDate(string value)
+/// <remarks>Year 1 BCE is a leap year.</remarks>
+/// <param name="year">to be checked</param>
+/// <returns>True if <paramref name="year"/> is a leap year</returns>
+public static bool IsLeapYear(System.Numerics.BigInteger year)
 {
-    int start = 0;
-    if (value[0] == '-')
+    // NOTE (mristin, 2022-11-02):
+    // We consider the years B.C. to be one-off.
+    // See the note at: https://www.w3.org/TR/xmlschema-2/#dateTime:
+    // "'-0001' is the lexical representation of the year 1 Before Common Era
+    // (1 BCE, sometimes written "1 BC")."
+    //
+    // Hence, -1 year in XML is 1 BCE, which is 0 year in astronomical years.
+    if (year < 0)
     {
-        start++;
+        year = -year - 1;
     }
 
-    int yearEnd = start;
-    for (; value[yearEnd] != '-'; yearEnd++)
+    // See: See: https://en.wikipedia.org/wiki/Leap_year#Algorithm
+    if (year % 4 > 0)
     {
-        // Intentionally empty.
+        return false;
     }
 
-    return (yearEnd == 4 && value.Length == 10)
-        ? value
-        : value.Substring(yearEnd - 4, 10);
+    if (year % 100 > 0)
+    {
+        return true;
+    }
+
+    if (year % 400 > 0)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+/// <summary>
+/// Check that the value starts with a valid date.
+/// </summary>
+/// <param name="value">
+///     an <c>xs:date</c>, an <c>xs:dateTime</c>,
+///     or an <c>xs:dateTimeStamp</c></param>
+/// <returns>
+///     <c>true</c> if the value starts with a valid date
+/// </returns>
+private static bool IsPrefixedWithValidDate(string value)
+{
+    // NOTE (mristin, 2022-11-02):
+    // We can not use System.DateTime.ParseExact since it does not handle the zero and
+    // BCE years correctly. Therefore, we have to roll out our own date validator.
+    var match = RegexDatePrefix.Match(value);
+    if (!match.Success)
+    {
+        return false;
+    }
+
+    bool ok = System.Numerics.BigInteger.TryParse(
+        match.Groups[1].Value,
+        out System.Numerics.BigInteger year);
+    if (!ok)
+    {
+        throw new System.InvalidOperationException(
+            $"Expected to parse the year from {match.Groups[1].Value}, " +
+            $"but the parsing failed");
+    }
+
+    ok = System.SByte.TryParse(match.Groups[2].Value, out sbyte month);
+    if (!ok)
+    {
+        throw new System.InvalidOperationException(
+            $"Expected to parse the month from {match.Groups[2].Value}, " +
+            $"but the parsing failed");
+    }
+
+    ok = System.SByte.TryParse(match.Groups[3].Value, out sbyte day);
+    if (!ok)
+    {
+        throw new System.InvalidOperationException(
+            $"Expected to parse the day from {match.Groups[3].Value}, " +
+            $"but the parsing failed");
+    }
+
+    // Year zero does not exist, see: https://www.w3.org/TR/xmlschema-2/#dateTime
+    if (year == 0)
+    {
+        return false;
+    }
+
+    if (day <= 0 || day > 31)
+    {
+        return false;
+    }
+
+    if (month <= 0 || month >= 13)
+    {
+        return false;
+    }
+
+    sbyte maxDaysInMonth;
+    switch (month)
+    {
+        case 1:
+            maxDaysInMonth = 31;
+            break;
+        case 2:
+            maxDaysInMonth = (IsLeapYear(year)) ? (sbyte)29 : (sbyte)28;
+            break;
+        case 3:
+            maxDaysInMonth = 31;
+            break;
+        case 4:
+            maxDaysInMonth = 30;
+            break;
+        case 5:
+            maxDaysInMonth = 31;
+            break;
+        case 6:
+            maxDaysInMonth = 30;
+            break;
+        case 7:
+            maxDaysInMonth = 31;
+            break;
+        case 8:
+            maxDaysInMonth = 31;
+            break;
+        case 9:
+            maxDaysInMonth = 30;
+            break;
+        case 10:
+            maxDaysInMonth = 31;
+            break;
+        case 11:
+            maxDaysInMonth = 30;
+            break;
+        case 12:
+            maxDaysInMonth = 31;
+            break;
+        default:
+            throw new System.InvalidOperationException($"Unexpected month: {month}");
+    }
+
+    if (day > maxDaysInMonth)
+    {
+        return false;
+    }
+
+    return true;
 }
 
 /// <summary>
@@ -54,18 +165,5 @@ public static bool IsXsDateTimeStampUtc(
         return false;
     }
 
-    try
-    {
-        // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
-        System.DateTime.ParseExact(
-            ClipToDate(value),
-            XsDateFormats,
-            System.Globalization.CultureInfo.InvariantCulture,
-            System.Globalization.DateTimeStyles.None);
-        return true;
-    }
-    catch (System.FormatException)
-    {
-        return false;
-    }
+    return IsPrefixedWithValidDate(value);
 }

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/input/snippets/Verification/value_consistent_with_xsd_type.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/input/snippets/Verification/value_consistent_with_xsd_type.cs
@@ -28,20 +28,7 @@ public static bool ValueConsistentWithXsdType(
                 return false;
             }
 
-            try
-            {
-                // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
-                System.DateTime.ParseExact(
-                    ClipToDate(value),
-                    XsDateFormats,
-                    System.Globalization.CultureInfo.InvariantCulture,
-                    System.Globalization.DateTimeStyles.None );
-                return true;
-            }
-            catch (System.FormatException)
-            {
-                return false;
-            }
+            return IsPrefixedWithValidDate(value);
         }
         case Aas.DataTypeDefXsd.DateTime:
         {
@@ -53,21 +40,7 @@ public static bool ValueConsistentWithXsdType(
             // The time part and the time zone part will be checked by
             // MatchesXsDateTime. We need to check that the date part is
             // correct in sense of the day/month combination.
-
-            try
-            {
-                // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
-                System.DateTime.ParseExact(
-                    ClipToDate(value),
-                    XsDateFormats,
-                    System.Globalization.CultureInfo.InvariantCulture,
-                    System.Globalization.DateTimeStyles.None );
-                return true;
-            }
-            catch (System.FormatException)
-            {
-                return false;
-            }
+            return IsPrefixedWithValidDate(value);
         }
         case Aas.DataTypeDefXsd.DateTimeStamp:
         {
@@ -79,21 +52,7 @@ public static bool ValueConsistentWithXsdType(
             // The time part and the time zone part will be checked by
             // MatchesXsDateTimeStamp. We need to check that the date part is
             // correct in sense of the day/month combination.
-
-            try
-            {
-                // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
-                System.DateTime.ParseExact(
-                    ClipToDate(value),
-                    XsDateFormats,
-                    System.Globalization.CultureInfo.InvariantCulture,
-                    System.Globalization.DateTimeStyles.None );
-                return true;
-            }
-            catch (System.FormatException)
-            {
-                return false;
-            }
+            return IsPrefixedWithValidDate(value);
         }
         case Aas.DataTypeDefXsd.Decimal:
         {


### PR DESCRIPTION
We explicitly tested for zero and BCE years in
[aas-core3.0rc02-testgen eeba8f71] which revealed that the C# SDK did not handle those edge cases correctly.

In this patch, we re-write the snippets for date verification in the test data for C# SDK.

[aas-core3.0rc02-testgen eeba8f71]: https://github.com/aas-core-works/aas-core3.0rc02-testgen/commit/eeba8f71