### PR TITLE
Fix ignored verification erros in ``main``

### DIFF
--- a/aas_core_codegen/csharp/main.py
+++ b/aas_core_codegen/csharp/main.py
@@ -190,9 +190,9 @@ def execute(context: run.Context, stdout: TextIO, stderr: TextIO) -> int:
         verification_functions=verified_ir_table.verification_functions,
     )
 
-    if errors is not None:
+    if verify_errors is not None:
         run.write_error_report(
-            message="Failed to verify the C#-specific structures",
+            message="Failed to verify for generation of C# verification code",
             errors=verify_errors,
             stderr=stderr,
         )

--- a/aas_core_codegen/python/main.py
+++ b/aas_core_codegen/python/main.py
@@ -213,7 +213,7 @@ def execute(context: run.Context, stdout: TextIO, stderr: TextIO) -> int:
         verification_functions=verified_ir_table.verification_functions,
     )
 
-    if errors is not None:
+    if verify_errors is not None:
         run.write_error_report(
             message="Failed to verify the Python-specific structures",
             errors=verify_errors,


### PR DESCRIPTION
In the ``main`` of the C# and Python generator we mistakenly ignored the verification errors due to misnaming of the local variable. We fix the issue in this patch.