### PR TITLE
Fix tests failing in remote CI

### DIFF
--- a/test_data/rdf_shacl/test_main/unexpected/regression_len_constraint_on_class_property/expected_output/stderr.txt
+++ b/test_data/rdf_shacl/test_main/unexpected/regression_len_constraint_on_class_property/expected_output/stderr.txt
@@ -1,3 +1,3 @@
-Failed to generate the SHACL schema based on C:\Users\rist\workspace\aas-core-works\aas-core-codegen\test_data\rdf_shacl\test_main\unexpected\regression_len_constraint_on_class_property\meta_model.py:
+Failed to generate the SHACL schema based on <repo dir>\test_data\rdf_shacl\test_main\unexpected\regression_len_constraint_on_class_property\meta_model.py:
 * Failed to generate the shape definition for Something
     At line 54 and column 6: (mristin, 2023-02-08): A length constraint has been inferred for the property 'value' in the class 'Something' whose type is a class, namely Optional[Value]. We do not know how to impose the length constraints on a property of type *class* in SHACL at this moment. If this is not a bug in your meta-model, please contact the developers to see how to implement this feature.

--- a/tests/rdf_shacl/test_main.py
+++ b/tests/rdf_shacl/test_main.py
@@ -178,7 +178,7 @@ class Test_against_recorded(unittest.TestCase):
 
                 stderr_pth = expected_output_dir / "stderr.txt"
                 normalized_stderr = stderr.getvalue().replace(
-                    str(output_dir), "<output dir>"
+                    str(REPO_DIR), "<repo dir>"
                 )
 
                 if tests.common.RERECORD:


### PR DESCRIPTION
Due to lack of time (deadlines + nearing holidays), we ignored the minor issue failing the remote CI. Namely, the paths in the recorded errors for RDF+SHACL were stored with the absolute paths, and thus failed on the remote machine.

This patch fixes the issue.