### PR TITLE
Fix order of modifiers in strengthening in C#

### DIFF
--- a/aas_core_codegen/csharp/structure/_generate.py
+++ b/aas_core_codegen/csharp/structure/_generate.py
@@ -416,7 +416,7 @@ def _generate_interface(
             blocks.append(
                 Stripped(
                     f"{prop_comment}\n"
-                    f"{maybe_new}public {prop_type} {prop_name} {{ get; set; }}"
+                    f"public {maybe_new}{prop_type} {prop_name} {{ get; set; }}"
                 )
             )
         else:

--- a/test_data/csharp/test_main/aas_core_meta.v3/expected_output/types.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3/expected_output/types.cs
@@ -471,7 +471,7 @@ namespace AasCore.Aas3_0
         /// see Constraint AASd-117.
         /// </para>
         /// </remarks>
-        new public string IdShort { get; set; }
+        public new string IdShort { get; set; }
 
         /// <summary>
         /// Administrative information of an identifiable element.


### PR DESCRIPTION
We change the order of modifiers (``new`` later) to satisfy InspectCode.