### PR TITLE
Transpile everything to C# in smoke mode

### DIFF
--- a/test_data/smoke/test_main/unexpected/type_error/expected_stderr.txt
+++ b/test_data/smoke/test_main/unexpected/type_error/expected_stderr.txt
@@ -1,0 +1,4 @@
+Failed to smoke-transpile what we could without snippets to C# based on <meta_model.py>:
+* At line 9 and column 2: Failed to transpile the invariant of the class 'Something'
+    At line 9 and column 26: Failed to transpile the comparison
+      At line 9 and column 26: We do not know how to compute the length on type Value

--- a/test_data/smoke/test_main/unexpected/type_error/meta_model.py
+++ b/test_data/smoke/test_main/unexpected/type_error/meta_model.py
@@ -1,0 +1,19 @@
+class Value:
+    text: str
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+# ERROR: ``len(.)`` on a class is not defined.
+@invariant(lambda self: len(self.value) > 1, "Value longer than 1")
+class Something:
+    value: Value
+
+    def __init__(self, value: Value) -> None:
+        self.value = value
+
+
+__book_version__ = "dummy"
+__book_url__ = "dummy"
+__xml_namespace__ = "https://dummy.com"


### PR DESCRIPTION
We encountered various errors during the design of the aas-core-meta V3 which would have been prevented if only we transpiled to C# (or any other language). Notably, we needed type inference which was missing in the current smoke tests.

This patch mocks all the implementation specific snippets and transpiles to C# in the smoke command, so that the errors in the meta-models can be discovered earlier during the design.