### PR TITLE
Fix CI errors not reported locally

### DIFF
--- a/aas_core_codegen/rdf_shacl/rdf.py
+++ b/aas_core_codegen/rdf_shacl/rdf.py
@@ -5,7 +5,7 @@ from typing import Tuple, Optional, List
 from icontract import ensure, require
 
 from aas_core_codegen import intermediate, specific_implementations
-from aas_core_codegen.common import Stripped, Error, assert_never, Identifier
+from aas_core_codegen.common import Stripped, Error, assert_never
 from aas_core_codegen.rdf_shacl import (
     naming as rdf_shacl_naming,
     common as rdf_shacl_common,

--- a/test_data/rdf_shacl/test_main/unexpected/regression_len_constraint_on_class_property/expected_output/stderr.txt
+++ b/test_data/rdf_shacl/test_main/unexpected/regression_len_constraint_on_class_property/expected_output/stderr.txt
@@ -1,3 +1,3 @@
-Failed to generate the SHACL schema based on <repo dir>\test_data\rdf_shacl\test_main\unexpected\regression_len_constraint_on_class_property\meta_model.py:
+Failed to generate the SHACL schema based on <meta_model.py>:
 * Failed to generate the shape definition for Something
     At line 54 and column 6: (mristin, 2023-02-08): A length constraint has been inferred for the property 'value' in the class 'Something' whose type is a class, namely Optional[Value]. We do not know how to impose the length constraints on a property of type *class* in SHACL at this moment. If this is not a bug in your meta-model, please contact the developers to see how to implement this feature.

--- a/tests/rdf_shacl/test_main.py
+++ b/tests/rdf_shacl/test_main.py
@@ -177,13 +177,20 @@ class Test_against_recorded(unittest.TestCase):
                 )
 
                 stderr_pth = expected_output_dir / "stderr.txt"
+
                 normalized_stderr = stderr.getvalue().replace(
-                    str(REPO_DIR), "<repo dir>"
+                    str(test_case.model_path), f"<{test_case.model_path.name}>"
                 )
 
                 if tests.common.RERECORD:
                     stderr_pth.write_text(normalized_stderr, encoding="utf-8")
                 else:
+                    # NOTE (mristin, 2023-03-08):
+                    # We need to see the full diff on the remote CI server. Otherwise,
+                    # we are completely in the dark why this test fails there. The test
+                    # passed locally, so it was very hard to debug.
+                    self.maxDiff = None
+
                     self.assertEqual(
                         normalized_stderr,
                         stderr_pth.read_text(encoding="utf-8"),


### PR DESCRIPTION
We fix a minor issue (unused import) that our local pylint missed, but
the pylint running on the remote continuous integration server detected.

We have no clue why our local pylint and the remote one differ on this
point.

Additionally, we fix recorded test data where we had discrepancy due to
Linux *versus* Windows paths. The fixed test data uses normalized paths
independent of the underlying OS.