### PR TITLE
Make pre-commit use ``sys.executable``

### DIFF
--- a/.idea/runConfigurations/Python_tests_in_tests.xml
+++ b/.idea/runConfigurations/Python_tests_in_tests.xml
@@ -3,9 +3,9 @@
     <module name="aas-core-csharp-codegen" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
-    <option name="SDK_HOME" value="$PROJECT_DIR$/venv/bin/python" />
+    <option name="SDK_HOME" value="" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/tests" />
-    <option name="IS_MODULE_SDK" value="false" />
+    <option name="IS_MODULE_SDK" value="true" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <option name="_new_additionalArguments" value="&quot;&quot;" />

--- a/.idea/runConfigurations/precommit_w__parallel_tests.xml
+++ b/.idea/runConfigurations/precommit_w__parallel_tests.xml
@@ -1,14 +1,14 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="precommit w/ tests" type="PythonConfigurationType" factoryName="Python">
+  <configuration default="false" name="precommit w/ parallel tests" type="PythonConfigurationType" factoryName="Python">
     <module name="aas-core-csharp-codegen" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
       <env name="PYTHONUNBUFFERED" value="1" />
     </envs>
-    <option name="SDK_HOME" value="$PROJECT_DIR$/venv/bin/python" />
+    <option name="SDK_HOME" value="" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/continuous_integration" />
-    <option name="IS_MODULE_SDK" value="false" />
+    <option name="IS_MODULE_SDK" value="true" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <option name="SCRIPT_NAME" value="$PROJECT_DIR$/continuous_integration/precommit.py" />

--- a/continuous_integration/precommit.py
+++ b/continuous_integration/precommit.py
@@ -122,7 +122,10 @@ def main() -> int:
         if overwrite:
             exit_code = call_and_report(
                 verb="black",
-                cmd=["black"] + reformat_targets + ["--exclude"] + exclude,
+                cmd=[sys.executable, "-m", "black"]
+                + reformat_targets
+                + ["--exclude"]
+                + exclude,
                 cwd=repo_root,
             )
             if exit_code != 0:
@@ -130,7 +133,10 @@ def main() -> int:
         else:
             exit_code = call_and_report(
                 verb="check with black",
-                cmd=["black", "--check"] + reformat_targets + ["--exclude"] + exclude,
+                cmd=[sys.executable, "-m", "black"]
+                + reformat_targets
+                + ["--exclude"]
+                + exclude,
                 cwd=repo_root,
             )
             if exit_code != 0:
@@ -150,7 +156,15 @@ def main() -> int:
 
         exit_code = call_and_report(
             verb="mypy",
-            cmd=["mypy", "--strict", "--config-file", str(config_file)] + mypy_targets,
+            cmd=[
+                sys.executable,
+                "-m",
+                "mypy",
+                "--strict",
+                "--config-file",
+                str(config_file),
+            ]
+            + mypy_targets,
             cwd=repo_root,
         )
         if exit_code != 0:
@@ -170,7 +184,7 @@ def main() -> int:
 
         exit_code = call_and_report(
             verb="pylint",
-            cmd=["pylint", f"--rcfile={rcfile}"] + pylint_targets,
+            cmd=[sys.executable, "-m", "pylint", f"--rcfile={rcfile}"] + pylint_targets,
             cwd=repo_root,
         )
         if exit_code != 0:
@@ -186,6 +200,8 @@ def main() -> int:
         exit_code = call_and_report(
             verb="execute unit tests",
             cmd=[
+                sys.executable,
+                "-m",
                 "coverage",
                 "run",
                 "--source",


### PR DESCRIPTION
We had problems with the pre-commit scripts since commands could not be found in the environment. This patch fixes the issue by invoking pre-commit commands such as black or mypy as modules through ``sys.executable``.