### PR TITLE
Update test data to aas-core-meta cbbc2d2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
             "twine",
             "jsonschema==3.2.0",
             "xmlschema==1.10.0",
-            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@e3707bf#egg=aas-core-meta",
+            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@cbbc2d2#egg=aas-core-meta",
         ]
     },
     # fmt: on

--- a/test_data/intermediate/real_meta_models/aas_core_meta.v3rc2/expected_symbol_table.txt
+++ b/test_data/intermediate/real_meta_models/aas_core_meta.v3rc2/expected_symbol_table.txt
@@ -31057,15 +31057,21 @@ SymbolTable(
   verification_functions_by_name=...,
   meta_model=MetaModel(
     description=DescriptionOfMetaModel(
-      summary='<paragraph>Provide the meta-model for Asset Administration Shell V3.0 Release Candidate 2.</paragraph>',
+      summary='<paragraph>Provide an implementation of the Asset Administration Shell V3.0 Release Candidate 2.</paragraph>',
       remarks=[
-        '<paragraph>We had to diverge from the book in the following points.</paragraph>',
         textwrap.dedent("""\
-          <paragraph>We could not implement the following constraints as they are too general and can not
+          <paragraph>The presented version of the Metamodel is related to the work of
+          aas-core-works, which can be found here: <reference refuri="https://github.com/aas-core-works">https://github.com/aas-core-works</reference>.</paragraph>"""),
+        textwrap.dedent("""\
+          <paragraph>The presented content is neither related to the IDTA nor
+          Plattform Industrie 4.0 and does not represent an official publication.</paragraph>"""),
+        '<paragraph>We diverge from the book in the following points.</paragraph>',
+        textwrap.dedent("""\
+          <paragraph>We did not implement the following constraints as they are too general and can not
           be formalized as part of the core library, but affects external components such as
           AAS registry or AAS server:</paragraph>"""),
         textwrap.dedent("""\
-          <paragraph>We could not implement the following constraints since they depend on registry and
+          <paragraph>We did not implement the following constraints since they depend on registry and
           de-referencing, so we can not formalize them with formalizing such external
           dependencies:</paragraph>"""),
         '<bullet_list bullet="*"><list_item><paragraph><ReferenceToConstraint refuri="AASd-006">AASd-006</ReferenceToConstraint></paragraph></list_item><list_item><paragraph><ReferenceToConstraint refuri="AASd-007">AASd-007</ReferenceToConstraint></paragraph></list_item></bullet_list>',

--- a/test_data/python/test_main/aas_core_meta.v3rc2/expected_output/types.py
+++ b/test_data/python/test_main/aas_core_meta.v3rc2/expected_output/types.py
@@ -1,13 +1,19 @@
 """
-Provide the meta-model for Asset Administration Shell V3.0 Release Candidate 2.
+Provide an implementation of the Asset Administration Shell V3.0 Release Candidate 2.
 
-We had to diverge from the book in the following points.
+The presented version of the Metamodel is related to the work of
+aas-core-works, which can be found here: https://github.com/aas-core-works.
 
-We could not implement the following constraints as they are too general and can not
+The presented content is neither related to the IDTA nor
+Plattform Industrie 4.0 and does not represent an official publication.
+
+We diverge from the book in the following points.
+
+We did not implement the following constraints as they are too general and can not
 be formalized as part of the core library, but affects external components such as
 AAS registry or AAS server:
 
-We could not implement the following constraints since they depend on registry and
+We did not implement the following constraints since they depend on registry and
 de-referencing, so we can not formalize them with formalizing such external
 dependencies:
 

--- a/test_data/typescript/test_main/aas_core_meta.v3rc2/expected_output/types.ts
+++ b/test_data/typescript/test_main/aas_core_meta.v3rc2/expected_output/types.ts
@@ -1,14 +1,20 @@
 /**
- * Provide the meta-model for Asset Administration Shell V3.0 Release Candidate 2.
+ * Provide an implementation of the Asset Administration Shell V3.0 Release Candidate 2.
  *
  * @remarks
- * We had to diverge from the book in the following points.
+ * The presented version of the Metamodel is related to the work of
+ * aas-core-works, which can be found here: https://github.com/aas-core-works.
  *
- * We could not implement the following constraints as they are too general and can not
+ * The presented content is neither related to the IDTA nor
+ * Plattform Industrie 4.0 and does not represent an official publication.
+ *
+ * We diverge from the book in the following points.
+ *
+ * We did not implement the following constraints as they are too general and can not
  * be formalized as part of the core library, but affects external components such as
  * AAS registry or AAS server:
  *
- * We could not implement the following constraints since they depend on registry and
+ * We did not implement the following constraints since they depend on registry and
  * de-referencing, so we can not formalize them with formalizing such external
  * dependencies:
  *


### PR DESCRIPTION
We update the test data for V3RC02 to [aas-core-meta cbbc2d2] to keep them up-to-date.

[aas-core-meta cbbc2d2]: https://github.com/aas-core-works/aas-core-meta/commit/cbbc2d2