### PR TITLE
Fix empty verification in Python

### DIFF
--- a/aas_core_codegen/python/verification/_generate.py
+++ b/aas_core_codegen/python/verification/_generate.py
@@ -1000,7 +1000,11 @@ def _generate_transform_for_class(
             Stripped(
                 f"""\
 # No verification has been defined for {cls_name}.
-pass"""
+return
+# For this uncommon return-yield construction, see:
+# https://stackoverflow.com/questions/13243766/how-to-define-an-empty-generator-function
+# noinspection PyUnreachableCode
+yield"""
             )
         )
 


### PR DESCRIPTION
When there is no verification for a class, we just ``passed`` instead of returning an empty iterator.

See [this StackOverflow question] for more information.

[this StackOverflow question]: https://stackoverflow.com/questions/13243766/how-to-define-an-empty-generator-function