### PR TITLE
Change JSON naming of model types for V3

### DIFF
--- a/aas_core_codegen/naming.py
+++ b/aas_core_codegen/naming.py
@@ -69,15 +69,12 @@ def json_model_type(identifier: Identifier) -> Identifier:
     'Something'
 
     >>> json_model_type(Identifier("Data_type_IEC_61360"))
-    'DataTypeIEC61360'
+    'DataTypeIec61360'
 
     >>> json_model_type(Identifier("URL_to_something"))
-    'URLToSomething'
+    'UrlToSomething'
     """
-    parts = identifier.split("_")
-    return Identifier(
-        "".join(part.capitalize() if part == part.lower() else part for part in parts)
-    )
+    return capitalized_camel_case(identifier)
 
 
 # fmt: off

--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/jsonization.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/jsonization.cs
@@ -13675,7 +13675,7 @@ namespace AasCore.Aas3_0_RC02
 
                 switch (modelType)
                 {
-                    case "DataSpecificationIEC61360":
+                    case "DataSpecificationIec61360":
                         return DataSpecificationIec61360From(
                             node, out error);
                     case "DataSpecificationPhysicalUnit":
@@ -19204,7 +19204,7 @@ namespace AasCore.Aas3_0_RC02
                         value);
                 }
 
-                result["modelType"] = "DataSpecificationIEC61360";
+                result["modelType"] = "DataSpecificationIec61360";
 
                 return result;
             }

--- a/test_data/jsonschema/test_main/aas_core_meta.v3rc2/expected_output/schema.json
+++ b/test_data/jsonschema/test_main/aas_core_meta.v3rc2/expected_output/schema.json
@@ -234,7 +234,7 @@
         "modelType"
       ]
     },
-    "DataSpecificationIEC61360": {
+    "DataSpecificationIec61360": {
       "allOf": [
         {
           "$ref": "#/definitions/DataSpecificationContent"
@@ -271,7 +271,7 @@
               "minLength": 1
             },
             "dataType": {
-              "$ref": "#/definitions/DataTypeIEC61360"
+              "$ref": "#/definitions/DataTypeIec61360"
             },
             "definition": {
               "type": "array",
@@ -409,7 +409,7 @@
         "xs:yearMonthDuration"
       ]
     },
-    "DataTypeIEC61360": {
+    "DataTypeIec61360": {
       "type": "string",
       "enum": [
         "BLOB",
@@ -756,7 +756,7 @@
         "Blob",
         "Capability",
         "ConceptDescription",
-        "DataSpecificationIEC61360",
+        "DataSpecificationIec61360",
         "DataSpecificationPhysicalUnit",
         "Entity",
         "File",

--- a/test_data/python/test_main/aas_core_meta.v3rc2/expected_output/jsonization.py
+++ b/test_data/python/test_main/aas_core_meta.v3rc2/expected_output/jsonization.py
@@ -11411,7 +11411,7 @@ _DATA_SPECIFICATION_CONTENT_FROM_JSONABLE_DISPATCH: Mapping[
     str,
     Callable[[Jsonable], aas_types.DataSpecificationContent]
 ] = {
-    'DataSpecificationIEC61360': data_specification_iec_61360_from_jsonable,
+    'DataSpecificationIec61360': data_specification_iec_61360_from_jsonable,
     'DataSpecificationPhysicalUnit': data_specification_physical_unit_from_jsonable,
 }
 
@@ -13108,7 +13108,7 @@ class _Serializer(
         if that.level_type is not None:
             jsonable['levelType'] = that.level_type.value
 
-        jsonable["modelType"] = 'DataSpecificationIEC61360'
+        jsonable["modelType"] = 'DataSpecificationIec61360'
 
         return jsonable
 

--- a/test_data/typescript/test_main/aas_core_meta.v3rc2/expected_output/jsonization.ts
+++ b/test_data/typescript/test_main/aas_core_meta.v3rc2/expected_output/jsonization.ts
@@ -17895,7 +17895,7 @@ const DATA_SPECIFICATION_CONTENT_FROM_JSONABLE_DISPATCH =
   >(
     [
       [
-        "DataSpecificationIEC61360",
+        "DataSpecificationIec61360",
         dataSpecificationIec61360FromJsonable
       ],
       [
@@ -20651,7 +20651,7 @@ class Serializer extends AasTypes.AbstractTransformer<JsonObject> {
         );
     }
 
-    jsonable["modelType"] = "DataSpecificationIEC61360";
+    jsonable["modelType"] = "DataSpecificationIec61360";
 
     return jsonable;
   }


### PR DESCRIPTION
The current naming algorithm for model types turned out to be rather fragile. Namely, we used CamelCase except for abbreviations, which were left as-are. This was brittle: if we forgot to uppercase the abbreviation in the meta-model, and published the JSON schema, there was no way to put the Gini back into the bottle.

Instead, in V3, we introduce a simpler, but also a more robust algorithm: we simply CamelCase everything, including the abbreviations.