### PR TITLE
De-duplicate code in ``naming``

### DIFF
--- a/aas_core_codegen/csharp/naming.py
+++ b/aas_core_codegen/csharp/naming.py
@@ -1,6 +1,7 @@
 """Generate C# identifiers based on the identifiers from the meta-model."""
 from typing import Union
 
+import aas_core_codegen.naming
 from aas_core_codegen import intermediate
 from aas_core_codegen.common import Identifier, assert_never
 
@@ -15,9 +16,7 @@ def interface_name(identifier: Identifier) -> Identifier:
     >>> interface_name(Identifier("URL_to_something"))
     'IUrlToSomething'
     """
-    parts = identifier.split("_")
-
-    return Identifier("I{}".format("".join(part.capitalize() for part in parts)))
+    return Identifier(f"I{aas_core_codegen.naming.capitalized_camel_case(identifier)}")
 
 
 def enum_name(identifier: Identifier) -> Identifier:
@@ -30,9 +29,7 @@ def enum_name(identifier: Identifier) -> Identifier:
     >>> enum_name(Identifier("URL_to_something"))
     'UrlToSomething'
     """
-    parts = identifier.split("_")
-
-    return Identifier("{}".format("".join(part.capitalize() for part in parts)))
+    return aas_core_codegen.naming.capitalized_camel_case(identifier)
 
 
 def enum_literal_name(identifier: Identifier) -> Identifier:
@@ -45,9 +42,7 @@ def enum_literal_name(identifier: Identifier) -> Identifier:
     >>> enum_literal_name(Identifier("URL_to_something"))
     'UrlToSomething'
     """
-    parts = identifier.split("_")
-
-    return Identifier("{}".format("".join(part.capitalize() for part in parts)))
+    return aas_core_codegen.naming.capitalized_camel_case(identifier)
 
 
 def class_name(identifier: Identifier) -> Identifier:
@@ -60,9 +55,7 @@ def class_name(identifier: Identifier) -> Identifier:
     >>> class_name(Identifier("URL_to_something"))
     'UrlToSomething'
     """
-    parts = identifier.split("_")
-
-    return Identifier("{}".format("".join(part.capitalize() for part in parts)))
+    return aas_core_codegen.naming.capitalized_camel_case(identifier)
 
 
 def name_of(
@@ -96,16 +89,7 @@ def property_name(identifier: Identifier) -> Identifier:
     >>> property_name(Identifier("something_to_URL"))
     'SomethingToUrl'
     """
-    parts = identifier.split("_")
-
-    if len(parts) == 1:
-        return Identifier(parts[0].capitalize())
-
-    return Identifier(
-        "{}{}".format(
-            parts[0].capitalize(), "".join(part.capitalize() for part in parts[1:])
-        )
-    )
+    return aas_core_codegen.naming.capitalized_camel_case(identifier)
 
 
 def private_property_name(identifier: Identifier) -> Identifier:
@@ -118,16 +102,7 @@ def private_property_name(identifier: Identifier) -> Identifier:
     >>> private_property_name(Identifier("something_to_URL"))
     '_somethingToUrl'
     """
-    parts = identifier.split("_")
-
-    if len(parts) == 1:
-        return Identifier(f"_{Identifier(parts[0].lower())}")
-
-    return Identifier(
-        "_{}{}".format(
-            parts[0].lower(), "".join(part.capitalize() for part in parts[1:])
-        )
-    )
+    return Identifier(f"_{aas_core_codegen.naming.lower_camel_case(identifier)}")
 
 
 def private_method_name(identifier: Identifier) -> Identifier:
@@ -140,16 +115,7 @@ def private_method_name(identifier: Identifier) -> Identifier:
     >>> private_method_name(Identifier("something_to_URL"))
     '_somethingToUrl'
     """
-    parts = identifier.split("_")
-
-    if len(parts) == 1:
-        return Identifier(f"_{Identifier(parts[0].lower())}")
-
-    return Identifier(
-        "_{}{}".format(
-            parts[0].lower(), "".join(part.capitalize() for part in parts[1:])
-        )
-    )
+    return Identifier(f"_{aas_core_codegen.naming.lower_camel_case(identifier)}")
 
 
 def method_name(identifier: Identifier) -> Identifier:
@@ -162,16 +128,7 @@ def method_name(identifier: Identifier) -> Identifier:
     >>> method_name(Identifier("do_something_to_URL"))
     'DoSomethingToUrl'
     """
-    parts = identifier.split("_")
-
-    if len(parts) == 1:
-        return Identifier(parts[0].capitalize())
-
-    return Identifier(
-        "{}{}".format(
-            parts[0].capitalize(), "".join(part.capitalize() for part in parts[1:])
-        )
-    )
+    return aas_core_codegen.naming.capitalized_camel_case(identifier)
 
 
 def argument_name(identifier: Identifier) -> Identifier:
@@ -184,16 +141,7 @@ def argument_name(identifier: Identifier) -> Identifier:
     >>> argument_name(Identifier("something_to_URL"))
     'somethingToUrl'
     """
-    parts = identifier.split("_")
-
-    if len(parts) == 1:
-        return Identifier(parts[0].lower())
-
-    return Identifier(
-        "{}{}".format(
-            parts[0].lower(), "".join(part.capitalize() for part in parts[1:])
-        )
-    )
+    return aas_core_codegen.naming.lower_camel_case(identifier)
 
 
 def variable_name(identifier: Identifier) -> Identifier:
@@ -206,13 +154,4 @@ def variable_name(identifier: Identifier) -> Identifier:
     >>> variable_name(Identifier("something_to_URL"))
     'somethingToUrl'
     """
-    parts = identifier.split("_")
-
-    if len(parts) == 1:
-        return Identifier(parts[0].lower())
-
-    return Identifier(
-        "{}{}".format(
-            parts[0].lower(), "".join(part.capitalize() for part in parts[1:])
-        )
-    )
+    return aas_core_codegen.naming.lower_camel_case(identifier)

--- a/aas_core_codegen/naming.py
+++ b/aas_core_codegen/naming.py
@@ -6,6 +6,33 @@ from icontract import ensure, require
 from aas_core_codegen.common import Identifier
 
 
+def lower_camel_case(identifier: Identifier) -> Identifier:
+    """Convert the identifier to a ``camelCase``."""
+    parts = identifier.split("_")
+
+    assert len(parts) > 0, "Expected at least one part in the identifier"
+
+    if len(parts) == 1:
+        return Identifier(parts[0].lower())
+
+    cased_parts = []  # type: List[str]
+
+    iterator = iter(parts)
+    first_part = next(iterator)
+    cased_parts.append(first_part.lower())
+
+    for part in iterator:
+        cased_parts.append(part.capitalize())
+
+    return Identifier("".join(cased_parts))
+
+
+def capitalized_camel_case(identifier: Identifier) -> Identifier:
+    """Convert the identifier to a ``CamelCase``."""
+    parts = identifier.split("_")
+    return Identifier("".join(part.capitalize() for part in parts))
+
+
 def json_property(identifier: Identifier) -> Identifier:
     """
     Generate a JSON name of a property based on its meta-model ``identifier``.
@@ -22,16 +49,7 @@ def json_property(identifier: Identifier) -> Identifier:
     >>> json_property(Identifier("specific_asset_IDs"))
     'specificAssetIds'
     """
-    parts = identifier.split("_")
-
-    if len(parts) == 1:
-        return Identifier(parts[0].lower())
-
-    cased_parts = [parts[0].lower()]  # type: List[str]
-    for part in parts[1:]:
-        cased_parts.append(part.capitalize())
-
-    return Identifier("".join(cased_parts))
+    return lower_camel_case(identifier)
 
 
 # fmt: off
@@ -57,7 +75,6 @@ def json_model_type(identifier: Identifier) -> Identifier:
     'URLToSomething'
     """
     parts = identifier.split("_")
-
     return Identifier(
         "".join(part.capitalize() if part == part.lower() else part for part in parts)
     )
@@ -79,20 +96,7 @@ def xml_class_name(identifier: Identifier) -> Identifier:
     >>> xml_class_name(Identifier("URL_to_something"))
     'urlToSomething'
     """
-    parts = identifier.split("_")
-    assert (
-        len(parts) >= 1
-    ), f"Expected at least one part for the valid identifier: {identifier}"
-
-    if len(parts) == 1:
-        return Identifier(parts[0].lower())
-
-    # pylint: disable=consider-using-f-string
-    return Identifier(
-        "{}{}".format(
-            parts[0].lower(), "".join(part.capitalize() for part in parts[1:])
-        )
-    )
+    return lower_camel_case(identifier)
 
 
 def xml_property(identifier: Identifier) -> Identifier:
@@ -105,17 +109,4 @@ def xml_property(identifier: Identifier) -> Identifier:
     >>> xml_property(Identifier("URL_to_something"))
     'urlToSomething'
     """
-    parts = identifier.split("_")
-    assert (
-        len(parts) >= 1
-    ), f"Expected at least one part for the valid identifier: {identifier}"
-
-    if len(parts) == 1:
-        return Identifier(parts[0].lower())
-
-    # pylint: disable=consider-using-f-string
-    return Identifier(
-        "{}{}".format(
-            parts[0].lower(), "".join(part.capitalize() for part in parts[1:])
-        )
-    )
+    return lower_camel_case(identifier)


### PR DESCRIPTION
We refactor the code in the ``naming`` module into fewer functions, so that the dependent naming modules can re-use them. This makes it more obvious for the reader which casing is used.

While duplication is in similar cases often better for readability, we already observed related bugs in the TypeScript generator (which is still a work-in-progress), so we react accordingly.