### PR TITLE
Fix C# code inspection issues due to 1d12eaed

### DIFF
--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/verification.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/verification.cs
@@ -97,7 +97,8 @@ namespace AasCore.Aas3_0_RC02
             return RegexMatchesXsDateTimeStampUtc.IsMatch(text);
         }
 
-        private static Regex RegexDatePrefix = new Regex("^(-?[0-9]+)-([0-9]{2})-([0-9]{2})");
+        private static readonly Regex RegexDatePrefix = (
+            new Regex("^(-?[0-9]+)-([0-9]{2})-([0-9]{2})"));
 
         /// <summary>
         /// Check whether the given year is a leap year.
@@ -165,7 +166,7 @@ namespace AasCore.Aas3_0_RC02
             {
                 throw new System.InvalidOperationException(
                     $"Expected to parse the year from {match.Groups[1].Value}, " +
-                    $"but the parsing failed");
+                    "but the parsing failed");
             }
 
             ok = System.SByte.TryParse(match.Groups[2].Value, out sbyte month);
@@ -173,7 +174,7 @@ namespace AasCore.Aas3_0_RC02
             {
                 throw new System.InvalidOperationException(
                     $"Expected to parse the month from {match.Groups[2].Value}, " +
-                    $"but the parsing failed");
+                    "but the parsing failed");
             }
 
             ok = System.SByte.TryParse(match.Groups[3].Value, out sbyte day);
@@ -181,7 +182,7 @@ namespace AasCore.Aas3_0_RC02
             {
                 throw new System.InvalidOperationException(
                     $"Expected to parse the day from {match.Groups[3].Value}, " +
-                    $"but the parsing failed");
+                    "but the parsing failed");
             }
 
             // Year zero does not exist, see: https://www.w3.org/TR/xmlschema-2/#dateTime

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/input/snippets/Verification/is_xs_date_time_stamp_UTC.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/input/snippets/Verification/is_xs_date_time_stamp_UTC.cs
@@ -1,4 +1,5 @@
-private static Regex RegexDatePrefix = new Regex("^(-?[0-9]+)-([0-9]{2})-([0-9]{2})");
+private static readonly Regex RegexDatePrefix = (
+    new Regex("^(-?[0-9]+)-([0-9]{2})-([0-9]{2})"));
 
 /// <summary>
 /// Check whether the given year is a leap year.
@@ -66,7 +67,7 @@ private static bool IsPrefixedWithValidDate(string value)
     {
         throw new System.InvalidOperationException(
             $"Expected to parse the year from {match.Groups[1].Value}, " +
-            $"but the parsing failed");
+            "but the parsing failed");
     }
 
     ok = System.SByte.TryParse(match.Groups[2].Value, out sbyte month);
@@ -74,7 +75,7 @@ private static bool IsPrefixedWithValidDate(string value)
     {
         throw new System.InvalidOperationException(
             $"Expected to parse the month from {match.Groups[2].Value}, " +
-            $"but the parsing failed");
+            "but the parsing failed");
     }
 
     ok = System.SByte.TryParse(match.Groups[3].Value, out sbyte day);
@@ -82,7 +83,7 @@ private static bool IsPrefixedWithValidDate(string value)
     {
         throw new System.InvalidOperationException(
             $"Expected to parse the day from {match.Groups[3].Value}, " +
-            $"but the parsing failed");
+            "but the parsing failed");
     }
 
     // Year zero does not exist, see: https://www.w3.org/TR/xmlschema-2/#dateTime


### PR DESCRIPTION
We were too hasty to merge in the changes in 1d12eaed which cause a couple of minor code inspection issues.

In this patch, we fix the snippets in the test data so that the code inspection for C# SDK passes.