### PR TITLE
Refactor test case finding to `tests.common`

### DIFF
--- a/.idea/aas-core-csharp-codegen.iml
+++ b/.idea/aas-core-csharp-codegen.iml
@@ -2,6 +2,7 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/.mypy_cache" />
       <excludeFolder url="file://$MODULE_DIR$/aas_core_csharp_codegen.egg-info" />
       <excludeFolder url="file://$MODULE_DIR$/build" />

--- a/test_data/jsonschema/test_main/test_regression_missing_constraints/meta_model.py
+++ b/test_data/jsonschema/test_main/test_regression_missing_constraints/meta_model.py
@@ -1,5 +1,7 @@
 """
-We encountered a bug when designing V3.0. The schema constraints on the descendant classes where not inferred if an invariant  involved properties inherited from the parent class.
+We encountered a bug when designing V3.0. The schema constraints on
+the descendant classes where not inferred if an invariant  involved properties
+inherited from the parent class.
 
 This unit test illustrates the setting, and prevents regressions.
 """


### PR DESCRIPTION
So far, we only iterated over the `test_main` directory of JSON Schema generator to collect the test cases. In the immediate future, we will generalize this logic to RDF+SHACL tests as well.

Hence, we refactor the functionality of the search for test cases into `tests.common`.