### PR TITLE
Infer for schema only from non-strengthened props

### DIFF
--- a/aas_core_codegen/infer_for_schema/_inline.py
+++ b/aas_core_codegen/infer_for_schema/_inline.py
@@ -259,7 +259,7 @@ def infer_constraints_by_class(
                 # In case your schema engine *does not* support inheritance or other
                 # forms of stacking constraints over classes, see the method
                 # ``merge_constraints_with_ancestors``.
-                and prop.specified_for is our_type
+                and (prop.specified_for is our_type and prop.strengthening_of is None)
             ):
                 len_constraint_from_type = len_constraints_by_constrained_primitive.get(
                     type_anno.our_type, None
@@ -367,7 +367,7 @@ def infer_constraints_by_class(
                 # In case your schema engine *does not* support inheritance or other
                 # forms of stacking constraints over classes, see the method
                 # ``merge_constraints_with_ancestors``.
-                and prop.specified_for is our_type
+                and (prop.specified_for is our_type and prop.strengthening_of is None)
             ):
                 patterns_from_type = patterns_by_constrained_primitive.get(
                     type_anno.our_type, []

--- a/test_data/jsonschema/test_main/aas_core_meta.v3/expected_output/schema.json
+++ b/test_data/jsonschema/test_main/aas_core_meta.v3/expected_output/schema.json
@@ -794,20 +794,6 @@
         },
         {
           "properties": {
-            "idShort": {
-              "allOf": [
-                {
-                  "minLength": 1,
-                  "maxLength": 128
-                },
-                {
-                  "pattern": "^([\\t\\n\\r -\ud7ff\ue000-\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$"
-                },
-                {
-                  "pattern": "^[a-zA-Z][a-zA-Z0-9_]*$"
-                }
-              ]
-            },
             "administration": {
               "$ref": "#/definitions/AdministrativeInformation"
             },

--- a/test_data/rdf_shacl/test_main/expected/aas_core_meta.v3/expected_output/shacl-schema.ttl
+++ b/test_data/rdf_shacl/test_main/expected/aas_core_meta.v3/expected_output/shacl-schema.ttl
@@ -745,10 +745,6 @@ aas:IdentifiableShape a sh:NodeShape ;
         sh:datatype xs:string ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
-        sh:minLength 1 ;
-        sh:maxLength 128 ;
-        sh:pattern "^[\\x09\\x0A\\x0D\\x20-\\uD7FF\\uE000-\\uFFFD\\U00010000-\\U0010FFFF]*$" ;
-        sh:pattern "^[a-zA-Z][a-zA-Z0-9_]*$" ;
     ] ;
     sh:property [
         a sh:PropertyShape ;


### PR DESCRIPTION
We infer the constraints from properties typed as constrained primitives only if they are specified for that particular class *and* the property is not a non-nullability strengthening. We can do that as non-nullability strengthenings do not affect constraints inferred for the schemas.