### PR TITLE
Make ``VerificationUnion`` public

### DIFF
--- a/aas_core_codegen/intermediate/__init__.py
+++ b/aas_core_codegen/intermediate/__init__.py
@@ -52,6 +52,7 @@ Verification = _types.Verification
 ImplementationSpecificVerification = _types.ImplementationSpecificVerification
 PatternVerification = _types.PatternVerification
 TranspilableVerification = _types.TranspilableVerification
+VerificationUnion = _types.VerificationUnion
 Signature = _types.Signature
 Interface = _types.Interface
 SymbolTable = _types.SymbolTable


### PR DESCRIPTION
We want to allow the downstream generators to discrimanate exhaustively on the verification functions, and therefore make ``VerificationUnion`` public in the ``intermediate`` module.