### PR TITLE
Skip model type in descendants in JSON schema

### DIFF
--- a/aas_core_codegen/jsonschema/main.py
+++ b/aas_core_codegen/jsonschema/main.py
@@ -518,7 +518,9 @@ def _generate_inheritable_definition(
 
     required = _list_required_properties(cls)
 
-    if cls.serialization.with_model_type:
+    if cls.serialization.with_model_type and not any(
+        inheritance.serialization.with_model_type for inheritance in cls.inheritances
+    ):
         # NOTE (mristin, 2023-03-13):
         # This is going to be an abstract definition for inheritance, so we can not pin
         # the ``modelType`` to a fixed, constant value.
@@ -537,7 +539,8 @@ def _generate_inheritable_definition(
         if len(required) > 0:
             definition["required"] = required
 
-    all_of.append(definition)
+    if len(definition) > 0:
+        all_of.append(definition)
 
     definition_name = None  # type: Optional[str]
     if isinstance(cls, intermediate.AbstractClass):

--- a/test_data/jsonschema/test_main/aas_core_meta.v3/expected_output/schema.json
+++ b/test_data/jsonschema/test_main/aas_core_meta.v3/expected_output/schema.json
@@ -318,21 +318,7 @@
       ]
     },
     "DataElement": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/SubmodelElement"
-        },
-        {
-          "properties": {
-            "modelType": {
-              "$ref": "#/definitions/ModelType"
-            }
-          },
-          "required": [
-            "modelType"
-          ]
-        }
-      ]
+      "$ref": "#/definitions/SubmodelElement"
     },
     "DataElement_choice": {
       "oneOf": [
@@ -605,21 +591,7 @@
       }
     },
     "EventElement": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/SubmodelElement"
-        },
-        {
-          "properties": {
-            "modelType": {
-              "$ref": "#/definitions/ModelType"
-            }
-          },
-          "required": [
-            "modelType"
-          ]
-        }
-      ]
+      "$ref": "#/definitions/SubmodelElement"
     },
     "EventPayload": {
       "type": "object",
@@ -802,14 +774,10 @@
               "minLength": 1,
               "maxLength": 2000,
               "pattern": "^([\\t\\n\\r -\ud7ff\ue000-\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$"
-            },
-            "modelType": {
-              "$ref": "#/definitions/ModelType"
             }
           },
           "required": [
-            "id",
-            "modelType"
+            "id"
           ]
         }
       ]
@@ -1289,15 +1257,11 @@
             },
             "second": {
               "$ref": "#/definitions/Reference"
-            },
-            "modelType": {
-              "$ref": "#/definitions/ModelType"
             }
           },
           "required": [
             "first",
-            "second",
-            "modelType"
+            "second"
           ]
         }
       ]
@@ -1433,16 +1397,6 @@
         },
         {
           "$ref": "#/definitions/HasDataSpecification"
-        },
-        {
-          "properties": {
-            "modelType": {
-              "$ref": "#/definitions/ModelType"
-            }
-          },
-          "required": [
-            "modelType"
-          ]
         }
       ]
     },


### PR DESCRIPTION
We added redundant definitions of `modelType` property in JSON schema, and remove them in this patch.