### PR TITLE
Fix transpilation of function names in Python

### DIFF
--- a/aas_core_codegen/python/transpilation.py
+++ b/aas_core_codegen/python/transpilation.py
@@ -395,7 +395,11 @@ not (
         if isinstance(
             func_type, intermediate_type_inference.VerificationTypeAnnotation
         ):
-            function_name = python_naming.function_name(func_type.func.name)
+            function_name, error = self.transform_name(node.name)
+            if error is not None:
+                return None, error
+
+            assert function_name is not None
 
             joined_args = ", ".join(args)
 


### PR DESCRIPTION
We simply transpiled the function name to Python casing in transpilation. While this works for the meta-models designed so far, it is a ticking bomb to explode if we have cross-module function calls.

This patch fixes the issue by delegating the transpilation of the name to the concrete implementation in the abstract transpiler class.