### PR TITLE
Fix Python gen for pylint

### DIFF
--- a/aas_core_codegen/python/description.py
+++ b/aas_core_codegen/python/description.py
@@ -424,7 +424,14 @@ def docstring(text: Stripped) -> Stripped:
 
 def documentation_comment(text: Stripped) -> Stripped:
     """Generate the documentation comment with the given ``text``."""
-    return Stripped("\n".join(f"#: {line}" for line in text.splitlines()))
+    commented_lines = []  # type: List[str]
+    for line in text.splitlines():
+        if len(line.strip()) == 0:
+            commented_lines.append("#:")
+        else:
+            commented_lines.append(f"#: {line}")
+
+    return Stripped("\n".join(commented_lines))
 
 
 def generate_docstring_for_signature(

--- a/aas_core_codegen/python/structure/_generate.py
+++ b/aas_core_codegen/python/structure/_generate.py
@@ -892,6 +892,21 @@ def _generate_class(
                     prop.type_annotation, prop.strengthening_of.type_annotation.value
                 )
             ):
+                unexpected_message = Stripped(
+                    f'''\
+"Unexpected None {prop_name} "
+"assigned to an instance of "
+"{cls_name}"'''
+                )
+
+                # NOTE (mristin, 2023-03-22):
+                # This is necessary since black does not format the string correctly.
+                if len(unexpected_message.replace("\n", "")) - 4 < 70:
+                    unexpected_message = Stripped(
+                        f'"Unexpected None {prop_name} assigned '
+                        f'to an instance of {cls_name}"'
+                    )
+
                 blocks.append(
                     Stripped(
                         f"""\
@@ -900,6 +915,7 @@ def _generate_class(
 def {prop_name}(
 {II}self
 ) -> {prop_type}:
+{I}# pylint: disable=missing-function-docstring
 {I}return self._{prop_name}
 
 @{prop_name}.setter
@@ -909,9 +925,7 @@ def {prop_name}(
 ) -> None:
 {I}if new_{prop_name} is None:
 {II}raise ValueError(
-{III}"Unexpected None {prop_name} "
-{III}"assigned to an instance of "
-{III}"{cls_name}"
+{III}{indent_but_first_line(unexpected_message, III)}
 {II})
 
 {I}self._{prop_name} = new_{prop_name}

--- a/test_data/python/test_main/aas_core_meta.v3/expected_output/types.py
+++ b/test_data/python/test_main/aas_core_meta.v3/expected_output/types.py
@@ -169,17 +169,17 @@ class HasSemantics(Class):
 
     #: Identifier of the semantic definition of the element. It is called semantic ID
     #: of the element or also main semantic ID of the element.
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     It is recommended to use a global reference.
     semantic_id: Optional['Reference']
 
     #: Identifier of a supplemental semantic definition of the element.
     #: It is called supplemental semantic ID of the element.
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     It is recommended to use a global reference.
     supplemental_semantic_ids: Optional[List['Reference']]
 
@@ -204,16 +204,16 @@ class Extension(HasSemantics):
     """Single extension of an element."""
 
     #: Name of the extension.
-    #: 
+    #:
     #: :constraint AASd-077:
     #:     .. _constraint_AASd-077:
-    #: 
+    #:
     #:     The name of an extension (Extension/name) within :py:class:`HasExtensions` needs
     #:     to be unique.
     name: str
 
     #: Type of the value of the extension.
-    #: 
+    #:
     #: Default: :py:attr:`DataTypeDefXSD.STRING`
     value_type: Optional['DataTypeDefXSD']
 
@@ -361,9 +361,9 @@ class Referable(HasExtensions):
     #: w.r.t. to the class of the element.
     #: It affects the expected existence of attributes and the applicability of
     #: constraints.
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     The category is not identical to the semantic definition
     #:     (:py:class:`HasSemantics`) of an element. The category e.g. could denote that
     #:     the element is a measurement value whereas the semantic definition of
@@ -373,9 +373,9 @@ class Referable(HasExtensions):
     #: In case of identifiables this attribute is a short name of the element.
     #: In case of referable this ID is an identifying string of the element within
     #: its name space.
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     In case the element is a property and the property has a semantic definition
     #:     (:py:attr:`HasSemantics.semantic_id`) conformant to IEC61360
     #:     the :py:attr:`id_short` is typically identical to the short name in English.
@@ -385,12 +385,12 @@ class Referable(HasExtensions):
     display_name: Optional[List['LangStringNameType']]
 
     #: Description or comments on the element.
-    #: 
+    #:
     #: The description can be provided in several languages.
-    #: 
+    #:
     #: If no description is defined, then the definition of the concept
     #: description that defines the semantics of the element is used.
-    #: 
+    #:
     #: Additional information can be provided, e.g., if the element is
     #: qualified and which qualifier types can be expected in which
     #: context or which additional data specification templates are
@@ -436,13 +436,13 @@ class Identifiable(Referable):
     #: In case of identifiables this attribute is a short name of the element.
     #: In case of referable this ID is an identifying string of the element within
     #: its name space.
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     In case the element is a property and the property has a semantic definition
     #:     (:py:attr:`HasSemantics.semantic_id`) conformant to IEC61360
     #:     the :py:attr:`id_short` is typically identical to the short name in English.
-    #: 
+    #:
     #: :py:attr:`id_short` is strengthened to required in this class,
     #: see :ref:`Constraint AASd-117 <constraint_AASd-117>`.
     id_short: str
@@ -452,6 +452,7 @@ class Identifiable(Referable):
     def id_short(
             self
     ) -> str:
+        # pylint: disable=missing-function-docstring
         return self._id_short
 
     @id_short.setter
@@ -461,18 +462,16 @@ class Identifiable(Referable):
     ) -> None:
         if new_id_short is None:
             raise ValueError(
-                "Unexpected None id_short "
-                "assigned to an instance of "
-                "Identifiable"
+                "Unexpected None id_short assigned to an instance of Identifiable"
             )
 
         self._id_short = new_id_short
     # endregion
 
     #: Administrative information of an identifiable element.
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     Some of the administrative information like the version number might need to
     #:     be part of the identification.
     administration: Optional['AdministrativeInformation']
@@ -529,7 +528,7 @@ class HasKind(Class):
     """
 
     #: Kind of the element: either type or instance.
-    #: 
+    #:
     #: Default: :py:attr:`ModellingKind.INSTANCE`
     kind: Optional['ModellingKind']
 
@@ -589,19 +588,19 @@ class AdministrativeInformation(HasDataSpecification):
     creator: Optional['Reference']
 
     #: Identifier of the template that guided the creation of the element.
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     In case of a submodel the :py:attr:`template_id` is the identifier
     #:     of the submodel template ID that guided the creation of the submodel
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     The :py:attr:`template_id` is not relevant for validation in Submodels.
     #:     For validation the :py:attr:`Submodel.semantic_id` shall be used.
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     Usage of :py:attr:`template_id` is not restricted to submodel instances. So also
     #:     the creation of submodel templates can be guided by another submodel template.
     template_id: Optional[str]
@@ -705,10 +704,10 @@ class Qualifiable(Class):
     """
 
     #: Additional qualification of a qualifiable element.
-    #: 
+    #:
     #: :constraint AASd-021:
     #:     .. _constraint_AASd-021:
-    #: 
+    #:
     #:     Every qualifiable can only have one qualifier with the same
     #:     :py:attr:`Qualifier.type`.
     qualifiers: Optional[List['Qualifier']]
@@ -736,7 +735,7 @@ class QualifierKind(enum.Enum):
     """
 
     #: qualifies the value of the element and can change during run-time.
-    #: 
+    #:
     #: Value qualifiers are only applicable to elements with kind
     #: :py:attr:`ModellingKind.INSTANCE`.
     VALUE_QUALIFIER = 'ValueQualifier'
@@ -746,7 +745,7 @@ class QualifierKind(enum.Enum):
     CONCEPT_QUALIFIER = 'ConceptQualifier'
 
     #: qualifies the elements within a specific submodel on concept level.
-    #: 
+    #:
     #: Template qualifiers are only applicable to elements with kind
     #: :py:attr:`ModellingKind.TEMPLATE`.
     TEMPLATE_QUALIFIER = 'TemplateQualifier'
@@ -774,7 +773,7 @@ class Qualifier(HasSemantics):
 
     #: The qualifier kind describes the kind of the qualifier that is applied to the
     #: element.
-    #: 
+    #:
     #: Default: :py:attr:`QualifierKind.CONCEPT_QUALIFIER`
     kind: Optional['QualifierKind']
 
@@ -789,9 +788,9 @@ class Qualifier(HasSemantics):
     value: Optional[str]
 
     #: Reference to the global unique ID of a coded value.
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     It is recommended to use a global reference.
     value_id: Optional['Reference']
 
@@ -901,11 +900,11 @@ class AssetAdministrationShell(Identifiable, HasDataSpecification):
     asset_information: 'AssetInformation'
 
     #: References to submodels of the AAS.
-    #: 
+    #:
     #: A submodel is a description of an aspect of the asset the AAS is representing.
-    #: 
+    #:
     #: The asset of an AAS is typically described by one or more submodels.
-    #: 
+    #:
     #: Temporarily no submodel might be assigned to the AAS.
     submodels: Optional[List['Reference']]
 
@@ -1112,14 +1111,14 @@ class AssetInformation(Class):
     asset_kind: 'AssetKind'
 
     #: Global identifier of the asset the AAS is representing.
-    #: 
+    #:
     #: This attribute is required as soon as the AAS is exchanged via partners in the life
     #: cycle of the asset. In a first phase of the life cycle the asset might not yet have
     #: a global ID but already an internal identifier. The internal identifier would be
     #: modelled via :py:attr:`specific_asset_ids`.
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     This is a global reference.
     global_asset_id: Optional[str]
 
@@ -1130,16 +1129,16 @@ class AssetInformation(Class):
     #: In case :py:attr:`asset_kind` is applicable the :py:attr:`asset_type` is the asset ID
     #: of the type asset of the asset under consideration
     #: as identified by :py:attr:`global_asset_id`.
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     In case :py:attr:`asset_kind` is "Instance" than the :py:attr:`asset_type` denotes
     #:     which "Type" the asset is of. But it is also possible
     #:     to have an :py:attr:`asset_type` of an asset of kind "Type".
     asset_type: Optional[str]
 
     #: Thumbnail of the asset represented by the Asset Administration Shell.
-    #: 
+    #:
     #: Used as default.
     default_thumbnail: Optional['Resource']
 
@@ -1234,12 +1233,12 @@ class Resource(Class):
     """
 
     #: Path and name of the resource (with file extension).
-    #: 
+    #:
     #: The path can be absolute or relative.
     path: str
 
     #: Content type of the content of the file.
-    #: 
+    #:
     #: The content type states which file extensions the file can have.
     content_type: Optional[str]
 
@@ -1347,9 +1346,9 @@ class SpecificAssetID(HasSemantics):
     value: str
 
     #: The (external) subject the key belongs to or has meaning to.
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     This is a global reference.
     external_subject_id: Optional['Reference']
 
@@ -1942,14 +1941,14 @@ class SubmodelElementList(SubmodelElement):
 
     #: Defines whether order in list is relevant. If :py:attr:`order_relevant` = ``False``
     #: then the list is representing a set or a bag.
-    #: 
+    #:
     #: Default: ``True``
     order_relevant: Optional[bool]
 
     #: Semantic ID the submodel elements contained in the list match to.
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     It is recommended to use a global reference.
     semantic_id_list_element: Optional['Reference']
 
@@ -1960,7 +1959,7 @@ class SubmodelElementList(SubmodelElement):
     value_type_list_element: Optional['DataTypeDefXSD']
 
     #: Submodel element contained in the list.
-    #: 
+    #:
     #: The list is ordered.
     value: Optional[List['SubmodelElement']]
 
@@ -2362,9 +2361,9 @@ class Property(DataElement):
     value: Optional[str]
 
     #: Reference to the global unique ID of a coded value.
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     It is recommended to use a global reference.
     value_id: Optional['Reference']
 
@@ -2531,9 +2530,9 @@ class MultiLanguageProperty(DataElement):
     value: Optional[List['LangStringTextType']]
 
     #: Reference to the global unique ID of a coded value.
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     It is recommended to use a global reference.
     value_id: Optional['Reference']
 
@@ -2707,12 +2706,12 @@ class Range(DataElement):
     value_type: 'DataTypeDefXSD'
 
     #: The minimum value of the range.
-    #: 
+    #:
     #: If the min value is missing, then the value is assumed to be negative infinite.
     min: Optional[str]
 
     #: The maximum value of the range.
-    #: 
+    #:
     #: If the max value is missing, then the value is assumed to be positive infinite.
     max: Optional[str]
 
@@ -3017,20 +3016,20 @@ class Blob(DataElement):
     """
 
     #: The value of the :py:class:`Blob` instance of a blob data element.
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     In contrast to the file property the file content is stored directly as value
     #:     in the :py:class:`Blob` data element.
     value: Optional[bytes]
 
     #: Content type of the content of the :py:class:`Blob`.
-    #: 
+    #:
     #: The content type (MIME type) states which file extensions the file can have.
-    #: 
+    #:
     #: Valid values are content types like e.g. ``application/json``, ``application/xls``,
     #: ``image/jpg``.
-    #: 
+    #:
     #: The allowed values are defined as in RFC2046.
     content_type: str
 
@@ -3179,12 +3178,12 @@ class File(DataElement):
     """
 
     #: Path and name of the referenced file (with file extension).
-    #: 
+    #:
     #: The path can be absolute or relative.
     value: Optional[str]
 
     #: Content type of the content of the file.
-    #: 
+    #:
     #: The content type states which file extensions the file can have.
     content_type: str
 
@@ -3522,9 +3521,9 @@ class Entity(SubmodelElement):
     entity_type: 'EntityType'
 
     #: Global identifier of the asset the entity is representing.
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     This is a global reference.
     global_asset_id: Optional[str]
 
@@ -3717,7 +3716,7 @@ class EntityType(enum.Enum):
 
     #: Self-Managed Entities have their own AAS but can be part of the bill of material of
     #: a composite self-managed entity.
-    #: 
+    #:
     #: The asset of an I4.0 Component is a self-managed entity per definition.
     SELF_MANAGED_ENTITY = 'SelfManagedEntity'
 
@@ -3772,23 +3771,23 @@ class EventPayload(Class):
     source: 'Reference'
 
     #: :py:attr:`HasSemantics.semantic_id` of the source event element, if available
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     It is recommended to use a global reference.
     source_semantic_id: Optional['Reference']
 
     #: Reference to the referable, which defines the scope of the event.
-    #: 
+    #:
     #: Can be :py:class:`AssetAdministrationShell`, :py:class:`Submodel` or
     #: :py:class:`SubmodelElement`.
     observable_reference: 'Reference'
 
     #: :py:attr:`HasSemantics.semantic_id` of the referable which defines the scope of
     #: the event, if available.
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     It is recommended to use a global reference.
     observable_semantic_id: Optional['Reference']
 
@@ -3797,9 +3796,9 @@ class EventPayload(Class):
     topic: Optional[str]
 
     #: Subject, who/which initiated the creation.
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     This is an external reference.
     subject_id: Optional['Reference']
 
@@ -3961,18 +3960,18 @@ class BasicEventElement(EventElement):
     #: Reference to the :py:class:`Referable`, which defines the scope of the event.
     #: Can be :py:class:`AssetAdministrationShell`, :py:class:`Submodel`, or
     #: :py:class:`SubmodelElement`.
-    #: 
+    #:
     #: Reference to a referable, e.g., a data element or
     #: a submodel, that is being observed.
     observed: 'Reference'
 
     #: Direction of event.
-    #: 
+    #:
     #: Can be ``{ Input, Output }``.
     direction: 'Direction'
 
     #: State of event.
-    #: 
+    #:
     #: Can be ``{ On, Off }``.
     state: 'StateOfEvent'
 
@@ -3985,9 +3984,9 @@ class BasicEventElement(EventElement):
     #: :py:class:`SubmodelElementList`, :py:class:`SubmodelElementCollection` or
     #: :py:class:`Entity`, which contains :py:class:`DataElement`'s describing
     #: the proprietary specification for the message broker.
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     For different message infrastructure, e.g., OPC UA or MQTT or AMQP, this
     #:     proprietary specification could be standardized by having respective Submodels.
     message_broker: Optional['Reference']
@@ -3998,19 +3997,19 @@ class BasicEventElement(EventElement):
 
     #: For input direction, reports on the maximum frequency, the software entity behind
     #: the respective Referable can handle input events.
-    #: 
+    #:
     #: For output events, specifies the maximum frequency of outputting this event to
     #: an outer infrastructure.
-    #: 
+    #:
     #: Might be not specified, that is, there is no minimum interval.
     min_interval: Optional[str]
 
     #: For input direction: not applicable.
-    #: 
+    #:
     #: For output direction: maximum interval in time, the respective Referable shall send
     #: an update of the status of the event, even if no other trigger condition for
     #: the event was not met.
-    #: 
+    #:
     #: Might be not specified, that is, there is no maximum interval
     max_interval: Optional[str]
 
@@ -4643,13 +4642,13 @@ class ConceptDescription(Identifiable, HasDataSpecification):
 
     #: Reference to an external definition the concept is compatible to or was derived
     #: from.
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     It is recommended to use a global reference.
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     Compare to is-case-of relationship in ISO 13584-32 & IEC EN 61360
     is_case_of: Optional[List['Reference']]
 
@@ -4895,17 +4894,17 @@ class Reference(Class):
     """
 
     #: Type of the reference.
-    #: 
+    #:
     #: Denotes, whether reference is an external reference or a model reference.
     type: 'ReferenceTypes'
 
     #: :py:attr:`HasSemantics.semantic_id` of the referenced model element
     #: (:py:attr:`type` = :py:attr:`ReferenceTypes.MODEL_REFERENCE`).
-    #: 
+    #:
     #: For external references there typically is no semantic ID.
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     It is recommended to use a external reference.
     referred_semantic_id: Optional['Reference']
 
@@ -4987,11 +4986,11 @@ class Key(Class):
     """A key is a reference to an element by its ID."""
 
     #: Denotes which kind of entity is referenced.
-    #: 
+    #:
     #: In case :py:attr:`type` = :py:attr:`KeyTypes.FRAGMENT_REFERENCE` the key represents
     #: a bookmark or a similar local identifier within its parent element as specified
     #: by the key that precedes this key.
-    #: 
+    #:
     #: In all other cases the key references a model element of the same or of another AAS.
     #: The name of the model element is explicitly listed.
     type: 'KeyTypes'
@@ -5083,9 +5082,9 @@ class KeyTypes(enum.Enum):
     CONCEPT_DESCRIPTION = 'ConceptDescription'
 
     #: Data element.
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     Data Element is abstract, *i.e.* if a key uses :py:attr:`DATA_ELEMENT`
     #:     the reference may be a Property, a File etc.
     DATA_ELEMENT = 'DataElement'
@@ -5093,9 +5092,9 @@ class KeyTypes(enum.Enum):
     ENTITY = 'Entity'
 
     #: Event.
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     :py:class:`EventElement` is abstract.
     EVENT_ELEMENT = 'EventElement'
 
@@ -5108,9 +5107,9 @@ class KeyTypes(enum.Enum):
     GLOBAL_REFERENCE = 'GlobalReference'
 
     #: Identifiable.
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     Identifiable is abstract, i.e. if a key uses “Identifiable” the reference
     #:     may be an Asset Administration Shell, a Submodel or a Concept Description.
     IDENTIFIABLE = 'Identifiable'
@@ -5136,9 +5135,9 @@ class KeyTypes(enum.Enum):
     SUBMODEL = 'Submodel'
 
     #: Submodel Element
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     Submodel Element is abstract, *i.e.* if a key uses :py:attr:`SUBMODEL_ELEMENT`
     #:     the reference may be a :py:class:`Property`, an :py:class:`Operation` etc.
     SUBMODEL_ELEMENT = 'SubmodelElement'
@@ -5643,20 +5642,20 @@ class DataTypeIEC61360(enum.Enum):
     BOOLEAN = 'BOOLEAN'
 
     #: values containing values of type STRING conformant to Rfc 3987
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     In IEC61360-1 (2017) only URI is supported.
     #:     An IRI type allows in particular to express an URL or an URI.
     IRI = 'IRI'
 
     #: values conforming to ISO/IEC 11179 series global identifier sequences
-    #: 
+    #:
     #: IRDI can be used instead of the more specific data types ICID or ISO29002_IRDI.
-    #: 
+    #:
     #: ICID values are value conformant to an IRDI, where the delimiter between RAI and ID
     #: is “#” while the delimiter between DI and VI is confined to “##”
-    #: 
+    #:
     #: ISO29002_IRDI values are values containing a global identifier that identifies an
     #: administrated item in a registry. The structure of this identifier complies with
     #: identifier syntax defined in ISO/TS 29002-5. The identifier shall fulfil the
@@ -5673,9 +5672,9 @@ class DataTypeIEC61360(enum.Enum):
 
     #: values containing a time, conformant to ISO 8601:2004 but restricted to what is
     #: allowed in the corresponding type in xml.
-    #: 
+    #:
     #: Format hh:mm (ECLASS)
-    #: 
+    #:
     #: Example from IEC 61360-1:2017: "13:20:00-05:00" is the [TIME] representation of:
     #: 1.20 p.m. for Eastern Standard Time, which is 5 hours behind Coordinated
     #: Universal Time (UTC).
@@ -5683,15 +5682,15 @@ class DataTypeIEC61360(enum.Enum):
 
     #: values containing a time, conformant to ISO 8601:2004 but restricted to what is
     #: allowed in the corresponding type in xml.
-    #: 
+    #:
     #: Format yyyy-mm-dd hh:mm (ECLASS)
     TIMESTAMP = 'TIMESTAMP'
 
     #: values containing an address to a file. The values are of type URI and can represent
     #: an absolute or relative path.
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     IEC61360 does not support the file type.
     FILE = 'FILE'
 
@@ -5700,9 +5699,9 @@ class DataTypeIEC61360(enum.Enum):
     HTML = 'HTML'
 
     #: values containing the content of a file. Values may be binaries.
-    #: 
+    #:
     #: HTML conformant to HTML5 is a special blob.
-    #: 
+    #:
     #: In IEC61360 binary is for a sequence of bits, each bit being represented by “0” and
     #: “1” only. A binary is a blob but a blob may also contain other source code.
     BLOB = 'BLOB'
@@ -5839,9 +5838,9 @@ class ValueReferencePair(Class):
     value: str
 
     #: Global unique id of the value.
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     It is recommended to use a global reference.
     value_id: 'Reference'
 
@@ -6248,14 +6247,14 @@ class DataSpecificationIEC61360(DataSpecificationContent):
     """
 
     #: Preferred name
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     It is advised to keep the length of the name limited to 35 characters.
-    #: 
+    #:
     #: :constraint AASc-3a-002:
     #:     .. _constraint_AASc-3a-002:
-    #: 
+    #:
     #:     :py:attr:`preferred_name` shall be provided at least in English.
     preferred_name: List['LangStringPreferredNameTypeIEC61360']
 
@@ -6266,12 +6265,12 @@ class DataSpecificationIEC61360(DataSpecificationContent):
     unit: Optional[str]
 
     #: Unique unit id
-    #: 
+    #:
     #: :py:attr:`unit` and :py:attr:`unit_id` need to be consistent if both attributes
     #: are set
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     It is recommended to use an external reference ID.
     unit_id: Optional['Reference']
 
@@ -6288,9 +6287,9 @@ class DataSpecificationIEC61360(DataSpecificationContent):
     definition: Optional[List['LangStringDefinitionTypeIEC61360']]
 
     #: Value Format
-    #: 
+    #:
     #: .. note::
-    #: 
+    #:
     #:     The value format is based on ISO 13584-42 and IEC 61360-2.
     value_format: Optional[str]
 


### PR DESCRIPTION
We make a couple of minor formatting fixes in the code generation to satisfy pylint on generated code.