### PR TITLE
Fix error message on reading snippets

### DIFF
--- a/aas_core_codegen/main.py
+++ b/aas_core_codegen/main.py
@@ -98,8 +98,7 @@ def execute(params: Parameters, stdout: TextIO, stderr: TextIO) -> int:
 
     if spec_impls_errors:
         run.write_error_report(
-            message="Failed to resolve the implementation-specific "
-            "JSON schema snippets",
+            message="Failed to resolve the implementation-specific snippets",
             errors=spec_impls_errors,
             stderr=stderr,
         )


### PR DESCRIPTION
We left a stale error message in the main program referring to JSON snippets instead of general snippets.

This patch fixes the issue.