### PR TITLE
Fix erroneous references to C# from Python

### DIFF
--- a/aas_core_codegen/python/common.py
+++ b/aas_core_codegen/python/common.py
@@ -257,7 +257,7 @@ PRIMITIVE_TYPE_MAP = {
 
 
 def _assert_all_primitive_types_are_mapped() -> None:
-    """Assert that we have explicitly mapped all the primitive types to C#."""
+    """Assert that all the primitive types are mapped to Python ones."""
     all_primitive_literals = set(literal.value for literal in PRIMITIVE_TYPE_MAP)
 
     mapped_primitive_literals = set(

--- a/aas_core_codegen/python/transpilation.py
+++ b/aas_core_codegen/python/transpilation.py
@@ -20,7 +20,7 @@ from aas_core_codegen.common import (
     indent_but_first_line,
     Identifier,
 )
-from aas_core_codegen.csharp.common import (
+from aas_core_codegen.python.common import (
     INDENT as I,
 )
 from aas_core_codegen.intermediate import type_inference as intermediate_type_inference

--- a/aas_core_codegen/python/verification/_generate.py
+++ b/aas_core_codegen/python/verification/_generate.py
@@ -22,7 +22,7 @@ from aas_core_codegen.common import (
     wrap_text_into_lines,
     assert_union_without_excluded,
 )
-from aas_core_codegen.csharp.common import (
+from aas_core_codegen.python.common import (
     INDENT as I,
     INDENT2 as II,
     INDENT3 as III,


### PR DESCRIPTION
We introduced a couple of innoucous invalid references in Python generator by copy/pasting from C# generator when we first wrote it.

We rectify these invalid references to Python in this patch.