### PR TITLE
Fix minor typo in Python jsonization

### DIFF
--- a/aas_core_codegen/python/jsonization/_generate.py
+++ b/aas_core_codegen/python/jsonization/_generate.py
@@ -1094,7 +1094,7 @@ class PropertySegment:
 class IndexSegment:
 {I}\"\"\"Represent an index access on a path to the erroneous value.\"\"\"
 
-{I}#: Containers that contains the item
+{I}#: Container that contains the item
 {I}container: Final[Iterable[Any]]
 
 {I}#: Index of the item

--- a/test_data/python/test_main/aas_core_meta.v3rc2/expected_output/jsonization.py
+++ b/test_data/python/test_main/aas_core_meta.v3rc2/expected_output/jsonization.py
@@ -58,7 +58,7 @@ class PropertySegment:
 class IndexSegment:
     """Represent an index access on a path to the erroneous value."""
 
-    #: Containers that contains the item
+    #: Container that contains the item
     container: Final[Iterable[Any]]
 
     #: Index of the item


### PR DESCRIPTION
We fix the error where we mistakenly wrote "Containers" instead of a single "container" in ``IndexSegment``. The ``IndexSegment`` refers to an array so there can not be multiple containers.