### PR TITLE
Add greenery to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ icontract>=2.5.2,<3
 sortedcontainers>=2.4.0,<3
 docutils>=0.18.1,<1
 more-itertools>=8,<9
+greenery==4.0.0


### PR DESCRIPTION
In one of the merges from ``v3`` development branch, we forgot to add the module ``greenery`` to the requirements. (Possibly in #352, but we are not sure.)