### PR TITLE
Introduce `*_choice` in JSON schema

### DIFF
--- a/test_data/jsonschema/test_main/aas_core_meta.v3rc2/expected_output/schema.json
+++ b/test_data/jsonschema/test_main/aas_core_meta.v3rc2/expected_output/schema.json
@@ -60,11 +60,17 @@
             "annotations": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/DataElement"
+                "$ref": "#/definitions/DataElement_choice"
               },
               "minItems": 1
+            },
+            "modelType": {
+              "const": "AnnotatedRelationshipElement"
             }
-          }
+          },
+          "required": [
+            "modelType"
+          ]
         }
       ]
     },
@@ -90,10 +96,14 @@
                 "$ref": "#/definitions/Reference"
               },
               "minItems": 1
+            },
+            "modelType": {
+              "const": "AssetAdministrationShell"
             }
           },
           "required": [
-            "assetInformation"
+            "assetInformation",
+            "modelType"
           ]
         }
       ]
@@ -163,12 +173,16 @@
             "maxInterval": {
               "type": "string",
               "pattern": "^-?(([1-9][0-9][0-9][0-9]+)|(0[0-9][0-9][0-9]))-((0[1-9])|(1[0-2]))-((0[1-9])|([12][0-9])|(3[01]))T(((([01][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.[0-9]+)?)|24:00:00(\\.0+)?)Z$"
+            },
+            "modelType": {
+              "const": "BasicEventElement"
             }
           },
           "required": [
             "observed",
             "direction",
-            "state"
+            "state",
+            "modelType"
           ]
         }
       ]
@@ -188,16 +202,34 @@
               "type": "string",
               "minLength": 1,
               "pattern": "^([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+/([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+([ \t]*;[ \t]*([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+=(([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+|\"(([\t !#-\\[\\]-~]|[\\x80-\\xff])|\\\\([\t !-~]|[\\x80-\\xff]))*\"))*$"
+            },
+            "modelType": {
+              "const": "Blob"
             }
           },
           "required": [
-            "contentType"
+            "contentType",
+            "modelType"
           ]
         }
       ]
     },
     "Capability": {
-      "$ref": "#/definitions/SubmodelElement"
+      "allOf": [
+        {
+          "$ref": "#/definitions/SubmodelElement"
+        },
+        {
+          "properties": {
+            "modelType": {
+              "const": "Capability"
+            }
+          },
+          "required": [
+            "modelType"
+          ]
+        }
+      ]
     },
     "ConceptDescription": {
       "allOf": [
@@ -215,13 +247,55 @@
                 "$ref": "#/definitions/Reference"
               },
               "minItems": 1
+            },
+            "modelType": {
+              "const": "ConceptDescription"
             }
-          }
+          },
+          "required": [
+            "modelType"
+          ]
         }
       ]
     },
     "DataElement": {
-      "$ref": "#/definitions/SubmodelElement"
+      "allOf": [
+        {
+          "$ref": "#/definitions/SubmodelElement"
+        },
+        {
+          "properties": {
+            "modelType": {
+              "$ref": "#/definitions/ModelType"
+            }
+          },
+          "required": [
+            "modelType"
+          ]
+        }
+      ]
+    },
+    "DataElement_choice": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/Blob"
+        },
+        {
+          "$ref": "#/definitions/File"
+        },
+        {
+          "$ref": "#/definitions/MultiLanguageProperty"
+        },
+        {
+          "$ref": "#/definitions/Property"
+        },
+        {
+          "$ref": "#/definitions/Range"
+        },
+        {
+          "$ref": "#/definitions/ReferenceElement"
+        }
+      ]
     },
     "DataSpecificationContent": {
       "type": "object",
@@ -232,6 +306,16 @@
       },
       "required": [
         "modelType"
+      ]
+    },
+    "DataSpecificationContent_choice": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/DataSpecificationIec61360"
+        },
+        {
+          "$ref": "#/definitions/DataSpecificationPhysicalUnit"
+        }
       ]
     },
     "DataSpecificationIec61360": {
@@ -292,10 +376,14 @@
             },
             "levelType": {
               "$ref": "#/definitions/LevelType"
+            },
+            "modelType": {
+              "const": "DataSpecificationIec61360"
             }
           },
           "required": [
-            "preferredName"
+            "preferredName",
+            "modelType"
           ]
         }
       ]
@@ -361,12 +449,16 @@
             "supplier": {
               "type": "string",
               "minLength": 1
+            },
+            "modelType": {
+              "const": "DataSpecificationPhysicalUnit"
             }
           },
           "required": [
             "unitName",
             "unitSymbol",
-            "definition"
+            "definition",
+            "modelType"
           ]
         }
       ]
@@ -447,7 +539,7 @@
           "$ref": "#/definitions/Reference"
         },
         "dataSpecificationContent": {
-          "$ref": "#/definitions/DataSpecificationContent"
+          "$ref": "#/definitions/DataSpecificationContent_choice"
         }
       },
       "required": [
@@ -465,7 +557,7 @@
             "statements": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/SubmodelElement"
+                "$ref": "#/definitions/SubmodelElement_choice"
               },
               "minItems": 1
             },
@@ -477,10 +569,14 @@
             },
             "specificAssetId": {
               "$ref": "#/definitions/SpecificAssetId"
+            },
+            "modelType": {
+              "const": "Entity"
             }
           },
           "required": [
-            "entityType"
+            "entityType",
+            "modelType"
           ]
         }
       ]
@@ -519,7 +615,21 @@
       }
     },
     "EventElement": {
-      "$ref": "#/definitions/SubmodelElement"
+      "allOf": [
+        {
+          "$ref": "#/definitions/SubmodelElement"
+        },
+        {
+          "properties": {
+            "modelType": {
+              "$ref": "#/definitions/ModelType"
+            }
+          },
+          "required": [
+            "modelType"
+          ]
+        }
+      ]
     },
     "EventPayload": {
       "type": "object",
@@ -601,10 +711,14 @@
               "type": "string",
               "minLength": 1,
               "pattern": "^([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+/([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+([ \t]*;[ \t]*([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+=(([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+|\"(([\t !#-\\[\\]-~]|[\\x80-\\xff])|\\\\([\t !-~]|[\\x80-\\xff]))*\"))*$"
+            },
+            "modelType": {
+              "const": "File"
             }
           },
           "required": [
-            "contentType"
+            "contentType",
+            "modelType"
           ]
         }
       ]
@@ -669,10 +783,14 @@
             "id": {
               "type": "string",
               "minLength": 1
+            },
+            "modelType": {
+              "$ref": "#/definitions/ModelType"
             }
           },
           "required": [
-            "id"
+            "id",
+            "modelType"
           ]
         }
       ]
@@ -794,8 +912,14 @@
             },
             "valueId": {
               "$ref": "#/definitions/Reference"
+            },
+            "modelType": {
+              "const": "MultiLanguageProperty"
             }
-          }
+          },
+          "required": [
+            "modelType"
+          ]
         }
       ]
     },
@@ -826,8 +950,14 @@
                 "$ref": "#/definitions/OperationVariable"
               },
               "minItems": 1
+            },
+            "modelType": {
+              "const": "Operation"
             }
-          }
+          },
+          "required": [
+            "modelType"
+          ]
         }
       ]
     },
@@ -835,7 +965,7 @@
       "type": "object",
       "properties": {
         "value": {
-          "$ref": "#/definitions/SubmodelElement"
+          "$ref": "#/definitions/SubmodelElement_choice"
         }
       },
       "required": [
@@ -857,10 +987,14 @@
             },
             "valueId": {
               "$ref": "#/definitions/Reference"
+            },
+            "modelType": {
+              "const": "Property"
             }
           },
           "required": [
-            "valueType"
+            "valueType",
+            "modelType"
           ]
         }
       ]
@@ -937,10 +1071,14 @@
             },
             "max": {
               "type": "string"
+            },
+            "modelType": {
+              "const": "Range"
             }
           },
           "required": [
-            "valueType"
+            "valueType",
+            "modelType"
           ]
         }
       ]
@@ -1020,8 +1158,14 @@
           "properties": {
             "value": {
               "$ref": "#/definitions/Reference"
+            },
+            "modelType": {
+              "const": "ReferenceElement"
             }
-          }
+          },
+          "required": [
+            "modelType"
+          ]
         }
       ]
     },
@@ -1044,11 +1188,15 @@
             },
             "second": {
               "$ref": "#/definitions/Reference"
+            },
+            "modelType": {
+              "const": "RelationshipElement"
             }
           },
           "required": [
             "first",
-            "second"
+            "second",
+            "modelType"
           ]
         }
       ]
@@ -1127,11 +1275,17 @@
             "submodelElements": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/SubmodelElement"
+                "$ref": "#/definitions/SubmodelElement_choice"
               },
               "minItems": 1
+            },
+            "modelType": {
+              "const": "Submodel"
             }
-          }
+          },
+          "required": [
+            "modelType"
+          ]
         }
       ]
     },
@@ -1151,6 +1305,16 @@
         },
         {
           "$ref": "#/definitions/HasDataSpecification"
+        },
+        {
+          "properties": {
+            "modelType": {
+              "$ref": "#/definitions/ModelType"
+            }
+          },
+          "required": [
+            "modelType"
+          ]
         }
       ]
     },
@@ -1164,11 +1328,17 @@
             "value": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/SubmodelElement"
+                "$ref": "#/definitions/SubmodelElement_choice"
               },
               "minItems": 1
+            },
+            "modelType": {
+              "const": "SubmodelElementCollection"
             }
-          }
+          },
+          "required": [
+            "modelType"
+          ]
         }
       ]
     },
@@ -1185,7 +1355,7 @@
             "value": {
               "type": "array",
               "items": {
-                "$ref": "#/definitions/SubmodelElement"
+                "$ref": "#/definitions/SubmodelElement_choice"
               },
               "minItems": 1
             },
@@ -1197,11 +1367,61 @@
             },
             "valueTypeListElement": {
               "$ref": "#/definitions/DataTypeDefXsd"
+            },
+            "modelType": {
+              "const": "SubmodelElementList"
             }
           },
           "required": [
-            "typeValueListElement"
+            "typeValueListElement",
+            "modelType"
           ]
+        }
+      ]
+    },
+    "SubmodelElement_choice": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/RelationshipElement"
+        },
+        {
+          "$ref": "#/definitions/AnnotatedRelationshipElement"
+        },
+        {
+          "$ref": "#/definitions/BasicEventElement"
+        },
+        {
+          "$ref": "#/definitions/Blob"
+        },
+        {
+          "$ref": "#/definitions/Capability"
+        },
+        {
+          "$ref": "#/definitions/Entity"
+        },
+        {
+          "$ref": "#/definitions/File"
+        },
+        {
+          "$ref": "#/definitions/MultiLanguageProperty"
+        },
+        {
+          "$ref": "#/definitions/Operation"
+        },
+        {
+          "$ref": "#/definitions/Property"
+        },
+        {
+          "$ref": "#/definitions/Range"
+        },
+        {
+          "$ref": "#/definitions/ReferenceElement"
+        },
+        {
+          "$ref": "#/definitions/SubmodelElementCollection"
+        },
+        {
+          "$ref": "#/definitions/SubmodelElementList"
         }
       ]
     },


### PR DESCRIPTION
Following the decision in the IDTA workstream AAS, we introduce `*_choice` definitions in JSON schema. This makes the schema much stricter.

For example, `value` property must conform in type to the corrsponding model type.

The issue was originally raised in:
https://github.com/admin-shell-io/aas-specs/issues/251