### PR TITLE
Generate constructors with no arguments in Python

### DIFF
--- a/aas_core_codegen/python/structure/_generate.py
+++ b/aas_core_codegen/python/structure/_generate.py
@@ -654,7 +654,7 @@ def _generate_constructor(
 
     Return empty string if there is an empty constructor.
     """
-    if len(cls.constructor.arguments) == 0:
+    if len(cls.constructor.arguments) == 0 and len(cls.constructor.statements) == 0:
         return Stripped(""), None
 
     # region Construct the body
@@ -762,6 +762,8 @@ self.{python_naming.property_name(stmt.name)} = (
 
     writer = io.StringIO()
 
+    if len(arg_codes) == 0:
+        writer.write("def __init__(self) -> None:\n")
     if len(arg_codes) == 1:
         writer.write(f"def __init__(self, {arg_codes[0]}) -> None:\n")
     else:


### PR DESCRIPTION
While we do not test for this logic at the moment, we reviewed the Python code while writing the TypeScript generator (which is still work-in-progress). It turns out that we missed the case where there are statements in constructors, but no arguments.

In this patch, we generate the constructors as soon as they have statements, regardless of the number of arguments (which can be zero or more).