### PR TITLE
Merge regular expressions in XSD

### DIFF
--- a/continuous_integration/mypy.ini
+++ b/continuous_integration/mypy.ini
@@ -35,3 +35,6 @@ ignore_missing_imports = True
 
 [mypy-jsonschema]
 ignore_missing_imports = True
+
+[mypy-greenery]
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ icontract>=2.5.2,<3
 sortedcontainers>=2.4.0,<3
 docutils>=0.18.1,<1
 more-itertools>=8,<9
+greenery==4.0.0


### PR DESCRIPTION
XSD does not allow for multiple pattern restrictions, see [this StackOverflow question]. Therefore, we use [greenery] to merge the patterns into one.

[this StackOverflow question]: https://stackoverflow.com/questions/26992786/specifying-multiple-patterns-in-a-restriction-in-a-xsd
[greenery]: https://github.com/qntm/greenery