### PR TITLE
Make C# code operate on interfaces

### DIFF
--- a/aas_core_codegen/csharp/common.py
+++ b/aas_core_codegen/csharp/common.py
@@ -1,6 +1,6 @@
 """Provide common functions shared among different C# code generation modules."""
 import re
-from typing import List, Union, cast, Iterator
+from typing import List, cast
 
 from icontract import ensure, require
 
@@ -176,32 +176,6 @@ WARNING = Stripped(
  * Do NOT edit or append.
  */"""
 )
-
-
-def over_enumerations_classes_and_interfaces(
-    symbol_table: intermediate.SymbolTable,
-) -> Iterator[
-    Union[intermediate.Enumeration, intermediate.ConcreteClass, intermediate.Interface]
-]:
-    """
-    Iterate over all enumerations, concrete classes and interfaces.
-
-    These intermediate structures form the base of the C# code.
-    """
-    for our_type in symbol_table.our_types:
-        if isinstance(our_type, intermediate.Enumeration):
-            yield our_type
-        elif isinstance(our_type, intermediate.ConstrainedPrimitive):
-            pass
-        elif isinstance(our_type, intermediate.AbstractClass):
-            yield our_type.interface
-        elif isinstance(our_type, intermediate.ConcreteClass):
-            if our_type.interface:
-                yield our_type.interface
-
-            yield our_type
-        else:
-            assert_never(our_type)
 
 
 # fmt: off

--- a/aas_core_codegen/csharp/copying/_generate.py
+++ b/aas_core_codegen/csharp/copying/_generate.py
@@ -66,9 +66,14 @@ return new Aas.{cls_name}(
 {I}{indent_but_first_line(args_joined, I)});"""
             )
 
+    interface_name = csharp_naming.interface_name(cls.name)
+    transform_name = csharp_naming.method_name(Identifier(f"transform_{cls.name}"))
+
     return Stripped(
         f"""\
-public override Aas.IClass Transform(Aas.{cls_name} that)
+public override Aas.IClass {transform_name}(
+{I}Aas.{interface_name} that
+)
 {{
 {I}{indent_but_first_line(return_statement, I)}
 }}"""
@@ -115,7 +120,8 @@ def _generate_shallow_copier(
         """\
 /// <summary>Dispatch the making of shallow copies.</summary>
 internal class ShallowCopier : Visitation.AbstractTransformer<Aas.IClass>
-{"""
+{
+"""
     )
 
     for i, block in enumerate(blocks):
@@ -283,9 +289,14 @@ if (that.{prop_name} != null)
 
         body_writer.write(body_block)
 
+    interface_name = csharp_naming.interface_name(cls.name)
+    transform_name = csharp_naming.method_name(Identifier(f"transform_{cls.name}"))
+
     return Stripped(
         f"""\
-public override Aas.IClass Transform(Aas.{cls_name} that)
+public override Aas.IClass {transform_name}(
+{I}Aas.{interface_name} that
+)
 {{
 {I}{indent_but_first_line(body_writer.getvalue(), I)}
 }}"""

--- a/aas_core_codegen/csharp/jsonization/_generate.py
+++ b/aas_core_codegen/csharp/jsonization/_generate.py
@@ -1187,7 +1187,6 @@ def _generate_transform_for_class(
 ) -> Tuple[Optional[Stripped], Optional[List[Error]]]:
     """Generate the transform method to a JSON object for the given concrete class."""
     errors = []  # type: List[Error]
-    name = csharp_naming.class_name(cls.name)
 
     blocks = [Stripped("var result = new Nodes.JsonObject();")]  # type: List[Stripped]
 
@@ -1209,9 +1208,15 @@ def _generate_transform_for_class(
     blocks.append(Stripped("return result;"))
 
     writer = io.StringIO()
+
+    interface_name = csharp_naming.interface_name(cls.name)
+    transform_name = csharp_naming.method_name(Identifier(f"transform_{cls.name}"))
+
     writer.write(
         f"""\
-public override Nodes.JsonObject Transform(Aas.{name} that)
+public override Nodes.JsonObject {transform_name}(
+{I}Aas.{interface_name} that
+)
 {{
 """
     )

--- a/aas_core_codegen/csharp/verification/_generate.py
+++ b/aas_core_codegen/csharp/verification/_generate.py
@@ -1448,11 +1448,16 @@ yield break;"""
         )
 
     writer = io.StringIO()
+
+    interface_name = csharp_naming.interface_name(cls.name)
+    transform_name = csharp_naming.method_name(Identifier(f"transform_{cls.name}"))
+
     writer.write(
         f"""\
 [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-public override IEnumerable<Reporting.Error> Transform(
-{I}Aas.{name} that)
+public override IEnumerable<Reporting.Error> {transform_name}(
+{I}Aas.{interface_name} that
+)
 {{
 """
     )

--- a/aas_core_codegen/csharp/xmlization/_generate.py
+++ b/aas_core_codegen/csharp/xmlization/_generate.py
@@ -1644,7 +1644,7 @@ def _generate_class_to_sequence(cls: intermediate.ConcreteClass) -> Stripped:
         body = _generate_serialize_property_as_content(prop=prop)
         blocks.append(body)
 
-    cls_name = csharp_naming.class_name(cls.name)
+    interface_name = csharp_naming.interface_name(cls.name)
     method_name = csharp_naming.method_name(Identifier(f"{cls.name}_to_sequence"))
 
     writer = io.StringIO()
@@ -1659,7 +1659,7 @@ def _generate_class_to_sequence(cls: intermediate.ConcreteClass) -> Stripped:
     writer.write(
         f"""\
 private void {method_name}(
-{I}{cls_name} that,
+{I}Aas.{interface_name} that,
 {I}Xml.XmlWriter writer)
 {{
 """
@@ -1677,19 +1677,25 @@ private void {method_name}(
 
 def _generate_visit_for_class(cls: intermediate.ConcreteClass) -> Stripped:
     """Generate the method to write the ``cls`` as an XML element."""
-    cls_name = csharp_naming.class_name(cls.name)
+    interface_name = csharp_naming.interface_name(cls.name)
+    visit_name = csharp_naming.method_name(Identifier(f"visit_{cls.name}"))
+
+    cls_to_sequence_name = csharp_naming.method_name(
+        Identifier(f"{cls.name}_to_sequence")
+    )
+
     xml_cls_name_literal = csharp_common.string_literal(naming.xml_class_name(cls.name))
 
     return Stripped(
         f"""\
-public override void Visit(
-{I}Aas.{cls_name} that,
+public override void {visit_name}(
+{I}Aas.{interface_name} that,
 {I}Xml.XmlWriter writer)
 {{
 {I}writer.WriteStartElement(
 {II}{xml_cls_name_literal},
 {II}NS);
-{I}this.{cls_name}ToSequence(
+{I}this.{cls_to_sequence_name}(
 {II}that,
 {II}writer);
 {I}writer.WriteEndElement();

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/copying.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/copying.cs
@@ -46,7 +46,10 @@ namespace AasCore.Aas3_0_RC02
 
         /// <summary>Dispatch the making of shallow copies.</summary>
         internal class ShallowCopier : Visitation.AbstractTransformer<Aas.IClass>
-        {    public override Aas.IClass Transform(Aas.Extension that)
+        {
+            public override Aas.IClass TransformExtension(
+                Aas.IExtension that
+            )
             {
                 return new Aas.Extension(
                     that.Name,
@@ -57,7 +60,9 @@ namespace AasCore.Aas3_0_RC02
                     that.RefersTo);
             }
 
-            public override Aas.IClass Transform(Aas.AdministrativeInformation that)
+            public override Aas.IClass TransformAdministrativeInformation(
+                Aas.IAdministrativeInformation that
+            )
             {
                 return new Aas.AdministrativeInformation(
                     that.EmbeddedDataSpecifications,
@@ -65,7 +70,9 @@ namespace AasCore.Aas3_0_RC02
                     that.Revision);
             }
 
-            public override Aas.IClass Transform(Aas.Qualifier that)
+            public override Aas.IClass TransformQualifier(
+                Aas.IQualifier that
+            )
             {
                 return new Aas.Qualifier(
                     that.Type,
@@ -77,7 +84,9 @@ namespace AasCore.Aas3_0_RC02
                     that.ValueId);
             }
 
-            public override Aas.IClass Transform(Aas.AssetAdministrationShell that)
+            public override Aas.IClass TransformAssetAdministrationShell(
+                Aas.IAssetAdministrationShell that
+            )
             {
                 return new Aas.AssetAdministrationShell(
                     that.Id,
@@ -94,7 +103,9 @@ namespace AasCore.Aas3_0_RC02
                     that.Submodels);
             }
 
-            public override Aas.IClass Transform(Aas.AssetInformation that)
+            public override Aas.IClass TransformAssetInformation(
+                Aas.IAssetInformation that
+            )
             {
                 return new Aas.AssetInformation(
                     that.AssetKind,
@@ -103,12 +114,16 @@ namespace AasCore.Aas3_0_RC02
                     that.DefaultThumbnail);
             }
 
-            public override Aas.IClass Transform(Aas.Resource that)
+            public override Aas.IClass TransformResource(
+                Aas.IResource that
+            )
             {
                 return new Aas.Resource(that.Path, that.ContentType);
             }
 
-            public override Aas.IClass Transform(Aas.SpecificAssetId that)
+            public override Aas.IClass TransformSpecificAssetId(
+                Aas.ISpecificAssetId that
+            )
             {
                 return new Aas.SpecificAssetId(
                     that.Name,
@@ -118,7 +133,9 @@ namespace AasCore.Aas3_0_RC02
                     that.SupplementalSemanticIds);
             }
 
-            public override Aas.IClass Transform(Aas.Submodel that)
+            public override Aas.IClass TransformSubmodel(
+                Aas.ISubmodel that
+            )
             {
                 return new Aas.Submodel(
                     that.Id,
@@ -137,7 +154,9 @@ namespace AasCore.Aas3_0_RC02
                     that.SubmodelElements);
             }
 
-            public override Aas.IClass Transform(Aas.RelationshipElement that)
+            public override Aas.IClass TransformRelationshipElement(
+                Aas.IRelationshipElement that
+            )
             {
                 return new Aas.RelationshipElement(
                     that.First,
@@ -155,7 +174,9 @@ namespace AasCore.Aas3_0_RC02
                     that.EmbeddedDataSpecifications);
             }
 
-            public override Aas.IClass Transform(Aas.SubmodelElementList that)
+            public override Aas.IClass TransformSubmodelElementList(
+                Aas.ISubmodelElementList that
+            )
             {
                 return new Aas.SubmodelElementList(
                     that.TypeValueListElement,
@@ -176,7 +197,9 @@ namespace AasCore.Aas3_0_RC02
                     that.ValueTypeListElement);
             }
 
-            public override Aas.IClass Transform(Aas.SubmodelElementCollection that)
+            public override Aas.IClass TransformSubmodelElementCollection(
+                Aas.ISubmodelElementCollection that
+            )
             {
                 return new Aas.SubmodelElementCollection(
                     that.Extensions,
@@ -193,7 +216,9 @@ namespace AasCore.Aas3_0_RC02
                     that.Value);
             }
 
-            public override Aas.IClass Transform(Aas.Property that)
+            public override Aas.IClass TransformProperty(
+                Aas.IProperty that
+            )
             {
                 return new Aas.Property(
                     that.ValueType,
@@ -212,7 +237,9 @@ namespace AasCore.Aas3_0_RC02
                     that.ValueId);
             }
 
-            public override Aas.IClass Transform(Aas.MultiLanguageProperty that)
+            public override Aas.IClass TransformMultiLanguageProperty(
+                Aas.IMultiLanguageProperty that
+            )
             {
                 return new Aas.MultiLanguageProperty(
                     that.Extensions,
@@ -230,7 +257,9 @@ namespace AasCore.Aas3_0_RC02
                     that.ValueId);
             }
 
-            public override Aas.IClass Transform(Aas.Range that)
+            public override Aas.IClass TransformRange(
+                Aas.IRange that
+            )
             {
                 return new Aas.Range(
                     that.ValueType,
@@ -249,7 +278,9 @@ namespace AasCore.Aas3_0_RC02
                     that.Max);
             }
 
-            public override Aas.IClass Transform(Aas.ReferenceElement that)
+            public override Aas.IClass TransformReferenceElement(
+                Aas.IReferenceElement that
+            )
             {
                 return new Aas.ReferenceElement(
                     that.Extensions,
@@ -266,7 +297,9 @@ namespace AasCore.Aas3_0_RC02
                     that.Value);
             }
 
-            public override Aas.IClass Transform(Aas.Blob that)
+            public override Aas.IClass TransformBlob(
+                Aas.IBlob that
+            )
             {
                 return new Aas.Blob(
                     that.ContentType,
@@ -284,7 +317,9 @@ namespace AasCore.Aas3_0_RC02
                     that.Value);
             }
 
-            public override Aas.IClass Transform(Aas.File that)
+            public override Aas.IClass TransformFile(
+                Aas.IFile that
+            )
             {
                 return new Aas.File(
                     that.ContentType,
@@ -302,7 +337,9 @@ namespace AasCore.Aas3_0_RC02
                     that.Value);
             }
 
-            public override Aas.IClass Transform(Aas.AnnotatedRelationshipElement that)
+            public override Aas.IClass TransformAnnotatedRelationshipElement(
+                Aas.IAnnotatedRelationshipElement that
+            )
             {
                 return new Aas.AnnotatedRelationshipElement(
                     that.First,
@@ -321,7 +358,9 @@ namespace AasCore.Aas3_0_RC02
                     that.Annotations);
             }
 
-            public override Aas.IClass Transform(Aas.Entity that)
+            public override Aas.IClass TransformEntity(
+                Aas.IEntity that
+            )
             {
                 return new Aas.Entity(
                     that.EntityType,
@@ -341,7 +380,9 @@ namespace AasCore.Aas3_0_RC02
                     that.SpecificAssetId);
             }
 
-            public override Aas.IClass Transform(Aas.EventPayload that)
+            public override Aas.IClass TransformEventPayload(
+                Aas.IEventPayload that
+            )
             {
                 return new Aas.EventPayload(
                     that.Source,
@@ -354,7 +395,9 @@ namespace AasCore.Aas3_0_RC02
                     that.Payload);
             }
 
-            public override Aas.IClass Transform(Aas.BasicEventElement that)
+            public override Aas.IClass TransformBasicEventElement(
+                Aas.IBasicEventElement that
+            )
             {
                 return new Aas.BasicEventElement(
                     that.Observed,
@@ -378,7 +421,9 @@ namespace AasCore.Aas3_0_RC02
                     that.MaxInterval);
             }
 
-            public override Aas.IClass Transform(Aas.Operation that)
+            public override Aas.IClass TransformOperation(
+                Aas.IOperation that
+            )
             {
                 return new Aas.Operation(
                     that.Extensions,
@@ -397,12 +442,16 @@ namespace AasCore.Aas3_0_RC02
                     that.InoutputVariables);
             }
 
-            public override Aas.IClass Transform(Aas.OperationVariable that)
+            public override Aas.IClass TransformOperationVariable(
+                Aas.IOperationVariable that
+            )
             {
                 return new Aas.OperationVariable(that.Value);
             }
 
-            public override Aas.IClass Transform(Aas.Capability that)
+            public override Aas.IClass TransformCapability(
+                Aas.ICapability that
+            )
             {
                 return new Aas.Capability(
                     that.Extensions,
@@ -418,7 +467,9 @@ namespace AasCore.Aas3_0_RC02
                     that.EmbeddedDataSpecifications);
             }
 
-            public override Aas.IClass Transform(Aas.ConceptDescription that)
+            public override Aas.IClass TransformConceptDescription(
+                Aas.IConceptDescription that
+            )
             {
                 return new Aas.ConceptDescription(
                     that.Id,
@@ -433,7 +484,9 @@ namespace AasCore.Aas3_0_RC02
                     that.IsCaseOf);
             }
 
-            public override Aas.IClass Transform(Aas.Reference that)
+            public override Aas.IClass TransformReference(
+                Aas.IReference that
+            )
             {
                 return new Aas.Reference(
                     that.Type,
@@ -441,17 +494,23 @@ namespace AasCore.Aas3_0_RC02
                     that.ReferredSemanticId);
             }
 
-            public override Aas.IClass Transform(Aas.Key that)
+            public override Aas.IClass TransformKey(
+                Aas.IKey that
+            )
             {
                 return new Aas.Key(that.Type, that.Value);
             }
 
-            public override Aas.IClass Transform(Aas.LangString that)
+            public override Aas.IClass TransformLangString(
+                Aas.ILangString that
+            )
             {
                 return new Aas.LangString(that.Language, that.Text);
             }
 
-            public override Aas.IClass Transform(Aas.Environment that)
+            public override Aas.IClass TransformEnvironment(
+                Aas.IEnvironment that
+            )
             {
                 return new Aas.Environment(
                     that.AssetAdministrationShells,
@@ -459,24 +518,32 @@ namespace AasCore.Aas3_0_RC02
                     that.ConceptDescriptions);
             }
 
-            public override Aas.IClass Transform(Aas.EmbeddedDataSpecification that)
+            public override Aas.IClass TransformEmbeddedDataSpecification(
+                Aas.IEmbeddedDataSpecification that
+            )
             {
                 return new Aas.EmbeddedDataSpecification(
                     that.DataSpecification,
                     that.DataSpecificationContent);
             }
 
-            public override Aas.IClass Transform(Aas.ValueReferencePair that)
+            public override Aas.IClass TransformValueReferencePair(
+                Aas.IValueReferencePair that
+            )
             {
                 return new Aas.ValueReferencePair(that.Value, that.ValueId);
             }
 
-            public override Aas.IClass Transform(Aas.ValueList that)
+            public override Aas.IClass TransformValueList(
+                Aas.IValueList that
+            )
             {
                 return new Aas.ValueList(that.ValueReferencePairs);
             }
 
-            public override Aas.IClass Transform(Aas.DataSpecificationIec61360 that)
+            public override Aas.IClass TransformDataSpecificationIec61360(
+                Aas.IDataSpecificationIec61360 that
+            )
             {
                 return new Aas.DataSpecificationIec61360(
                     that.PreferredName,
@@ -493,7 +560,9 @@ namespace AasCore.Aas3_0_RC02
                     that.LevelType);
             }
 
-            public override Aas.IClass Transform(Aas.DataSpecificationPhysicalUnit that)
+            public override Aas.IClass TransformDataSpecificationPhysicalUnit(
+                Aas.IDataSpecificationPhysicalUnit that
+            )
             {
                 return new Aas.DataSpecificationPhysicalUnit(
                     that.UnitName,
@@ -514,7 +583,9 @@ namespace AasCore.Aas3_0_RC02
 
         /// <summary>Dispatch the making of deep copies.</summary>
         internal class DeepCopier : Visitation.AbstractTransformer<Aas.IClass>
-        {    public override Aas.IClass Transform(Aas.Extension that)
+        {    public override Aas.IClass TransformExtension(
+                Aas.IExtension that
+            )
             {
                 List<Reference>? theSupplementalSemanticIds = null;
                 if (that.SupplementalSemanticIds != null)
@@ -541,7 +612,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.AdministrativeInformation that)
+            public override Aas.IClass TransformAdministrativeInformation(
+                Aas.IAdministrativeInformation that
+            )
             {
                 List<EmbeddedDataSpecification>? theEmbeddedDataSpecifications = null;
                 if (that.EmbeddedDataSpecifications != null)
@@ -561,7 +634,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.Qualifier that)
+            public override Aas.IClass TransformQualifier(
+                Aas.IQualifier that
+            )
             {
                 List<Reference>? theSupplementalSemanticIds = null;
                 if (that.SupplementalSemanticIds != null)
@@ -589,7 +664,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.AssetAdministrationShell that)
+            public override Aas.IClass TransformAssetAdministrationShell(
+                Aas.IAssetAdministrationShell that
+            )
             {
                 List<Extension>? theExtensions = null;
                 if (that.Extensions != null)
@@ -666,7 +743,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.AssetInformation that)
+            public override Aas.IClass TransformAssetInformation(
+                Aas.IAssetInformation that
+            )
             {
                 List<SpecificAssetId>? theSpecificAssetIds = null;
                 if (that.SpecificAssetIds != null)
@@ -691,7 +770,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.Resource that)
+            public override Aas.IClass TransformResource(
+                Aas.IResource that
+            )
             {
                 return new Aas.Resource(
                     that.Path,
@@ -699,7 +780,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.SpecificAssetId that)
+            public override Aas.IClass TransformSpecificAssetId(
+                Aas.ISpecificAssetId that
+            )
             {
                 List<Reference>? theSupplementalSemanticIds = null;
                 if (that.SupplementalSemanticIds != null)
@@ -723,7 +806,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.Submodel that)
+            public override Aas.IClass TransformSubmodel(
+                Aas.ISubmodel that
+            )
             {
                 List<Extension>? theExtensions = null;
                 if (that.Extensions != null)
@@ -824,7 +909,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.RelationshipElement that)
+            public override Aas.IClass TransformRelationshipElement(
+                Aas.IRelationshipElement that
+            )
             {
                 List<Extension>? theExtensions = null;
                 if (that.Extensions != null)
@@ -911,7 +998,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.SubmodelElementList that)
+            public override Aas.IClass TransformSubmodelElementList(
+                Aas.ISubmodelElementList that
+            )
             {
                 List<Extension>? theExtensions = null;
                 if (that.Extensions != null)
@@ -1014,7 +1103,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.SubmodelElementCollection that)
+            public override Aas.IClass TransformSubmodelElementCollection(
+                Aas.ISubmodelElementCollection that
+            )
             {
                 List<Extension>? theExtensions = null;
                 if (that.Extensions != null)
@@ -1111,7 +1202,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.Property that)
+            public override Aas.IClass TransformProperty(
+                Aas.IProperty that
+            )
             {
                 List<Extension>? theExtensions = null;
                 if (that.Extensions != null)
@@ -1201,7 +1294,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.MultiLanguageProperty that)
+            public override Aas.IClass TransformMultiLanguageProperty(
+                Aas.IMultiLanguageProperty that
+            )
             {
                 List<Extension>? theExtensions = null;
                 if (that.Extensions != null)
@@ -1301,7 +1396,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.Range that)
+            public override Aas.IClass TransformRange(
+                Aas.IRange that
+            )
             {
                 List<Extension>? theExtensions = null;
                 if (that.Extensions != null)
@@ -1389,7 +1486,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.ReferenceElement that)
+            public override Aas.IClass TransformReferenceElement(
+                Aas.IReferenceElement that
+            )
             {
                 List<Extension>? theExtensions = null;
                 if (that.Extensions != null)
@@ -1477,7 +1576,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.Blob that)
+            public override Aas.IClass TransformBlob(
+                Aas.IBlob that
+            )
             {
                 List<Extension>? theExtensions = null;
                 if (that.Extensions != null)
@@ -1564,7 +1665,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.File that)
+            public override Aas.IClass TransformFile(
+                Aas.IFile that
+            )
             {
                 List<Extension>? theExtensions = null;
                 if (that.Extensions != null)
@@ -1651,7 +1754,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.AnnotatedRelationshipElement that)
+            public override Aas.IClass TransformAnnotatedRelationshipElement(
+                Aas.IAnnotatedRelationshipElement that
+            )
             {
                 List<Extension>? theExtensions = null;
                 if (that.Extensions != null)
@@ -1750,7 +1855,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.Entity that)
+            public override Aas.IClass TransformEntity(
+                Aas.IEntity that
+            )
             {
                 List<Extension>? theExtensions = null;
                 if (that.Extensions != null)
@@ -1854,7 +1961,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.EventPayload that)
+            public override Aas.IClass TransformEventPayload(
+                Aas.IEventPayload that
+            )
             {
                 return new Aas.EventPayload(
                     Deep(that.Source),
@@ -1874,7 +1983,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.BasicEventElement that)
+            public override Aas.IClass TransformBasicEventElement(
+                Aas.IBasicEventElement that
+            )
             {
                 List<Extension>? theExtensions = null;
                 if (that.Extensions != null)
@@ -1969,7 +2080,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.Operation that)
+            public override Aas.IClass TransformOperation(
+                Aas.IOperation that
+            )
             {
                 List<Extension>? theExtensions = null;
                 if (that.Extensions != null)
@@ -2090,14 +2203,18 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.OperationVariable that)
+            public override Aas.IClass TransformOperationVariable(
+                Aas.IOperationVariable that
+            )
             {
                 return new Aas.OperationVariable(
                     Deep(that.Value)
                 );
             }
 
-            public override Aas.IClass Transform(Aas.Capability that)
+            public override Aas.IClass TransformCapability(
+                Aas.ICapability that
+            )
             {
                 List<Extension>? theExtensions = null;
                 if (that.Extensions != null)
@@ -2182,7 +2299,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.ConceptDescription that)
+            public override Aas.IClass TransformConceptDescription(
+                Aas.IConceptDescription that
+            )
             {
                 List<Extension>? theExtensions = null;
                 if (that.Extensions != null)
@@ -2255,7 +2374,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.Reference that)
+            public override Aas.IClass TransformReference(
+                Aas.IReference that
+            )
             {
                 var theKeys = new List<Key>(
                     that.Keys.Count);
@@ -2273,7 +2394,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.Key that)
+            public override Aas.IClass TransformKey(
+                Aas.IKey that
+            )
             {
                 return new Aas.Key(
                     that.Type,
@@ -2281,7 +2404,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.LangString that)
+            public override Aas.IClass TransformLangString(
+                Aas.ILangString that
+            )
             {
                 return new Aas.LangString(
                     that.Language,
@@ -2289,7 +2414,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.Environment that)
+            public override Aas.IClass TransformEnvironment(
+                Aas.IEnvironment that
+            )
             {
                 List<AssetAdministrationShell>? theAssetAdministrationShells = null;
                 if (that.AssetAdministrationShells != null)
@@ -2331,7 +2458,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.EmbeddedDataSpecification that)
+            public override Aas.IClass TransformEmbeddedDataSpecification(
+                Aas.IEmbeddedDataSpecification that
+            )
             {
                 return new Aas.EmbeddedDataSpecification(
                     Deep(that.DataSpecification),
@@ -2339,7 +2468,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.ValueReferencePair that)
+            public override Aas.IClass TransformValueReferencePair(
+                Aas.IValueReferencePair that
+            )
             {
                 return new Aas.ValueReferencePair(
                     that.Value,
@@ -2347,7 +2478,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.ValueList that)
+            public override Aas.IClass TransformValueList(
+                Aas.IValueList that
+            )
             {
                 var theValueReferencePairs = new List<ValueReferencePair>(
                     that.ValueReferencePairs.Count);
@@ -2361,7 +2494,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.DataSpecificationIec61360 that)
+            public override Aas.IClass TransformDataSpecificationIec61360(
+                Aas.IDataSpecificationIec61360 that
+            )
             {
                 var thePreferredName = new List<LangString>(
                     that.PreferredName.Count);
@@ -2412,7 +2547,9 @@ namespace AasCore.Aas3_0_RC02
                 );
             }
 
-            public override Aas.IClass Transform(Aas.DataSpecificationPhysicalUnit that)
+            public override Aas.IClass TransformDataSpecificationPhysicalUnit(
+                Aas.IDataSpecificationPhysicalUnit that
+            )
             {
                 var theDefinition = new List<LangString>(
                     that.Definition.Count);

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/jsonization.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/jsonization.cs
@@ -16454,7 +16454,9 @@ namespace AasCore.Aas3_0_RC02
                 return Nodes.JsonValue.Create(that);
             }
 
-            public override Nodes.JsonObject Transform(Aas.Extension that)
+            public override Nodes.JsonObject TransformExtension(
+                Aas.IExtension that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -16503,7 +16505,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.AdministrativeInformation that)
+            public override Nodes.JsonObject TransformAdministrativeInformation(
+                Aas.IAdministrativeInformation that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -16534,7 +16538,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.Qualifier that)
+            public override Nodes.JsonObject TransformQualifier(
+                Aas.IQualifier that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -16586,7 +16592,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.AssetAdministrationShell that)
+            public override Nodes.JsonObject TransformAssetAdministrationShell(
+                Aas.IAssetAdministrationShell that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -16691,7 +16699,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.AssetInformation that)
+            public override Nodes.JsonObject TransformAssetInformation(
+                Aas.IAssetInformation that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -16725,7 +16735,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.Resource that)
+            public override Nodes.JsonObject TransformResource(
+                Aas.IResource that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -16741,7 +16753,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.SpecificAssetId that)
+            public override Nodes.JsonObject TransformSpecificAssetId(
+                Aas.ISpecificAssetId that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -16775,7 +16789,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.Submodel that)
+            public override Nodes.JsonObject TransformSubmodel(
+                Aas.ISubmodel that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -16910,7 +16926,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.RelationshipElement that)
+            public override Nodes.JsonObject TransformRelationshipElement(
+                Aas.IRelationshipElement that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -17030,7 +17048,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.SubmodelElementList that)
+            public override Nodes.JsonObject TransformSubmodelElementList(
+                Aas.ISubmodelElementList that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -17180,7 +17200,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.SubmodelElementCollection that)
+            public override Nodes.JsonObject TransformSubmodelElementCollection(
+                Aas.ISubmodelElementCollection that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -17306,7 +17328,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.Property that)
+            public override Nodes.JsonObject TransformProperty(
+                Aas.IProperty that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -17435,7 +17459,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.MultiLanguageProperty that)
+            public override Nodes.JsonObject TransformMultiLanguageProperty(
+                Aas.IMultiLanguageProperty that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -17567,7 +17593,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.Range that)
+            public override Nodes.JsonObject TransformRange(
+                Aas.IRange that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -17696,7 +17724,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.ReferenceElement that)
+            public override Nodes.JsonObject TransformReferenceElement(
+                Aas.IReferenceElement that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -17816,7 +17846,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.Blob that)
+            public override Nodes.JsonObject TransformBlob(
+                Aas.IBlob that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -17940,7 +17972,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.File that)
+            public override Nodes.JsonObject TransformFile(
+                Aas.IFile that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -18063,7 +18097,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.AnnotatedRelationshipElement that)
+            public override Nodes.JsonObject TransformAnnotatedRelationshipElement(
+                Aas.IAnnotatedRelationshipElement that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -18195,7 +18231,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.Entity that)
+            public override Nodes.JsonObject TransformEntity(
+                Aas.IEntity that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -18336,7 +18374,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.EventPayload that)
+            public override Nodes.JsonObject TransformEventPayload(
+                Aas.IEventPayload that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -18382,7 +18422,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.BasicEventElement that)
+            public override Nodes.JsonObject TransformBasicEventElement(
+                Aas.IBasicEventElement that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -18535,7 +18577,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.Operation that)
+            public override Nodes.JsonObject TransformOperation(
+                Aas.IOperation that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -18685,7 +18729,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.OperationVariable that)
+            public override Nodes.JsonObject TransformOperationVariable(
+                Aas.IOperationVariable that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -18695,7 +18741,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.Capability that)
+            public override Nodes.JsonObject TransformCapability(
+                Aas.ICapability that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -18809,7 +18857,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.ConceptDescription that)
+            public override Nodes.JsonObject TransformConceptDescription(
+                Aas.IConceptDescription that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -18905,7 +18955,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.Reference that)
+            public override Nodes.JsonObject TransformReference(
+                Aas.IReference that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -18930,7 +18982,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.Key that)
+            public override Nodes.JsonObject TransformKey(
+                Aas.IKey that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -18943,7 +18997,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.LangString that)
+            public override Nodes.JsonObject TransformLangString(
+                Aas.ILangString that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -18956,7 +19012,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.Environment that)
+            public override Nodes.JsonObject TransformEnvironment(
+                Aas.IEnvironment that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -18999,7 +19057,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.EmbeddedDataSpecification that)
+            public override Nodes.JsonObject TransformEmbeddedDataSpecification(
+                Aas.IEmbeddedDataSpecification that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -19012,7 +19072,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.ValueReferencePair that)
+            public override Nodes.JsonObject TransformValueReferencePair(
+                Aas.IValueReferencePair that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -19025,7 +19087,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.ValueList that)
+            public override Nodes.JsonObject TransformValueList(
+                Aas.IValueList that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -19041,7 +19105,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.DataSpecificationIec61360 that)
+            public override Nodes.JsonObject TransformDataSpecificationIec61360(
+                Aas.IDataSpecificationIec61360 that
+            )
             {
                 var result = new Nodes.JsonObject();
 
@@ -19143,7 +19209,9 @@ namespace AasCore.Aas3_0_RC02
                 return result;
             }
 
-            public override Nodes.JsonObject Transform(Aas.DataSpecificationPhysicalUnit that)
+            public override Nodes.JsonObject TransformDataSpecificationPhysicalUnit(
+                Aas.IDataSpecificationPhysicalUnit that
+            )
             {
                 var result = new Nodes.JsonObject();
 

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/types.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/types.cs
@@ -10,7 +10,6 @@ using System.Collections.Generic;  // can't alias
 
 namespace AasCore.Aas3_0_RC02
 {
-
     /// <summary>
     /// Represent a general class of an AAS model.
     /// </summary>
@@ -96,7 +95,49 @@ namespace AasCore.Aas3_0_RC02
     /// <summary>
     /// Single extension of an element.
     /// </summary>
-    public class Extension : IHasSemantics
+    public interface IExtension : IHasSemantics
+    {
+        /// <summary>
+        /// Name of the extension.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Constraints:
+        /// </para>
+        /// <ul>
+        ///   <li>
+        ///     Constraint AASd-077:
+        ///     The name of an extension within <see cref="Aas.IHasExtensions" /> needs to be unique.
+        ///   </li>
+        /// </ul>
+        /// </remarks>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Type of the value of the extension.
+        /// </summary>
+        /// <remarks>
+        /// Default: <see cref="Aas.DataTypeDefXsd.String" />
+        /// </remarks>
+        public DataTypeDefXsd? ValueType { get; set; }
+
+        /// <summary>
+        /// Value of the extension
+        /// </summary>
+        public string? Value { get; set; }
+
+        /// <summary>
+        /// Reference to an element the extension refers to.
+        /// </summary>
+        public Reference? RefersTo { get; set; }
+
+        public DataTypeDefXsd ValueTypeOrDefault();
+    }
+
+    /// <summary>
+    /// Single extension of an element.
+    /// </summary>
+    public class Extension : IExtension
     {
         /// <summary>
         /// Identifier of the semantic definition of the element. It is called semantic ID
@@ -241,7 +282,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitExtension(this);
         }
 
         /// <summary>
@@ -252,7 +293,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitExtension(this, context);
         }
 
         /// <summary>
@@ -261,7 +302,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformExtension(this);
         }
 
         /// <summary>
@@ -272,7 +313,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformExtension(this, context);
         }
 
         public Extension(
@@ -514,7 +555,37 @@ namespace AasCore.Aas3_0_RC02
     ///   </li>
     /// </ul>
     /// </remarks>
-    public class AdministrativeInformation : IHasDataSpecification
+    public interface IAdministrativeInformation : IHasDataSpecification
+    {
+        /// <summary>
+        /// Version of the element.
+        /// </summary>
+        public string? Version { get; set; }
+
+        /// <summary>
+        /// Revision of the element.
+        /// </summary>
+        public string? Revision { get; set; }
+    }
+
+    /// <summary>
+    /// Administrative meta-information for an element like version
+    /// information.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Constraints:
+    /// </para>
+    /// <ul>
+    ///   <li>
+    ///     Constraint AASd-005:
+    ///     If <see cref="Aas.AdministrativeInformation.Version" /> is not specified then also <see cref="Aas.AdministrativeInformation.Revision" /> shall be
+    ///     unspecified. This means, a revision requires a version. If there is no version
+    ///     there is no revision neither. Revision is optional.
+    ///   </li>
+    /// </ul>
+    /// </remarks>
+    public class AdministrativeInformation : IAdministrativeInformation
     {
         /// <summary>
         /// Embedded data specification.
@@ -581,7 +652,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitAdministrativeInformation(this);
         }
 
         /// <summary>
@@ -592,7 +663,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitAdministrativeInformation(this, context);
         }
 
         /// <summary>
@@ -601,7 +672,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformAdministrativeInformation(this);
         }
 
         /// <summary>
@@ -612,7 +683,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformAdministrativeInformation(this, context);
         }
 
         public AdministrativeInformation(
@@ -720,7 +791,68 @@ namespace AasCore.Aas3_0_RC02
     ///   </li>
     /// </ul>
     /// </remarks>
-    public class Qualifier : IHasSemantics
+    public interface IQualifier : IHasSemantics
+    {
+        /// <summary>
+        /// The qualifier kind describes the kind of the qualifier that is applied to the
+        /// element.
+        /// </summary>
+        /// <remarks>
+        /// Default: <see cref="Aas.QualifierKind.ConceptQualifier" />
+        /// </remarks>
+        public QualifierKind? Kind { get; set; }
+
+        /// <summary>
+        /// The qualifier <em>type</em> describes the type of the qualifier that is applied to
+        /// the element.
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Data type of the qualifier value.
+        /// </summary>
+        public DataTypeDefXsd ValueType { get; set; }
+
+        /// <summary>
+        /// The qualifier value is the value of the qualifier.
+        /// </summary>
+        public string? Value { get; set; }
+
+        /// <summary>
+        /// Reference to the global unique ID of a coded value.
+        /// </summary>
+        /// <remarks>
+        /// It is recommended to use a global reference.
+        /// </remarks>
+        public Reference? ValueId { get; set; }
+
+        public QualifierKind KindOrDefault();
+    }
+
+    /// <summary>
+    /// A qualifier is a type-value-pair that makes additional statements w.r.t. the value
+    /// of the element.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Constraints:
+    /// </para>
+    /// <ul>
+    ///   <li>
+    ///     Constraint AASd-006:
+    ///     If both the <see cref="Aas.Qualifier.Value" /> and the <see cref="Aas.Qualifier.ValueId" /> of
+    ///     a <see cref="Aas.Qualifier" /> are present then the <see cref="Aas.Qualifier.Value" /> needs
+    ///     to be identical to the value of the referenced coded value
+    ///     in <see cref="Aas.Qualifier.ValueId" />.
+    ///   </li>
+    ///   <li>
+    ///     Constraint AASd-020:
+    ///     The value of <see cref="Aas.Qualifier.Value" /> shall be consistent to the data type as
+    ///     defined in <see cref="Aas.Qualifier.ValueType" />.
+    ///   </li>
+    /// </ul>
+    /// </remarks>
+    public class Qualifier : IQualifier
     {
         /// <summary>
         /// Identifier of the semantic definition of the element. It is called semantic ID
@@ -864,7 +996,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitQualifier(this);
         }
 
         /// <summary>
@@ -875,7 +1007,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitQualifier(this, context);
         }
 
         /// <summary>
@@ -884,7 +1016,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformQualifier(this);
         }
 
         /// <summary>
@@ -895,7 +1027,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformQualifier(this, context);
         }
 
         public Qualifier(
@@ -920,9 +1052,41 @@ namespace AasCore.Aas3_0_RC02
     /// <summary>
     /// An asset administration shell.
     /// </summary>
-    public class AssetAdministrationShell :
+    public interface IAssetAdministrationShell :
             IIdentifiable,
             IHasDataSpecification
+    {
+        /// <summary>
+        /// The reference to the AAS the AAS was derived from.
+        /// </summary>
+        public Reference? DerivedFrom { get; set; }
+
+        /// <summary>
+        /// Meta-information about the asset the AAS is representing.
+        /// </summary>
+        public AssetInformation AssetInformation { get; set; }
+
+        /// <summary>
+        /// References to submodels of the AAS.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// A submodel is a description of an aspect of the asset the AAS is representing.
+        /// </para>
+        /// <para>
+        /// The asset of an AAS is typically described by one or more submodels.
+        /// </para>
+        /// <para>
+        /// Temporarily no submodel might be assigned to the AAS.
+        /// </para>
+        /// </remarks>
+        public List<Reference>? Submodels { get; set; }
+    }
+
+    /// <summary>
+    /// An asset administration shell.
+    /// </summary>
+    public class AssetAdministrationShell : IAssetAdministrationShell
     {
         /// <summary>
         /// An extension of the element.
@@ -1280,7 +1444,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitAssetAdministrationShell(this);
         }
 
         /// <summary>
@@ -1291,7 +1455,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitAssetAdministrationShell(this, context);
         }
 
         /// <summary>
@@ -1300,7 +1464,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformAssetAdministrationShell(this);
         }
 
         /// <summary>
@@ -1311,7 +1475,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformAssetAdministrationShell(this, context);
         }
 
         public AssetAdministrationShell(
@@ -1369,7 +1533,72 @@ namespace AasCore.Aas3_0_RC02
     ///   </li>
     /// </ul>
     /// </remarks>
-    public class AssetInformation : IClass
+    public interface IAssetInformation : IClass
+    {
+        /// <summary>
+        /// Denotes whether the Asset is of kind <see cref="Aas.AssetKind.Type" /> or
+        /// <see cref="Aas.AssetKind.Instance" />.
+        /// </summary>
+        public AssetKind AssetKind { get; set; }
+
+        /// <summary>
+        /// Global identifier of the asset the AAS is representing.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This attribute is required as soon as the AAS is exchanged via partners in the life
+        /// cycle of the asset. In a first phase of the life cycle the asset might not yet have
+        /// a global ID but already an internal identifier. The internal identifier would be
+        /// modelled via <see cref="Aas.AssetInformation.SpecificAssetIds" />.
+        /// </para>
+        /// <para>
+        /// This is a global reference.
+        /// </para>
+        /// </remarks>
+        public Reference? GlobalAssetId { get; set; }
+
+        /// <summary>
+        /// Additional domain-specific, typically proprietary identifier for the asset like
+        /// e.g., serial number etc.
+        /// </summary>
+        public List<SpecificAssetId>? SpecificAssetIds { get; set; }
+
+        /// <summary>
+        /// Thumbnail of the asset represented by the Asset Administration Shell.
+        /// </summary>
+        /// <remarks>
+        /// Used as default.
+        /// </remarks>
+        public Resource? DefaultThumbnail { get; set; }
+    }
+
+    /// <summary>
+    /// In <see cref="Aas.AssetInformation" /> identifying meta data of the asset that is
+    /// represented by an AAS is defined.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The asset may either represent an asset type or an asset instance.
+    /// </para>
+    /// <para>
+    /// The asset has a globally unique identifier plus – if needed – additional domain
+    /// specific (proprietary) identifiers. However, to support the corner case of very
+    /// first phase of lifecycle where a stabilised/constant_set global asset identifier does
+    /// not already exist, the corresponding attribute <see cref="Aas.AssetInformation.GlobalAssetId" /> is optional.
+    /// </para>
+    /// <para>
+    /// Constraints:
+    /// </para>
+    /// <ul>
+    ///   <li>
+    ///     Constraint AASd-116:
+    ///     <c>globalAssetId</c> (case-insensitive) is a reserved key. If used as value for
+    ///     <see cref="Aas.SpecificAssetId.Name" /> then <see cref="Aas.SpecificAssetId.Value" /> shall be
+    ///     identical to <see cref="Aas.AssetInformation.GlobalAssetId" />.
+    ///   </li>
+    /// </ul>
+    /// </remarks>
+    public class AssetInformation : IAssetInformation
     {
         /// <summary>
         /// Denotes whether the Asset is of kind <see cref="Aas.AssetKind.Type" /> or
@@ -1489,7 +1718,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitAssetInformation(this);
         }
 
         /// <summary>
@@ -1500,7 +1729,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitAssetInformation(this, context);
         }
 
         /// <summary>
@@ -1509,7 +1738,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformAssetInformation(this);
         }
 
         /// <summary>
@@ -1520,7 +1749,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformAssetInformation(this, context);
         }
 
         public AssetInformation(
@@ -1540,7 +1769,30 @@ namespace AasCore.Aas3_0_RC02
     /// Resource represents an address to a file (a locator). The value is an URI that
     /// can represent an absolute or relative path
     /// </summary>
-    public class Resource : IClass
+    public interface IResource : IClass
+    {
+        /// <summary>
+        /// Path and name of the resource (with file extension).
+        /// </summary>
+        /// <remarks>
+        /// The path can be absolute or relative.
+        /// </remarks>
+        public string Path { get; set; }
+
+        /// <summary>
+        /// Content type of the content of the file.
+        /// </summary>
+        /// <remarks>
+        /// The content type states which file extensions the file can have.
+        /// </remarks>
+        public string? ContentType { get; set; }
+    }
+
+    /// <summary>
+    /// Resource represents an address to a file (a locator). The value is an URI that
+    /// can represent an absolute or relative path
+    /// </summary>
+    public class Resource : IResource
     {
         /// <summary>
         /// Path and name of the resource (with file extension).
@@ -1583,7 +1835,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitResource(this);
         }
 
         /// <summary>
@@ -1594,7 +1846,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitResource(this, context);
         }
 
         /// <summary>
@@ -1603,7 +1855,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformResource(this);
         }
 
         /// <summary>
@@ -1614,7 +1866,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformResource(this, context);
         }
 
         public Resource(
@@ -1668,7 +1920,35 @@ namespace AasCore.Aas3_0_RC02
     /// <remarks>
     /// The specific asset ID is not necessarily globally unique.
     /// </remarks>
-    public class SpecificAssetId : IHasSemantics
+    public interface ISpecificAssetId : IHasSemantics
+    {
+        /// <summary>
+        /// Name of the identifier
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The value of the specific asset identifier with the corresponding name.
+        /// </summary>
+        public string Value { get; set; }
+
+        /// <summary>
+        /// The (external) subject the key belongs to or has meaning to.
+        /// </summary>
+        /// <remarks>
+        /// This is a global reference.
+        /// </remarks>
+        public Reference ExternalSubjectId { get; set; }
+    }
+
+    /// <summary>
+    /// A specific asset ID describes a generic supplementary identifying attribute of the
+    /// asset.
+    /// </summary>
+    /// <remarks>
+    /// The specific asset ID is not necessarily globally unique.
+    /// </remarks>
+    public class SpecificAssetId : ISpecificAssetId
     {
         /// <summary>
         /// Identifier of the semantic definition of the element. It is called semantic ID
@@ -1782,7 +2062,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitSpecificAssetId(this);
         }
 
         /// <summary>
@@ -1793,7 +2073,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitSpecificAssetId(this, context);
         }
 
         /// <summary>
@@ -1802,7 +2082,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformSpecificAssetId(this);
         }
 
         /// <summary>
@@ -1813,7 +2093,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformSpecificAssetId(this, context);
         }
 
         public SpecificAssetId(
@@ -1840,12 +2120,29 @@ namespace AasCore.Aas3_0_RC02
     /// refers to a well-defined domain or subject matter. Submodels can become
     /// standardized and, thus, become submodels templates.
     /// </remarks>
-    public class Submodel :
+    public interface ISubmodel :
             IIdentifiable,
             IHasKind,
             IHasSemantics,
             IQualifiable,
             IHasDataSpecification
+    {
+        /// <summary>
+        /// A submodel consists of zero or more submodel elements.
+        /// </summary>
+        public List<ISubmodelElement>? SubmodelElements { get; set; }
+    }
+
+    /// <summary>
+    /// A submodel defines a specific aspect of the asset represented by the AAS.
+    /// </summary>
+    /// <remarks>
+    /// A submodel is used to structure the digital representation and technical
+    /// functionality of an Administration Shell into distinguishable parts. Each submodel
+    /// refers to a well-defined domain or subject matter. Submodels can become
+    /// standardized and, thus, become submodels templates.
+    /// </remarks>
+    public class Submodel : ISubmodel
     {
         /// <summary>
         /// An extension of the element.
@@ -2286,7 +2583,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitSubmodel(this);
         }
 
         /// <summary>
@@ -2297,7 +2594,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitSubmodel(this, context);
         }
 
         /// <summary>
@@ -2306,7 +2603,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformSubmodel(this);
         }
 
         /// <summary>
@@ -2317,7 +2614,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformSubmodel(this, context);
         }
 
         public Submodel(
@@ -2796,7 +3093,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitRelationshipElement(this);
         }
 
         /// <summary>
@@ -2807,7 +3104,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitRelationshipElement(this, context);
         }
 
         /// <summary>
@@ -2816,7 +3113,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformRelationshipElement(this);
         }
 
         /// <summary>
@@ -2827,7 +3124,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformRelationshipElement(this, context);
         }
 
         public RelationshipElement(
@@ -2962,7 +3259,95 @@ namespace AasCore.Aas3_0_RC02
     ///   </li>
     /// </ul>
     /// </remarks>
-    public class SubmodelElementList : ISubmodelElement
+    public interface ISubmodelElementList : ISubmodelElement
+    {
+        /// <summary>
+        /// Defines whether order in list is relevant. If <see cref="Aas.SubmodelElementList.OrderRelevant" /> = <c>False</c>
+        /// then the list is representing a set or a bag.
+        /// </summary>
+        /// <remarks>
+        /// Default: <c>True</c>
+        /// </remarks>
+        public bool? OrderRelevant { get; set; }
+
+        /// <summary>
+        /// Submodel element contained in the list.
+        /// </summary>
+        /// <remarks>
+        /// The list is ordered.
+        /// </remarks>
+        public List<ISubmodelElement>? Value { get; set; }
+
+        /// <summary>
+        /// Semantic ID the submodel elements contained in the list match to.
+        /// </summary>
+        /// <remarks>
+        /// It is recommended to use a global reference.
+        /// </remarks>
+        public Reference? SemanticIdListElement { get; set; }
+
+        /// <summary>
+        /// The submodel element type of the submodel elements contained in the list.
+        /// </summary>
+        public AasSubmodelElements TypeValueListElement { get; set; }
+
+        /// <summary>
+        /// The value type of the submodel element contained in the list.
+        /// </summary>
+        public DataTypeDefXsd? ValueTypeListElement { get; set; }
+
+        public bool OrderRelevantOrDefault();
+        /// <summary>
+        /// Iterate over Value, if set, and otherwise return an empty enumerable.
+        /// </summary>
+        public IEnumerable<ISubmodelElement> OverValueOrEmpty();
+    }
+
+    /// <summary>
+    /// A submodel element list is an ordered list of submodel elements.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The numbering starts with zero (0).
+    /// </para>
+    /// <para>
+    /// Constraints:
+    /// </para>
+    /// <ul>
+    ///   <li>
+    ///     Constraint AASd-107:
+    ///     If a first level child element in a <see cref="Aas.SubmodelElementList" /> has
+    ///     a <see cref="Aas.IHasSemantics.SemanticId" /> it
+    ///     shall be identical to <see cref="Aas.SubmodelElementList.SemanticIdListElement" />.
+    ///   </li>
+    ///   <li>
+    ///     Constraint AASd-114:
+    ///     If two first level child elements in a <see cref="Aas.SubmodelElementList" /> have
+    ///     a <see cref="Aas.IHasSemantics.SemanticId" /> then they shall be identical.
+    ///   </li>
+    ///   <li>
+    ///     Constraint AASd-115:
+    ///     If a first level child element in a <see cref="Aas.SubmodelElementList" /> does not
+    ///     specify a <see cref="Aas.IHasSemantics.SemanticId" /> then the value is assumed to be
+    ///     identical to <see cref="Aas.SubmodelElementList.SemanticIdListElement" />.
+    ///   </li>
+    ///   <li>
+    ///     Constraint AASd-108:
+    ///     All first level child elements in a <see cref="Aas.SubmodelElementList" /> shall have
+    ///     the same submodel element type as specified in <see cref="Aas.SubmodelElementList.TypeValueListElement" />.
+    ///   </li>
+    ///   <li>
+    ///     Constraint AASd-109:
+    ///     If <see cref="Aas.SubmodelElementList.TypeValueListElement" /> is equal to
+    ///     <see cref="Aas.AasSubmodelElements.Property" /> or
+    ///     <see cref="Aas.AasSubmodelElements.Range" />
+    ///     <see cref="Aas.SubmodelElementList.ValueTypeListElement" /> shall be set and all first
+    ///     level child elements in the <see cref="Aas.SubmodelElementList" /> shall have
+    ///     the value type as specified in <see cref="Aas.SubmodelElementList.ValueTypeListElement" />.
+    ///   </li>
+    /// </ul>
+    /// </remarks>
+    public class SubmodelElementList : ISubmodelElementList
     {
         /// <summary>
         /// An extension of the element.
@@ -3428,7 +3813,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitSubmodelElementList(this);
         }
 
         /// <summary>
@@ -3439,7 +3824,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitSubmodelElementList(this, context);
         }
 
         /// <summary>
@@ -3448,7 +3833,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformSubmodelElementList(this);
         }
 
         /// <summary>
@@ -3459,7 +3844,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformSubmodelElementList(this, context);
         }
 
         public SubmodelElementList(
@@ -3503,7 +3888,19 @@ namespace AasCore.Aas3_0_RC02
     /// A submodel element collection is a kind of struct, i.e. a a logical encapsulation
     /// of multiple named values. It has a fixed number of submodel elements.
     /// </summary>
-    public class SubmodelElementCollection : ISubmodelElement
+    public interface ISubmodelElementCollection : ISubmodelElement
+    {
+        /// <summary>
+        /// Submodel element contained in the collection.
+        /// </summary>
+        public List<ISubmodelElement>? Value { get; set; }
+    }
+
+    /// <summary>
+    /// A submodel element collection is a kind of struct, i.e. a a logical encapsulation
+    /// of multiple named values. It has a fixed number of submodel elements.
+    /// </summary>
+    public class SubmodelElementCollection : ISubmodelElementCollection
     {
         /// <summary>
         /// An extension of the element.
@@ -3914,7 +4311,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitSubmodelElementCollection(this);
         }
 
         /// <summary>
@@ -3925,7 +4322,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitSubmodelElementCollection(this, context);
         }
 
         /// <summary>
@@ -3934,7 +4331,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformSubmodelElementCollection(this);
         }
 
         /// <summary>
@@ -3945,7 +4342,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformSubmodelElementCollection(this, context);
         }
 
         public SubmodelElementCollection(
@@ -4023,7 +4420,44 @@ namespace AasCore.Aas3_0_RC02
     ///   </li>
     /// </ul>
     /// </remarks>
-    public class Property : IDataElement
+    public interface IProperty : IDataElement
+    {
+        /// <summary>
+        /// Data type of the value
+        /// </summary>
+        public DataTypeDefXsd ValueType { get; set; }
+
+        /// <summary>
+        /// The value of the property instance.
+        /// </summary>
+        public string? Value { get; set; }
+
+        /// <summary>
+        /// Reference to the global unique ID of a coded value.
+        /// </summary>
+        /// <remarks>
+        /// It is recommended to use a global reference.
+        /// </remarks>
+        public Reference? ValueId { get; set; }
+    }
+
+    /// <summary>
+    /// A property is a data element that has a single value.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Constraints:
+    /// </para>
+    /// <ul>
+    ///   <li>
+    ///     Constraint AASd-007:
+    ///     If both, the <see cref="Aas.Property.Value" /> and the <see cref="Aas.Property.ValueId" /> are
+    ///     present then the value of <see cref="Aas.Property.Value" /> needs to be identical to
+    ///     the value of the referenced coded value in <see cref="Aas.Property.ValueId" />.
+    ///   </li>
+    /// </ul>
+    /// </remarks>
+    public class Property : IProperty
     {
         /// <summary>
         /// An extension of the element.
@@ -4453,7 +4887,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitProperty(this);
         }
 
         /// <summary>
@@ -4464,7 +4898,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitProperty(this, context);
         }
 
         /// <summary>
@@ -4473,7 +4907,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformProperty(this);
         }
 
         /// <summary>
@@ -4484,7 +4918,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformProperty(this, context);
         }
 
         public Property(
@@ -4536,7 +4970,39 @@ namespace AasCore.Aas3_0_RC02
     ///   </li>
     /// </ul>
     /// </remarks>
-    public class MultiLanguageProperty : IDataElement
+    public interface IMultiLanguageProperty : IDataElement
+    {
+        /// <summary>
+        /// The value of the property instance.
+        /// </summary>
+        public List<LangString>? Value { get; set; }
+
+        /// <summary>
+        /// Reference to the global unique ID of a coded value.
+        /// </summary>
+        /// <remarks>
+        /// It is recommended to use a global reference.
+        /// </remarks>
+        public Reference? ValueId { get; set; }
+    }
+
+    /// <summary>
+    /// A property is a data element that has a multi-language value.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Constraints:
+    /// </para>
+    /// <ul>
+    ///   <li>
+    ///     Constraint AASd-012:
+    ///     If both the <see cref="Aas.MultiLanguageProperty.Value" /> and the <see cref="Aas.MultiLanguageProperty.ValueId" /> are present then for each
+    ///     string in a specific language the meaning must be the same as specified in
+    ///     <see cref="Aas.MultiLanguageProperty.ValueId" />.
+    ///   </li>
+    /// </ul>
+    /// </remarks>
+    public class MultiLanguageProperty : IMultiLanguageProperty
     {
         /// <summary>
         /// An extension of the element.
@@ -4992,7 +5458,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitMultiLanguageProperty(this);
         }
 
         /// <summary>
@@ -5003,7 +5469,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitMultiLanguageProperty(this, context);
         }
 
         /// <summary>
@@ -5012,7 +5478,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformMultiLanguageProperty(this);
         }
 
         /// <summary>
@@ -5023,7 +5489,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformMultiLanguageProperty(this, context);
         }
 
         public MultiLanguageProperty(
@@ -5060,7 +5526,34 @@ namespace AasCore.Aas3_0_RC02
     /// <summary>
     /// A range data element is a data element that defines a range with min and max.
     /// </summary>
-    public class Range : IDataElement
+    public interface IRange : IDataElement
+    {
+        /// <summary>
+        /// Data type of the min und max
+        /// </summary>
+        public DataTypeDefXsd ValueType { get; set; }
+
+        /// <summary>
+        /// The minimum value of the range.
+        /// </summary>
+        /// <remarks>
+        /// If the min value is missing, then the value is assumed to be negative infinite.
+        /// </remarks>
+        public string? Min { get; set; }
+
+        /// <summary>
+        /// The maximum value of the range.
+        /// </summary>
+        /// <remarks>
+        /// If the max value is missing, then the value is assumed to be positive infinite.
+        /// </remarks>
+        public string? Max { get; set; }
+    }
+
+    /// <summary>
+    /// A range data element is a data element that defines a range with min and max.
+    /// </summary>
+    public class Range : IRange
     {
         /// <summary>
         /// An extension of the element.
@@ -5477,7 +5970,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitRange(this);
         }
 
         /// <summary>
@@ -5488,7 +5981,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitRange(this, context);
         }
 
         /// <summary>
@@ -5497,7 +5990,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformRange(this);
         }
 
         /// <summary>
@@ -5508,7 +6001,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformRange(this, context);
         }
 
         public Range(
@@ -5549,7 +6042,22 @@ namespace AasCore.Aas3_0_RC02
     /// element within the same or another AAS or a reference to an external object or
     /// entity.
     /// </summary>
-    public class ReferenceElement : IDataElement
+    public interface IReferenceElement : IDataElement
+    {
+        /// <summary>
+        /// Global reference to an external object or entity or a logical reference to
+        /// another element within the same or another AAS (i.e. a model reference to
+        /// a Referable).
+        /// </summary>
+        public Reference? Value { get; set; }
+    }
+
+    /// <summary>
+    /// A reference element is a data element that defines a logical reference to another
+    /// element within the same or another AAS or a reference to an external object or
+    /// entity.
+    /// </summary>
+    public class ReferenceElement : IReferenceElement
     {
         /// <summary>
         /// An extension of the element.
@@ -5968,7 +6476,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitReferenceElement(this);
         }
 
         /// <summary>
@@ -5979,7 +6487,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitReferenceElement(this, context);
         }
 
         /// <summary>
@@ -5988,7 +6496,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformReferenceElement(this);
         }
 
         /// <summary>
@@ -5999,7 +6507,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformReferenceElement(this, context);
         }
 
         public ReferenceElement(
@@ -6035,7 +6543,40 @@ namespace AasCore.Aas3_0_RC02
     /// A <see cref="Aas.Blob" /> is a data element that represents a file that is contained with its
     /// source code in the value attribute.
     /// </summary>
-    public class Blob : IDataElement
+    public interface IBlob : IDataElement
+    {
+        /// <summary>
+        /// The value of the <see cref="Aas.Blob" /> instance of a blob data element.
+        /// </summary>
+        /// <remarks>
+        /// In contrast to the file property the file content is stored directly as value
+        /// in the <see cref="Aas.Blob" /> data element.
+        /// </remarks>
+        public byte[]? Value { get; set; }
+
+        /// <summary>
+        /// Content type of the content of the <see cref="Aas.Blob" />.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The content type (MIME type) states which file extensions the file can have.
+        /// </para>
+        /// <para>
+        /// Valid values are content types like e.g. <c>application/json</c>, <c>application/xls</c>,
+        /// <c>image/jpg</c>.
+        /// </para>
+        /// <para>
+        /// The allowed values are defined as in RFC2046.
+        /// </para>
+        /// </remarks>
+        public string ContentType { get; set; }
+    }
+
+    /// <summary>
+    /// A <see cref="Aas.Blob" /> is a data element that represents a file that is contained with its
+    /// source code in the value attribute.
+    /// </summary>
+    public class Blob : IBlob
     {
         /// <summary>
         /// An extension of the element.
@@ -6457,7 +6998,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitBlob(this);
         }
 
         /// <summary>
@@ -6468,7 +7009,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitBlob(this, context);
         }
 
         /// <summary>
@@ -6477,7 +7018,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformBlob(this);
         }
 
         /// <summary>
@@ -6488,7 +7029,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformBlob(this, context);
         }
 
         public Blob(
@@ -6528,7 +7069,32 @@ namespace AasCore.Aas3_0_RC02
     /// <remarks>
     /// The value is an URI that can represent an absolute or relative path.
     /// </remarks>
-    public class File : IDataElement
+    public interface IFile : IDataElement
+    {
+        /// <summary>
+        /// Path and name of the referenced file (with file extension).
+        /// </summary>
+        /// <remarks>
+        /// The path can be absolute or relative.
+        /// </remarks>
+        public string? Value { get; set; }
+
+        /// <summary>
+        /// Content type of the content of the file.
+        /// </summary>
+        /// <remarks>
+        /// The content type states which file extensions the file can have.
+        /// </remarks>
+        public string ContentType { get; set; }
+    }
+
+    /// <summary>
+    /// A File is a data element that represents an address to a file (a locator).
+    /// </summary>
+    /// <remarks>
+    /// The value is an URI that can represent an absolute or relative path.
+    /// </remarks>
+    public class File : IFile
     {
         /// <summary>
         /// An extension of the element.
@@ -6940,7 +7506,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitFile(this);
         }
 
         /// <summary>
@@ -6951,7 +7517,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitFile(this, context);
         }
 
         /// <summary>
@@ -6960,7 +7526,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformFile(this);
         }
 
         /// <summary>
@@ -6971,7 +7537,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformFile(this, context);
         }
 
         public File(
@@ -7009,7 +7575,20 @@ namespace AasCore.Aas3_0_RC02
     /// An annotated relationship element is a relationship element that can be annotated
     /// with additional data elements.
     /// </summary>
-    public class AnnotatedRelationshipElement : IRelationshipElement
+    public interface IAnnotatedRelationshipElement : IRelationshipElement
+    {
+        /// <summary>
+        /// A data element that represents an annotation that holds for the relationship
+        /// between the two elements
+        /// </summary>
+        public List<IDataElement>? Annotations { get; set; }
+    }
+
+    /// <summary>
+    /// An annotated relationship element is a relationship element that can be annotated
+    /// with additional data elements.
+    /// </summary>
+    public class AnnotatedRelationshipElement : IAnnotatedRelationshipElement
     {
         /// <summary>
         /// An extension of the element.
@@ -7451,7 +8030,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitAnnotatedRelationshipElement(this);
         }
 
         /// <summary>
@@ -7462,7 +8041,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitAnnotatedRelationshipElement(this, context);
         }
 
         /// <summary>
@@ -7471,7 +8050,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformAnnotatedRelationshipElement(this);
         }
 
         /// <summary>
@@ -7482,7 +8061,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformAnnotatedRelationshipElement(this, context);
         }
 
         public AnnotatedRelationshipElement(
@@ -7558,7 +8137,51 @@ namespace AasCore.Aas3_0_RC02
     ///   </li>
     /// </ul>
     /// </remarks>
-    public class Entity : ISubmodelElement
+    public interface IEntity : ISubmodelElement
+    {
+        /// <summary>
+        /// Describes statements applicable to the entity by a set of submodel elements,
+        /// typically with a qualified value.
+        /// </summary>
+        public List<ISubmodelElement>? Statements { get; set; }
+
+        /// <summary>
+        /// Describes whether the entity is a co-managed entity or a self-managed entity.
+        /// </summary>
+        public EntityType EntityType { get; set; }
+
+        /// <summary>
+        /// Global identifier of the asset the entity is representing.
+        /// </summary>
+        /// <remarks>
+        /// This is a global reference.
+        /// </remarks>
+        public Reference? GlobalAssetId { get; set; }
+
+        /// <summary>
+        /// Reference to a specific asset ID representing a supplementary identifier
+        /// of the asset represented by the Asset Administration Shell.
+        /// </summary>
+        public SpecificAssetId? SpecificAssetId { get; set; }
+    }
+
+    /// <summary>
+    /// An entity is a submodel element that is used to model entities.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Constraints:
+    /// </para>
+    /// <ul>
+    ///   <li>
+    ///     Constraint AASd-014:
+    ///     Either the attribute <see cref="Aas.Entity.GlobalAssetId" /> or <see cref="Aas.Entity.SpecificAssetId" />
+    ///     of an <see cref="Aas.Entity" /> must be set if <see cref="Aas.Entity.EntityType" /> is set to
+    ///     <see cref="Aas.EntityType.SelfManagedEntity" />. They are not existing otherwise.
+    ///   </li>
+    /// </ul>
+    /// </remarks>
+    public class Entity : IEntity
     {
         /// <summary>
         /// An extension of the element.
@@ -8021,7 +8644,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitEntity(this);
         }
 
         /// <summary>
@@ -8032,7 +8655,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitEntity(this, context);
         }
 
         /// <summary>
@@ -8041,7 +8664,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformEntity(this);
         }
 
         /// <summary>
@@ -8052,7 +8675,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformEntity(this, context);
         }
 
         public Entity(
@@ -8129,7 +8752,70 @@ namespace AasCore.Aas3_0_RC02
     /// <summary>
     /// Defines the necessary information of an event instance sent out or received.
     /// </summary>
-    public class EventPayload : IClass
+    public interface IEventPayload : IClass
+    {
+        /// <summary>
+        /// Reference to the source event element, including identification of
+        /// <see cref="Aas.AssetAdministrationShell" />, <see cref="Aas.Submodel" />,
+        /// <see cref="Aas.ISubmodelElement" />'s.
+        /// </summary>
+        public Reference Source { get; set; }
+
+        /// <summary>
+        /// <see cref="Aas.IHasSemantics.SemanticId" /> of the source event element, if available
+        /// </summary>
+        /// <remarks>
+        /// It is recommended to use a global reference.
+        /// </remarks>
+        public Reference? SourceSemanticId { get; set; }
+
+        /// <summary>
+        /// Reference to the referable, which defines the scope of the event.
+        /// </summary>
+        /// <remarks>
+        /// Can be <see cref="Aas.AssetAdministrationShell" />, <see cref="Aas.Submodel" /> or
+        /// <see cref="Aas.ISubmodelElement" />.
+        /// </remarks>
+        public Reference ObservableReference { get; set; }
+
+        /// <summary>
+        /// <see cref="Aas.IHasSemantics.SemanticId" /> of the referable which defines the scope of
+        /// the event, if available.
+        /// </summary>
+        /// <remarks>
+        /// It is recommended to use a global reference.
+        /// </remarks>
+        public Reference? ObservableSemanticId { get; set; }
+
+        /// <summary>
+        /// Information for the outer message infrastructure for scheduling the event to
+        /// the respective communication channel.
+        /// </summary>
+        public string? Topic { get; set; }
+
+        /// <summary>
+        /// Subject, who/which initiated the creation.
+        /// </summary>
+        /// <remarks>
+        /// This is a global reference.
+        /// </remarks>
+        public Reference? SubjectId { get; set; }
+
+        /// <summary>
+        /// Timestamp in UTC, when this event was triggered.
+        /// </summary>
+        public string TimeStamp { get; set; }
+
+        /// <summary>
+        /// Event specific payload.
+        /// </summary>
+        public string? Payload { get; set; }
+    }
+
+    /// <summary>
+    /// Defines the necessary information of an event instance sent out or received.
+    /// </summary>
+    public class EventPayload : IEventPayload
     {
         /// <summary>
         /// Reference to the source event element, including identification of
@@ -8275,7 +8961,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitEventPayload(this);
         }
 
         /// <summary>
@@ -8286,7 +8972,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitEventPayload(this, context);
         }
 
         /// <summary>
@@ -8295,7 +8981,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformEventPayload(this);
         }
 
         /// <summary>
@@ -8306,7 +8992,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformEventPayload(this, context);
         }
 
         public EventPayload(
@@ -8341,7 +9027,95 @@ namespace AasCore.Aas3_0_RC02
     /// <summary>
     /// A basic event element.
     /// </summary>
-    public class BasicEventElement : IEventElement
+    public interface IBasicEventElement : IEventElement
+    {
+        /// <summary>
+        /// Reference to the <see cref="Aas.IReferable" />, which defines the scope of the event.
+        /// Can be <see cref="Aas.AssetAdministrationShell" />, <see cref="Aas.Submodel" />, or
+        /// <see cref="Aas.ISubmodelElement" />.
+        /// </summary>
+        /// <remarks>
+        /// Reference to a referable, e.g., a data element or
+        /// a submodel, that is being observed.
+        /// </remarks>
+        public Reference Observed { get; set; }
+
+        /// <summary>
+        /// Direction of event.
+        /// </summary>
+        /// <remarks>
+        /// Can be <c>{ Input, Output }</c>.
+        /// </remarks>
+        public Direction Direction { get; set; }
+
+        /// <summary>
+        /// State of event.
+        /// </summary>
+        /// <remarks>
+        /// Can be <c>{ On, Off }</c>.
+        /// </remarks>
+        public StateOfEvent State { get; set; }
+
+        /// <summary>
+        /// Information for the outer message infrastructure for scheduling the event to the
+        /// respective communication channel.
+        /// </summary>
+        public string? MessageTopic { get; set; }
+
+        /// <summary>
+        /// Information, which outer message infrastructure shall handle messages for
+        /// the <see cref="Aas.IEventElement" />. Refers to a <see cref="Aas.Submodel" />,
+        /// <see cref="Aas.SubmodelElementList" />, <see cref="Aas.SubmodelElementCollection" /> or
+        /// <see cref="Aas.Entity" />, which contains <see cref="Aas.IDataElement" />'s describing
+        /// the proprietary specification for the message broker.
+        /// </summary>
+        /// <remarks>
+        /// For different message infrastructure, e.g., OPC UA or MQTT or AMQP, this
+        /// proprietary specification could be standardized by having respective Submodels.
+        /// </remarks>
+        public Reference? MessageBroker { get; set; }
+
+        /// <summary>
+        /// Timestamp in UTC, when the last event was received (input direction) or sent
+        /// (output direction).
+        /// </summary>
+        public string? LastUpdate { get; set; }
+
+        /// <summary>
+        /// For input direction, reports on the maximum frequency, the software entity behind
+        /// the respective Referable can handle input events.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// For output events, specifies the maximum frequency of outputting this event to
+        /// an outer infrastructure.
+        /// </para>
+        /// <para>
+        /// Might be not specified, that is, there is no minimum interval.
+        /// </para>
+        /// </remarks>
+        public string? MinInterval { get; set; }
+
+        /// <summary>
+        /// For input direction: not applicable.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// For output direction: maximum interval in time, the respective Referable shall send
+        /// an update of the status of the event, even if no other trigger condition for
+        /// the event was not met.
+        /// </para>
+        /// <para>
+        /// Might be not specified, that is, there is no maximum interval
+        /// </para>
+        /// </remarks>
+        public string? MaxInterval { get; set; }
+    }
+
+    /// <summary>
+    /// A basic event element.
+    /// </summary>
+    public class BasicEventElement : IBasicEventElement
     {
         /// <summary>
         /// An extension of the element.
@@ -8824,7 +9598,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitBasicEventElement(this);
         }
 
         /// <summary>
@@ -8835,7 +9609,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitBasicEventElement(this, context);
         }
 
         /// <summary>
@@ -8844,7 +9618,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformBasicEventElement(this);
         }
 
         /// <summary>
@@ -8855,7 +9629,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformBasicEventElement(this, context);
         }
 
         public BasicEventElement(
@@ -8904,7 +9678,28 @@ namespace AasCore.Aas3_0_RC02
     /// <summary>
     /// An operation is a submodel element with input and output variables.
     /// </summary>
-    public class Operation : ISubmodelElement
+    public interface IOperation : ISubmodelElement
+    {
+        /// <summary>
+        /// Input parameter of the operation.
+        /// </summary>
+        public List<OperationVariable>? InputVariables { get; set; }
+
+        /// <summary>
+        /// Output parameter of the operation.
+        /// </summary>
+        public List<OperationVariable>? OutputVariables { get; set; }
+
+        /// <summary>
+        /// Parameter that is input and output of the operation.
+        /// </summary>
+        public List<OperationVariable>? InoutputVariables { get; set; }
+    }
+
+    /// <summary>
+    /// An operation is a submodel element with input and output variables.
+    /// </summary>
+    public class Operation : IOperation
     {
         /// <summary>
         /// An extension of the element.
@@ -9387,7 +10182,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitOperation(this);
         }
 
         /// <summary>
@@ -9398,7 +10193,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitOperation(this, context);
         }
 
         /// <summary>
@@ -9407,7 +10202,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformOperation(this);
         }
 
         /// <summary>
@@ -9418,7 +10213,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformOperation(this, context);
         }
 
         public Operation(
@@ -9458,7 +10253,19 @@ namespace AasCore.Aas3_0_RC02
     /// The value of an operation variable is a submodel element that is used as input
     /// and/or output variable of an operation.
     /// </summary>
-    public class OperationVariable : IClass
+    public interface IOperationVariable : IClass
+    {
+        /// <summary>
+        /// Describes an argument or result of an operation via a submodel element
+        /// </summary>
+        public ISubmodelElement Value { get; set; }
+    }
+
+    /// <summary>
+    /// The value of an operation variable is a submodel element that is used as input
+    /// and/or output variable of an operation.
+    /// </summary>
+    public class OperationVariable : IOperationVariable
     {
         /// <summary>
         /// Describes an argument or result of an operation via a submodel element
@@ -9494,7 +10301,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitOperationVariable(this);
         }
 
         /// <summary>
@@ -9505,7 +10312,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitOperationVariable(this, context);
         }
 
         /// <summary>
@@ -9514,7 +10321,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformOperationVariable(this);
         }
 
         /// <summary>
@@ -9525,7 +10332,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformOperationVariable(this, context);
         }
 
         public OperationVariable(ISubmodelElement value)
@@ -9542,7 +10349,20 @@ namespace AasCore.Aas3_0_RC02
     /// The <see cref="Aas.Capability.SemanticId" /> of a capability is typically an ontology.
     /// Thus, reasoning on capabilities is enabled.
     /// </remarks>
-    public class Capability : ISubmodelElement
+    public interface ICapability : ISubmodelElement
+    {
+        // Intentionally empty.
+    }
+
+    /// <summary>
+    /// A capability is the implementation-independent description of the potential of an
+    /// asset to achieve a certain effect in the physical or virtual world.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="Aas.Capability.SemanticId" /> of a capability is typically an ontology.
+    /// Thus, reasoning on capabilities is enabled.
+    /// </remarks>
+    public class Capability : ICapability
     {
         /// <summary>
         /// An extension of the element.
@@ -9917,7 +10737,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitCapability(this);
         }
 
         /// <summary>
@@ -9928,7 +10748,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitCapability(this, context);
         }
 
         /// <summary>
@@ -9937,7 +10757,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformCapability(this);
         }
 
         /// <summary>
@@ -9948,7 +10768,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformCapability(this, context);
         }
 
         public Capability(
@@ -10048,9 +10868,102 @@ namespace AasCore.Aas3_0_RC02
     ///   </li>
     /// </ul>
     /// </remarks>
-    public class ConceptDescription :
+    public interface IConceptDescription :
             IIdentifiable,
             IHasDataSpecification
+    {
+        /// <summary>
+        /// Reference to an external definition the concept is compatible to or was derived
+        /// from.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// It is recommended to use a global reference.
+        /// </para>
+        /// <para>
+        /// Compare to is-case-of relationship in ISO 13584-32 &amp; IEC EN 61360"
+        /// </para>
+        /// </remarks>
+        public List<Reference>? IsCaseOf { get; set; }
+
+        public string CategoryOrDefault();
+        /// <summary>
+        /// Iterate over IsCaseOf, if set, and otherwise return an empty enumerable.
+        /// </summary>
+        public IEnumerable<Reference> OverIsCaseOfOrEmpty();
+    }
+
+    /// <summary>
+    /// The semantics of a property or other elements that may have a semantic description
+    /// is defined by a concept description.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The description of the concept should follow a standardized schema (realized as
+    /// data specification template).
+    /// </para>
+    /// <para>
+    /// Constraints:
+    /// </para>
+    /// <ul>
+    ///   <li>
+    ///     <para>
+    ///     Constraint AASd-051:
+    ///     A <see cref="Aas.ConceptDescription" /> shall have one of the following categories
+    ///     <c>VALUE</c>, <c>PROPERTY</c>, <c>REFERENCE</c>, <c>DOCUMENT</c>, <c>CAPABILITY</c>,
+    ///     <c>RELATIONSHIP</c>, <c>COLLECTION</c>, <c>FUNCTION</c>, <c>EVENT</c>, <c>ENTITY</c>,
+    ///     <c>APPLICATION_CLASS</c>, <c>QUALIFIER</c>, <c>VIEW</c>.
+    ///     </para>
+    ///     <para>
+    ///     Default: <c>PROPERTY</c>.
+    ///     </para>
+    ///   </li>
+    ///   <li>
+    ///     Constraint AASc-004:
+    ///     For a <see cref="Aas.ConceptDescription" /> with <see cref="Aas.ConceptDescription.Category" /> <c>PROPERTY</c> or
+    ///     <c>VALUE</c> using data specification IEC61360,
+    ///     the <see cref="Aas.DataSpecificationIec61360.DataType" /> is mandatory and shall be
+    ///     one of: <c>DATE</c>, <c>STRING</c>, <c>STRING_TRANSLATABLE</c>, <c>INTEGER_MEASURE</c>,
+    ///     <c>INTEGER_COUNT</c>, <c>INTEGER_CURRENCY</c>, <c>REAL_MEASURE</c>, <c>REAL_COUNT</c>,
+    ///     <c>REAL_CURRENCY</c>, <c>BOOLEAN</c>, <c>RATIONAL</c>, <c>RATIONAL_MEASURE</c>,
+    ///     <c>TIME</c>, <c>TIMESTAMP</c>.
+    ///   </li>
+    ///   <li>
+    ///     Constraint AASc-005:
+    ///     For a <see cref="Aas.ConceptDescription" /> with <see cref="Aas.ConceptDescription.Category" /> <c>REFERENCE</c>
+    ///     using data specification IEC61360,
+    ///     the <see cref="Aas.DataSpecificationIec61360.DataType" /> is mandatory and shall be
+    ///     one of: <c>STRING</c>, <c>IRI</c>, <c>IRDI</c>.
+    ///   </li>
+    ///   <li>
+    ///     Constraint AASc-006:
+    ///     For a <see cref="Aas.ConceptDescription" /> with <see cref="Aas.ConceptDescription.Category" /> <c>DOCUMENT</c>
+    ///     using data specification IEC61360,
+    ///     the <see cref="Aas.DataSpecificationIec61360.DataType" /> is mandatory and shall be
+    ///     defined.
+    ///   </li>
+    ///   <li>
+    ///     Constraint AASc-007:
+    ///     For a <see cref="Aas.ConceptDescription" /> with <see cref="Aas.ConceptDescription.Category" /> <c>QUALIFIER_TYPE</c>
+    ///     using data specification IEC61360,
+    ///     the <see cref="Aas.DataSpecificationIec61360.DataType" /> is mandatory and shall be
+    ///   </li>
+    ///   <li>
+    ///     Constraint AASc-008:
+    ///     For all <see cref="Aas.ConceptDescription" />'s with a category except
+    ///     <see cref="Aas.ConceptDescription.Category" /> <c>VALUE</c> using data specification IEC61360,
+    ///     <see cref="Aas.DataSpecificationIec61360.Definition" /> is mandatory and shall be
+    ///     defined at least in English.
+    ///   </li>
+    ///   <li>
+    ///     Constraint AASc-003:
+    ///     For a <see cref="Aas.ConceptDescription" /> with <see cref="Aas.ConceptDescription.Category" /> <c>VALUE</c>
+    ///     using data specification IEC61360,
+    ///     the <see cref="Aas.DataSpecificationIec61360.Value" /> shall be set.
+    ///   </li>
+    /// </ul>
+    /// </remarks>
+    public class ConceptDescription : IConceptDescription
     {
         /// <summary>
         /// An extension of the element.
@@ -10391,7 +11304,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitConceptDescription(this);
         }
 
         /// <summary>
@@ -10402,7 +11315,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitConceptDescription(this, context);
         }
 
         /// <summary>
@@ -10411,7 +11324,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformConceptDescription(this);
         }
 
         /// <summary>
@@ -10422,7 +11335,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformConceptDescription(this, context);
         }
 
         public ConceptDescription(
@@ -10562,7 +11475,131 @@ namespace AasCore.Aas3_0_RC02
     ///   </li>
     /// </ul>
     /// </remarks>
-    public class Reference : IClass
+    public interface IReference : IClass
+    {
+        /// <summary>
+        /// Type of the reference.
+        /// </summary>
+        /// <remarks>
+        /// Denotes, whether reference is a global reference or a model reference.
+        /// </remarks>
+        public ReferenceTypes Type { get; set; }
+
+        /// <summary>
+        /// <see cref="Aas.IHasSemantics.SemanticId" /> of the referenced model element
+        /// (<see cref="Aas.Reference.Type" /> = <see cref="Aas.ReferenceTypes.ModelReference" />).
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// For global references there typically is no semantic ID.
+        /// </para>
+        /// <para>
+        /// It is recommended to use a global reference.
+        /// </para>
+        /// </remarks>
+        public Reference? ReferredSemanticId { get; set; }
+
+        /// <summary>
+        /// Unique references in their name space.
+        /// </summary>
+        public List<Key> Keys { get; set; }
+    }
+
+    /// <summary>
+    /// Reference to either a model element of the same or another AAS or to an external
+    /// entity.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A reference is an ordered list of keys.
+    /// </para>
+    /// <para>
+    /// A model reference is an ordered list of keys, each key referencing an element. The
+    /// complete list of keys may for example be concatenated to a path that then gives
+    /// unique access to an element.
+    /// </para>
+    /// <para>
+    /// A global reference is a reference to an external entity.
+    /// </para>
+    /// <para>
+    /// Constraints:
+    /// </para>
+    /// <ul>
+    ///   <li>
+    ///     Constraint AASd-121:
+    ///     For <see cref="Aas.Reference" />'s the <see cref="Aas.Key.Type" /> of the first key of
+    ///     <see cref="Aas.Reference.Keys" /> shall be one of <see cref="Aas.Constants.GloballyIdentifiables" />.
+    ///   </li>
+    ///   <li>
+    ///     Constraint AASd-122:
+    ///     For global references, i.e. <see cref="Aas.Reference" />'s with
+    ///     <see cref="Aas.Reference.Type" /> = <see cref="Aas.ReferenceTypes.GlobalReference" />, the type
+    ///     of the first key of <see cref="Aas.Reference.Keys" /> shall be one of
+    ///     <see cref="Aas.Constants.GenericGloballyIdentifiables" />.
+    ///   </li>
+    ///   <li>
+    ///     Constraint AASd-123:
+    ///     For model references, i.e. <see cref="Aas.Reference" />'s with
+    ///     <see cref="Aas.Reference.Type" /> = <see cref="Aas.ReferenceTypes.ModelReference" />, the type
+    ///     of the first key of <see cref="Aas.Reference.Keys" /> shall be one of
+    ///     <see cref="Aas.Constants.AasIdentifiables" />.
+    ///   </li>
+    ///   <li>
+    ///     Constraint AASd-124:
+    ///     For global references, i.e. <see cref="Aas.Reference" />'s with
+    ///     <see cref="Aas.Reference.Type" /> = <see cref="Aas.ReferenceTypes.GlobalReference" />, the last
+    ///     key of <see cref="Aas.Reference.Keys" /> shall be either one of
+    ///     <see cref="Aas.Constants.GenericGloballyIdentifiables" /> or one of
+    ///     <see cref="Aas.Constants.GenericFragmentKeys" />.
+    ///   </li>
+    ///   <li>
+    ///     <para>
+    ///     Constraint AASd-125:
+    ///     For model references, i.e. <see cref="Aas.Reference" />'s with
+    ///     <see cref="Aas.Reference.Type" /> = <see cref="Aas.ReferenceTypes.ModelReference" />, with more
+    ///     than one key in <see cref="Aas.Reference.Keys" /> the type of the keys following the first
+    ///     key of <see cref="Aas.Reference.Keys" /> shall be one of <see cref="Aas.Constants.FragmentKeys" />.
+    ///     </para>
+    ///     <para>
+    ///     Constraint AASd-125 ensures that the shortest path is used.
+    ///     </para>
+    ///   </li>
+    ///   <li>
+    ///     Constraint AASd-126:
+    ///     For model references, i.e. <see cref="Aas.Reference" />'s with
+    ///     <see cref="Aas.Reference.Type" /> = <see cref="Aas.ReferenceTypes.ModelReference" />, with more
+    ///     than one key in <see cref="Aas.Reference.Keys" /> the type of the last key in the
+    ///     reference key chain may be one of <see cref="Aas.Constants.GenericFragmentKeys" /> or no key
+    ///     at all shall have a value out of <see cref="Aas.Constants.GenericFragmentKeys" />.
+    ///   </li>
+    ///   <li>
+    ///     <para>
+    ///     Constraint AASd-127:
+    ///     For model references, i.e. <see cref="Aas.Reference" />'s with
+    ///     <see cref="Aas.Reference.Type" /> = <see cref="Aas.ReferenceTypes.ModelReference" />, with more
+    ///     than one key in <see cref="Aas.Reference.Keys" /> a key with <see cref="Aas.Key.Type" />
+    ///     <see cref="Aas.KeyTypes.FragmentReference" /> shall be preceded by a key with
+    ///     <see cref="Aas.Key.Type" /> <see cref="Aas.KeyTypes.File" /> or <see cref="Aas.KeyTypes.Blob" />. All other
+    ///     AAS fragments, i.e. type values out of <see cref="Aas.Constants.AasSubmodelElementsAsKeys" />,
+    ///     do not support fragments.
+    ///     </para>
+    ///     <para>
+    ///     Which kind of fragments are supported depends on the content type and the
+    ///     specification of allowed fragment identifiers for the corresponding resource
+    ///     being referenced via the reference.
+    ///     </para>
+    ///   </li>
+    ///   <li>
+    ///     Constraint AASd-128:
+    ///     For model references, i.e. <see cref="Aas.Reference" />'s with
+    ///     <see cref="Aas.Reference.Type" /> = <see cref="Aas.ReferenceTypes.ModelReference" />, the
+    ///     <see cref="Aas.Key.Value" /> of a <see cref="Aas.Key" /> preceded by a <see cref="Aas.Key" /> with
+    ///     <see cref="Aas.Key.Type" /> = <see cref="Aas.KeyTypes.SubmodelElementList" /> is an integer
+    ///     number denoting the position in the array of the submodel element list.
+    ///   </li>
+    /// </ul>
+    /// </remarks>
+    public class Reference : IReference
     {
         /// <summary>
         /// Type of the reference.
@@ -10642,7 +11679,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitReference(this);
         }
 
         /// <summary>
@@ -10653,7 +11690,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitReference(this, context);
         }
 
         /// <summary>
@@ -10662,7 +11699,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformReference(this);
         }
 
         /// <summary>
@@ -10673,7 +11710,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformReference(this, context);
         }
 
         public Reference(
@@ -10690,7 +11727,34 @@ namespace AasCore.Aas3_0_RC02
     /// <summary>
     /// A key is a reference to an element by its ID.
     /// </summary>
-    public class Key : IClass
+    public interface IKey : IClass
+    {
+        /// <summary>
+        /// Denotes which kind of entity is referenced.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// In case <see cref="Aas.Key.Type" /> = <see cref="Aas.KeyTypes.FragmentReference" /> the key represents
+        /// a bookmark or a similar local identifier within its parent element as specified
+        /// by the key that precedes this key.
+        /// </para>
+        /// <para>
+        /// In all other cases the key references a model element of the same or of another AAS.
+        /// The name of the model element is explicitly listed.
+        /// </para>
+        /// </remarks>
+        public KeyTypes Type { get; set; }
+
+        /// <summary>
+        /// The key value, for example an IRDI or an URI
+        /// </summary>
+        public string Value { get; set; }
+    }
+
+    /// <summary>
+    /// A key is a reference to an element by its ID.
+    /// </summary>
+    public class Key : IKey
     {
         /// <summary>
         /// Denotes which kind of entity is referenced.
@@ -10738,7 +11802,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitKey(this);
         }
 
         /// <summary>
@@ -10749,7 +11813,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitKey(this, context);
         }
 
         /// <summary>
@@ -10758,7 +11822,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformKey(this);
         }
 
         /// <summary>
@@ -10769,7 +11833,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformKey(this, context);
         }
 
         public Key(
@@ -11016,7 +12080,23 @@ namespace AasCore.Aas3_0_RC02
     /// <summary>
     /// Strings with language tags
     /// </summary>
-    public class LangString : IClass
+    public interface ILangString : IClass
+    {
+        /// <summary>
+        /// Language tag conforming to BCP 47
+        /// </summary>
+        public string Language { get; set; }
+
+        /// <summary>
+        /// Text in the <see cref="Aas.LangString.Language" />
+        /// </summary>
+        public string Text { get; set; }
+    }
+
+    /// <summary>
+    /// Strings with language tags
+    /// </summary>
+    public class LangString : ILangString
     {
         /// <summary>
         /// Language tag conforming to BCP 47
@@ -11053,7 +12133,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitLangString(this);
         }
 
         /// <summary>
@@ -11064,7 +12144,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitLangString(this, context);
         }
 
         /// <summary>
@@ -11073,7 +12153,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformLangString(this);
         }
 
         /// <summary>
@@ -11084,7 +12164,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformLangString(this, context);
         }
 
         public LangString(
@@ -11104,7 +12184,33 @@ namespace AasCore.Aas3_0_RC02
     /// files the contained elements are split. If the file is split then there
     /// shall be no element with the same identifier in two different files.
     /// </remarks>
-    public class Environment : IClass
+    public interface IEnvironment : IClass
+    {
+        /// <summary>
+        /// Asset administration shell
+        /// </summary>
+        public List<AssetAdministrationShell>? AssetAdministrationShells { get; set; }
+
+        /// <summary>
+        /// Submodel
+        /// </summary>
+        public List<Submodel>? Submodels { get; set; }
+
+        /// <summary>
+        /// Concept description
+        /// </summary>
+        public List<ConceptDescription>? ConceptDescriptions { get; set; }
+    }
+
+    /// <summary>
+    /// Container for the sets of different identifiables.
+    /// </summary>
+    /// <remarks>
+    /// w.r.t. file exchange: There is exactly one environment independent on how many
+    /// files the contained elements are split. If the file is split then there
+    /// shall be no element with the same identifier in two different files.
+    /// </remarks>
+    public class Environment : IEnvironment
     {
         /// <summary>
         /// Asset administration shell
@@ -11233,7 +12339,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitEnvironment(this);
         }
 
         /// <summary>
@@ -11244,7 +12350,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitEnvironment(this, context);
         }
 
         /// <summary>
@@ -11253,7 +12359,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformEnvironment(this);
         }
 
         /// <summary>
@@ -11264,7 +12370,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformEnvironment(this, context);
         }
 
         public Environment(
@@ -11291,7 +12397,23 @@ namespace AasCore.Aas3_0_RC02
     /// <summary>
     /// Embed the content of a data specification.
     /// </summary>
-    public class EmbeddedDataSpecification : IClass
+    public interface IEmbeddedDataSpecification : IClass
+    {
+        /// <summary>
+        /// Reference to the data specification
+        /// </summary>
+        public Reference DataSpecification { get; set; }
+
+        /// <summary>
+        /// Actual content of the data specification
+        /// </summary>
+        public IDataSpecificationContent DataSpecificationContent { get; set; }
+    }
+
+    /// <summary>
+    /// Embed the content of a data specification.
+    /// </summary>
+    public class EmbeddedDataSpecification : IEmbeddedDataSpecification
     {
         /// <summary>
         /// Reference to the data specification
@@ -11342,7 +12464,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitEmbeddedDataSpecification(this);
         }
 
         /// <summary>
@@ -11353,7 +12475,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitEmbeddedDataSpecification(this, context);
         }
 
         /// <summary>
@@ -11362,7 +12484,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformEmbeddedDataSpecification(this);
         }
 
         /// <summary>
@@ -11373,7 +12495,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformEmbeddedDataSpecification(this, context);
         }
 
         public EmbeddedDataSpecification(
@@ -11578,7 +12700,27 @@ namespace AasCore.Aas3_0_RC02
     /// A value reference pair within a value list. Each value has a global unique id
     /// defining its semantic.
     /// </summary>
-    public class ValueReferencePair : IClass
+    public interface IValueReferencePair : IClass
+    {
+        /// <summary>
+        /// The value of the referenced concept definition of the value in valueId.
+        /// </summary>
+        public string Value { get; set; }
+
+        /// <summary>
+        /// Global unique id of the value.
+        /// </summary>
+        /// <remarks>
+        /// It is recommended to use a global reference.
+        /// </remarks>
+        public Reference ValueId { get; set; }
+    }
+
+    /// <summary>
+    /// A value reference pair within a value list. Each value has a global unique id
+    /// defining its semantic.
+    /// </summary>
+    public class ValueReferencePair : IValueReferencePair
     {
         /// <summary>
         /// The value of the referenced concept definition of the value in valueId.
@@ -11622,7 +12764,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitValueReferencePair(this);
         }
 
         /// <summary>
@@ -11633,7 +12775,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitValueReferencePair(this, context);
         }
 
         /// <summary>
@@ -11642,7 +12784,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformValueReferencePair(this);
         }
 
         /// <summary>
@@ -11653,7 +12795,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformValueReferencePair(this, context);
         }
 
         public ValueReferencePair(
@@ -11668,7 +12810,18 @@ namespace AasCore.Aas3_0_RC02
     /// <summary>
     /// A set of value reference pairs.
     /// </summary>
-    public class ValueList : IClass
+    public interface IValueList : IClass
+    {
+        /// <summary>
+        /// A pair of a value together with its global unique id.
+        /// </summary>
+        public List<ValueReferencePair> ValueReferencePairs { get; set; }
+    }
+
+    /// <summary>
+    /// A set of value reference pairs.
+    /// </summary>
+    public class ValueList : IValueList
     {
         /// <summary>
         /// A pair of a value together with its global unique id.
@@ -11710,7 +12863,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitValueList(this);
         }
 
         /// <summary>
@@ -11721,7 +12874,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitValueList(this, context);
         }
 
         /// <summary>
@@ -11730,7 +12883,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformValueList(this);
         }
 
         /// <summary>
@@ -11741,7 +12894,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformValueList(this, context);
         }
 
         public ValueList(List<ValueReferencePair> valueReferencePairs)
@@ -11791,7 +12944,137 @@ namespace AasCore.Aas3_0_RC02
     ///   </li>
     /// </ul>
     /// </remarks>
-    public class DataSpecificationIec61360 : IDataSpecificationContent
+    public interface IDataSpecificationIec61360 : IDataSpecificationContent
+    {
+        /// <summary>
+        /// Preferred name
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Constraints:
+        /// </para>
+        /// <ul>
+        ///   <li>
+        ///     Constraint AASc-002:
+        ///     <see cref="Aas.DataSpecificationIec61360.PreferredName" /> shall be provided at least in English.
+        ///   </li>
+        /// </ul>
+        /// </remarks>
+        public List<LangString> PreferredName { get; set; }
+
+        /// <summary>
+        /// Short name
+        /// </summary>
+        public List<LangString>? ShortName { get; set; }
+
+        /// <summary>
+        /// Unit
+        /// </summary>
+        public string? Unit { get; set; }
+
+        /// <summary>
+        /// Unique unit id
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <see cref="Aas.DataSpecificationIec61360.Unit" /> and <see cref="Aas.DataSpecificationIec61360.UnitId" /> need to be consistent if both attributes
+        /// are set
+        /// </para>
+        /// <para>
+        /// It is recommended to use a global reference.
+        /// </para>
+        /// <para>
+        /// Although the <see cref="Aas.DataSpecificationIec61360.UnitId" /> is a global reference there might exist a
+        /// <see cref="Aas.ConceptDescription" />
+        /// with data specification <see cref="Aas.DataSpecificationPhysicalUnit" /> with
+        /// the same ID.
+        /// </para>
+        /// </remarks>
+        public Reference? UnitId { get; set; }
+
+        /// <summary>
+        /// Source of definition
+        /// </summary>
+        public string? SourceOfDefinition { get; set; }
+
+        /// <summary>
+        /// Symbol
+        /// </summary>
+        public string? Symbol { get; set; }
+
+        /// <summary>
+        /// Data Type
+        /// </summary>
+        public DataTypeIec61360? DataType { get; set; }
+
+        /// <summary>
+        /// Definition in different languages
+        /// </summary>
+        public List<LangString>? Definition { get; set; }
+
+        /// <summary>
+        /// Value Format
+        /// </summary>
+        public string? ValueFormat { get; set; }
+
+        /// <summary>
+        /// List of allowed values
+        /// </summary>
+        public ValueList? ValueList { get; set; }
+
+        /// <summary>
+        /// Value
+        /// </summary>
+        public string? Value { get; set; }
+
+        /// <summary>
+        /// Set of levels.
+        /// </summary>
+        public LevelType? LevelType { get; set; }
+    }
+
+    /// <summary>
+    /// Content of data specification template for concept descriptions for properties,
+    /// values and value lists conformant to IEC 61360.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// IEC61360 requires also a globally unique identifier for a concept
+    /// description. This ID is not part of the data specification template.
+    /// Instead the <see cref="Aas.ConceptDescription.Id" /> as inherited via
+    /// <see cref="Aas.IIdentifiable" /> is used. Same holds for administrative
+    /// information like the version and revision.
+    /// </para>
+    /// <para>
+    /// <see cref="Aas.ConceptDescription.IdShort" /> and <see cref="Aas.DataSpecificationIec61360.ShortName" /> are very
+    /// similar. However, in this case the decision was to add
+    /// <see cref="Aas.DataSpecificationIec61360.ShortName" /> explicitly to the data specification. Same holds for
+    /// <see cref="Aas.ConceptDescription.DisplayName" /> and
+    /// <see cref="Aas.DataSpecificationIec61360.PreferredName" />. Same holds for
+    /// <see cref="Aas.ConceptDescription.Description" /> and <see cref="Aas.DataSpecificationIec61360.Definition" />.
+    /// </para>
+    /// <para>
+    /// Constraints:
+    /// </para>
+    /// <ul>
+    ///   <li>
+    ///     Constraint AASc-010:
+    ///     If <see cref="Aas.DataSpecificationIec61360.Value" /> is not empty then <see cref="Aas.DataSpecificationIec61360.ValueList" /> shall be empty
+    ///     and vice versa.
+    ///   </li>
+    ///   <li>
+    ///     Constraint AASc-009:
+    ///     If <see cref="Aas.DataSpecificationIec61360.DataType" /> one of:
+    ///     <see cref="Aas.DataTypeIec61360.IntegerMeasure" />,
+    ///     <see cref="Aas.DataTypeIec61360.RealMeasure" />,
+    ///     <see cref="Aas.DataTypeIec61360.RationalMeasure" />,
+    ///     <see cref="Aas.DataTypeIec61360.IntegerCurrency" />,
+    ///     <see cref="Aas.DataTypeIec61360.RealCurrency" />, then <see cref="Aas.DataSpecificationIec61360.Unit" /> or
+    ///     <see cref="Aas.DataSpecificationIec61360.UnitId" /> shall be defined.
+    ///   </li>
+    /// </ul>
+    /// </remarks>
+    public class DataSpecificationIec61360 : IDataSpecificationIec61360
     {
         /// <summary>
         /// Preferred name
@@ -12008,7 +13291,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitDataSpecificationIec61360(this);
         }
 
         /// <summary>
@@ -12019,7 +13302,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitDataSpecificationIec61360(this, context);
         }
 
         /// <summary>
@@ -12028,7 +13311,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformDataSpecificationIec61360(this);
         }
 
         /// <summary>
@@ -12039,7 +13322,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformDataSpecificationIec61360(this, context);
         }
 
         public DataSpecificationIec61360(
@@ -12071,7 +13354,75 @@ namespace AasCore.Aas3_0_RC02
         }
     }
 
-    public class DataSpecificationPhysicalUnit : IDataSpecificationContent
+    public interface IDataSpecificationPhysicalUnit : IDataSpecificationContent
+    {
+        /// <summary>
+        /// Name of the physical unit
+        /// </summary>
+        public string UnitName { get; set; }
+
+        /// <summary>
+        /// Symbol for the physical unit
+        /// </summary>
+        public string UnitSymbol { get; set; }
+
+        /// <summary>
+        /// Definition in different languages
+        /// </summary>
+        public List<LangString> Definition { get; set; }
+
+        /// <summary>
+        /// Notation of SI physical unit
+        /// </summary>
+        public string? SiNotation { get; set; }
+
+        /// <summary>
+        /// Name of SI physical unit
+        /// </summary>
+        public string? SiName { get; set; }
+
+        /// <summary>
+        /// Notation of physical unit conformant to DIN
+        /// </summary>
+        public string? DinNotation { get; set; }
+
+        /// <summary>
+        /// Name of physical unit conformant to ECE
+        /// </summary>
+        public string? EceName { get; set; }
+
+        /// <summary>
+        /// Code of physical unit conformant to ECE
+        /// </summary>
+        public string? EceCode { get; set; }
+
+        /// <summary>
+        /// Name of NIST physical unit
+        /// </summary>
+        public string? NistName { get; set; }
+
+        /// <summary>
+        /// Source of definition
+        /// </summary>
+        public string? SourceOfDefinition { get; set; }
+
+        /// <summary>
+        /// Conversion factor
+        /// </summary>
+        public string? ConversionFactor { get; set; }
+
+        /// <summary>
+        /// Registration authority ID
+        /// </summary>
+        public string? RegistrationAuthorityId { get; set; }
+
+        /// <summary>
+        /// Supplier
+        /// </summary>
+        public string? Supplier { get; set; }
+    }
+
+    public class DataSpecificationPhysicalUnit : IDataSpecificationPhysicalUnit
     {
         /// <summary>
         /// Name of the physical unit
@@ -12173,7 +13524,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitDataSpecificationPhysicalUnit(this);
         }
 
         /// <summary>
@@ -12184,7 +13535,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitDataSpecificationPhysicalUnit(this, context);
         }
 
         /// <summary>
@@ -12193,7 +13544,7 @@ namespace AasCore.Aas3_0_RC02
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformDataSpecificationPhysicalUnit(this);
         }
 
         /// <summary>
@@ -12204,7 +13555,7 @@ namespace AasCore.Aas3_0_RC02
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformDataSpecificationPhysicalUnit(this, context);
         }
 
         public DataSpecificationPhysicalUnit(
@@ -12237,7 +13588,6 @@ namespace AasCore.Aas3_0_RC02
             Supplier = supplier;
         }
     }
-
 }  // namespace AasCore.Aas3_0_RC02
 
 /*

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/verification.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/verification.cs
@@ -2647,8 +2647,9 @@ namespace AasCore.Aas3_0_RC02
             : Visitation.AbstractTransformer<IEnumerable<Reporting.Error>>
         {
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.Extension that)
+            public override IEnumerable<Reporting.Error> TransformExtension(
+                Aas.IExtension that
+            )
             {
                 if (!(
                     !(that.SupplementalSemanticIds != null)
@@ -2755,8 +2756,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.AdministrativeInformation that)
+            public override IEnumerable<Reporting.Error> TransformAdministrativeInformation(
+                Aas.IAdministrativeInformation that
+            )
             {
                 if (!(
                     !(that.EmbeddedDataSpecifications != null)
@@ -2823,8 +2825,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.Qualifier that)
+            public override IEnumerable<Reporting.Error> TransformQualifier(
+                Aas.IQualifier that
+            )
             {
                 if (!(
                     !(that.SupplementalSemanticIds != null)
@@ -2940,8 +2943,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.AssetAdministrationShell that)
+            public override IEnumerable<Reporting.Error> TransformAssetAdministrationShell(
+                Aas.IAssetAdministrationShell that
+            )
             {
                 if (!(
                     !(that.Extensions != null)
@@ -3210,8 +3214,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.AssetInformation that)
+            public override IEnumerable<Reporting.Error> TransformAssetInformation(
+                Aas.IAssetInformation that
+            )
             {
                 if (!(
                     !(that.SpecificAssetIds != null)
@@ -3274,8 +3279,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.Resource that)
+            public override IEnumerable<Reporting.Error> TransformResource(
+                Aas.IResource that
+            )
             {
                 foreach (var error in Verification.VerifyPathType(that.Path))
                 {
@@ -3298,8 +3304,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.SpecificAssetId that)
+            public override IEnumerable<Reporting.Error> TransformSpecificAssetId(
+                Aas.ISpecificAssetId that
+            )
             {
                 if (!(
                     !(that.SupplementalSemanticIds != null)
@@ -3377,8 +3384,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.Submodel that)
+            public override IEnumerable<Reporting.Error> TransformSubmodel(
+                Aas.ISubmodel that
+            )
             {
                 if (!(
                     !(that.Extensions != null)
@@ -3747,8 +3755,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.RelationshipElement that)
+            public override IEnumerable<Reporting.Error> TransformRelationshipElement(
+                Aas.IRelationshipElement that
+            )
             {
                 if (!(
                     !(that.Extensions != null)
@@ -4063,8 +4072,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.SubmodelElementList that)
+            public override IEnumerable<Reporting.Error> TransformSubmodelElementList(
+                Aas.ISubmodelElementList that
+            )
             {
                 if (!(
                     !(that.Extensions != null)
@@ -4502,8 +4512,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.SubmodelElementCollection that)
+            public override IEnumerable<Reporting.Error> TransformSubmodelElementCollection(
+                Aas.ISubmodelElementCollection that
+            )
             {
                 if (!(
                     !(that.Extensions != null)
@@ -4851,8 +4862,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.Property that)
+            public override IEnumerable<Reporting.Error> TransformProperty(
+                Aas.IProperty that
+            )
             {
                 if (!(
                     !(that.Extensions != null)
@@ -5200,8 +5212,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.MultiLanguageProperty that)
+            public override IEnumerable<Reporting.Error> TransformMultiLanguageProperty(
+                Aas.IMultiLanguageProperty that
+            )
             {
                 if (!(
                     !(that.Extensions != null)
@@ -5558,8 +5571,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.Range that)
+            public override IEnumerable<Reporting.Error> TransformRange(
+                Aas.IRange that
+            )
             {
                 if (!(
                     !(that.Extensions != null)
@@ -5916,8 +5930,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.ReferenceElement that)
+            public override IEnumerable<Reporting.Error> TransformReferenceElement(
+                Aas.IReferenceElement that
+            )
             {
                 if (!(
                     !(that.Extensions != null)
@@ -6237,8 +6252,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.Blob that)
+            public override IEnumerable<Reporting.Error> TransformBlob(
+                Aas.IBlob that
+            )
             {
                 if (!(
                     !(that.Extensions != null)
@@ -6566,8 +6582,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.File that)
+            public override IEnumerable<Reporting.Error> TransformFile(
+                Aas.IFile that
+            )
             {
                 if (!(
                     !(that.Extensions != null)
@@ -6895,8 +6912,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.AnnotatedRelationshipElement that)
+            public override IEnumerable<Reporting.Error> TransformAnnotatedRelationshipElement(
+                Aas.IAnnotatedRelationshipElement that
+            )
             {
                 if (!(
                     !(that.Extensions != null)
@@ -7239,8 +7257,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.Entity that)
+            public override IEnumerable<Reporting.Error> TransformEntity(
+                Aas.IEntity that
+            )
             {
                 if (!(
                     !(that.Extensions != null)
@@ -7623,8 +7642,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.EventPayload that)
+            public override IEnumerable<Reporting.Error> TransformEventPayload(
+                Aas.IEventPayload that
+            )
             {
                 if (!(
                     Verification.IsModelReferenceToReferable(that.Source)))
@@ -7724,8 +7744,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.BasicEventElement that)
+            public override IEnumerable<Reporting.Error> TransformBasicEventElement(
+                Aas.IBasicEventElement that
+            )
             {
                 if (!(
                     !(that.Extensions != null)
@@ -8129,8 +8150,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.Operation that)
+            public override IEnumerable<Reporting.Error> TransformOperation(
+                Aas.IOperation that
+            )
             {
                 if (!(
                     !(that.Extensions != null)
@@ -8516,8 +8538,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.OperationVariable that)
+            public override IEnumerable<Reporting.Error> TransformOperationVariable(
+                Aas.IOperationVariable that
+            )
             {
                 foreach (var error in Verification.Verify(that.Value))
                 {
@@ -8529,8 +8552,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.Capability that)
+            public override IEnumerable<Reporting.Error> TransformCapability(
+                Aas.ICapability that
+            )
             {
                 if (!(
                     !(that.Extensions != null)
@@ -8829,8 +8853,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.ConceptDescription that)
+            public override IEnumerable<Reporting.Error> TransformConceptDescription(
+                Aas.IConceptDescription that
+            )
             {
                 if (!(
                     !(that.Extensions != null)
@@ -9170,8 +9195,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.Reference that)
+            public override IEnumerable<Reporting.Error> TransformReference(
+                Aas.IReference that
+            )
             {
                 if (!(that.Keys.Count >= 1))
                 {
@@ -9352,8 +9378,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.Key that)
+            public override IEnumerable<Reporting.Error> TransformKey(
+                Aas.IKey that
+            )
             {
                 foreach (var error in Verification.VerifyKeyTypes(that.Type))
                 {
@@ -9373,8 +9400,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.LangString that)
+            public override IEnumerable<Reporting.Error> TransformLangString(
+                Aas.ILangString that
+            )
             {
                 foreach (var error in Verification.VerifyBcp47LanguageTag(that.Language))
                 {
@@ -9386,8 +9414,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.Environment that)
+            public override IEnumerable<Reporting.Error> TransformEnvironment(
+                Aas.IEnvironment that
+            )
             {
                 if (!(
                     !(that.ConceptDescriptions != null)
@@ -9477,8 +9506,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.EmbeddedDataSpecification that)
+            public override IEnumerable<Reporting.Error> TransformEmbeddedDataSpecification(
+                Aas.IEmbeddedDataSpecification that
+            )
             {
                 foreach (var error in Verification.Verify(that.DataSpecification))
                 {
@@ -9498,8 +9528,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.ValueReferencePair that)
+            public override IEnumerable<Reporting.Error> TransformValueReferencePair(
+                Aas.IValueReferencePair that
+            )
             {
                 foreach (var error in Verification.Verify(that.ValueId))
                 {
@@ -9511,8 +9542,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.ValueList that)
+            public override IEnumerable<Reporting.Error> TransformValueList(
+                Aas.IValueList that
+            )
             {
                 if (!(that.ValueReferencePairs.Count >= 1))
                 {
@@ -9539,8 +9571,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.DataSpecificationIec61360 that)
+            public override IEnumerable<Reporting.Error> TransformDataSpecificationIec61360(
+                Aas.IDataSpecificationIec61360 that
+            )
             {
                 if (!(
                     (
@@ -9789,8 +9822,9 @@ namespace AasCore.Aas3_0_RC02
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.DataSpecificationPhysicalUnit that)
+            public override IEnumerable<Reporting.Error> TransformDataSpecificationPhysicalUnit(
+                Aas.IDataSpecificationPhysicalUnit that
+            )
             {
                 if (!(that.Definition.Count >= 1))
                 {

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/visitation.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/visitation.cs
@@ -10,43 +10,116 @@ namespace AasCore.Aas3_0_RC02
         /// <summary>
         /// Define the interface for a visitor which visits the instances of the model.
         /// </summary>
+        /// <remarks>
+        /// When you use the visitor, please always call the main dispatching method 
+        /// <see cref="Visit" />. You should most probably never call the <c>Visit*</c>
+        /// methods directly. They are only made public so that model classes can access them.
+        /// </remarks>  
         public interface IVisitor
         {
             public void Visit(IClass that);
-            public void Visit(Extension that);
-            public void Visit(AdministrativeInformation that);
-            public void Visit(Qualifier that);
-            public void Visit(AssetAdministrationShell that);
-            public void Visit(AssetInformation that);
-            public void Visit(Resource that);
-            public void Visit(SpecificAssetId that);
-            public void Visit(Submodel that);
-            public void Visit(RelationshipElement that);
-            public void Visit(SubmodelElementList that);
-            public void Visit(SubmodelElementCollection that);
-            public void Visit(Property that);
-            public void Visit(MultiLanguageProperty that);
-            public void Visit(Range that);
-            public void Visit(ReferenceElement that);
-            public void Visit(Blob that);
-            public void Visit(File that);
-            public void Visit(AnnotatedRelationshipElement that);
-            public void Visit(Entity that);
-            public void Visit(EventPayload that);
-            public void Visit(BasicEventElement that);
-            public void Visit(Operation that);
-            public void Visit(OperationVariable that);
-            public void Visit(Capability that);
-            public void Visit(ConceptDescription that);
-            public void Visit(Reference that);
-            public void Visit(Key that);
-            public void Visit(LangString that);
-            public void Visit(Environment that);
-            public void Visit(EmbeddedDataSpecification that);
-            public void Visit(ValueReferencePair that);
-            public void Visit(ValueList that);
-            public void Visit(DataSpecificationIec61360 that);
-            public void Visit(DataSpecificationPhysicalUnit that);
+            public void VisitExtension(
+                IExtension that
+            );
+            public void VisitAdministrativeInformation(
+                IAdministrativeInformation that
+            );
+            public void VisitQualifier(
+                IQualifier that
+            );
+            public void VisitAssetAdministrationShell(
+                IAssetAdministrationShell that
+            );
+            public void VisitAssetInformation(
+                IAssetInformation that
+            );
+            public void VisitResource(
+                IResource that
+            );
+            public void VisitSpecificAssetId(
+                ISpecificAssetId that
+            );
+            public void VisitSubmodel(
+                ISubmodel that
+            );
+            public void VisitRelationshipElement(
+                IRelationshipElement that
+            );
+            public void VisitSubmodelElementList(
+                ISubmodelElementList that
+            );
+            public void VisitSubmodelElementCollection(
+                ISubmodelElementCollection that
+            );
+            public void VisitProperty(
+                IProperty that
+            );
+            public void VisitMultiLanguageProperty(
+                IMultiLanguageProperty that
+            );
+            public void VisitRange(
+                IRange that
+            );
+            public void VisitReferenceElement(
+                IReferenceElement that
+            );
+            public void VisitBlob(
+                IBlob that
+            );
+            public void VisitFile(
+                IFile that
+            );
+            public void VisitAnnotatedRelationshipElement(
+                IAnnotatedRelationshipElement that
+            );
+            public void VisitEntity(
+                IEntity that
+            );
+            public void VisitEventPayload(
+                IEventPayload that
+            );
+            public void VisitBasicEventElement(
+                IBasicEventElement that
+            );
+            public void VisitOperation(
+                IOperation that
+            );
+            public void VisitOperationVariable(
+                IOperationVariable that
+            );
+            public void VisitCapability(
+                ICapability that
+            );
+            public void VisitConceptDescription(
+                IConceptDescription that
+            );
+            public void VisitReference(
+                IReference that
+            );
+            public void VisitKey(
+                IKey that
+            );
+            public void VisitLangString(
+                ILangString that
+            );
+            public void VisitEnvironment(
+                IEnvironment that
+            );
+            public void VisitEmbeddedDataSpecification(
+                IEmbeddedDataSpecification that
+            );
+            public void VisitValueReferencePair(
+                IValueReferencePair that
+            );
+            public void VisitValueList(
+                IValueList that
+            );
+            public void VisitDataSpecificationIec61360(
+                IDataSpecificationIec61360 that
+            );
+            public void VisitDataSpecificationPhysicalUnit(
+                IDataSpecificationPhysicalUnit that
+            );
         }  // public interface IVisitor
 
         /// <summary>
@@ -64,7 +137,9 @@ namespace AasCore.Aas3_0_RC02
                 that.Accept(this);
             }
 
-            public virtual void Visit(Extension that)
+            public virtual void VisitExtension(
+                IExtension that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -73,7 +148,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(AdministrativeInformation that)
+            public virtual void VisitAdministrativeInformation(
+                IAdministrativeInformation that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -82,7 +159,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(Qualifier that)
+            public virtual void VisitQualifier(
+                IQualifier that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -91,7 +170,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(AssetAdministrationShell that)
+            public virtual void VisitAssetAdministrationShell(
+                IAssetAdministrationShell that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -100,7 +181,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(AssetInformation that)
+            public virtual void VisitAssetInformation(
+                IAssetInformation that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -109,7 +192,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(Resource that)
+            public virtual void VisitResource(
+                IResource that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -118,7 +203,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(SpecificAssetId that)
+            public virtual void VisitSpecificAssetId(
+                ISpecificAssetId that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -127,7 +214,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(Submodel that)
+            public virtual void VisitSubmodel(
+                ISubmodel that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -136,7 +225,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(RelationshipElement that)
+            public virtual void VisitRelationshipElement(
+                IRelationshipElement that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -145,7 +236,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(SubmodelElementList that)
+            public virtual void VisitSubmodelElementList(
+                ISubmodelElementList that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -154,7 +247,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(SubmodelElementCollection that)
+            public virtual void VisitSubmodelElementCollection(
+                ISubmodelElementCollection that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -163,7 +258,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(Property that)
+            public virtual void VisitProperty(
+                IProperty that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -172,7 +269,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(MultiLanguageProperty that)
+            public virtual void VisitMultiLanguageProperty(
+                IMultiLanguageProperty that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -181,7 +280,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(Range that)
+            public virtual void VisitRange(
+                IRange that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -190,7 +291,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(ReferenceElement that)
+            public virtual void VisitReferenceElement(
+                IReferenceElement that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -199,7 +302,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(Blob that)
+            public virtual void VisitBlob(
+                IBlob that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -208,7 +313,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(File that)
+            public virtual void VisitFile(
+                IFile that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -217,7 +324,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(AnnotatedRelationshipElement that)
+            public virtual void VisitAnnotatedRelationshipElement(
+                IAnnotatedRelationshipElement that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -226,7 +335,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(Entity that)
+            public virtual void VisitEntity(
+                IEntity that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -235,7 +346,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(EventPayload that)
+            public virtual void VisitEventPayload(
+                IEventPayload that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -244,7 +357,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(BasicEventElement that)
+            public virtual void VisitBasicEventElement(
+                IBasicEventElement that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -253,7 +368,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(Operation that)
+            public virtual void VisitOperation(
+                IOperation that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -262,7 +379,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(OperationVariable that)
+            public virtual void VisitOperationVariable(
+                IOperationVariable that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -271,7 +390,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(Capability that)
+            public virtual void VisitCapability(
+                ICapability that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -280,7 +401,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(ConceptDescription that)
+            public virtual void VisitConceptDescription(
+                IConceptDescription that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -289,7 +412,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(Reference that)
+            public virtual void VisitReference(
+                IReference that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -298,7 +423,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(Key that)
+            public virtual void VisitKey(
+                IKey that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -307,7 +434,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(LangString that)
+            public virtual void VisitLangString(
+                ILangString that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -316,7 +445,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(Environment that)
+            public virtual void VisitEnvironment(
+                IEnvironment that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -325,7 +456,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(EmbeddedDataSpecification that)
+            public virtual void VisitEmbeddedDataSpecification(
+                IEmbeddedDataSpecification that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -334,7 +467,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(ValueReferencePair that)
+            public virtual void VisitValueReferencePair(
+                IValueReferencePair that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -343,7 +478,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(ValueList that)
+            public virtual void VisitValueList(
+                IValueList that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -352,7 +489,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(DataSpecificationIec61360 that)
+            public virtual void VisitDataSpecificationIec61360(
+                IDataSpecificationIec61360 that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -361,7 +500,9 @@ namespace AasCore.Aas3_0_RC02
                 }
             }
 
-            public virtual void Visit(DataSpecificationPhysicalUnit that)
+            public virtual void VisitDataSpecificationPhysicalUnit(
+                IDataSpecificationPhysicalUnit that
+            )
             {
                 // Just descend through, do nothing with <c>that</c>
                 foreach (var something in that.DescendOnce())
@@ -380,83 +521,258 @@ namespace AasCore.Aas3_0_RC02
             {
                 that.Accept(this);
             }
-            public abstract void Visit(Extension that);
-            public abstract void Visit(AdministrativeInformation that);
-            public abstract void Visit(Qualifier that);
-            public abstract void Visit(AssetAdministrationShell that);
-            public abstract void Visit(AssetInformation that);
-            public abstract void Visit(Resource that);
-            public abstract void Visit(SpecificAssetId that);
-            public abstract void Visit(Submodel that);
-            public abstract void Visit(RelationshipElement that);
-            public abstract void Visit(SubmodelElementList that);
-            public abstract void Visit(SubmodelElementCollection that);
-            public abstract void Visit(Property that);
-            public abstract void Visit(MultiLanguageProperty that);
-            public abstract void Visit(Range that);
-            public abstract void Visit(ReferenceElement that);
-            public abstract void Visit(Blob that);
-            public abstract void Visit(File that);
-            public abstract void Visit(AnnotatedRelationshipElement that);
-            public abstract void Visit(Entity that);
-            public abstract void Visit(EventPayload that);
-            public abstract void Visit(BasicEventElement that);
-            public abstract void Visit(Operation that);
-            public abstract void Visit(OperationVariable that);
-            public abstract void Visit(Capability that);
-            public abstract void Visit(ConceptDescription that);
-            public abstract void Visit(Reference that);
-            public abstract void Visit(Key that);
-            public abstract void Visit(LangString that);
-            public abstract void Visit(Environment that);
-            public abstract void Visit(EmbeddedDataSpecification that);
-            public abstract void Visit(ValueReferencePair that);
-            public abstract void Visit(ValueList that);
-            public abstract void Visit(DataSpecificationIec61360 that);
-            public abstract void Visit(DataSpecificationPhysicalUnit that);
+            public abstract void VisitExtension(
+                IExtension that
+            );
+            public abstract void VisitAdministrativeInformation(
+                IAdministrativeInformation that
+            );
+            public abstract void VisitQualifier(
+                IQualifier that
+            );
+            public abstract void VisitAssetAdministrationShell(
+                IAssetAdministrationShell that
+            );
+            public abstract void VisitAssetInformation(
+                IAssetInformation that
+            );
+            public abstract void VisitResource(
+                IResource that
+            );
+            public abstract void VisitSpecificAssetId(
+                ISpecificAssetId that
+            );
+            public abstract void VisitSubmodel(
+                ISubmodel that
+            );
+            public abstract void VisitRelationshipElement(
+                IRelationshipElement that
+            );
+            public abstract void VisitSubmodelElementList(
+                ISubmodelElementList that
+            );
+            public abstract void VisitSubmodelElementCollection(
+                ISubmodelElementCollection that
+            );
+            public abstract void VisitProperty(
+                IProperty that
+            );
+            public abstract void VisitMultiLanguageProperty(
+                IMultiLanguageProperty that
+            );
+            public abstract void VisitRange(
+                IRange that
+            );
+            public abstract void VisitReferenceElement(
+                IReferenceElement that
+            );
+            public abstract void VisitBlob(
+                IBlob that
+            );
+            public abstract void VisitFile(
+                IFile that
+            );
+            public abstract void VisitAnnotatedRelationshipElement(
+                IAnnotatedRelationshipElement that
+            );
+            public abstract void VisitEntity(
+                IEntity that
+            );
+            public abstract void VisitEventPayload(
+                IEventPayload that
+            );
+            public abstract void VisitBasicEventElement(
+                IBasicEventElement that
+            );
+            public abstract void VisitOperation(
+                IOperation that
+            );
+            public abstract void VisitOperationVariable(
+                IOperationVariable that
+            );
+            public abstract void VisitCapability(
+                ICapability that
+            );
+            public abstract void VisitConceptDescription(
+                IConceptDescription that
+            );
+            public abstract void VisitReference(
+                IReference that
+            );
+            public abstract void VisitKey(
+                IKey that
+            );
+            public abstract void VisitLangString(
+                ILangString that
+            );
+            public abstract void VisitEnvironment(
+                IEnvironment that
+            );
+            public abstract void VisitEmbeddedDataSpecification(
+                IEmbeddedDataSpecification that
+            );
+            public abstract void VisitValueReferencePair(
+                IValueReferencePair that
+            );
+            public abstract void VisitValueList(
+                IValueList that
+            );
+            public abstract void VisitDataSpecificationIec61360(
+                IDataSpecificationIec61360 that
+            );
+            public abstract void VisitDataSpecificationPhysicalUnit(
+                IDataSpecificationPhysicalUnit that
+            );
         }  // public abstract class AbstractVisitor
 
         /// <summary>
         /// Define the interface for a visitor which visits the instances of the model.
         /// </summary>
+        /// <remarks>
+        /// When you use the visitor, please always call the main dispatching method 
+        /// <see cref="Visit" />. You should most probably never call the <c>Visit*</c>
+        /// methods directly. They are only made public so that model classes can access them.
+        /// </remarks>
         /// <typeparam name="TContext">Context type</typeparam>
         public interface IVisitorWithContext<in TContext>
         {
             public void Visit(IClass that, TContext context);
-            public void Visit(Extension that, TContext context);
-            public void Visit(AdministrativeInformation that, TContext context);
-            public void Visit(Qualifier that, TContext context);
-            public void Visit(AssetAdministrationShell that, TContext context);
-            public void Visit(AssetInformation that, TContext context);
-            public void Visit(Resource that, TContext context);
-            public void Visit(SpecificAssetId that, TContext context);
-            public void Visit(Submodel that, TContext context);
-            public void Visit(RelationshipElement that, TContext context);
-            public void Visit(SubmodelElementList that, TContext context);
-            public void Visit(SubmodelElementCollection that, TContext context);
-            public void Visit(Property that, TContext context);
-            public void Visit(MultiLanguageProperty that, TContext context);
-            public void Visit(Range that, TContext context);
-            public void Visit(ReferenceElement that, TContext context);
-            public void Visit(Blob that, TContext context);
-            public void Visit(File that, TContext context);
-            public void Visit(AnnotatedRelationshipElement that, TContext context);
-            public void Visit(Entity that, TContext context);
-            public void Visit(EventPayload that, TContext context);
-            public void Visit(BasicEventElement that, TContext context);
-            public void Visit(Operation that, TContext context);
-            public void Visit(OperationVariable that, TContext context);
-            public void Visit(Capability that, TContext context);
-            public void Visit(ConceptDescription that, TContext context);
-            public void Visit(Reference that, TContext context);
-            public void Visit(Key that, TContext context);
-            public void Visit(LangString that, TContext context);
-            public void Visit(Environment that, TContext context);
-            public void Visit(EmbeddedDataSpecification that, TContext context);
-            public void Visit(ValueReferencePair that, TContext context);
-            public void Visit(ValueList that, TContext context);
-            public void Visit(DataSpecificationIec61360 that, TContext context);
-            public void Visit(DataSpecificationPhysicalUnit that, TContext context);
+            public void VisitExtension(
+                IExtension that,
+                TContext context
+            );
+            public void VisitAdministrativeInformation(
+                IAdministrativeInformation that,
+                TContext context
+            );
+            public void VisitQualifier(
+                IQualifier that,
+                TContext context
+            );
+            public void VisitAssetAdministrationShell(
+                IAssetAdministrationShell that,
+                TContext context
+            );
+            public void VisitAssetInformation(
+                IAssetInformation that,
+                TContext context
+            );
+            public void VisitResource(
+                IResource that,
+                TContext context
+            );
+            public void VisitSpecificAssetId(
+                ISpecificAssetId that,
+                TContext context
+            );
+            public void VisitSubmodel(
+                ISubmodel that,
+                TContext context
+            );
+            public void VisitRelationshipElement(
+                IRelationshipElement that,
+                TContext context
+            );
+            public void VisitSubmodelElementList(
+                ISubmodelElementList that,
+                TContext context
+            );
+            public void VisitSubmodelElementCollection(
+                ISubmodelElementCollection that,
+                TContext context
+            );
+            public void VisitProperty(
+                IProperty that,
+                TContext context
+            );
+            public void VisitMultiLanguageProperty(
+                IMultiLanguageProperty that,
+                TContext context
+            );
+            public void VisitRange(
+                IRange that,
+                TContext context
+            );
+            public void VisitReferenceElement(
+                IReferenceElement that,
+                TContext context
+            );
+            public void VisitBlob(
+                IBlob that,
+                TContext context
+            );
+            public void VisitFile(
+                IFile that,
+                TContext context
+            );
+            public void VisitAnnotatedRelationshipElement(
+                IAnnotatedRelationshipElement that,
+                TContext context
+            );
+            public void VisitEntity(
+                IEntity that,
+                TContext context
+            );
+            public void VisitEventPayload(
+                IEventPayload that,
+                TContext context
+            );
+            public void VisitBasicEventElement(
+                IBasicEventElement that,
+                TContext context
+            );
+            public void VisitOperation(
+                IOperation that,
+                TContext context
+            );
+            public void VisitOperationVariable(
+                IOperationVariable that,
+                TContext context
+            );
+            public void VisitCapability(
+                ICapability that,
+                TContext context
+            );
+            public void VisitConceptDescription(
+                IConceptDescription that,
+                TContext context
+            );
+            public void VisitReference(
+                IReference that,
+                TContext context
+            );
+            public void VisitKey(
+                IKey that,
+                TContext context
+            );
+            public void VisitLangString(
+                ILangString that,
+                TContext context
+            );
+            public void VisitEnvironment(
+                IEnvironment that,
+                TContext context
+            );
+            public void VisitEmbeddedDataSpecification(
+                IEmbeddedDataSpecification that,
+                TContext context
+            );
+            public void VisitValueReferencePair(
+                IValueReferencePair that,
+                TContext context
+            );
+            public void VisitValueList(
+                IValueList that,
+                TContext context
+            );
+            public void VisitDataSpecificationIec61360(
+                IDataSpecificationIec61360 that,
+                TContext context
+            );
+            public void VisitDataSpecificationPhysicalUnit(
+                IDataSpecificationPhysicalUnit that,
+                TContext context
+            );
         }  // public interface IVisitorWithContext
 
         /// <summary>
@@ -471,84 +787,259 @@ namespace AasCore.Aas3_0_RC02
             {
                 that.Accept(this, context);
             }
-            public abstract void Visit(Extension that, TContext context);
-            public abstract void Visit(AdministrativeInformation that, TContext context);
-            public abstract void Visit(Qualifier that, TContext context);
-            public abstract void Visit(AssetAdministrationShell that, TContext context);
-            public abstract void Visit(AssetInformation that, TContext context);
-            public abstract void Visit(Resource that, TContext context);
-            public abstract void Visit(SpecificAssetId that, TContext context);
-            public abstract void Visit(Submodel that, TContext context);
-            public abstract void Visit(RelationshipElement that, TContext context);
-            public abstract void Visit(SubmodelElementList that, TContext context);
-            public abstract void Visit(SubmodelElementCollection that, TContext context);
-            public abstract void Visit(Property that, TContext context);
-            public abstract void Visit(MultiLanguageProperty that, TContext context);
-            public abstract void Visit(Range that, TContext context);
-            public abstract void Visit(ReferenceElement that, TContext context);
-            public abstract void Visit(Blob that, TContext context);
-            public abstract void Visit(File that, TContext context);
-            public abstract void Visit(AnnotatedRelationshipElement that, TContext context);
-            public abstract void Visit(Entity that, TContext context);
-            public abstract void Visit(EventPayload that, TContext context);
-            public abstract void Visit(BasicEventElement that, TContext context);
-            public abstract void Visit(Operation that, TContext context);
-            public abstract void Visit(OperationVariable that, TContext context);
-            public abstract void Visit(Capability that, TContext context);
-            public abstract void Visit(ConceptDescription that, TContext context);
-            public abstract void Visit(Reference that, TContext context);
-            public abstract void Visit(Key that, TContext context);
-            public abstract void Visit(LangString that, TContext context);
-            public abstract void Visit(Environment that, TContext context);
-            public abstract void Visit(EmbeddedDataSpecification that, TContext context);
-            public abstract void Visit(ValueReferencePair that, TContext context);
-            public abstract void Visit(ValueList that, TContext context);
-            public abstract void Visit(DataSpecificationIec61360 that, TContext context);
-            public abstract void Visit(DataSpecificationPhysicalUnit that, TContext context);
+            public abstract void VisitExtension(
+                IExtension that,
+                TContext context
+            );
+            public abstract void VisitAdministrativeInformation(
+                IAdministrativeInformation that,
+                TContext context
+            );
+            public abstract void VisitQualifier(
+                IQualifier that,
+                TContext context
+            );
+            public abstract void VisitAssetAdministrationShell(
+                IAssetAdministrationShell that,
+                TContext context
+            );
+            public abstract void VisitAssetInformation(
+                IAssetInformation that,
+                TContext context
+            );
+            public abstract void VisitResource(
+                IResource that,
+                TContext context
+            );
+            public abstract void VisitSpecificAssetId(
+                ISpecificAssetId that,
+                TContext context
+            );
+            public abstract void VisitSubmodel(
+                ISubmodel that,
+                TContext context
+            );
+            public abstract void VisitRelationshipElement(
+                IRelationshipElement that,
+                TContext context
+            );
+            public abstract void VisitSubmodelElementList(
+                ISubmodelElementList that,
+                TContext context
+            );
+            public abstract void VisitSubmodelElementCollection(
+                ISubmodelElementCollection that,
+                TContext context
+            );
+            public abstract void VisitProperty(
+                IProperty that,
+                TContext context
+            );
+            public abstract void VisitMultiLanguageProperty(
+                IMultiLanguageProperty that,
+                TContext context
+            );
+            public abstract void VisitRange(
+                IRange that,
+                TContext context
+            );
+            public abstract void VisitReferenceElement(
+                IReferenceElement that,
+                TContext context
+            );
+            public abstract void VisitBlob(
+                IBlob that,
+                TContext context
+            );
+            public abstract void VisitFile(
+                IFile that,
+                TContext context
+            );
+            public abstract void VisitAnnotatedRelationshipElement(
+                IAnnotatedRelationshipElement that,
+                TContext context
+            );
+            public abstract void VisitEntity(
+                IEntity that,
+                TContext context
+            );
+            public abstract void VisitEventPayload(
+                IEventPayload that,
+                TContext context
+            );
+            public abstract void VisitBasicEventElement(
+                IBasicEventElement that,
+                TContext context
+            );
+            public abstract void VisitOperation(
+                IOperation that,
+                TContext context
+            );
+            public abstract void VisitOperationVariable(
+                IOperationVariable that,
+                TContext context
+            );
+            public abstract void VisitCapability(
+                ICapability that,
+                TContext context
+            );
+            public abstract void VisitConceptDescription(
+                IConceptDescription that,
+                TContext context
+            );
+            public abstract void VisitReference(
+                IReference that,
+                TContext context
+            );
+            public abstract void VisitKey(
+                IKey that,
+                TContext context
+            );
+            public abstract void VisitLangString(
+                ILangString that,
+                TContext context
+            );
+            public abstract void VisitEnvironment(
+                IEnvironment that,
+                TContext context
+            );
+            public abstract void VisitEmbeddedDataSpecification(
+                IEmbeddedDataSpecification that,
+                TContext context
+            );
+            public abstract void VisitValueReferencePair(
+                IValueReferencePair that,
+                TContext context
+            );
+            public abstract void VisitValueList(
+                IValueList that,
+                TContext context
+            );
+            public abstract void VisitDataSpecificationIec61360(
+                IDataSpecificationIec61360 that,
+                TContext context
+            );
+            public abstract void VisitDataSpecificationPhysicalUnit(
+                IDataSpecificationPhysicalUnit that,
+                TContext context
+            );
         }  // public abstract class AbstractVisitorWithContext
 
         /// <summary>
         /// Define the interface for a transformer which transforms recursively
         /// the instances into something else.
         /// </summary>
+        /// <remarks>
+        /// When you use the transformer, please always call the main dispatching method 
+        /// <see cref="Transform" />. You should most probably never call the <c>Transform*</c>
+        /// methods directly. They are only made public so that model classes can access them.
+        /// </remarks>
         /// <typeparam name="T">The type of the transformation result</typeparam>
         public interface ITransformer<out T>
         {
             public T Transform(IClass that);
-            public T Transform(Extension that);
-            public T Transform(AdministrativeInformation that);
-            public T Transform(Qualifier that);
-            public T Transform(AssetAdministrationShell that);
-            public T Transform(AssetInformation that);
-            public T Transform(Resource that);
-            public T Transform(SpecificAssetId that);
-            public T Transform(Submodel that);
-            public T Transform(RelationshipElement that);
-            public T Transform(SubmodelElementList that);
-            public T Transform(SubmodelElementCollection that);
-            public T Transform(Property that);
-            public T Transform(MultiLanguageProperty that);
-            public T Transform(Range that);
-            public T Transform(ReferenceElement that);
-            public T Transform(Blob that);
-            public T Transform(File that);
-            public T Transform(AnnotatedRelationshipElement that);
-            public T Transform(Entity that);
-            public T Transform(EventPayload that);
-            public T Transform(BasicEventElement that);
-            public T Transform(Operation that);
-            public T Transform(OperationVariable that);
-            public T Transform(Capability that);
-            public T Transform(ConceptDescription that);
-            public T Transform(Reference that);
-            public T Transform(Key that);
-            public T Transform(LangString that);
-            public T Transform(Environment that);
-            public T Transform(EmbeddedDataSpecification that);
-            public T Transform(ValueReferencePair that);
-            public T Transform(ValueList that);
-            public T Transform(DataSpecificationIec61360 that);
-            public T Transform(DataSpecificationPhysicalUnit that);
+            public T TransformExtension(
+                IExtension that
+            );
+            public T TransformAdministrativeInformation(
+                IAdministrativeInformation that
+            );
+            public T TransformQualifier(
+                IQualifier that
+            );
+            public T TransformAssetAdministrationShell(
+                IAssetAdministrationShell that
+            );
+            public T TransformAssetInformation(
+                IAssetInformation that
+            );
+            public T TransformResource(
+                IResource that
+            );
+            public T TransformSpecificAssetId(
+                ISpecificAssetId that
+            );
+            public T TransformSubmodel(
+                ISubmodel that
+            );
+            public T TransformRelationshipElement(
+                IRelationshipElement that
+            );
+            public T TransformSubmodelElementList(
+                ISubmodelElementList that
+            );
+            public T TransformSubmodelElementCollection(
+                ISubmodelElementCollection that
+            );
+            public T TransformProperty(
+                IProperty that
+            );
+            public T TransformMultiLanguageProperty(
+                IMultiLanguageProperty that
+            );
+            public T TransformRange(
+                IRange that
+            );
+            public T TransformReferenceElement(
+                IReferenceElement that
+            );
+            public T TransformBlob(
+                IBlob that
+            );
+            public T TransformFile(
+                IFile that
+            );
+            public T TransformAnnotatedRelationshipElement(
+                IAnnotatedRelationshipElement that
+            );
+            public T TransformEntity(
+                IEntity that
+            );
+            public T TransformEventPayload(
+                IEventPayload that
+            );
+            public T TransformBasicEventElement(
+                IBasicEventElement that
+            );
+            public T TransformOperation(
+                IOperation that
+            );
+            public T TransformOperationVariable(
+                IOperationVariable that
+            );
+            public T TransformCapability(
+                ICapability that
+            );
+            public T TransformConceptDescription(
+                IConceptDescription that
+            );
+            public T TransformReference(
+                IReference that
+            );
+            public T TransformKey(
+                IKey that
+            );
+            public T TransformLangString(
+                ILangString that
+            );
+            public T TransformEnvironment(
+                IEnvironment that
+            );
+            public T TransformEmbeddedDataSpecification(
+                IEmbeddedDataSpecification that
+            );
+            public T TransformValueReferencePair(
+                IValueReferencePair that
+            );
+            public T TransformValueList(
+                IValueList that
+            );
+            public T TransformDataSpecificationIec61360(
+                IDataSpecificationIec61360 that
+            );
+            public T TransformDataSpecificationPhysicalUnit(
+                IDataSpecificationPhysicalUnit that
+            );
         }  // public interface ITransformer
 
         /// <summary>
@@ -563,124 +1054,304 @@ namespace AasCore.Aas3_0_RC02
                 return that.Transform(this);
             }
 
-            public abstract T Transform(Extension that);
+            public abstract T TransformExtension(
+                IExtension that
+            );
 
-            public abstract T Transform(AdministrativeInformation that);
+            public abstract T TransformAdministrativeInformation(
+                IAdministrativeInformation that
+            );
 
-            public abstract T Transform(Qualifier that);
+            public abstract T TransformQualifier(
+                IQualifier that
+            );
 
-            public abstract T Transform(AssetAdministrationShell that);
+            public abstract T TransformAssetAdministrationShell(
+                IAssetAdministrationShell that
+            );
 
-            public abstract T Transform(AssetInformation that);
+            public abstract T TransformAssetInformation(
+                IAssetInformation that
+            );
 
-            public abstract T Transform(Resource that);
+            public abstract T TransformResource(
+                IResource that
+            );
 
-            public abstract T Transform(SpecificAssetId that);
+            public abstract T TransformSpecificAssetId(
+                ISpecificAssetId that
+            );
 
-            public abstract T Transform(Submodel that);
+            public abstract T TransformSubmodel(
+                ISubmodel that
+            );
 
-            public abstract T Transform(RelationshipElement that);
+            public abstract T TransformRelationshipElement(
+                IRelationshipElement that
+            );
 
-            public abstract T Transform(SubmodelElementList that);
+            public abstract T TransformSubmodelElementList(
+                ISubmodelElementList that
+            );
 
-            public abstract T Transform(SubmodelElementCollection that);
+            public abstract T TransformSubmodelElementCollection(
+                ISubmodelElementCollection that
+            );
 
-            public abstract T Transform(Property that);
+            public abstract T TransformProperty(
+                IProperty that
+            );
 
-            public abstract T Transform(MultiLanguageProperty that);
+            public abstract T TransformMultiLanguageProperty(
+                IMultiLanguageProperty that
+            );
 
-            public abstract T Transform(Range that);
+            public abstract T TransformRange(
+                IRange that
+            );
 
-            public abstract T Transform(ReferenceElement that);
+            public abstract T TransformReferenceElement(
+                IReferenceElement that
+            );
 
-            public abstract T Transform(Blob that);
+            public abstract T TransformBlob(
+                IBlob that
+            );
 
-            public abstract T Transform(File that);
+            public abstract T TransformFile(
+                IFile that
+            );
 
-            public abstract T Transform(AnnotatedRelationshipElement that);
+            public abstract T TransformAnnotatedRelationshipElement(
+                IAnnotatedRelationshipElement that
+            );
 
-            public abstract T Transform(Entity that);
+            public abstract T TransformEntity(
+                IEntity that
+            );
 
-            public abstract T Transform(EventPayload that);
+            public abstract T TransformEventPayload(
+                IEventPayload that
+            );
 
-            public abstract T Transform(BasicEventElement that);
+            public abstract T TransformBasicEventElement(
+                IBasicEventElement that
+            );
 
-            public abstract T Transform(Operation that);
+            public abstract T TransformOperation(
+                IOperation that
+            );
 
-            public abstract T Transform(OperationVariable that);
+            public abstract T TransformOperationVariable(
+                IOperationVariable that
+            );
 
-            public abstract T Transform(Capability that);
+            public abstract T TransformCapability(
+                ICapability that
+            );
 
-            public abstract T Transform(ConceptDescription that);
+            public abstract T TransformConceptDescription(
+                IConceptDescription that
+            );
 
-            public abstract T Transform(Reference that);
+            public abstract T TransformReference(
+                IReference that
+            );
 
-            public abstract T Transform(Key that);
+            public abstract T TransformKey(
+                IKey that
+            );
 
-            public abstract T Transform(LangString that);
+            public abstract T TransformLangString(
+                ILangString that
+            );
 
-            public abstract T Transform(Environment that);
+            public abstract T TransformEnvironment(
+                IEnvironment that
+            );
 
-            public abstract T Transform(EmbeddedDataSpecification that);
+            public abstract T TransformEmbeddedDataSpecification(
+                IEmbeddedDataSpecification that
+            );
 
-            public abstract T Transform(ValueReferencePair that);
+            public abstract T TransformValueReferencePair(
+                IValueReferencePair that
+            );
 
-            public abstract T Transform(ValueList that);
+            public abstract T TransformValueList(
+                IValueList that
+            );
 
-            public abstract T Transform(DataSpecificationIec61360 that);
+            public abstract T TransformDataSpecificationIec61360(
+                IDataSpecificationIec61360 that
+            );
 
-            public abstract T Transform(DataSpecificationPhysicalUnit that);
+            public abstract T TransformDataSpecificationPhysicalUnit(
+                IDataSpecificationPhysicalUnit that
+            );
         }  // public abstract class AbstractTransformer
 
         /// <summary>
         /// Define the interface for a transformer which recursively transforms
         /// the instances into something else while the context is passed along.
         /// </summary>
+        /// <remarks>
+        /// When you use the transformer, please always call the main dispatching method 
+        /// <see cref="Transform" />. You should most probably never call the <c>Transform*</c>
+        /// methods directly. They are only made public so that model classes can access them.
+        /// </remarks>
         /// <typeparam name="TContext">Type of the transformation context</typeparam>
         /// <typeparam name="T">The type of the transformation result</typeparam>
         public interface ITransformerWithContext<in TContext, out T>
         {
             public T Transform(IClass that, TContext context);
-            public T Transform(Extension that, TContext context);
-            public T Transform(AdministrativeInformation that, TContext context);
-            public T Transform(Qualifier that, TContext context);
-            public T Transform(AssetAdministrationShell that, TContext context);
-            public T Transform(AssetInformation that, TContext context);
-            public T Transform(Resource that, TContext context);
-            public T Transform(SpecificAssetId that, TContext context);
-            public T Transform(Submodel that, TContext context);
-            public T Transform(RelationshipElement that, TContext context);
-            public T Transform(SubmodelElementList that, TContext context);
-            public T Transform(SubmodelElementCollection that, TContext context);
-            public T Transform(Property that, TContext context);
-            public T Transform(MultiLanguageProperty that, TContext context);
-            public T Transform(Range that, TContext context);
-            public T Transform(ReferenceElement that, TContext context);
-            public T Transform(Blob that, TContext context);
-            public T Transform(File that, TContext context);
-            public T Transform(AnnotatedRelationshipElement that, TContext context);
-            public T Transform(Entity that, TContext context);
-            public T Transform(EventPayload that, TContext context);
-            public T Transform(BasicEventElement that, TContext context);
-            public T Transform(Operation that, TContext context);
-            public T Transform(OperationVariable that, TContext context);
-            public T Transform(Capability that, TContext context);
-            public T Transform(ConceptDescription that, TContext context);
-            public T Transform(Reference that, TContext context);
-            public T Transform(Key that, TContext context);
-            public T Transform(LangString that, TContext context);
-            public T Transform(Environment that, TContext context);
-            public T Transform(EmbeddedDataSpecification that, TContext context);
-            public T Transform(ValueReferencePair that, TContext context);
-            public T Transform(ValueList that, TContext context);
-            public T Transform(DataSpecificationIec61360 that, TContext context);
-            public T Transform(DataSpecificationPhysicalUnit that, TContext context);
+            public T TransformExtension(
+                IExtension that,
+                TContext context
+            );
+            public T TransformAdministrativeInformation(
+                IAdministrativeInformation that,
+                TContext context
+            );
+            public T TransformQualifier(
+                IQualifier that,
+                TContext context
+            );
+            public T TransformAssetAdministrationShell(
+                IAssetAdministrationShell that,
+                TContext context
+            );
+            public T TransformAssetInformation(
+                IAssetInformation that,
+                TContext context
+            );
+            public T TransformResource(
+                IResource that,
+                TContext context
+            );
+            public T TransformSpecificAssetId(
+                ISpecificAssetId that,
+                TContext context
+            );
+            public T TransformSubmodel(
+                ISubmodel that,
+                TContext context
+            );
+            public T TransformRelationshipElement(
+                IRelationshipElement that,
+                TContext context
+            );
+            public T TransformSubmodelElementList(
+                ISubmodelElementList that,
+                TContext context
+            );
+            public T TransformSubmodelElementCollection(
+                ISubmodelElementCollection that,
+                TContext context
+            );
+            public T TransformProperty(
+                IProperty that,
+                TContext context
+            );
+            public T TransformMultiLanguageProperty(
+                IMultiLanguageProperty that,
+                TContext context
+            );
+            public T TransformRange(
+                IRange that,
+                TContext context
+            );
+            public T TransformReferenceElement(
+                IReferenceElement that,
+                TContext context
+            );
+            public T TransformBlob(
+                IBlob that,
+                TContext context
+            );
+            public T TransformFile(
+                IFile that,
+                TContext context
+            );
+            public T TransformAnnotatedRelationshipElement(
+                IAnnotatedRelationshipElement that,
+                TContext context
+            );
+            public T TransformEntity(
+                IEntity that,
+                TContext context
+            );
+            public T TransformEventPayload(
+                IEventPayload that,
+                TContext context
+            );
+            public T TransformBasicEventElement(
+                IBasicEventElement that,
+                TContext context
+            );
+            public T TransformOperation(
+                IOperation that,
+                TContext context
+            );
+            public T TransformOperationVariable(
+                IOperationVariable that,
+                TContext context
+            );
+            public T TransformCapability(
+                ICapability that,
+                TContext context
+            );
+            public T TransformConceptDescription(
+                IConceptDescription that,
+                TContext context
+            );
+            public T TransformReference(
+                IReference that,
+                TContext context
+            );
+            public T TransformKey(
+                IKey that,
+                TContext context
+            );
+            public T TransformLangString(
+                ILangString that,
+                TContext context
+            );
+            public T TransformEnvironment(
+                IEnvironment that,
+                TContext context
+            );
+            public T TransformEmbeddedDataSpecification(
+                IEmbeddedDataSpecification that,
+                TContext context
+            );
+            public T TransformValueReferencePair(
+                IValueReferencePair that,
+                TContext context
+            );
+            public T TransformValueList(
+                IValueList that,
+                TContext context
+            );
+            public T TransformDataSpecificationIec61360(
+                IDataSpecificationIec61360 that,
+                TContext context
+            );
+            public T TransformDataSpecificationPhysicalUnit(
+                IDataSpecificationPhysicalUnit that,
+                TContext context
+            );
         }  // public interface ITransformerWithContext
 
         /// <summary>
         /// Perform double-dispatch to transform recursively
         /// the instances into something else.
         /// </summary>
+        /// <remarks>
+        /// When you use the transformer, please always call the main dispatching method 
+        /// <see cref="Transform" />. You should most probably never call the <c>Transform*</c>
+        /// methods directly. They are only made public so that model classes can access them.
+        /// </remarks>
         /// <typeparam name="TContext">The type of the transformation context</typeparam>
         /// <typeparam name="T">The type of the transformation result</typeparam>
         public abstract class AbstractTransformerWithContext<TContext, T>
@@ -691,73 +1362,175 @@ namespace AasCore.Aas3_0_RC02
                 return that.Transform(this, context);
             }
 
-            public abstract T Transform(Extension that, TContext context);
+            public abstract T TransformExtension(
+                IExtension that,
+                TContext context
+            );
 
-            public abstract T Transform(AdministrativeInformation that, TContext context);
+            public abstract T TransformAdministrativeInformation(
+                IAdministrativeInformation that,
+                TContext context
+            );
 
-            public abstract T Transform(Qualifier that, TContext context);
+            public abstract T TransformQualifier(
+                IQualifier that,
+                TContext context
+            );
 
-            public abstract T Transform(AssetAdministrationShell that, TContext context);
+            public abstract T TransformAssetAdministrationShell(
+                IAssetAdministrationShell that,
+                TContext context
+            );
 
-            public abstract T Transform(AssetInformation that, TContext context);
+            public abstract T TransformAssetInformation(
+                IAssetInformation that,
+                TContext context
+            );
 
-            public abstract T Transform(Resource that, TContext context);
+            public abstract T TransformResource(
+                IResource that,
+                TContext context
+            );
 
-            public abstract T Transform(SpecificAssetId that, TContext context);
+            public abstract T TransformSpecificAssetId(
+                ISpecificAssetId that,
+                TContext context
+            );
 
-            public abstract T Transform(Submodel that, TContext context);
+            public abstract T TransformSubmodel(
+                ISubmodel that,
+                TContext context
+            );
 
-            public abstract T Transform(RelationshipElement that, TContext context);
+            public abstract T TransformRelationshipElement(
+                IRelationshipElement that,
+                TContext context
+            );
 
-            public abstract T Transform(SubmodelElementList that, TContext context);
+            public abstract T TransformSubmodelElementList(
+                ISubmodelElementList that,
+                TContext context
+            );
 
-            public abstract T Transform(SubmodelElementCollection that, TContext context);
+            public abstract T TransformSubmodelElementCollection(
+                ISubmodelElementCollection that,
+                TContext context
+            );
 
-            public abstract T Transform(Property that, TContext context);
+            public abstract T TransformProperty(
+                IProperty that,
+                TContext context
+            );
 
-            public abstract T Transform(MultiLanguageProperty that, TContext context);
+            public abstract T TransformMultiLanguageProperty(
+                IMultiLanguageProperty that,
+                TContext context
+            );
 
-            public abstract T Transform(Range that, TContext context);
+            public abstract T TransformRange(
+                IRange that,
+                TContext context
+            );
 
-            public abstract T Transform(ReferenceElement that, TContext context);
+            public abstract T TransformReferenceElement(
+                IReferenceElement that,
+                TContext context
+            );
 
-            public abstract T Transform(Blob that, TContext context);
+            public abstract T TransformBlob(
+                IBlob that,
+                TContext context
+            );
 
-            public abstract T Transform(File that, TContext context);
+            public abstract T TransformFile(
+                IFile that,
+                TContext context
+            );
 
-            public abstract T Transform(AnnotatedRelationshipElement that, TContext context);
+            public abstract T TransformAnnotatedRelationshipElement(
+                IAnnotatedRelationshipElement that,
+                TContext context
+            );
 
-            public abstract T Transform(Entity that, TContext context);
+            public abstract T TransformEntity(
+                IEntity that,
+                TContext context
+            );
 
-            public abstract T Transform(EventPayload that, TContext context);
+            public abstract T TransformEventPayload(
+                IEventPayload that,
+                TContext context
+            );
 
-            public abstract T Transform(BasicEventElement that, TContext context);
+            public abstract T TransformBasicEventElement(
+                IBasicEventElement that,
+                TContext context
+            );
 
-            public abstract T Transform(Operation that, TContext context);
+            public abstract T TransformOperation(
+                IOperation that,
+                TContext context
+            );
 
-            public abstract T Transform(OperationVariable that, TContext context);
+            public abstract T TransformOperationVariable(
+                IOperationVariable that,
+                TContext context
+            );
 
-            public abstract T Transform(Capability that, TContext context);
+            public abstract T TransformCapability(
+                ICapability that,
+                TContext context
+            );
 
-            public abstract T Transform(ConceptDescription that, TContext context);
+            public abstract T TransformConceptDescription(
+                IConceptDescription that,
+                TContext context
+            );
 
-            public abstract T Transform(Reference that, TContext context);
+            public abstract T TransformReference(
+                IReference that,
+                TContext context
+            );
 
-            public abstract T Transform(Key that, TContext context);
+            public abstract T TransformKey(
+                IKey that,
+                TContext context
+            );
 
-            public abstract T Transform(LangString that, TContext context);
+            public abstract T TransformLangString(
+                ILangString that,
+                TContext context
+            );
 
-            public abstract T Transform(Environment that, TContext context);
+            public abstract T TransformEnvironment(
+                IEnvironment that,
+                TContext context
+            );
 
-            public abstract T Transform(EmbeddedDataSpecification that, TContext context);
+            public abstract T TransformEmbeddedDataSpecification(
+                IEmbeddedDataSpecification that,
+                TContext context
+            );
 
-            public abstract T Transform(ValueReferencePair that, TContext context);
+            public abstract T TransformValueReferencePair(
+                IValueReferencePair that,
+                TContext context
+            );
 
-            public abstract T Transform(ValueList that, TContext context);
+            public abstract T TransformValueList(
+                IValueList that,
+                TContext context
+            );
 
-            public abstract T Transform(DataSpecificationIec61360 that, TContext context);
+            public abstract T TransformDataSpecificationIec61360(
+                IDataSpecificationIec61360 that,
+                TContext context
+            );
 
-            public abstract T Transform(DataSpecificationPhysicalUnit that, TContext context);
+            public abstract T TransformDataSpecificationPhysicalUnit(
+                IDataSpecificationPhysicalUnit that,
+                TContext context
+            );
         }  // public abstract class AbstractTransformerWithContext
     }  // public static class Visitation
 }  // namespace AasCore.Aas3_0_RC02

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/xmlization.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/xmlization.cs
@@ -21175,7 +21175,7 @@ namespace AasCore.Aas3_0_RC02
             : Visitation.AbstractVisitorWithContext<Xml.XmlWriter>
         {
             private void ExtensionToSequence(
-                Extension that,
+                Aas.IExtension that,
                 Xml.XmlWriter writer)
             {
                 if (that.SemanticId != null)
@@ -21259,8 +21259,8 @@ namespace AasCore.Aas3_0_RC02
                 }
             }  // private void ExtensionToSequence
 
-            public override void Visit(
-                Aas.Extension that,
+            public override void VisitExtension(
+                Aas.IExtension that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -21273,7 +21273,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void AdministrativeInformationToSequence(
-                AdministrativeInformation that,
+                Aas.IAdministrativeInformation that,
                 Xml.XmlWriter writer)
             {
                 if (that.EmbeddedDataSpecifications != null)
@@ -21317,8 +21317,8 @@ namespace AasCore.Aas3_0_RC02
                 }
             }  // private void AdministrativeInformationToSequence
 
-            public override void Visit(
-                Aas.AdministrativeInformation that,
+            public override void VisitAdministrativeInformation(
+                Aas.IAdministrativeInformation that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -21331,7 +21331,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void QualifierToSequence(
-                Qualifier that,
+                Aas.IQualifier that,
                 Xml.XmlWriter writer)
             {
                 if (that.SemanticId != null)
@@ -21429,8 +21429,8 @@ namespace AasCore.Aas3_0_RC02
                 }
             }  // private void QualifierToSequence
 
-            public override void Visit(
-                Aas.Qualifier that,
+            public override void VisitQualifier(
+                Aas.IQualifier that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -21443,7 +21443,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void AssetAdministrationShellToSequence(
-                AssetAdministrationShell that,
+                Aas.IAssetAdministrationShell that,
                 Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
@@ -21608,8 +21608,8 @@ namespace AasCore.Aas3_0_RC02
                 }
             }  // private void AssetAdministrationShellToSequence
 
-            public override void Visit(
-                Aas.AssetAdministrationShell that,
+            public override void VisitAssetAdministrationShell(
+                Aas.IAssetAdministrationShell that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -21622,7 +21622,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void AssetInformationToSequence(
-                AssetInformation that,
+                Aas.IAssetInformation that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -21682,8 +21682,8 @@ namespace AasCore.Aas3_0_RC02
                 }
             }  // private void AssetInformationToSequence
 
-            public override void Visit(
-                Aas.AssetInformation that,
+            public override void VisitAssetInformation(
+                Aas.IAssetInformation that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -21696,7 +21696,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void ResourceToSequence(
-                Resource that,
+                Aas.IResource that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -21721,8 +21721,8 @@ namespace AasCore.Aas3_0_RC02
                 }
             }  // private void ResourceToSequence
 
-            public override void Visit(
-                Aas.Resource that,
+            public override void VisitResource(
+                Aas.IResource that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -21735,7 +21735,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void SpecificAssetIdToSequence(
-                SpecificAssetId that,
+                Aas.ISpecificAssetId that,
                 Xml.XmlWriter writer)
             {
                 if (that.SemanticId != null)
@@ -21796,8 +21796,8 @@ namespace AasCore.Aas3_0_RC02
                 writer.WriteEndElement();
             }  // private void SpecificAssetIdToSequence
 
-            public override void Visit(
-                Aas.SpecificAssetId that,
+            public override void VisitSpecificAssetId(
+                Aas.ISpecificAssetId that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -21810,7 +21810,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void SubmodelToSequence(
-                Submodel that,
+                Aas.ISubmodel that,
                 Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
@@ -22014,8 +22014,8 @@ namespace AasCore.Aas3_0_RC02
                 }
             }  // private void SubmodelToSequence
 
-            public override void Visit(
-                Aas.Submodel that,
+            public override void VisitSubmodel(
+                Aas.ISubmodel that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -22028,7 +22028,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void RelationshipElementToSequence(
-                RelationshipElement that,
+                Aas.IRelationshipElement that,
                 Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
@@ -22214,8 +22214,8 @@ namespace AasCore.Aas3_0_RC02
                 writer.WriteEndElement();
             }  // private void RelationshipElementToSequence
 
-            public override void Visit(
-                Aas.RelationshipElement that,
+            public override void VisitRelationshipElement(
+                Aas.IRelationshipElement that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -22228,7 +22228,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void SubmodelElementListToSequence(
-                SubmodelElementList that,
+                Aas.ISubmodelElementList that,
                 Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
@@ -22466,8 +22466,8 @@ namespace AasCore.Aas3_0_RC02
                 }
             }  // private void SubmodelElementListToSequence
 
-            public override void Visit(
-                Aas.SubmodelElementList that,
+            public override void VisitSubmodelElementList(
+                Aas.ISubmodelElementList that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -22480,7 +22480,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void SubmodelElementCollectionToSequence(
-                SubmodelElementCollection that,
+                Aas.ISubmodelElementCollection that,
                 Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
@@ -22662,8 +22662,8 @@ namespace AasCore.Aas3_0_RC02
                 }
             }  // private void SubmodelElementCollectionToSequence
 
-            public override void Visit(
-                Aas.SubmodelElementCollection that,
+            public override void VisitSubmodelElementCollection(
+                Aas.ISubmodelElementCollection that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -22676,7 +22676,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void PropertyToSequence(
-                Property that,
+                Aas.IProperty that,
                 Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
@@ -22881,8 +22881,8 @@ namespace AasCore.Aas3_0_RC02
                 }
             }  // private void PropertyToSequence
 
-            public override void Visit(
-                Aas.Property that,
+            public override void VisitProperty(
+                Aas.IProperty that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -22895,7 +22895,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void MultiLanguagePropertyToSequence(
-                MultiLanguageProperty that,
+                Aas.IMultiLanguageProperty that,
                 Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
@@ -23090,8 +23090,8 @@ namespace AasCore.Aas3_0_RC02
                 }
             }  // private void MultiLanguagePropertyToSequence
 
-            public override void Visit(
-                Aas.MultiLanguageProperty that,
+            public override void VisitMultiLanguageProperty(
+                Aas.IMultiLanguageProperty that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -23104,7 +23104,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void RangeToSequence(
-                Range that,
+                Aas.IRange that,
                 Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
@@ -23308,8 +23308,8 @@ namespace AasCore.Aas3_0_RC02
                 }
             }  // private void RangeToSequence
 
-            public override void Visit(
-                Aas.Range that,
+            public override void VisitRange(
+                Aas.IRange that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -23322,7 +23322,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void ReferenceElementToSequence(
-                ReferenceElement that,
+                Aas.IReferenceElement that,
                 Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
@@ -23501,8 +23501,8 @@ namespace AasCore.Aas3_0_RC02
                 }
             }  // private void ReferenceElementToSequence
 
-            public override void Visit(
-                Aas.ReferenceElement that,
+            public override void VisitReferenceElement(
+                Aas.IReferenceElement that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -23515,7 +23515,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void BlobToSequence(
-                Blob that,
+                Aas.IBlob that,
                 Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
@@ -23704,8 +23704,8 @@ namespace AasCore.Aas3_0_RC02
                 writer.WriteEndElement();
             }  // private void BlobToSequence
 
-            public override void Visit(
-                Aas.Blob that,
+            public override void VisitBlob(
+                Aas.IBlob that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -23718,7 +23718,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void FileToSequence(
-                File that,
+                Aas.IFile that,
                 Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
@@ -23905,8 +23905,8 @@ namespace AasCore.Aas3_0_RC02
                 writer.WriteEndElement();
             }  // private void FileToSequence
 
-            public override void Visit(
-                Aas.File that,
+            public override void VisitFile(
+                Aas.IFile that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -23919,7 +23919,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void AnnotatedRelationshipElementToSequence(
-                AnnotatedRelationshipElement that,
+                Aas.IAnnotatedRelationshipElement that,
                 Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
@@ -24121,8 +24121,8 @@ namespace AasCore.Aas3_0_RC02
                 }
             }  // private void AnnotatedRelationshipElementToSequence
 
-            public override void Visit(
-                Aas.AnnotatedRelationshipElement that,
+            public override void VisitAnnotatedRelationshipElement(
+                Aas.IAnnotatedRelationshipElement that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -24135,7 +24135,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void EntityToSequence(
-                Entity that,
+                Aas.IEntity that,
                 Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
@@ -24357,8 +24357,8 @@ namespace AasCore.Aas3_0_RC02
                 }
             }  // private void EntityToSequence
 
-            public override void Visit(
-                Aas.Entity that,
+            public override void VisitEntity(
+                Aas.IEntity that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -24371,7 +24371,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void EventPayloadToSequence(
-                EventPayload that,
+                Aas.IEventPayload that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -24467,8 +24467,8 @@ namespace AasCore.Aas3_0_RC02
                 }
             }  // private void EventPayloadToSequence
 
-            public override void Visit(
-                Aas.EventPayload that,
+            public override void VisitEventPayload(
+                Aas.IEventPayload that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -24481,7 +24481,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void BasicEventElementToSequence(
-                BasicEventElement that,
+                Aas.IBasicEventElement that,
                 Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
@@ -24746,8 +24746,8 @@ namespace AasCore.Aas3_0_RC02
                 }
             }  // private void BasicEventElementToSequence
 
-            public override void Visit(
-                Aas.BasicEventElement that,
+            public override void VisitBasicEventElement(
+                Aas.IBasicEventElement that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -24760,7 +24760,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void OperationToSequence(
-                Operation that,
+                Aas.IOperation that,
                 Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
@@ -24974,8 +24974,8 @@ namespace AasCore.Aas3_0_RC02
                 }
             }  // private void OperationToSequence
 
-            public override void Visit(
-                Aas.Operation that,
+            public override void VisitOperation(
+                Aas.IOperation that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -24988,7 +24988,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void OperationVariableToSequence(
-                OperationVariable that,
+                Aas.IOperationVariable that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -25002,8 +25002,8 @@ namespace AasCore.Aas3_0_RC02
                 writer.WriteEndElement();
             }  // private void OperationVariableToSequence
 
-            public override void Visit(
-                Aas.OperationVariable that,
+            public override void VisitOperationVariable(
+                Aas.IOperationVariable that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -25016,7 +25016,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void CapabilityToSequence(
-                Capability that,
+                Aas.ICapability that,
                 Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
@@ -25182,8 +25182,8 @@ namespace AasCore.Aas3_0_RC02
                 }
             }  // private void CapabilityToSequence
 
-            public override void Visit(
-                Aas.Capability that,
+            public override void VisitCapability(
+                Aas.ICapability that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -25196,7 +25196,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void ConceptDescriptionToSequence(
-                ConceptDescription that,
+                Aas.IConceptDescription that,
                 Xml.XmlWriter writer)
             {
                 if (that.Extensions != null)
@@ -25338,8 +25338,8 @@ namespace AasCore.Aas3_0_RC02
                 }
             }  // private void ConceptDescriptionToSequence
 
-            public override void Visit(
-                Aas.ConceptDescription that,
+            public override void VisitConceptDescription(
+                Aas.IConceptDescription that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -25352,7 +25352,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void ReferenceToSequence(
-                Reference that,
+                Aas.IReference that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -25396,8 +25396,8 @@ namespace AasCore.Aas3_0_RC02
                 writer.WriteEndElement();
             }  // private void ReferenceToSequence
 
-            public override void Visit(
-                Aas.Reference that,
+            public override void VisitReference(
+                Aas.IReference that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -25410,7 +25410,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void KeyToSequence(
-                Key that,
+                Aas.IKey that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -25437,8 +25437,8 @@ namespace AasCore.Aas3_0_RC02
                 writer.WriteEndElement();
             }  // private void KeyToSequence
 
-            public override void Visit(
-                Aas.Key that,
+            public override void VisitKey(
+                Aas.IKey that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -25451,7 +25451,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void LangStringToSequence(
-                LangString that,
+                Aas.ILangString that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -25473,8 +25473,8 @@ namespace AasCore.Aas3_0_RC02
                 writer.WriteEndElement();
             }  // private void LangStringToSequence
 
-            public override void Visit(
-                Aas.LangString that,
+            public override void VisitLangString(
+                Aas.ILangString that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -25487,7 +25487,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void EnvironmentToSequence(
-                Environment that,
+                Aas.IEnvironment that,
                 Xml.XmlWriter writer)
             {
                 if (that.AssetAdministrationShells != null)
@@ -25539,8 +25539,8 @@ namespace AasCore.Aas3_0_RC02
                 }
             }  // private void EnvironmentToSequence
 
-            public override void Visit(
-                Aas.Environment that,
+            public override void VisitEnvironment(
+                Aas.IEnvironment that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -25553,7 +25553,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void EmbeddedDataSpecificationToSequence(
-                EmbeddedDataSpecification that,
+                Aas.IEmbeddedDataSpecification that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -25577,8 +25577,8 @@ namespace AasCore.Aas3_0_RC02
                 writer.WriteEndElement();
             }  // private void EmbeddedDataSpecificationToSequence
 
-            public override void Visit(
-                Aas.EmbeddedDataSpecification that,
+            public override void VisitEmbeddedDataSpecification(
+                Aas.IEmbeddedDataSpecification that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -25591,7 +25591,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void ValueReferencePairToSequence(
-                ValueReferencePair that,
+                Aas.IValueReferencePair that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -25614,8 +25614,8 @@ namespace AasCore.Aas3_0_RC02
                 writer.WriteEndElement();
             }  // private void ValueReferencePairToSequence
 
-            public override void Visit(
-                Aas.ValueReferencePair that,
+            public override void VisitValueReferencePair(
+                Aas.IValueReferencePair that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -25628,7 +25628,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void ValueListToSequence(
-                ValueList that,
+                Aas.IValueList that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -25645,8 +25645,8 @@ namespace AasCore.Aas3_0_RC02
                 writer.WriteEndElement();
             }  // private void ValueListToSequence
 
-            public override void Visit(
-                Aas.ValueList that,
+            public override void VisitValueList(
+                Aas.IValueList that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -25659,7 +25659,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void DataSpecificationIec61360ToSequence(
-                DataSpecificationIec61360 that,
+                Aas.IDataSpecificationIec61360 that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -25828,8 +25828,8 @@ namespace AasCore.Aas3_0_RC02
                 }
             }  // private void DataSpecificationIec61360ToSequence
 
-            public override void Visit(
-                Aas.DataSpecificationIec61360 that,
+            public override void VisitDataSpecificationIec61360(
+                Aas.IDataSpecificationIec61360 that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -25842,7 +25842,7 @@ namespace AasCore.Aas3_0_RC02
             }
 
             private void DataSpecificationPhysicalUnitToSequence(
-                DataSpecificationPhysicalUnit that,
+                Aas.IDataSpecificationPhysicalUnit that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
@@ -25997,8 +25997,8 @@ namespace AasCore.Aas3_0_RC02
                 }
             }  // private void DataSpecificationPhysicalUnitToSequence
 
-            public override void Visit(
-                Aas.DataSpecificationPhysicalUnit that,
+            public override void VisitDataSpecificationPhysicalUnit(
+                Aas.IDataSpecificationPhysicalUnit that,
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(

--- a/test_data/csharp/test_structure/concrete_class_with_descendants/expected_types.cs
+++ b/test_data/csharp/test_structure/concrete_class_with_descendants/expected_types.cs
@@ -10,7 +10,6 @@ using System.Collections.Generic;  // can't alias
 
 namespace dummyNamespace
 {
-
     /// <summary>
     /// Represent a general class of an AAS model.
     /// </summary>
@@ -88,7 +87,7 @@ namespace dummyNamespace
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitParent(this);
         }
 
         /// <summary>
@@ -99,7 +98,7 @@ namespace dummyNamespace
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitParent(this, context);
         }
 
         /// <summary>
@@ -108,7 +107,7 @@ namespace dummyNamespace
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformParent(this);
         }
 
         /// <summary>
@@ -119,11 +118,16 @@ namespace dummyNamespace
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformParent(this, context);
         }
     }
 
-    public class Child : IParent
+    public interface IChild : IParent
+    {
+        // Intentionally empty.
+    }
+
+    public class Child : IChild
     {
         /// <summary>
         /// Iterate over all the class instances referenced from this instance
@@ -150,7 +154,7 @@ namespace dummyNamespace
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitChild(this);
         }
 
         /// <summary>
@@ -161,7 +165,7 @@ namespace dummyNamespace
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitChild(this, context);
         }
 
         /// <summary>
@@ -170,7 +174,7 @@ namespace dummyNamespace
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformChild(this);
         }
 
         /// <summary>
@@ -181,10 +185,9 @@ namespace dummyNamespace
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformChild(this, context);
         }
     }
-
 }  // namespace dummyNamespace
 
 /*

--- a/test_data/csharp/test_structure/constructor_without_arguments/all_properties_optional/expected_types.cs
+++ b/test_data/csharp/test_structure/constructor_without_arguments/all_properties_optional/expected_types.cs
@@ -10,7 +10,6 @@ using System.Collections.Generic;  // can't alias
 
 namespace dummyNamespace
 {
-
     /// <summary>
     /// Represent a general class of an AAS model.
     /// </summary>
@@ -56,7 +55,12 @@ namespace dummyNamespace
             TContext context);
     }
 
-    public class Something : IClass
+    public interface ISomething : IClass
+    {
+        public string? SomeProperty { get; set; }
+    }
+
+    public class Something : ISomething
     {
         public string? SomeProperty { get; set; }
 
@@ -85,7 +89,7 @@ namespace dummyNamespace
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitSomething(this);
         }
 
         /// <summary>
@@ -96,7 +100,7 @@ namespace dummyNamespace
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitSomething(this, context);
         }
 
         /// <summary>
@@ -105,7 +109,7 @@ namespace dummyNamespace
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformSomething(this);
         }
 
         /// <summary>
@@ -116,7 +120,7 @@ namespace dummyNamespace
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformSomething(this, context);
         }
 
         public Something(string? someProperty = null)
@@ -124,7 +128,6 @@ namespace dummyNamespace
             SomeProperty = someProperty;
         }
     }
-
 }  // namespace dummyNamespace
 
 /*

--- a/test_data/csharp/test_structure/constructor_without_arguments/no_properties/expected_types.cs
+++ b/test_data/csharp/test_structure/constructor_without_arguments/no_properties/expected_types.cs
@@ -10,7 +10,6 @@ using System.Collections.Generic;  // can't alias
 
 namespace dummyNamespace
 {
-
     /// <summary>
     /// Represent a general class of an AAS model.
     /// </summary>
@@ -56,7 +55,12 @@ namespace dummyNamespace
             TContext context);
     }
 
-    public class Something : IClass
+    public interface ISomething : IClass
+    {
+        // Intentionally empty.
+    }
+
+    public class Something : ISomething
     {
         /// <summary>
         /// Iterate over all the class instances referenced from this instance
@@ -83,7 +87,7 @@ namespace dummyNamespace
         /// </summary>
         public void Accept(Visitation.IVisitor visitor)
         {
-            visitor.Visit(this);
+            visitor.VisitSomething(this);
         }
 
         /// <summary>
@@ -94,7 +98,7 @@ namespace dummyNamespace
             Visitation.IVisitorWithContext<TContext> visitor,
             TContext context)
         {
-            visitor.Visit(this, context);
+            visitor.VisitSomething(this, context);
         }
 
         /// <summary>
@@ -103,7 +107,7 @@ namespace dummyNamespace
         /// </summary>
         public T Transform<T>(Visitation.ITransformer<T> transformer)
         {
-            return transformer.Transform(this);
+            return transformer.TransformSomething(this);
         }
 
         /// <summary>
@@ -114,10 +118,9 @@ namespace dummyNamespace
             Visitation.ITransformerWithContext<TContext, T> transformer,
             TContext context)
         {
-            return transformer.Transform(this, context);
+            return transformer.TransformSomething(this, context);
         }
     }
-
 }  // namespace dummyNamespace
 
 /*

--- a/test_data/csharp/test_verification/builtin_functions/len/on_list/expected_verification.cs
+++ b/test_data/csharp/test_verification/builtin_functions/len/on_list/expected_verification.cs
@@ -47,16 +47,18 @@ namespace dummyNamespace
             : Visitation.AbstractTransformer<IEnumerable<Reporting.Error>>
         {
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.Item that)
+            public override IEnumerable<Reporting.Error> TransformItem(
+                Aas.IItem that
+            )
             {
                 // No verification has been defined for Item.
                 yield break;
             }
 
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.Something that)
+            public override IEnumerable<Reporting.Error> TransformSomething(
+                Aas.ISomething that
+            )
             {
                 if (!(that.SomeProperty.Count >= 1))
                 {

--- a/test_data/csharp/test_verification/builtin_functions/len/on_str/expected_verification.cs
+++ b/test_data/csharp/test_verification/builtin_functions/len/on_str/expected_verification.cs
@@ -47,8 +47,9 @@ namespace dummyNamespace
             : Visitation.AbstractTransformer<IEnumerable<Reporting.Error>>
         {
             [CodeAnalysis.SuppressMessage("ReSharper", "NegativeEqualityExpression")]
-            public override IEnumerable<Reporting.Error> Transform(
-                Aas.Something that)
+            public override IEnumerable<Reporting.Error> TransformSomething(
+                Aas.ISomething that
+            )
             {
                 if (!(that.SomeProperty.Length >= 1))
                 {


### PR DESCRIPTION
We operate on *interfaces* instead of concrete classes to allow for custom extensions and wrappers around our model classes.

Originally, we used type overloading to dispatch the visit calls. After we decided to support custom wrappers and enhancements to our classes, we had to switch here to interfaces instead of concrete classes. The type overloading does not work anymore in this setting, as descendants of *concrete* classes would be wrongly dispatched. That is why we dispatch explicitly, by having different visit method names instead of mere type overloads.