### PR TITLE
Report errors if classes missing for RDF and XSD

### DIFF
--- a/aas_core_codegen/rdf_shacl/shacl.py
+++ b/aas_core_codegen/rdf_shacl/shacl.py
@@ -325,28 +325,27 @@ def generate(
     if some_errors is not None:
         errors.extend(some_errors)
 
+    lang_string_cls, lang_string_error = rdf_shacl_common.get_lang_string_as_expected(
+        symbol_table=symbol_table
+    )
+    if lang_string_error is not None:
+        errors.append(lang_string_error)
+
     if len(errors) > 0:
         return None, errors
 
     assert constraints_by_class is not None
+    assert lang_string_cls is not None
 
     for our_type in sorted(
         symbol_table.our_types,
         key=lambda another_our_type: rdf_shacl_naming.class_name(another_our_type.name),
     ):
-        if our_type.name == "Lang_string":
+        if our_type is lang_string_cls:
             # NOTE (mristin, 2022-09-01):
-            # We hard-wire the langString's to rdf:langString. Admittedly, this is
-            # hacky. We could have made the class ``Lang_string``
-            # implementation-specific and defined its ``rdfs:range`` manually as
-            # a snippet.
-            #
-            # However, we decided against that as such a design would force us to
-            # define langString for every language and schema which do not natively
-            # support it, write custom data generation methods *etc.* Given that
-            # RDF+SHACL codegen is one out of many code generators we leave the
-            # other code generators and test data generators as simple as possible,
-            # and make this code generator a bit hacky in return.
+            # Please see
+            # :py:const`aas_core_codegen.rdf_shacl.common._EXPLANATION_ABOUT_WHY_WE_EXPECT_LANG_STRING`
+            # on why we hard-wire ``Lang_string`` here.
             continue
 
         # noinspection PyUnusedLocal


### PR DESCRIPTION
We hard-wire ``Lang_string`` and ``Value_data_type`` in RDF and XSD generators, respectively. This is indeed hacky (see the explanations in the patch), but this way we keep the other code and test data generators much simpler.

Previously, if the expected types ``Lang_string`` and ``Value_data_type`` have not been defined in the meta-model, we raised exceptions which confused the user. In this patch, we report informative errors explaining the background to the user as well.