### PR TITLE
Fix xmlization docs for C# in test data

### DIFF
--- a/aas_core_codegen/csharp/xmlization/_generate.py
+++ b/aas_core_codegen/csharp/xmlization/_generate.py
@@ -1843,21 +1843,6 @@ public static void To(
 /// {I}{an_instance_variable},
 /// {I}writer);
 /// </code>
-///
-/// </example>
-/// <example>
-/// You can also set the namespace and the prefix:
-/// <code>
-/// var {an_instance_variable} = new Aas.{cls_name}(
-///     /* ... some constructor arguments ... */
-/// );
-/// var writer = new System.Xml.XmlWriter( /* some arguments */ );
-/// Serialize.To(
-/// {I}{an_instance_variable},
-/// {I}writer,
-/// {I}"somePrefix",
-/// {I}"https://some-namespace.com");
-/// </code>
 /// </example>
 """
         )

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/xmlization.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/xmlization.cs
@@ -26025,21 +26025,6 @@ namespace AasCore.Aas3_0_RC02
         ///     anInstance,
         ///     writer);
         /// </code>
-        ///
-        /// </example>
-        /// <example>
-        /// You can also set the namespace and the prefix:
-        /// <code>
-        /// var anInstance = new Aas.IHasSemantics(
-        ///     /* ... some constructor arguments ... */
-        /// );
-        /// var writer = new System.Xml.XmlWriter( /* some arguments */ );
-        /// Serialize.To(
-        ///     anInstance,
-        ///     writer,
-        ///     "somePrefix",
-        ///     "https://some-namespace.com");
-        /// </code>
         /// </example>
         public static class Serialize
         {


### PR DESCRIPTION
The docs for XML serialization for C# has been outdated. It still listed the namespace and the prefix argument from the original design which has been removed in the meanwhile.

This patch fixes the generator so that the generated docs are in sync with the generated code.