### PR TITLE
Refactor unwrapper from enhancer in C#

### DIFF
--- a/aas_core_codegen/csharp/enhancing/_generate.py
+++ b/aas_core_codegen/csharp/enhancing/_generate.py
@@ -573,26 +573,11 @@ public abstract class Enhanced<TEnhancement> where TEnhancement : class
         Stripped(
             f"""\
 /// <summary>
-/// Wrap and unwrap the instances of model classes with enhancement.
+/// Unwrap enhancements from the wrapped instances.
 /// </summary>
 /// <typeparam name="TEnhancement">type of the enhancement</typeparam>
-public class Enhancer<TEnhancement> where TEnhancement : class
+public class Unwrapper<TEnhancement> where TEnhancement : class
 {{
-{I}private readonly Wrapper<TEnhancement> _wrapper;
-
-{I}/// <param name="enhancementFactory">
-{I}/// <para>how to enhance the instances.</para>
-{I}///
-{I}/// <para>If it returns <c>null</c>, the instance will not be wrapped. However,
-{I}/// the wrapping will continue recursively.</para>
-{I}///</param>
-{I}public Enhancer(
-{II}System.Func<Aas.IClass, TEnhancement?> enhancementFactory
-{I})
-{I}{{
-{II}_wrapper = new Wrapper<TEnhancement>(enhancementFactory);
-{I}}}
-
 {I}/// <summary>
 {I}/// Unwrap the given model instance.
 {I}/// </summary>
@@ -623,6 +608,35 @@ public class Enhancer<TEnhancement> where TEnhancement : class
 {II}return Unwrap(that) ?? throw new System.ArgumentException(
 {III}$"Expected the instance to have been wrapped, but it was not: {{that}}"
 {II});
+{I}}}
+}}  // public class Unwrapper"""
+        )
+    )
+
+    enhancing_blocks.append(
+        Stripped(
+            f"""\
+/// <summary>
+/// Wrap and unwrap the instances of model classes with enhancement.
+/// </summary>
+/// <typeparam name="TEnhancement">type of the enhancement</typeparam>
+public class Enhancer<TEnhancement>
+{I}: Unwrapper<TEnhancement>
+{I}where TEnhancement : class
+{{
+{I}private readonly Wrapper<TEnhancement> _wrapper;
+
+{I}/// <param name="enhancementFactory">
+{I}/// <para>how to enhance the instances.</para>
+{I}///
+{I}/// <para>If it returns <c>null</c>, the instance will not be wrapped. However,
+{I}/// the wrapping will continue recursively.</para>
+{I}///</param>
+{I}public Enhancer(
+{II}System.Func<Aas.IClass, TEnhancement?> enhancementFactory
+{I})
+{I}{{
+{II}_wrapper = new Wrapper<TEnhancement>(enhancementFactory);
 {I}}}
 
 {I}/// <summary>

--- a/test_data/csharp/test_main/aas_core_meta.v3/expected_output/enhancing.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3/expected_output/enhancing.cs
@@ -7941,26 +7941,11 @@ namespace AasCore.Aas3_0
         }
 
         /// <summary>
-        /// Wrap and unwrap the instances of model classes with enhancement.
+        /// Unwrap enhancements from the wrapped instances.
         /// </summary>
         /// <typeparam name="TEnhancement">type of the enhancement</typeparam>
-        public class Enhancer<TEnhancement> where TEnhancement : class
+        public class Unwrapper<TEnhancement> where TEnhancement : class
         {
-            private readonly Wrapper<TEnhancement> _wrapper;
-
-            /// <param name="enhancementFactory">
-            /// <para>how to enhance the instances.</para>
-            ///
-            /// <para>If it returns <c>null</c>, the instance will not be wrapped. However,
-            /// the wrapping will continue recursively.</para>
-            ///</param>
-            public Enhancer(
-                System.Func<Aas.IClass, TEnhancement?> enhancementFactory
-            )
-            {
-                _wrapper = new Wrapper<TEnhancement>(enhancementFactory);
-            }
-
             /// <summary>
             /// Unwrap the given model instance.
             /// </summary>
@@ -7991,6 +7976,30 @@ namespace AasCore.Aas3_0
                 return Unwrap(that) ?? throw new System.ArgumentException(
                     $"Expected the instance to have been wrapped, but it was not: {that}"
                 );
+            }
+        }  // public class Unwrapper
+
+        /// <summary>
+        /// Wrap and unwrap the instances of model classes with enhancement.
+        /// </summary>
+        /// <typeparam name="TEnhancement">type of the enhancement</typeparam>
+        public class Enhancer<TEnhancement>
+            : Unwrapper<TEnhancement>
+            where TEnhancement : class
+        {
+            private readonly Wrapper<TEnhancement> _wrapper;
+
+            /// <param name="enhancementFactory">
+            /// <para>how to enhance the instances.</para>
+            ///
+            /// <para>If it returns <c>null</c>, the instance will not be wrapped. However,
+            /// the wrapping will continue recursively.</para>
+            ///</param>
+            public Enhancer(
+                System.Func<Aas.IClass, TEnhancement?> enhancementFactory
+            )
+            {
+                _wrapper = new Wrapper<TEnhancement>(enhancementFactory);
             }
 
             /// <summary>


### PR DESCRIPTION
Currently, you can only specify the unwrapping if you also specify the wrapping. This is unfortunate, as wrapping might occur in a different part of the code base from where you define the unwrapping.

In particular, the enhancer needs an enhancement factory -- which might not be available at the time of unwrapping.

Therefore, we refactor the unwrapping bits from the enhancer.