### PR TITLE
Remove referenes to V3RC02 from TypeScript codegen

### DIFF
--- a/test_data/typescript/test_main/aas_core_meta.v3/expected_output/verification.ts
+++ b/test_data/typescript/test_main/aas_core_meta.v3/expected_output/verification.ts
@@ -4,8 +4,8 @@
  * Here is an example how to verify an instance of {@link types.Extension}:
  *
  * ```ts
- * import * as AasTypes from "@aas-core-works/aas-core3.0rc02-typescript/types";
- * import * as AasVerification from "@aas-core-works/aas-core3.0rc02-typescript/verification";
+ * import * as AasTypes from "@aas-core-works/aas-core3.0-typescript/types";
+ * import * as AasVerification from "@aas-core-works/aas-core3.0-typescript/verification";
  *
  * const anInstance = new AasTypes.Extension(
  *   // ... some constructor arguments ...

--- a/test_data/typescript/test_main/aas_core_meta.v3/input/snippets/package_identifier.txt
+++ b/test_data/typescript/test_main/aas_core_meta.v3/input/snippets/package_identifier.txt
@@ -1,0 +1,1 @@
+@aas-core-works/aas-core3.0-typescript


### PR DESCRIPTION
We erroneously hard-wired references to package identifier of V3RC02 in TypeScript codegen.

This patch introduces a snippet to let the user specify the package identifier so that the module comment description corresponds to the actual version of the SDK.