### PR TITLE
Rename ``Unroller`` to ``AbstractUnroller``

### DIFF
--- a/aas_core_codegen/csharp/structure/_generate.py
+++ b/aas_core_codegen/csharp/structure/_generate.py
@@ -447,7 +447,7 @@ public IEnumerable<{items_type}> Over{prop_name}OrEmpty();"""
     return Stripped(writer.getvalue()), None
 
 
-class _DescendBodyUnroller(csharp_unrolling.Unroller):
+class _DescendBodyUnroller(csharp_unrolling.AbstractUnroller):
     """Generate the code that unrolls descent into an element."""
 
     #: If set, generates the code with unrolled yields.
@@ -503,7 +503,7 @@ class _DescendBodyUnroller(csharp_unrolling.Unroller):
 
         if self._recurse:
             if self._descendability[type_annotation]:
-                recurse_var = csharp_unrolling.Unroller._loop_var_name(
+                recurse_var = csharp_unrolling.AbstractUnroller._loop_var_name(
                     level=item_level, suffix="Item"
                 )
 
@@ -538,7 +538,7 @@ class _DescendBodyUnroller(csharp_unrolling.Unroller):
         key_value_level: int,
     ) -> List[csharp_unrolling.Node]:
         """Generate code for the given specific ``type_annotation``."""
-        item_var = csharp_unrolling.Unroller._loop_var_name(
+        item_var = csharp_unrolling.AbstractUnroller._loop_var_name(
             level=item_level, suffix="Item"
         )
 

--- a/aas_core_codegen/csharp/unrolling.py
+++ b/aas_core_codegen/csharp/unrolling.py
@@ -55,7 +55,7 @@ def render(node: Node) -> str:
     return writer.getvalue()
 
 
-class Unroller(DBC):
+class AbstractUnroller(DBC):
     """Generate code to unroll recursion into generic types."""
 
     # NOTE (mristin, 2022-09-15):

--- a/aas_core_codegen/python/structure/_generate.py
+++ b/aas_core_codegen/python/structure/_generate.py
@@ -382,7 +382,7 @@ def _generate_enum(
     return Stripped(writer.getvalue()), None
 
 
-class _DescendBodyUnroller(python_unrolling.Unroller):
+class _DescendBodyUnroller(python_unrolling.AbstractUnroller):
     """Generate the code that unrolls descent into an element."""
 
     #: If set, generates the code with unrolled yields.

--- a/aas_core_codegen/python/unrolling.py
+++ b/aas_core_codegen/python/unrolling.py
@@ -52,7 +52,7 @@ def render(node: Node) -> str:
     return writer.getvalue()
 
 
-class Unroller(DBC):
+class AbstractUnroller(DBC):
     """Generate code to unroll recursion into generic types."""
 
     @require(lambda list_loop_level: list_loop_level >= 0)


### PR DESCRIPTION
Since ``Unroller`` is an abstract class, and intentionally so, we rename it to ``AbstractUnroller`` to aid the reader so that it is obvious that the concrete class is an implementation, while the abstract class gives only a scaffolding.