### PR TITLE
Allow for selective enhancements in C#

### DIFF
--- a/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/enhancing.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3rc2/expected_output/enhancing.cs
@@ -4315,19 +4315,19 @@ namespace AasCore.Aas3_0_RC02
         }
 
         internal class Wrapper<TEnhancement>
-            : Aas.Visitation.AbstractTransformer<Enhanced<TEnhancement>>
+            : Aas.Visitation.AbstractTransformer<Aas.IClass>
             where TEnhancement : class
         {
-            private readonly System.Func<Aas.IClass, TEnhancement> _enhancementFactory;
+            private readonly System.Func<Aas.IClass, TEnhancement?> _enhancementFactory;
 
             internal Wrapper(
-                System.Func<Aas.IClass, TEnhancement> enhancementFactory
+                System.Func<Aas.IClass, TEnhancement?> enhancementFactory
             )
             {
                 _enhancementFactory = enhancementFactory;
             }
 
-            public override Enhanced<TEnhancement> TransformExtension(
+            public override Aas.IClass TransformExtension(
                 Aas.IExtension that
             )
             {
@@ -4384,13 +4384,16 @@ namespace AasCore.Aas3_0_RC02
                     that.RefersTo = castedRefersTo;
                 }
 
-                return new EnhancedExtension<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedExtension<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformAdministrativeInformation(
+            public override Aas.IClass TransformAdministrativeInformation(
                 Aas.IAdministrativeInformation that
             )
             {
@@ -4419,13 +4422,16 @@ namespace AasCore.Aas3_0_RC02
                     ).ToList();
                 }
 
-                return new EnhancedAdministrativeInformation<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedAdministrativeInformation<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformQualifier(
+            public override Aas.IClass TransformQualifier(
                 Aas.IQualifier that
             )
             {
@@ -4482,13 +4488,16 @@ namespace AasCore.Aas3_0_RC02
                     that.ValueId = castedValueId;
                 }
 
-                return new EnhancedQualifier<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedQualifier<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformAssetAdministrationShell(
+            public override Aas.IClass TransformAssetAdministrationShell(
                 Aas.IAssetAdministrationShell that
             )
             {
@@ -4628,13 +4637,16 @@ namespace AasCore.Aas3_0_RC02
                     ).ToList();
                 }
 
-                return new EnhancedAssetAdministrationShell<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedAssetAdministrationShell<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformAssetInformation(
+            public override Aas.IClass TransformAssetInformation(
                 Aas.IAssetInformation that
             )
             {
@@ -4691,13 +4703,16 @@ namespace AasCore.Aas3_0_RC02
                     that.DefaultThumbnail = castedDefaultThumbnail;
                 }
 
-                return new EnhancedAssetInformation<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedAssetInformation<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformResource(
+            public override Aas.IClass TransformResource(
                 Aas.IResource that
             )
             {
@@ -4708,13 +4723,16 @@ namespace AasCore.Aas3_0_RC02
                     );
                 }
 
-                return new EnhancedResource<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedResource<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformSpecificAssetId(
+            public override Aas.IClass TransformSpecificAssetId(
                 Aas.ISpecificAssetId that
             )
             {
@@ -4768,13 +4786,16 @@ namespace AasCore.Aas3_0_RC02
                 );
                 that.ExternalSubjectId = castedExternalSubjectId;
 
-                return new EnhancedSpecificAssetId<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedSpecificAssetId<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformSubmodel(
+            public override Aas.IClass TransformSubmodel(
                 Aas.ISubmodel that
             )
             {
@@ -4939,13 +4960,16 @@ namespace AasCore.Aas3_0_RC02
                     ).ToList();
                 }
 
-                return new EnhancedSubmodel<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedSubmodel<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformRelationshipElement(
+            public override Aas.IClass TransformRelationshipElement(
                 Aas.IRelationshipElement that
             )
             {
@@ -5100,13 +5124,16 @@ namespace AasCore.Aas3_0_RC02
                 );
                 that.Second = castedSecond;
 
-                return new EnhancedRelationshipElement<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedRelationshipElement<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformSubmodelElementList(
+            public override Aas.IClass TransformSubmodelElementList(
                 Aas.ISubmodelElementList that
             )
             {
@@ -5271,13 +5298,16 @@ namespace AasCore.Aas3_0_RC02
                     that.SemanticIdListElement = castedSemanticIdListElement;
                 }
 
-                return new EnhancedSubmodelElementList<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedSubmodelElementList<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformSubmodelElementCollection(
+            public override Aas.IClass TransformSubmodelElementCollection(
                 Aas.ISubmodelElementCollection that
             )
             {
@@ -5428,13 +5458,16 @@ namespace AasCore.Aas3_0_RC02
                     ).ToList();
                 }
 
-                return new EnhancedSubmodelElementCollection<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedSubmodelElementCollection<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformProperty(
+            public override Aas.IClass TransformProperty(
                 Aas.IProperty that
             )
             {
@@ -5581,13 +5614,16 @@ namespace AasCore.Aas3_0_RC02
                     that.ValueId = castedValueId;
                 }
 
-                return new EnhancedProperty<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedProperty<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformMultiLanguageProperty(
+            public override Aas.IClass TransformMultiLanguageProperty(
                 Aas.IMultiLanguageProperty that
             )
             {
@@ -5752,13 +5788,16 @@ namespace AasCore.Aas3_0_RC02
                     that.ValueId = castedValueId;
                 }
 
-                return new EnhancedMultiLanguageProperty<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedMultiLanguageProperty<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformRange(
+            public override Aas.IClass TransformRange(
                 Aas.IRange that
             )
             {
@@ -5891,13 +5930,16 @@ namespace AasCore.Aas3_0_RC02
                     ).ToList();
                 }
 
-                return new EnhancedRange<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedRange<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformReferenceElement(
+            public override Aas.IClass TransformReferenceElement(
                 Aas.IReferenceElement that
             )
             {
@@ -6044,13 +6086,16 @@ namespace AasCore.Aas3_0_RC02
                     that.Value = castedValue;
                 }
 
-                return new EnhancedReferenceElement<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedReferenceElement<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformBlob(
+            public override Aas.IClass TransformBlob(
                 Aas.IBlob that
             )
             {
@@ -6183,13 +6228,16 @@ namespace AasCore.Aas3_0_RC02
                     ).ToList();
                 }
 
-                return new EnhancedBlob<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedBlob<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformFile(
+            public override Aas.IClass TransformFile(
                 Aas.IFile that
             )
             {
@@ -6322,13 +6370,16 @@ namespace AasCore.Aas3_0_RC02
                     ).ToList();
                 }
 
-                return new EnhancedFile<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedFile<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformAnnotatedRelationshipElement(
+            public override Aas.IClass TransformAnnotatedRelationshipElement(
                 Aas.IAnnotatedRelationshipElement that
             )
             {
@@ -6501,13 +6552,16 @@ namespace AasCore.Aas3_0_RC02
                     ).ToList();
                 }
 
-                return new EnhancedAnnotatedRelationshipElement<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedAnnotatedRelationshipElement<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformEntity(
+            public override Aas.IClass TransformEntity(
                 Aas.IEntity that
             )
             {
@@ -6686,13 +6740,16 @@ namespace AasCore.Aas3_0_RC02
                     that.SpecificAssetId = castedSpecificAssetId;
                 }
 
-                return new EnhancedEntity<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedEntity<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformEventPayload(
+            public override Aas.IClass TransformEventPayload(
                 Aas.IEventPayload that
             )
             {
@@ -6767,13 +6824,16 @@ namespace AasCore.Aas3_0_RC02
                     that.SubjectId = castedSubjectId;
                 }
 
-                return new EnhancedEventPayload<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedEventPayload<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformBasicEventElement(
+            public override Aas.IClass TransformBasicEventElement(
                 Aas.IBasicEventElement that
             )
             {
@@ -6931,13 +6991,16 @@ namespace AasCore.Aas3_0_RC02
                     that.MessageBroker = castedMessageBroker;
                 }
 
-                return new EnhancedBasicEventElement<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedBasicEventElement<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformOperation(
+            public override Aas.IClass TransformOperation(
                 Aas.IOperation that
             )
             {
@@ -7124,13 +7187,16 @@ namespace AasCore.Aas3_0_RC02
                     ).ToList();
                 }
 
-                return new EnhancedOperation<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedOperation<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformOperationVariable(
+            public override Aas.IClass TransformOperationVariable(
                 Aas.IOperationVariable that
             )
             {
@@ -7152,13 +7218,16 @@ namespace AasCore.Aas3_0_RC02
                 );
                 that.Value = castedValue;
 
-                return new EnhancedOperationVariable<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedOperationVariable<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformCapability(
+            public override Aas.IClass TransformCapability(
                 Aas.ICapability that
             )
             {
@@ -7291,13 +7360,16 @@ namespace AasCore.Aas3_0_RC02
                     ).ToList();
                 }
 
-                return new EnhancedCapability<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedCapability<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformConceptDescription(
+            public override Aas.IClass TransformConceptDescription(
                 Aas.IConceptDescription that
             )
             {
@@ -7412,13 +7484,16 @@ namespace AasCore.Aas3_0_RC02
                     ).ToList();
                 }
 
-                return new EnhancedConceptDescription<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedConceptDescription<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformReference(
+            public override Aas.IClass TransformReference(
                 Aas.IReference that
             )
             {
@@ -7458,13 +7533,16 @@ namespace AasCore.Aas3_0_RC02
                     )
                 ).ToList();
 
-                return new EnhancedReference<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedReference<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformKey(
+            public override Aas.IClass TransformKey(
                 Aas.IKey that
             )
             {
@@ -7475,13 +7553,16 @@ namespace AasCore.Aas3_0_RC02
                     );
                 }
 
-                return new EnhancedKey<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedKey<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformLangString(
+            public override Aas.IClass TransformLangString(
                 Aas.ILangString that
             )
             {
@@ -7492,13 +7573,16 @@ namespace AasCore.Aas3_0_RC02
                     );
                 }
 
-                return new EnhancedLangString<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedLangString<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformEnvironment(
+            public override Aas.IClass TransformEnvironment(
                 Aas.IEnvironment that
             )
             {
@@ -7563,13 +7647,16 @@ namespace AasCore.Aas3_0_RC02
                     ).ToList();
                 }
 
-                return new EnhancedEnvironment<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedEnvironment<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformEmbeddedDataSpecification(
+            public override Aas.IClass TransformEmbeddedDataSpecification(
                 Aas.IEmbeddedDataSpecification that
             )
             {
@@ -7602,13 +7689,16 @@ namespace AasCore.Aas3_0_RC02
                 );
                 that.DataSpecificationContent = castedDataSpecificationContent;
 
-                return new EnhancedEmbeddedDataSpecification<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedEmbeddedDataSpecification<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformValueReferencePair(
+            public override Aas.IClass TransformValueReferencePair(
                 Aas.IValueReferencePair that
             )
             {
@@ -7630,13 +7720,16 @@ namespace AasCore.Aas3_0_RC02
                 );
                 that.ValueId = castedValueId;
 
-                return new EnhancedValueReferencePair<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedValueReferencePair<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformValueList(
+            public override Aas.IClass TransformValueList(
                 Aas.IValueList that
             )
             {
@@ -7662,13 +7755,16 @@ namespace AasCore.Aas3_0_RC02
                     )
                 ).ToList();
 
-                return new EnhancedValueList<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedValueList<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformDataSpecificationIec61360(
+            public override Aas.IClass TransformDataSpecificationIec61360(
                 Aas.IDataSpecificationIec61360 that
             )
             {
@@ -7758,13 +7854,16 @@ namespace AasCore.Aas3_0_RC02
                     that.ValueList = castedValueList;
                 }
 
-                return new EnhancedDataSpecificationIec61360<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedDataSpecificationIec61360<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
 
-            public override Enhanced<TEnhancement> TransformDataSpecificationPhysicalUnit(
+            public override Aas.IClass TransformDataSpecificationPhysicalUnit(
                 Aas.IDataSpecificationPhysicalUnit that
             )
             {
@@ -7790,10 +7889,13 @@ namespace AasCore.Aas3_0_RC02
                     )
                 ).ToList();
 
-                return new EnhancedDataSpecificationPhysicalUnit<TEnhancement>(
-                    that,
-                    _enhancementFactory(that)
-                );
+                var enhancement = _enhancementFactory(that);
+                return (enhancement == null)
+                    ? that
+                    : new EnhancedDataSpecificationPhysicalUnit<TEnhancement>(
+                        that,
+                        enhancement
+                    );
             }
         }
 
@@ -7805,9 +7907,14 @@ namespace AasCore.Aas3_0_RC02
         {
             private readonly Wrapper<TEnhancement> _wrapper;
 
-            /// <param name="enhancementFactory">how to enhance the instances</param>
+            /// <param name="enhancementFactory">
+            /// <para>how to enhance the instances.</para>
+            ///
+            /// <para>If it returns <c>null</c>, the instance will not be wrapped. However,
+            /// the wrapping will continue recursively.</para>
+            ///</param>
             public Enhancer(
-                System.Func<Aas.IClass, TEnhancement> enhancementFactory
+                System.Func<Aas.IClass, TEnhancement?> enhancementFactory
             )
             {
                 _wrapper = new Wrapper<TEnhancement>(enhancementFactory);
@@ -7867,7 +7974,7 @@ namespace AasCore.Aas3_0_RC02
             {
                 var wrapped = _wrapper.Transform(that);
                 return (
-                    wrapped as Aas.IClass
+                    wrapped
                 ) ?? throw new System.InvalidOperationException(
                     "Expected the wrapped instance to be an instance of IClass, " +
                     $"but got: {wrapped}"


### PR DESCRIPTION
It can be wasteful to enhance all the instances in large environments. Therefore, we allow for selective enhancements. To that end, we allow the enhancement factories to return a `null` to signal a missing enhancement.