### PR TITLE
Exclude ``greenery`` from mypy

### DIFF
--- a/continuous_integration/mypy.ini
+++ b/continuous_integration/mypy.ini
@@ -35,3 +35,6 @@ ignore_missing_imports = True
 
 [mypy-jsonschema]
 ignore_missing_imports = True
+
+[mypy-greenery]
+ignore_missing_imports = True


### PR DESCRIPTION
Since the module ``greenery`` from the requirements comes without type annotations, we exclude it from the mypy checks.