### PR TITLE
Fix RDF+SHACL when ``Lang_string`` is missing

### DIFF
--- a/aas_core_codegen/rdf_shacl/rdf.py
+++ b/aas_core_codegen/rdf_shacl/rdf.py
@@ -367,8 +367,6 @@ def generate(
     if len(errors) > 0:
         return None, errors
 
-    assert lang_string_cls is not None
-
     for our_type in sorted(
         symbol_table.our_types,
         key=lambda another_our_type: rdf_shacl_naming.class_name(another_our_type.name),

--- a/aas_core_codegen/rdf_shacl/shacl.py
+++ b/aas_core_codegen/rdf_shacl/shacl.py
@@ -335,7 +335,6 @@ def generate(
         return None, errors
 
     assert constraints_by_class is not None
-    assert lang_string_cls is not None
 
     for our_type in sorted(
         symbol_table.our_types,

--- a/test_data/rdf_shacl/test_main/regression_when_lang_string_class_is_missing/expected_output/rdf-ontology.ttl
+++ b/test_data/rdf_shacl/test_main/regression_when_lang_string_class_is_missing/expected_output/rdf-ontology.ttl
@@ -1,0 +1,30 @@
+@prefix aas: <https://dummy.com/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+@base <https://dummy.com/> .
+
+<https://dummy.com/> rdf:type owl:Ontology ;
+    owl:versionInfo "dummy" ;
+    rdfs:comment "This ontology represents the data model for the Asset Administration Shell according to the specification 'Details of the Asset Administration Shell - Part 1 - Version dummy'."@en ;
+    rdfs:isDefinedBy <https://dummy.com/> ;
+.
+
+###  https://dummy.com/Something
+aas:Something rdf:type owl:Class ;
+    rdfs:subClassOf aas:SomethingAbstract ;
+    rdfs:label "Something"^^xs:string ;
+.
+
+###  https://dummy.com/SomethingAbstract
+aas:SomethingAbstract rdf:type owl:Class ;
+    rdfs:label "Something Abstract"^^xs:string ;
+.
+
+###  https://dummy.com/SomethingAbstract/text
+<https://dummy.com/SomethingAbstract/text> rdf:type owl:DatatypeProperty ;
+    rdfs:label "has text"^^xs:string ;
+    rdfs:domain aas:SomethingAbstract ;
+    rdfs:range xs:string ;
+.

--- a/test_data/rdf_shacl/test_main/regression_when_lang_string_class_is_missing/expected_output/shacl-schema.ttl
+++ b/test_data/rdf_shacl/test_main/regression_when_lang_string_class_is_missing/expected_output/shacl-schema.ttl
@@ -1,0 +1,45 @@
+@prefix aas: <https://dummy.com/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema#> .
+
+# Metadata
+<https://dummy.com/> a owl:Ontology ;
+    owl:imports <http://datashapes.org/dash> ;
+    owl:imports sh: ;
+    sh:declare [
+        a sh:PrefixDeclaration ;
+        sh:namespace "https://dummy.com/"^^xs:anyURI ;
+        sh:prefix "aas"^^xs:string ;
+    ] ;
+.
+
+aas:SomethingShape a sh:NodeShape ;
+    sh:targetClass aas:Something ;
+    rdfs:subClassOf aas:SomethingAbstractShape ;
+.
+
+aas:SomethingAbstractShape a sh:NodeShape ;
+    sh:targetClass aas:SomethingAbstract ;
+    sh:sparql [
+        a sh:SPARQLConstraint ;
+        sh:message "(SomethingAbstractShape): An aas:SomethingAbstract is an abstract class. Please use one of the subclasses for the generation of instances."@en ;
+        sh:prefixes aas: ;
+        sh:select """
+            SELECT ?this ?type
+            WHERE {
+                ?this rdf:type ?type .
+                FILTER (?type = aas:SomethingAbstract)
+            }
+        """ ;
+    ] ;
+    sh:property [
+        a sh:PropertyShape ;
+        sh:path <https://dummy.com/SomethingAbstract/text> ;
+        sh:datatype xs:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+.

--- a/test_data/rdf_shacl/test_main/regression_when_lang_string_class_is_missing/expected_output/stdout.txt
+++ b/test_data/rdf_shacl/test_main/regression_when_lang_string_class_is_missing/expected_output/stdout.txt
@@ -1,0 +1,1 @@
+Code generated to: <output dir>

--- a/test_data/rdf_shacl/test_main/regression_when_lang_string_class_is_missing/input/snippets/.gitignore
+++ b/test_data/rdf_shacl/test_main/regression_when_lang_string_class_is_missing/input/snippets/.gitignore
@@ -1,0 +1,2 @@
+# This file is empty on purpose so that we keep the directory in the Git.
+

--- a/test_data/rdf_shacl/test_main/regression_when_lang_string_class_is_missing/meta_model.py
+++ b/test_data/rdf_shacl/test_main/regression_when_lang_string_class_is_missing/meta_model.py
@@ -1,0 +1,30 @@
+"""
+We encountered a bug when designing V3.0. When the class ``Lang_string`` is missing,
+RDF generation breaks as we hard-wired certain blocks to generate specific code
+for that particular class.
+
+This unit test tests that RDF+SHACL generation does not break even though the class
+``Lang_string`` is missing.
+"""
+
+
+@abstract
+class Something_abstract(DBC):
+    text: str
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+@invariant(
+    lambda self: len(self.text) <= 128,
+    "Text shall have a maximum length of 128 characters.",
+)
+class Something(Something_abstract, DBC):
+    def __init__(self, text: str) -> None:
+        Something_abstract.__init__(self, text=text)
+
+
+__book_url__ = "dummy"
+__book_version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/tests/rdf_shacl/test_main.py
+++ b/tests/rdf_shacl/test_main.py
@@ -15,26 +15,26 @@ import tests.common
 
 
 class Test_against_recorded(unittest.TestCase):
-    def test_against_aas_core_meta(self) -> None:
+    def test_against_meta_models(self) -> None:
         repo_dir = pathlib.Path(os.path.realpath(__file__)).parent.parent.parent
 
         parent_case_dir = repo_dir / "test_data" / "rdf_shacl" / "test_main"
         assert parent_case_dir.exists() and parent_case_dir.is_dir(), parent_case_dir
 
-        for module in [aas_core_meta.v3rc2]:
-            case_dir = parent_case_dir / module.__name__
-            assert case_dir.is_dir(), case_dir
+        # fmt: off
+        test_cases = (
+            tests.common.find_meta_models_in_parent_directory_of_test_cases_and_modules(
+                parent_case_dir=parent_case_dir,
+                aas_core_meta_modules=[aas_core_meta.v3rc2]
+            )
+        )
+        # fmt: on
 
-            assert (
-                module.__file__ is not None
-            ), f"Expected the module {module!r} to have a __file__, but it has None"
-            model_pth = pathlib.Path(module.__file__)
-            assert model_pth.exists() and model_pth.is_file(), model_pth
-
-            snippets_dir = case_dir / "input/snippets"
+        for test_case in test_cases:
+            snippets_dir = test_case.case_dir / "input/snippets"
             assert snippets_dir.exists() and snippets_dir.is_dir(), snippets_dir
 
-            expected_output_dir = case_dir / "expected_output"
+            expected_output_dir = test_case.case_dir / "expected_output"
 
             with contextlib.ExitStack() as exit_stack:
                 if tests.common.RERECORD:
@@ -51,7 +51,7 @@ class Test_against_recorded(unittest.TestCase):
                     output_dir = pathlib.Path(tmp_dir.name)
 
                 params = aas_core_codegen.main.Parameters(
-                    model_path=model_pth,
+                    model_path=test_case.model_path,
                     target=aas_core_codegen.main.Target.RDF_SHACL,
                     snippets_dir=snippets_dir,
                     output_dir=output_dir,


### PR DESCRIPTION
We assumed that ``Lang_string`` will always be defined, and hard-wired certain parts of the RDF+SHACL codegen to that particular class.

However, this assumption did not hold long: already the first iteration of V3.0 of the metamodel came without a ``Lang_string``.

In this patch, we make RDF+SHACL more robust in face of missing ``Lang_string``, and allow the generation without its definition.