### PR TITLE
Fix missing constraints on inherited props in JSON

### DIFF
--- a/aas_core_codegen/infer_for_schema/_inline.py
+++ b/aas_core_codegen/infer_for_schema/_inline.py
@@ -247,8 +247,19 @@ def infer_constraints_by_class(
                 prop, None
             )
 
-            if isinstance(type_anno, intermediate.OurTypeAnnotation) and isinstance(
-                type_anno.our_type, intermediate.ConstrainedPrimitive
+            if (
+                isinstance(type_anno, intermediate.OurTypeAnnotation)
+                and isinstance(type_anno.our_type, intermediate.ConstrainedPrimitive)
+                # NOTE (mristin, 2023-02-06):
+                # We infer constraints for constrained primitives only for
+                # the class that defines the property, and skip these constraints
+                # in the descendant classes. This is necessary to avoid
+                # unnecessary repetitions of constraints in the schemas.
+                #
+                # In case your schema engine *does not* support inheritance or other
+                # forms of stacking constraints over classes, see the method
+                # ``merge_constraints_with_ancestors``.
+                and prop.specified_for is our_type
             ):
                 len_constraint_from_type = len_constraints_by_constrained_primitive.get(
                     type_anno.our_type, None
@@ -344,8 +355,19 @@ def infer_constraints_by_class(
                 prop, []
             )
 
-            if isinstance(type_anno, intermediate.OurTypeAnnotation) and isinstance(
-                type_anno.our_type, intermediate.ConstrainedPrimitive
+            if (
+                isinstance(type_anno, intermediate.OurTypeAnnotation)
+                and isinstance(type_anno.our_type, intermediate.ConstrainedPrimitive)
+                # NOTE (mristin, 2023-02-06):
+                # We infer constraints for constrained primitives only for
+                # the class that defines the property, and skip these constraints
+                # in the descendant classes. This is necessary to avoid
+                # unnecessary repetitions of constraints in the schemas.
+                #
+                # In case your schema engine *does not* support inheritance or other
+                # forms of stacking constraints over classes, see the method
+                # ``merge_constraints_with_ancestors``.
+                and prop.specified_for is our_type
             ):
                 patterns_from_type = patterns_by_constrained_primitive.get(
                     type_anno.our_type, []

--- a/test_data/jsonschema/test_main/test_regression_missing_constraints/expected_output/schema.json
+++ b/test_data/jsonschema/test_main/test_regression_missing_constraints/expected_output/schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "AssetAdministrationShellEnvironment",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/LangStringNameType"
+    }
+  ],
+  "$id": "https://dummy.com",
+  "definitions": {
+    "AbstractLangString": {
+      "type": "object",
+      "properties": {
+        "text": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "text"
+      ]
+    },
+    "LangStringNameType": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/AbstractLangString"
+        },
+        {
+          "properties": {
+            "text": {
+              "maxLength": 128
+            }
+          }
+        }
+      ]
+    },
+    "ModelType": {
+      "type": "string",
+      "enum": []
+    }
+  }
+}

--- a/test_data/jsonschema/test_main/test_regression_missing_constraints/expected_output/stdout.txt
+++ b/test_data/jsonschema/test_main/test_regression_missing_constraints/expected_output/stdout.txt
@@ -1,0 +1,1 @@
+Code generated to: <output dir>

--- a/test_data/jsonschema/test_main/test_regression_missing_constraints/input/snippets/schema_base.json
+++ b/test_data/jsonschema/test_main/test_regression_missing_constraints/input/snippets/schema_base.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "AssetAdministrationShellEnvironment",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/LangStringNameType"
+    }
+  ]
+}

--- a/test_data/jsonschema/test_main/test_regression_missing_constraints/meta_model.py
+++ b/test_data/jsonschema/test_main/test_regression_missing_constraints/meta_model.py
@@ -1,0 +1,27 @@
+"""
+We encountered a bug when designing V3.0. The schema constraints on the descendant classes where not inferred if an invariant  involved properties inherited from the parent class.
+
+This unit test illustrates the setting, and prevents regressions.
+"""
+
+
+@abstract
+class Abstract_lang_string(DBC):
+    text: str
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+@invariant(
+    lambda self: len(self.text) <= 128,
+    "String shall have a maximum length of 128 characters.",
+)
+class Lang_string_name_type(Abstract_lang_string, DBC):
+    def __init__(self, text: str) -> None:
+        Abstract_lang_string.__init__(self, text=text)
+
+
+__book_url__ = "dummy"
+__book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"


### PR DESCRIPTION
We skipped to define constraints on properties which are inherited. This is a bug, as the schema can verify them with ``allOf`` just fine.

This patch fixes the issue.