### PR TITLE
[V3] Change naming in RDF & SHACL

### DIFF
--- a/aas_core_codegen/rdf_shacl/naming.py
+++ b/aas_core_codegen/rdf_shacl/naming.py
@@ -3,7 +3,38 @@ from typing import List
 
 from icontract import require
 
+from aas_core_codegen import naming
 from aas_core_codegen.common import Identifier, Stripped
+
+_LOWERCASE_WORDS_IN_LABEL = {"to", "in"}
+
+
+def _capitalized_label(identifier: Identifier) -> Stripped:
+    """
+    Generate the label starting with a capital letter.
+
+    >>> _capitalized_label(Identifier("Something"))
+    'Something'
+
+    >>> _capitalized_label(Identifier("Something_good_to_URL"))
+    'Something Good to URL'
+
+    >>> _capitalized_label(Identifier("URL_to_something"))
+    'URL to Something'
+    """
+    parts = identifier.split("_")
+
+    cased = []  # type: List[str]
+    for part in parts:
+        if part in _LOWERCASE_WORDS_IN_LABEL:
+            cased.append(part.lower())
+        else:
+            if part == part.lower():
+                cased.append(part.capitalize())
+            else:
+                cased.append(part)
+
+    return Stripped(" ".join(cased))
 
 
 # fmt: off
@@ -20,19 +51,12 @@ def class_name(identifier: Identifier) -> Identifier:
     'Something'
 
     >>> class_name(Identifier("Something_to_URL"))
-    'SomethingToURL'
+    'SomethingToUrl'
 
     >>> class_name(Identifier("URL_to_something"))
-    'URLToSomething'
+    'UrlToSomething'
     """
-    parts = identifier.split("_")
-
-    return Identifier(
-        "".join(part.capitalize() if part == part.lower() else part for part in parts)
-    )
-
-
-_LOWERCASE_WORDS_IN_LABEL = {"to", "in"}
+    return naming.capitalized_camel_case(identifier)
 
 
 # fmt: off
@@ -54,19 +78,7 @@ def class_label(identifier: Identifier) -> Stripped:
     >>> class_label(Identifier("URL_to_something"))
     'URL to Something'
     """
-    parts = identifier.split("_")
-
-    cased = []  # type: List[str]
-    for part in parts:
-        if part in _LOWERCASE_WORDS_IN_LABEL:
-            cased.append(part.lower())
-        else:
-            if part == part.lower():
-                cased.append(part.capitalize())
-            else:
-                cased.append(part)
-
-    return Stripped(" ".join(cased))
+    return _capitalized_label(identifier)
 
 
 def property_name(identifier: Identifier) -> Identifier:
@@ -77,24 +89,12 @@ def property_name(identifier: Identifier) -> Identifier:
     'something'
 
     >>> property_name(Identifier("something_to_URL"))
-    'somethingToURL'
+    'somethingToUrl'
 
     >>> property_name(Identifier("URL_to_something"))
     'urlToSomething'
     """
-    parts = identifier.split("_")
-
-    cased = []  # type: List[str]
-    for i, part in enumerate(parts):
-        if i == 0:
-            cased.append(part.lower())
-        else:
-            if part == part.upper():
-                cased.append(part)
-            else:
-                cased.append(part.capitalize())
-
-    return Identifier("".join(cased))
+    return naming.lower_camel_case(identifier)
 
 
 def property_label(identifier: Identifier) -> Stripped:
@@ -126,8 +126,7 @@ def enumeration_literal(identifier: Identifier) -> Stripped:
     >>> enumeration_literal(Identifier("URL_to_something"))
     'UrlToSomething'
     """
-    parts = identifier.split("_")
-    return Stripped("".join(part.capitalize() for part in parts))
+    return naming.capitalized_camel_case(identifier)
 
 
 def enumeration_literal_label(identifier: Identifier) -> Stripped:
@@ -143,16 +142,4 @@ def enumeration_literal_label(identifier: Identifier) -> Stripped:
     >>> enumeration_literal_label(Identifier("URL_to_something_good"))
     'URL to Something Good'
     """
-    parts = identifier.split("_")
-
-    cased = []  # type: List[str]
-    for part in parts:
-        if part in _LOWERCASE_WORDS_IN_LABEL:
-            cased.append(part.lower())
-        else:
-            if part == part.lower():
-                cased.append(part.capitalize())
-            else:
-                cased.append(part)
-
-    return Stripped(" ".join(cased))
+    return _capitalized_label(identifier)

--- a/test_data/rdf_shacl/test_main/expected/aas_core_meta.v3/expected_output/rdf-ontology.ttl
+++ b/test_data/rdf_shacl/test_main/expected/aas_core_meta.v3/expected_output/rdf-ontology.ttl
@@ -11,113 +11,113 @@
     rdfs:isDefinedBy <https://admin-shell.io/aas/3/0/> ;
 .
 
-###  https://admin-shell.io/aas/3/0/AASSubmodelElements
-aas:AASSubmodelElements rdf:type owl:Class ;
+###  https://admin-shell.io/aas/3/0/AasSubmodelElements
+aas:AasSubmodelElements rdf:type owl:Class ;
     rdfs:label "AAS Submodel Elements"^^xs:string ;
     rdfs:comment "Enumeration of all possible elements of a 'SubmodelElementList'."@en ;
     owl:oneOf (
-        <https://admin-shell.io/aas/3/0/AASSubmodelElements/AnnotatedRelationshipElement>
-        <https://admin-shell.io/aas/3/0/AASSubmodelElements/BasicEventElement>
-        <https://admin-shell.io/aas/3/0/AASSubmodelElements/Blob>
-        <https://admin-shell.io/aas/3/0/AASSubmodelElements/Capability>
-        <https://admin-shell.io/aas/3/0/AASSubmodelElements/DataElement>
-        <https://admin-shell.io/aas/3/0/AASSubmodelElements/Entity>
-        <https://admin-shell.io/aas/3/0/AASSubmodelElements/EventElement>
-        <https://admin-shell.io/aas/3/0/AASSubmodelElements/File>
-        <https://admin-shell.io/aas/3/0/AASSubmodelElements/MultiLanguageProperty>
-        <https://admin-shell.io/aas/3/0/AASSubmodelElements/Operation>
-        <https://admin-shell.io/aas/3/0/AASSubmodelElements/Property>
-        <https://admin-shell.io/aas/3/0/AASSubmodelElements/Range>
-        <https://admin-shell.io/aas/3/0/AASSubmodelElements/ReferenceElement>
-        <https://admin-shell.io/aas/3/0/AASSubmodelElements/RelationshipElement>
-        <https://admin-shell.io/aas/3/0/AASSubmodelElements/SubmodelElement>
-        <https://admin-shell.io/aas/3/0/AASSubmodelElements/SubmodelElementCollection>
-        <https://admin-shell.io/aas/3/0/AASSubmodelElements/SubmodelElementList>
+        <https://admin-shell.io/aas/3/0/AasSubmodelElements/AnnotatedRelationshipElement>
+        <https://admin-shell.io/aas/3/0/AasSubmodelElements/BasicEventElement>
+        <https://admin-shell.io/aas/3/0/AasSubmodelElements/Blob>
+        <https://admin-shell.io/aas/3/0/AasSubmodelElements/Capability>
+        <https://admin-shell.io/aas/3/0/AasSubmodelElements/DataElement>
+        <https://admin-shell.io/aas/3/0/AasSubmodelElements/Entity>
+        <https://admin-shell.io/aas/3/0/AasSubmodelElements/EventElement>
+        <https://admin-shell.io/aas/3/0/AasSubmodelElements/File>
+        <https://admin-shell.io/aas/3/0/AasSubmodelElements/MultiLanguageProperty>
+        <https://admin-shell.io/aas/3/0/AasSubmodelElements/Operation>
+        <https://admin-shell.io/aas/3/0/AasSubmodelElements/Property>
+        <https://admin-shell.io/aas/3/0/AasSubmodelElements/Range>
+        <https://admin-shell.io/aas/3/0/AasSubmodelElements/ReferenceElement>
+        <https://admin-shell.io/aas/3/0/AasSubmodelElements/RelationshipElement>
+        <https://admin-shell.io/aas/3/0/AasSubmodelElements/SubmodelElement>
+        <https://admin-shell.io/aas/3/0/AasSubmodelElements/SubmodelElementCollection>
+        <https://admin-shell.io/aas/3/0/AasSubmodelElements/SubmodelElementList>
     ) ;
 .
 
-###  https://admin-shell.io/aas/3/0/AASSubmodelElements/AnnotatedRelationshipElement
-<https://admin-shell.io/aas/3/0/AASSubmodelElements/AnnotatedRelationshipElement> rdf:type aas:AASSubmodelElements ;
+###  https://admin-shell.io/aas/3/0/AasSubmodelElements/AnnotatedRelationshipElement
+<https://admin-shell.io/aas/3/0/AasSubmodelElements/AnnotatedRelationshipElement> rdf:type aas:AasSubmodelElements ;
     rdfs:label "Annotated Relationship Element"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/AASSubmodelElements/BasicEventElement
-<https://admin-shell.io/aas/3/0/AASSubmodelElements/BasicEventElement> rdf:type aas:AASSubmodelElements ;
+###  https://admin-shell.io/aas/3/0/AasSubmodelElements/BasicEventElement
+<https://admin-shell.io/aas/3/0/AasSubmodelElements/BasicEventElement> rdf:type aas:AasSubmodelElements ;
     rdfs:label "Basic Event Element"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/AASSubmodelElements/Blob
-<https://admin-shell.io/aas/3/0/AASSubmodelElements/Blob> rdf:type aas:AASSubmodelElements ;
+###  https://admin-shell.io/aas/3/0/AasSubmodelElements/Blob
+<https://admin-shell.io/aas/3/0/AasSubmodelElements/Blob> rdf:type aas:AasSubmodelElements ;
     rdfs:label "Blob"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/AASSubmodelElements/Capability
-<https://admin-shell.io/aas/3/0/AASSubmodelElements/Capability> rdf:type aas:AASSubmodelElements ;
+###  https://admin-shell.io/aas/3/0/AasSubmodelElements/Capability
+<https://admin-shell.io/aas/3/0/AasSubmodelElements/Capability> rdf:type aas:AasSubmodelElements ;
     rdfs:label "Capability"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/AASSubmodelElements/DataElement
-<https://admin-shell.io/aas/3/0/AASSubmodelElements/DataElement> rdf:type aas:AASSubmodelElements ;
+###  https://admin-shell.io/aas/3/0/AasSubmodelElements/DataElement
+<https://admin-shell.io/aas/3/0/AasSubmodelElements/DataElement> rdf:type aas:AasSubmodelElements ;
     rdfs:label "Data Element"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/AASSubmodelElements/Entity
-<https://admin-shell.io/aas/3/0/AASSubmodelElements/Entity> rdf:type aas:AASSubmodelElements ;
+###  https://admin-shell.io/aas/3/0/AasSubmodelElements/Entity
+<https://admin-shell.io/aas/3/0/AasSubmodelElements/Entity> rdf:type aas:AasSubmodelElements ;
     rdfs:label "Entity"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/AASSubmodelElements/EventElement
-<https://admin-shell.io/aas/3/0/AASSubmodelElements/EventElement> rdf:type aas:AASSubmodelElements ;
+###  https://admin-shell.io/aas/3/0/AasSubmodelElements/EventElement
+<https://admin-shell.io/aas/3/0/AasSubmodelElements/EventElement> rdf:type aas:AasSubmodelElements ;
     rdfs:label "Event Element"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/AASSubmodelElements/File
-<https://admin-shell.io/aas/3/0/AASSubmodelElements/File> rdf:type aas:AASSubmodelElements ;
+###  https://admin-shell.io/aas/3/0/AasSubmodelElements/File
+<https://admin-shell.io/aas/3/0/AasSubmodelElements/File> rdf:type aas:AasSubmodelElements ;
     rdfs:label "File"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/AASSubmodelElements/MultiLanguageProperty
-<https://admin-shell.io/aas/3/0/AASSubmodelElements/MultiLanguageProperty> rdf:type aas:AASSubmodelElements ;
+###  https://admin-shell.io/aas/3/0/AasSubmodelElements/MultiLanguageProperty
+<https://admin-shell.io/aas/3/0/AasSubmodelElements/MultiLanguageProperty> rdf:type aas:AasSubmodelElements ;
     rdfs:label "Multi Language Property"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/AASSubmodelElements/Operation
-<https://admin-shell.io/aas/3/0/AASSubmodelElements/Operation> rdf:type aas:AASSubmodelElements ;
+###  https://admin-shell.io/aas/3/0/AasSubmodelElements/Operation
+<https://admin-shell.io/aas/3/0/AasSubmodelElements/Operation> rdf:type aas:AasSubmodelElements ;
     rdfs:label "Operation"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/AASSubmodelElements/Property
-<https://admin-shell.io/aas/3/0/AASSubmodelElements/Property> rdf:type aas:AASSubmodelElements ;
+###  https://admin-shell.io/aas/3/0/AasSubmodelElements/Property
+<https://admin-shell.io/aas/3/0/AasSubmodelElements/Property> rdf:type aas:AasSubmodelElements ;
     rdfs:label "Property"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/AASSubmodelElements/Range
-<https://admin-shell.io/aas/3/0/AASSubmodelElements/Range> rdf:type aas:AASSubmodelElements ;
+###  https://admin-shell.io/aas/3/0/AasSubmodelElements/Range
+<https://admin-shell.io/aas/3/0/AasSubmodelElements/Range> rdf:type aas:AasSubmodelElements ;
     rdfs:label "Range"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/AASSubmodelElements/ReferenceElement
-<https://admin-shell.io/aas/3/0/AASSubmodelElements/ReferenceElement> rdf:type aas:AASSubmodelElements ;
+###  https://admin-shell.io/aas/3/0/AasSubmodelElements/ReferenceElement
+<https://admin-shell.io/aas/3/0/AasSubmodelElements/ReferenceElement> rdf:type aas:AasSubmodelElements ;
     rdfs:label "Reference Element"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/AASSubmodelElements/RelationshipElement
-<https://admin-shell.io/aas/3/0/AASSubmodelElements/RelationshipElement> rdf:type aas:AASSubmodelElements ;
+###  https://admin-shell.io/aas/3/0/AasSubmodelElements/RelationshipElement
+<https://admin-shell.io/aas/3/0/AasSubmodelElements/RelationshipElement> rdf:type aas:AasSubmodelElements ;
     rdfs:label "Relationship Element"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/AASSubmodelElements/SubmodelElement
-<https://admin-shell.io/aas/3/0/AASSubmodelElements/SubmodelElement> rdf:type aas:AASSubmodelElements ;
+###  https://admin-shell.io/aas/3/0/AasSubmodelElements/SubmodelElement
+<https://admin-shell.io/aas/3/0/AasSubmodelElements/SubmodelElement> rdf:type aas:AasSubmodelElements ;
     rdfs:label "Submodel Element"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/AASSubmodelElements/SubmodelElementCollection
-<https://admin-shell.io/aas/3/0/AASSubmodelElements/SubmodelElementCollection> rdf:type aas:AASSubmodelElements ;
+###  https://admin-shell.io/aas/3/0/AasSubmodelElements/SubmodelElementCollection
+<https://admin-shell.io/aas/3/0/AasSubmodelElements/SubmodelElementCollection> rdf:type aas:AasSubmodelElements ;
     rdfs:label "Submodel Element Collection"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/AASSubmodelElements/SubmodelElementList
-<https://admin-shell.io/aas/3/0/AASSubmodelElements/SubmodelElementList> rdf:type aas:AASSubmodelElements ;
+###  https://admin-shell.io/aas/3/0/AasSubmodelElements/SubmodelElementList
+<https://admin-shell.io/aas/3/0/AasSubmodelElements/SubmodelElementList> rdf:type aas:AasSubmodelElements ;
     rdfs:label "Submodel Element List"^^xs:string ;
 .
 
@@ -166,8 +166,8 @@ aas:AdministrativeInformation rdf:type owl:Class ;
     rdfs:comment "Revision of the element."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/AdministrativeInformation/templateID
-<https://admin-shell.io/aas/3/0/AdministrativeInformation/templateID> rdf:type owl:DatatypeProperty ;
+###  https://admin-shell.io/aas/3/0/AdministrativeInformation/templateId
+<https://admin-shell.io/aas/3/0/AdministrativeInformation/templateId> rdf:type owl:DatatypeProperty ;
     rdfs:label "has template ID"^^xs:string ;
     rdfs:domain aas:AdministrativeInformation ;
     rdfs:range xs:string ;
@@ -248,7 +248,7 @@ aas:AssetInformation rdf:type owl:Class ;
     rdfs:label "has asset type"^^xs:string ;
     rdfs:domain aas:AssetInformation ;
     rdfs:range xs:string ;
-    rdfs:comment "In case 'assetKind' is applicable the 'assetType' is the asset ID of the type asset of the asset under consideration as identified by 'globalAssetID'."@en ;
+    rdfs:comment "In case 'assetKind' is applicable the 'assetType' is the asset ID of the type asset of the asset under consideration as identified by 'globalAssetId'."@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/AssetInformation/defaultThumbnail
@@ -259,8 +259,8 @@ aas:AssetInformation rdf:type owl:Class ;
     rdfs:comment "Thumbnail of the asset represented by the Asset Administration Shell."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/AssetInformation/globalAssetID
-<https://admin-shell.io/aas/3/0/AssetInformation/globalAssetID> rdf:type owl:DatatypeProperty ;
+###  https://admin-shell.io/aas/3/0/AssetInformation/globalAssetId
+<https://admin-shell.io/aas/3/0/AssetInformation/globalAssetId> rdf:type owl:DatatypeProperty ;
     rdfs:label "has global asset ID"^^xs:string ;
     rdfs:domain aas:AssetInformation ;
     rdfs:range xs:string ;
@@ -271,7 +271,7 @@ aas:AssetInformation rdf:type owl:Class ;
 <https://admin-shell.io/aas/3/0/AssetInformation/specificAssetIds> rdf:type owl:ObjectProperty ;
     rdfs:label "has specific asset IDs"^^xs:string ;
     rdfs:domain aas:AssetInformation ;
-    rdfs:range aas:SpecificAssetID ;
+    rdfs:range aas:SpecificAssetId ;
     rdfs:comment "Additional domain-specific, typically proprietary identifier for the asset like e.g., serial number etc."@en ;
 .
 
@@ -434,433 +434,433 @@ aas:DataSpecificationContent rdf:type owl:Class ;
     rdfs:comment "Data specification content is part of a data specification template and defines which additional attributes shall be added to the element instance that references the data specification template and meta information about the template itself."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataSpecificationIEC61360
-aas:DataSpecificationIEC61360 rdf:type owl:Class ;
+###  https://admin-shell.io/aas/3/0/DataSpecificationIec61360
+aas:DataSpecificationIec61360 rdf:type owl:Class ;
     rdfs:subClassOf aas:DataSpecificationContent ;
     rdfs:label "Data Specification IEC 61360"^^xs:string ;
     rdfs:comment "Content of data specification template for concept descriptions for properties, values and value lists conformant to IEC 61360."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/dataType
-<https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/dataType> rdf:type owl:ObjectProperty ;
+###  https://admin-shell.io/aas/3/0/DataSpecificationIec61360/dataType
+<https://admin-shell.io/aas/3/0/DataSpecificationIec61360/dataType> rdf:type owl:ObjectProperty ;
     rdfs:label "has data type"^^xs:string ;
-    rdfs:domain aas:DataSpecificationIEC61360 ;
-    rdfs:range aas:DataTypeIEC61360 ;
+    rdfs:domain aas:DataSpecificationIec61360 ;
+    rdfs:range aas:DataTypeIec61360 ;
     rdfs:comment "Data Type"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/definition
-<https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/definition> rdf:type owl:ObjectProperty ;
+###  https://admin-shell.io/aas/3/0/DataSpecificationIec61360/definition
+<https://admin-shell.io/aas/3/0/DataSpecificationIec61360/definition> rdf:type owl:ObjectProperty ;
     rdfs:label "has definition"^^xs:string ;
-    rdfs:domain aas:DataSpecificationIEC61360 ;
-    rdfs:range aas:LangStringDefinitionTypeIEC61360 ;
+    rdfs:domain aas:DataSpecificationIec61360 ;
+    rdfs:range aas:LangStringDefinitionTypeIec61360 ;
     rdfs:comment "Definition in different languages"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/levelType
-<https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/levelType> rdf:type owl:ObjectProperty ;
+###  https://admin-shell.io/aas/3/0/DataSpecificationIec61360/levelType
+<https://admin-shell.io/aas/3/0/DataSpecificationIec61360/levelType> rdf:type owl:ObjectProperty ;
     rdfs:label "has level type"^^xs:string ;
-    rdfs:domain aas:DataSpecificationIEC61360 ;
+    rdfs:domain aas:DataSpecificationIec61360 ;
     rdfs:range aas:LevelType ;
     rdfs:comment "Set of levels."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/preferredName
-<https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/preferredName> rdf:type owl:ObjectProperty ;
+###  https://admin-shell.io/aas/3/0/DataSpecificationIec61360/preferredName
+<https://admin-shell.io/aas/3/0/DataSpecificationIec61360/preferredName> rdf:type owl:ObjectProperty ;
     rdfs:label "has preferred name"^^xs:string ;
-    rdfs:domain aas:DataSpecificationIEC61360 ;
-    rdfs:range aas:LangStringPreferredNameTypeIEC61360 ;
+    rdfs:domain aas:DataSpecificationIec61360 ;
+    rdfs:range aas:LangStringPreferredNameTypeIec61360 ;
     rdfs:comment "Preferred name"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/shortName
-<https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/shortName> rdf:type owl:ObjectProperty ;
+###  https://admin-shell.io/aas/3/0/DataSpecificationIec61360/shortName
+<https://admin-shell.io/aas/3/0/DataSpecificationIec61360/shortName> rdf:type owl:ObjectProperty ;
     rdfs:label "has short name"^^xs:string ;
-    rdfs:domain aas:DataSpecificationIEC61360 ;
-    rdfs:range aas:LangStringShortNameTypeIEC61360 ;
+    rdfs:domain aas:DataSpecificationIec61360 ;
+    rdfs:range aas:LangStringShortNameTypeIec61360 ;
     rdfs:comment "Short name"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/sourceOfDefinition
-<https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/sourceOfDefinition> rdf:type owl:DatatypeProperty ;
+###  https://admin-shell.io/aas/3/0/DataSpecificationIec61360/sourceOfDefinition
+<https://admin-shell.io/aas/3/0/DataSpecificationIec61360/sourceOfDefinition> rdf:type owl:DatatypeProperty ;
     rdfs:label "has source of definition"^^xs:string ;
-    rdfs:domain aas:DataSpecificationIEC61360 ;
+    rdfs:domain aas:DataSpecificationIec61360 ;
     rdfs:range xs:string ;
     rdfs:comment "Source of definition"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/symbol
-<https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/symbol> rdf:type owl:DatatypeProperty ;
+###  https://admin-shell.io/aas/3/0/DataSpecificationIec61360/symbol
+<https://admin-shell.io/aas/3/0/DataSpecificationIec61360/symbol> rdf:type owl:DatatypeProperty ;
     rdfs:label "has symbol"^^xs:string ;
-    rdfs:domain aas:DataSpecificationIEC61360 ;
+    rdfs:domain aas:DataSpecificationIec61360 ;
     rdfs:range xs:string ;
     rdfs:comment "Symbol"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/unit
-<https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/unit> rdf:type owl:DatatypeProperty ;
+###  https://admin-shell.io/aas/3/0/DataSpecificationIec61360/unit
+<https://admin-shell.io/aas/3/0/DataSpecificationIec61360/unit> rdf:type owl:DatatypeProperty ;
     rdfs:label "has unit"^^xs:string ;
-    rdfs:domain aas:DataSpecificationIEC61360 ;
+    rdfs:domain aas:DataSpecificationIec61360 ;
     rdfs:range xs:string ;
     rdfs:comment "Unit"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/unitID
-<https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/unitID> rdf:type owl:ObjectProperty ;
+###  https://admin-shell.io/aas/3/0/DataSpecificationIec61360/unitId
+<https://admin-shell.io/aas/3/0/DataSpecificationIec61360/unitId> rdf:type owl:ObjectProperty ;
     rdfs:label "has unit ID"^^xs:string ;
-    rdfs:domain aas:DataSpecificationIEC61360 ;
+    rdfs:domain aas:DataSpecificationIec61360 ;
     rdfs:range aas:Reference ;
     rdfs:comment "Unique unit id"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/value
-<https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/value> rdf:type owl:DatatypeProperty ;
+###  https://admin-shell.io/aas/3/0/DataSpecificationIec61360/value
+<https://admin-shell.io/aas/3/0/DataSpecificationIec61360/value> rdf:type owl:DatatypeProperty ;
     rdfs:label "has value"^^xs:string ;
-    rdfs:domain aas:DataSpecificationIEC61360 ;
+    rdfs:domain aas:DataSpecificationIec61360 ;
     rdfs:range xs:string ;
     rdfs:comment "Value"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/valueFormat
-<https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/valueFormat> rdf:type owl:DatatypeProperty ;
+###  https://admin-shell.io/aas/3/0/DataSpecificationIec61360/valueFormat
+<https://admin-shell.io/aas/3/0/DataSpecificationIec61360/valueFormat> rdf:type owl:DatatypeProperty ;
     rdfs:label "has value format"^^xs:string ;
-    rdfs:domain aas:DataSpecificationIEC61360 ;
+    rdfs:domain aas:DataSpecificationIec61360 ;
     rdfs:range xs:string ;
     rdfs:comment "Value Format"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/valueList
-<https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/valueList> rdf:type owl:ObjectProperty ;
+###  https://admin-shell.io/aas/3/0/DataSpecificationIec61360/valueList
+<https://admin-shell.io/aas/3/0/DataSpecificationIec61360/valueList> rdf:type owl:ObjectProperty ;
     rdfs:label "has value list"^^xs:string ;
-    rdfs:domain aas:DataSpecificationIEC61360 ;
+    rdfs:domain aas:DataSpecificationIec61360 ;
     rdfs:range aas:ValueList ;
     rdfs:comment "List of allowed values"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD
-aas:DataTypeDefXSD rdf:type owl:Class ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd
+aas:DataTypeDefXsd rdf:type owl:Class ;
     rdfs:label "Data Type Def XSD"^^xs:string ;
     rdfs:comment "Enumeration listing all XSD anySimpleTypes"@en ;
     owl:oneOf (
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/AnyUri>
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/Base64Binary>
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/Boolean>
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/Byte>
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/Date>
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/DateTime>
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/Decimal>
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/Double>
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/Duration>
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/Float>
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/GDay>
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/GMonth>
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/GMonthDay>
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/GYear>
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/GYearMonth>
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/HexBinary>
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/Int>
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/Integer>
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/Long>
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/NegativeInteger>
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/NonNegativeInteger>
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/NonPositiveInteger>
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/PositiveInteger>
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/Short>
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/String>
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/Time>
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/UnsignedByte>
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/UnsignedInt>
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/UnsignedLong>
-        <https://admin-shell.io/aas/3/0/DataTypeDefXSD/UnsignedShort>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/AnyUri>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/Base64Binary>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/Boolean>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/Byte>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/Date>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/DateTime>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/Decimal>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/Double>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/Duration>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/Float>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/GDay>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/GMonth>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/GMonthDay>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/GYear>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/GYearMonth>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/HexBinary>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/Int>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/Integer>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/Long>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/NegativeInteger>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/NonNegativeInteger>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/NonPositiveInteger>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/PositiveInteger>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/Short>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/String>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/Time>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/UnsignedByte>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/UnsignedInt>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/UnsignedLong>
+        <https://admin-shell.io/aas/3/0/DataTypeDefXsd/UnsignedShort>
     ) ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/AnyUri
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/AnyUri> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/AnyUri
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/AnyUri> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "Any URI"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/Base64Binary
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/Base64Binary> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/Base64Binary
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/Base64Binary> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "Base 64 Binary"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/Boolean
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/Boolean> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/Boolean
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/Boolean> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "Boolean"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/Byte
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/Byte> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/Byte
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/Byte> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "Byte"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/Date
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/Date> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/Date
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/Date> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "Date"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/DateTime
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/DateTime> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/DateTime
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/DateTime> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "Date Time"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/Decimal
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/Decimal> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/Decimal
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/Decimal> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "Decimal"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/Double
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/Double> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/Double
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/Double> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "Double"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/Duration
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/Duration> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/Duration
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/Duration> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "Duration"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/Float
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/Float> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/Float
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/Float> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "Float"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/GDay
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/GDay> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/GDay
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/GDay> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "G Day"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/GMonth
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/GMonth> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/GMonth
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/GMonth> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "G Month"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/GMonthDay
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/GMonthDay> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/GMonthDay
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/GMonthDay> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "G Month Day"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/GYear
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/GYear> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/GYear
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/GYear> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "G Year"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/GYearMonth
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/GYearMonth> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/GYearMonth
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/GYearMonth> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "G Year Month"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/HexBinary
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/HexBinary> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/HexBinary
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/HexBinary> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "Hex Binary"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/Int
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/Int> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/Int
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/Int> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "Int"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/Integer
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/Integer> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/Integer
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/Integer> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "Integer"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/Long
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/Long> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/Long
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/Long> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "Long"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/NegativeInteger
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/NegativeInteger> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/NegativeInteger
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/NegativeInteger> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "Negative Integer"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/NonNegativeInteger
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/NonNegativeInteger> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/NonNegativeInteger
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/NonNegativeInteger> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "Non Negative Integer"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/NonPositiveInteger
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/NonPositiveInteger> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/NonPositiveInteger
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/NonPositiveInteger> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "Non Positive Integer"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/PositiveInteger
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/PositiveInteger> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/PositiveInteger
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/PositiveInteger> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "Positive Integer"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/Short
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/Short> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/Short
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/Short> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "Short"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/String
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/String> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/String
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/String> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "String"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/Time
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/Time> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/Time
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/Time> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "Time"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/UnsignedByte
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/UnsignedByte> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/UnsignedByte
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/UnsignedByte> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "Unsigned Byte"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/UnsignedInt
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/UnsignedInt> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/UnsignedInt
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/UnsignedInt> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "Unsigned Int"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/UnsignedLong
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/UnsignedLong> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/UnsignedLong
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/UnsignedLong> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "Unsigned Long"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeDefXSD/UnsignedShort
-<https://admin-shell.io/aas/3/0/DataTypeDefXSD/UnsignedShort> rdf:type aas:DataTypeDefXSD ;
+###  https://admin-shell.io/aas/3/0/DataTypeDefXsd/UnsignedShort
+<https://admin-shell.io/aas/3/0/DataTypeDefXsd/UnsignedShort> rdf:type aas:DataTypeDefXsd ;
     rdfs:label "Unsigned Short"^^xs:string ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeIEC61360
-aas:DataTypeIEC61360 rdf:type owl:Class ;
+###  https://admin-shell.io/aas/3/0/DataTypeIec61360
+aas:DataTypeIec61360 rdf:type owl:Class ;
     rdfs:label "Data Type IEC 61360"^^xs:string ;
     owl:oneOf (
-        <https://admin-shell.io/aas/3/0/DataTypeIEC61360/Blob>
-        <https://admin-shell.io/aas/3/0/DataTypeIEC61360/Boolean>
-        <https://admin-shell.io/aas/3/0/DataTypeIEC61360/Date>
-        <https://admin-shell.io/aas/3/0/DataTypeIEC61360/File>
-        <https://admin-shell.io/aas/3/0/DataTypeIEC61360/Html>
-        <https://admin-shell.io/aas/3/0/DataTypeIEC61360/IntegerCount>
-        <https://admin-shell.io/aas/3/0/DataTypeIEC61360/IntegerCurrency>
-        <https://admin-shell.io/aas/3/0/DataTypeIEC61360/IntegerMeasure>
-        <https://admin-shell.io/aas/3/0/DataTypeIEC61360/Irdi>
-        <https://admin-shell.io/aas/3/0/DataTypeIEC61360/Iri>
-        <https://admin-shell.io/aas/3/0/DataTypeIEC61360/Rational>
-        <https://admin-shell.io/aas/3/0/DataTypeIEC61360/RationalMeasure>
-        <https://admin-shell.io/aas/3/0/DataTypeIEC61360/RealCount>
-        <https://admin-shell.io/aas/3/0/DataTypeIEC61360/RealCurrency>
-        <https://admin-shell.io/aas/3/0/DataTypeIEC61360/RealMeasure>
-        <https://admin-shell.io/aas/3/0/DataTypeIEC61360/String>
-        <https://admin-shell.io/aas/3/0/DataTypeIEC61360/StringTranslatable>
-        <https://admin-shell.io/aas/3/0/DataTypeIEC61360/Time>
-        <https://admin-shell.io/aas/3/0/DataTypeIEC61360/Timestamp>
+        <https://admin-shell.io/aas/3/0/DataTypeIec61360/Blob>
+        <https://admin-shell.io/aas/3/0/DataTypeIec61360/Boolean>
+        <https://admin-shell.io/aas/3/0/DataTypeIec61360/Date>
+        <https://admin-shell.io/aas/3/0/DataTypeIec61360/File>
+        <https://admin-shell.io/aas/3/0/DataTypeIec61360/Html>
+        <https://admin-shell.io/aas/3/0/DataTypeIec61360/IntegerCount>
+        <https://admin-shell.io/aas/3/0/DataTypeIec61360/IntegerCurrency>
+        <https://admin-shell.io/aas/3/0/DataTypeIec61360/IntegerMeasure>
+        <https://admin-shell.io/aas/3/0/DataTypeIec61360/Irdi>
+        <https://admin-shell.io/aas/3/0/DataTypeIec61360/Iri>
+        <https://admin-shell.io/aas/3/0/DataTypeIec61360/Rational>
+        <https://admin-shell.io/aas/3/0/DataTypeIec61360/RationalMeasure>
+        <https://admin-shell.io/aas/3/0/DataTypeIec61360/RealCount>
+        <https://admin-shell.io/aas/3/0/DataTypeIec61360/RealCurrency>
+        <https://admin-shell.io/aas/3/0/DataTypeIec61360/RealMeasure>
+        <https://admin-shell.io/aas/3/0/DataTypeIec61360/String>
+        <https://admin-shell.io/aas/3/0/DataTypeIec61360/StringTranslatable>
+        <https://admin-shell.io/aas/3/0/DataTypeIec61360/Time>
+        <https://admin-shell.io/aas/3/0/DataTypeIec61360/Timestamp>
     ) ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeIEC61360/Blob
-<https://admin-shell.io/aas/3/0/DataTypeIEC61360/Blob> rdf:type aas:DataTypeIEC61360 ;
+###  https://admin-shell.io/aas/3/0/DataTypeIec61360/Blob
+<https://admin-shell.io/aas/3/0/DataTypeIec61360/Blob> rdf:type aas:DataTypeIec61360 ;
     rdfs:label "Blob"^^xs:string ;
     rdfs:comment "values containing the content of a file. Values may be binaries."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeIEC61360/Boolean
-<https://admin-shell.io/aas/3/0/DataTypeIEC61360/Boolean> rdf:type aas:DataTypeIEC61360 ;
+###  https://admin-shell.io/aas/3/0/DataTypeIec61360/Boolean
+<https://admin-shell.io/aas/3/0/DataTypeIec61360/Boolean> rdf:type aas:DataTypeIec61360 ;
     rdfs:label "Boolean"^^xs:string ;
     rdfs:comment "values representing truth of logic or Boolean algebra (TRUE, FALSE)"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeIEC61360/Date
-<https://admin-shell.io/aas/3/0/DataTypeIEC61360/Date> rdf:type aas:DataTypeIEC61360 ;
+###  https://admin-shell.io/aas/3/0/DataTypeIec61360/Date
+<https://admin-shell.io/aas/3/0/DataTypeIec61360/Date> rdf:type aas:DataTypeIec61360 ;
     rdfs:label "Date"^^xs:string ;
     rdfs:comment "values containing a calendar date, conformant to ISO 8601:2004 Format yyyy-mm-dd Example from IEC 61360-1:2017: \"1999-05-31\" is the [DATE] representation of: \"31 May 1999\"."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeIEC61360/File
-<https://admin-shell.io/aas/3/0/DataTypeIEC61360/File> rdf:type aas:DataTypeIEC61360 ;
+###  https://admin-shell.io/aas/3/0/DataTypeIec61360/File
+<https://admin-shell.io/aas/3/0/DataTypeIec61360/File> rdf:type aas:DataTypeIec61360 ;
     rdfs:label "File"^^xs:string ;
     rdfs:comment "values containing an address to a file. The values are of type URI and can represent an absolute or relative path."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeIEC61360/Html
-<https://admin-shell.io/aas/3/0/DataTypeIEC61360/Html> rdf:type aas:DataTypeIEC61360 ;
+###  https://admin-shell.io/aas/3/0/DataTypeIec61360/Html
+<https://admin-shell.io/aas/3/0/DataTypeIec61360/Html> rdf:type aas:DataTypeIec61360 ;
     rdfs:label "HTML"^^xs:string ;
     rdfs:comment "Values containing string with any sequence of characters, using the syntax of HTML5 (see W3C Recommendation 28:2014)"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeIEC61360/IntegerCount
-<https://admin-shell.io/aas/3/0/DataTypeIEC61360/IntegerCount> rdf:type aas:DataTypeIEC61360 ;
+###  https://admin-shell.io/aas/3/0/DataTypeIec61360/IntegerCount
+<https://admin-shell.io/aas/3/0/DataTypeIec61360/IntegerCount> rdf:type aas:DataTypeIec61360 ;
     rdfs:label "Integer Count"^^xs:string ;
     rdfs:comment "values containing values of type INTEGER but are no currencies or measures"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeIEC61360/IntegerCurrency
-<https://admin-shell.io/aas/3/0/DataTypeIEC61360/IntegerCurrency> rdf:type aas:DataTypeIEC61360 ;
+###  https://admin-shell.io/aas/3/0/DataTypeIec61360/IntegerCurrency
+<https://admin-shell.io/aas/3/0/DataTypeIec61360/IntegerCurrency> rdf:type aas:DataTypeIec61360 ;
     rdfs:label "Integer Currency"^^xs:string ;
     rdfs:comment "values containing values of type INTEGER that are currencies"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeIEC61360/IntegerMeasure
-<https://admin-shell.io/aas/3/0/DataTypeIEC61360/IntegerMeasure> rdf:type aas:DataTypeIEC61360 ;
+###  https://admin-shell.io/aas/3/0/DataTypeIec61360/IntegerMeasure
+<https://admin-shell.io/aas/3/0/DataTypeIec61360/IntegerMeasure> rdf:type aas:DataTypeIec61360 ;
     rdfs:label "Integer Measure"^^xs:string ;
     rdfs:comment "values containing values that are measure of type INTEGER. In addition such a value comes with a physical unit."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeIEC61360/Irdi
-<https://admin-shell.io/aas/3/0/DataTypeIEC61360/Irdi> rdf:type aas:DataTypeIEC61360 ;
+###  https://admin-shell.io/aas/3/0/DataTypeIec61360/Irdi
+<https://admin-shell.io/aas/3/0/DataTypeIec61360/Irdi> rdf:type aas:DataTypeIec61360 ;
     rdfs:label "IRDI"^^xs:string ;
     rdfs:comment "values conforming to ISO/IEC 11179 series global identifier sequences"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeIEC61360/Iri
-<https://admin-shell.io/aas/3/0/DataTypeIEC61360/Iri> rdf:type aas:DataTypeIEC61360 ;
+###  https://admin-shell.io/aas/3/0/DataTypeIec61360/Iri
+<https://admin-shell.io/aas/3/0/DataTypeIec61360/Iri> rdf:type aas:DataTypeIec61360 ;
     rdfs:label "IRI"^^xs:string ;
     rdfs:comment "values containing values of type STRING conformant to Rfc 3987"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeIEC61360/Rational
-<https://admin-shell.io/aas/3/0/DataTypeIEC61360/Rational> rdf:type aas:DataTypeIEC61360 ;
+###  https://admin-shell.io/aas/3/0/DataTypeIec61360/Rational
+<https://admin-shell.io/aas/3/0/DataTypeIec61360/Rational> rdf:type aas:DataTypeIec61360 ;
     rdfs:label "Rational"^^xs:string ;
     rdfs:comment "values containing values of type rational"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeIEC61360/RationalMeasure
-<https://admin-shell.io/aas/3/0/DataTypeIEC61360/RationalMeasure> rdf:type aas:DataTypeIEC61360 ;
+###  https://admin-shell.io/aas/3/0/DataTypeIec61360/RationalMeasure
+<https://admin-shell.io/aas/3/0/DataTypeIec61360/RationalMeasure> rdf:type aas:DataTypeIec61360 ;
     rdfs:label "Rational Measure"^^xs:string ;
     rdfs:comment "values containing values of type rational. In addition such a value comes with a physical unit."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeIEC61360/RealCount
-<https://admin-shell.io/aas/3/0/DataTypeIEC61360/RealCount> rdf:type aas:DataTypeIEC61360 ;
+###  https://admin-shell.io/aas/3/0/DataTypeIec61360/RealCount
+<https://admin-shell.io/aas/3/0/DataTypeIec61360/RealCount> rdf:type aas:DataTypeIec61360 ;
     rdfs:label "Real Count"^^xs:string ;
     rdfs:comment "values containing numbers that can be written as a terminating or non-terminating decimal; a rational or irrational number but are no currencies or measures"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeIEC61360/RealCurrency
-<https://admin-shell.io/aas/3/0/DataTypeIEC61360/RealCurrency> rdf:type aas:DataTypeIEC61360 ;
+###  https://admin-shell.io/aas/3/0/DataTypeIec61360/RealCurrency
+<https://admin-shell.io/aas/3/0/DataTypeIec61360/RealCurrency> rdf:type aas:DataTypeIec61360 ;
     rdfs:label "Real Currency"^^xs:string ;
     rdfs:comment "values containing values of type REAL that are currencies"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeIEC61360/RealMeasure
-<https://admin-shell.io/aas/3/0/DataTypeIEC61360/RealMeasure> rdf:type aas:DataTypeIEC61360 ;
+###  https://admin-shell.io/aas/3/0/DataTypeIec61360/RealMeasure
+<https://admin-shell.io/aas/3/0/DataTypeIec61360/RealMeasure> rdf:type aas:DataTypeIec61360 ;
     rdfs:label "Real Measure"^^xs:string ;
     rdfs:comment "values containing values that are measures of type REAL. In addition such a value comes with a physical unit."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeIEC61360/String
-<https://admin-shell.io/aas/3/0/DataTypeIEC61360/String> rdf:type aas:DataTypeIEC61360 ;
+###  https://admin-shell.io/aas/3/0/DataTypeIec61360/String
+<https://admin-shell.io/aas/3/0/DataTypeIec61360/String> rdf:type aas:DataTypeIec61360 ;
     rdfs:label "String"^^xs:string ;
     rdfs:comment "values consisting of sequence of characters but cannot be translated into other languages"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeIEC61360/StringTranslatable
-<https://admin-shell.io/aas/3/0/DataTypeIEC61360/StringTranslatable> rdf:type aas:DataTypeIEC61360 ;
+###  https://admin-shell.io/aas/3/0/DataTypeIec61360/StringTranslatable
+<https://admin-shell.io/aas/3/0/DataTypeIec61360/StringTranslatable> rdf:type aas:DataTypeIec61360 ;
     rdfs:label "String Translatable"^^xs:string ;
     rdfs:comment "values containing string but shall be represented as different string in different languages"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeIEC61360/Time
-<https://admin-shell.io/aas/3/0/DataTypeIEC61360/Time> rdf:type aas:DataTypeIEC61360 ;
+###  https://admin-shell.io/aas/3/0/DataTypeIec61360/Time
+<https://admin-shell.io/aas/3/0/DataTypeIec61360/Time> rdf:type aas:DataTypeIec61360 ;
     rdfs:label "Time"^^xs:string ;
     rdfs:comment "values containing a time, conformant to ISO 8601:2004 but restricted to what is allowed in the corresponding type in xml."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/DataTypeIEC61360/Timestamp
-<https://admin-shell.io/aas/3/0/DataTypeIEC61360/Timestamp> rdf:type aas:DataTypeIEC61360 ;
+###  https://admin-shell.io/aas/3/0/DataTypeIec61360/Timestamp
+<https://admin-shell.io/aas/3/0/DataTypeIec61360/Timestamp> rdf:type aas:DataTypeIec61360 ;
     rdfs:label "Timestamp"^^xs:string ;
     rdfs:comment "values containing a time, conformant to ISO 8601:2004 but restricted to what is allowed in the corresponding type in xml."@en ;
 .
@@ -924,8 +924,8 @@ aas:Entity rdf:type owl:Class ;
     rdfs:comment "Describes whether the entity is a co-managed entity or a self-managed entity."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/Entity/globalAssetID
-<https://admin-shell.io/aas/3/0/Entity/globalAssetID> rdf:type owl:DatatypeProperty ;
+###  https://admin-shell.io/aas/3/0/Entity/globalAssetId
+<https://admin-shell.io/aas/3/0/Entity/globalAssetId> rdf:type owl:DatatypeProperty ;
     rdfs:label "has global asset ID"^^xs:string ;
     rdfs:domain aas:Entity ;
     rdfs:range xs:string ;
@@ -936,7 +936,7 @@ aas:Entity rdf:type owl:Class ;
 <https://admin-shell.io/aas/3/0/Entity/specificAssetIds> rdf:type owl:ObjectProperty ;
     rdfs:label "has specific asset IDs"^^xs:string ;
     rdfs:domain aas:Entity ;
-    rdfs:range aas:SpecificAssetID ;
+    rdfs:range aas:SpecificAssetId ;
     rdfs:comment "Reference to a specific asset ID representing a supplementary identifier of the asset represented by the Asset Administration Shell."@en ;
 .
 
@@ -1021,12 +1021,12 @@ aas:EventPayload rdf:type owl:Class ;
     rdfs:comment "Reference to the referable, which defines the scope of the event."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/EventPayload/observableSemanticID
-<https://admin-shell.io/aas/3/0/EventPayload/observableSemanticID> rdf:type owl:ObjectProperty ;
+###  https://admin-shell.io/aas/3/0/EventPayload/observableSemanticId
+<https://admin-shell.io/aas/3/0/EventPayload/observableSemanticId> rdf:type owl:ObjectProperty ;
     rdfs:label "has observable semantic ID"^^xs:string ;
     rdfs:domain aas:EventPayload ;
     rdfs:range aas:Reference ;
-    rdfs:comment "'semanticID' of the referable which defines the scope of the event, if available."@en ;
+    rdfs:comment "'semanticId' of the referable which defines the scope of the event, if available."@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/EventPayload/payload
@@ -1045,16 +1045,16 @@ aas:EventPayload rdf:type owl:Class ;
     rdfs:comment "Reference to the source event element, including identification of 'AssetAdministrationShell', 'Submodel', 'SubmodelElement''s."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/EventPayload/sourceSemanticID
-<https://admin-shell.io/aas/3/0/EventPayload/sourceSemanticID> rdf:type owl:ObjectProperty ;
+###  https://admin-shell.io/aas/3/0/EventPayload/sourceSemanticId
+<https://admin-shell.io/aas/3/0/EventPayload/sourceSemanticId> rdf:type owl:ObjectProperty ;
     rdfs:label "has source semantic ID"^^xs:string ;
     rdfs:domain aas:EventPayload ;
     rdfs:range aas:Reference ;
-    rdfs:comment "'semanticID' of the source event element, if available"@en ;
+    rdfs:comment "'semanticId' of the source event element, if available"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/EventPayload/subjectID
-<https://admin-shell.io/aas/3/0/EventPayload/subjectID> rdf:type owl:ObjectProperty ;
+###  https://admin-shell.io/aas/3/0/EventPayload/subjectId
+<https://admin-shell.io/aas/3/0/EventPayload/subjectId> rdf:type owl:ObjectProperty ;
     rdfs:label "has subject ID"^^xs:string ;
     rdfs:domain aas:EventPayload ;
     rdfs:range aas:Reference ;
@@ -1112,7 +1112,7 @@ aas:Extension rdf:type owl:Class ;
 <https://admin-shell.io/aas/3/0/Extension/valueType> rdf:type owl:ObjectProperty ;
     rdfs:label "has value type"^^xs:string ;
     rdfs:domain aas:Extension ;
-    rdfs:range aas:DataTypeDefXSD ;
+    rdfs:range aas:DataTypeDefXsd ;
     rdfs:comment "Type of the value of the extension."@en ;
 .
 
@@ -1187,8 +1187,8 @@ aas:HasSemantics rdf:type owl:Class ;
     rdfs:comment "Element that can have a semantic definition plus some supplemental semantic definitions."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/HasSemantics/semanticID
-<https://admin-shell.io/aas/3/0/HasSemantics/semanticID> rdf:type owl:ObjectProperty ;
+###  https://admin-shell.io/aas/3/0/HasSemantics/semanticId
+<https://admin-shell.io/aas/3/0/HasSemantics/semanticId> rdf:type owl:ObjectProperty ;
     rdfs:label "has semantic ID"^^xs:string ;
     rdfs:domain aas:HasSemantics ;
     rdfs:range aas:Reference ;
@@ -1411,8 +1411,8 @@ aas:KeyTypes rdf:type owl:Class ;
     rdfs:comment "List of Submodel Elements"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/LangStringDefinitionTypeIEC61360
-aas:LangStringDefinitionTypeIEC61360 rdf:type owl:Class ;
+###  https://admin-shell.io/aas/3/0/LangStringDefinitionTypeIec61360
+aas:LangStringDefinitionTypeIec61360 rdf:type owl:Class ;
     rdfs:subClassOf aas:AbstractLangString ;
     rdfs:label "Lang String Definition Type IEC 61360"^^xs:string ;
     rdfs:comment "String with length 1023 maximum and minimum 1 characters and with language tags"@en ;
@@ -1425,15 +1425,15 @@ aas:LangStringNameType rdf:type owl:Class ;
     rdfs:comment "String with length 128 maximum and minimum 1 characters and with language tags"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/LangStringPreferredNameTypeIEC61360
-aas:LangStringPreferredNameTypeIEC61360 rdf:type owl:Class ;
+###  https://admin-shell.io/aas/3/0/LangStringPreferredNameTypeIec61360
+aas:LangStringPreferredNameTypeIec61360 rdf:type owl:Class ;
     rdfs:subClassOf aas:AbstractLangString ;
     rdfs:label "Lang String Preferred Name Type IEC 61360"^^xs:string ;
     rdfs:comment "String with length 255 maximum and minimum 1 characters and with language tags"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/LangStringShortNameTypeIEC61360
-aas:LangStringShortNameTypeIEC61360 rdf:type owl:Class ;
+###  https://admin-shell.io/aas/3/0/LangStringShortNameTypeIec61360
+aas:LangStringShortNameTypeIec61360 rdf:type owl:Class ;
     rdfs:subClassOf aas:AbstractLangString ;
     rdfs:label "Lang String Short Name Type IEC 61360"^^xs:string ;
     rdfs:comment "String with length 18 maximum and minimum 1 characters and with language tags"@en ;
@@ -1521,8 +1521,8 @@ aas:MultiLanguageProperty rdf:type owl:Class ;
     rdfs:comment "The value of the property instance."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/MultiLanguageProperty/valueID
-<https://admin-shell.io/aas/3/0/MultiLanguageProperty/valueID> rdf:type owl:ObjectProperty ;
+###  https://admin-shell.io/aas/3/0/MultiLanguageProperty/valueId
+<https://admin-shell.io/aas/3/0/MultiLanguageProperty/valueId> rdf:type owl:ObjectProperty ;
     rdfs:label "has value ID"^^xs:string ;
     rdfs:domain aas:MultiLanguageProperty ;
     rdfs:range aas:Reference ;
@@ -1589,8 +1589,8 @@ aas:Property rdf:type owl:Class ;
     rdfs:comment "The value of the property instance."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/Property/valueID
-<https://admin-shell.io/aas/3/0/Property/valueID> rdf:type owl:ObjectProperty ;
+###  https://admin-shell.io/aas/3/0/Property/valueId
+<https://admin-shell.io/aas/3/0/Property/valueId> rdf:type owl:ObjectProperty ;
     rdfs:label "has value ID"^^xs:string ;
     rdfs:domain aas:Property ;
     rdfs:range aas:Reference ;
@@ -1601,7 +1601,7 @@ aas:Property rdf:type owl:Class ;
 <https://admin-shell.io/aas/3/0/Property/valueType> rdf:type owl:ObjectProperty ;
     rdfs:label "has value type"^^xs:string ;
     rdfs:domain aas:Property ;
-    rdfs:range aas:DataTypeDefXSD ;
+    rdfs:range aas:DataTypeDefXsd ;
     rdfs:comment "Data type of the value"@en ;
 .
 
@@ -1650,8 +1650,8 @@ aas:Qualifier rdf:type owl:Class ;
     rdfs:comment "The qualifier value is the value of the qualifier."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/Qualifier/valueID
-<https://admin-shell.io/aas/3/0/Qualifier/valueID> rdf:type owl:ObjectProperty ;
+###  https://admin-shell.io/aas/3/0/Qualifier/valueId
+<https://admin-shell.io/aas/3/0/Qualifier/valueId> rdf:type owl:ObjectProperty ;
     rdfs:label "has value ID"^^xs:string ;
     rdfs:domain aas:Qualifier ;
     rdfs:range aas:Reference ;
@@ -1662,7 +1662,7 @@ aas:Qualifier rdf:type owl:Class ;
 <https://admin-shell.io/aas/3/0/Qualifier/valueType> rdf:type owl:ObjectProperty ;
     rdfs:label "has value type"^^xs:string ;
     rdfs:domain aas:Qualifier ;
-    rdfs:range aas:DataTypeDefXSD ;
+    rdfs:range aas:DataTypeDefXsd ;
     rdfs:comment "Data type of the qualifier value."@en ;
 .
 
@@ -1680,7 +1680,7 @@ aas:QualifierKind rdf:type owl:Class ;
 ###  https://admin-shell.io/aas/3/0/QualifierKind/ConceptQualifier
 <https://admin-shell.io/aas/3/0/QualifierKind/ConceptQualifier> rdf:type aas:QualifierKind ;
     rdfs:label "Concept Qualifier"^^xs:string ;
-    rdfs:comment "qualifies the semantic definition the element is referring to ('semanticID')"@en ;
+    rdfs:comment "qualifies the semantic definition the element is referring to ('semanticId')"@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/QualifierKind/TemplateQualifier
@@ -1722,7 +1722,7 @@ aas:Range rdf:type owl:Class ;
 <https://admin-shell.io/aas/3/0/Range/valueType> rdf:type owl:ObjectProperty ;
     rdfs:label "has value type"^^xs:string ;
     rdfs:domain aas:Range ;
-    rdfs:range aas:DataTypeDefXSD ;
+    rdfs:range aas:DataTypeDefXsd ;
     rdfs:comment "Data type of the min und max"@en ;
 .
 
@@ -1779,12 +1779,12 @@ aas:Reference rdf:type owl:Class ;
     rdfs:comment "Unique references in their name space."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/Reference/referredSemanticID
-<https://admin-shell.io/aas/3/0/Reference/referredSemanticID> rdf:type owl:ObjectProperty ;
+###  https://admin-shell.io/aas/3/0/Reference/referredSemanticId
+<https://admin-shell.io/aas/3/0/Reference/referredSemanticId> rdf:type owl:ObjectProperty ;
     rdfs:label "has referred semantic ID"^^xs:string ;
     rdfs:domain aas:Reference ;
     rdfs:range aas:Reference ;
-    rdfs:comment "'semanticID' of the referenced model element ('type' = 'ModelReference')."@en ;
+    rdfs:comment "'semanticId' of the referenced model element ('type' = 'ModelReference')."@en ;
 .
 
 ###  https://admin-shell.io/aas/3/0/Reference/type
@@ -1877,33 +1877,33 @@ aas:Resource rdf:type owl:Class ;
     rdfs:comment "Path and name of the resource (with file extension)."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/SpecificAssetID
-aas:SpecificAssetID rdf:type owl:Class ;
+###  https://admin-shell.io/aas/3/0/SpecificAssetId
+aas:SpecificAssetId rdf:type owl:Class ;
     rdfs:subClassOf aas:HasSemantics ;
     rdfs:label "Specific Asset ID"^^xs:string ;
     rdfs:comment "A specific asset ID describes a generic supplementary identifying attribute of the asset."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/SpecificAssetID/externalSubjectID
-<https://admin-shell.io/aas/3/0/SpecificAssetID/externalSubjectID> rdf:type owl:ObjectProperty ;
+###  https://admin-shell.io/aas/3/0/SpecificAssetId/externalSubjectId
+<https://admin-shell.io/aas/3/0/SpecificAssetId/externalSubjectId> rdf:type owl:ObjectProperty ;
     rdfs:label "has external subject ID"^^xs:string ;
-    rdfs:domain aas:SpecificAssetID ;
+    rdfs:domain aas:SpecificAssetId ;
     rdfs:range aas:Reference ;
     rdfs:comment "The (external) subject the key belongs to or has meaning to."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/SpecificAssetID/name
-<https://admin-shell.io/aas/3/0/SpecificAssetID/name> rdf:type owl:DatatypeProperty ;
+###  https://admin-shell.io/aas/3/0/SpecificAssetId/name
+<https://admin-shell.io/aas/3/0/SpecificAssetId/name> rdf:type owl:DatatypeProperty ;
     rdfs:label "has name"^^xs:string ;
-    rdfs:domain aas:SpecificAssetID ;
+    rdfs:domain aas:SpecificAssetId ;
     rdfs:range xs:string ;
     rdfs:comment "Name of the identifier"@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/SpecificAssetID/value
-<https://admin-shell.io/aas/3/0/SpecificAssetID/value> rdf:type owl:DatatypeProperty ;
+###  https://admin-shell.io/aas/3/0/SpecificAssetId/value
+<https://admin-shell.io/aas/3/0/SpecificAssetId/value> rdf:type owl:DatatypeProperty ;
     rdfs:label "has value"^^xs:string ;
-    rdfs:domain aas:SpecificAssetID ;
+    rdfs:domain aas:SpecificAssetId ;
     rdfs:range xs:string ;
     rdfs:comment "The value of the specific asset identifier with the corresponding name."@en ;
 .
@@ -1989,8 +1989,8 @@ aas:SubmodelElementList rdf:type owl:Class ;
     rdfs:comment "Defines whether order in list is relevant. If 'orderRelevant' = False then the list is representing a set or a bag."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/SubmodelElementList/semanticIDListElement
-<https://admin-shell.io/aas/3/0/SubmodelElementList/semanticIDListElement> rdf:type owl:ObjectProperty ;
+###  https://admin-shell.io/aas/3/0/SubmodelElementList/semanticIdListElement
+<https://admin-shell.io/aas/3/0/SubmodelElementList/semanticIdListElement> rdf:type owl:ObjectProperty ;
     rdfs:label "has semantic ID list element"^^xs:string ;
     rdfs:domain aas:SubmodelElementList ;
     rdfs:range aas:Reference ;
@@ -2001,7 +2001,7 @@ aas:SubmodelElementList rdf:type owl:Class ;
 <https://admin-shell.io/aas/3/0/SubmodelElementList/typeValueListElement> rdf:type owl:ObjectProperty ;
     rdfs:label "has type value list element"^^xs:string ;
     rdfs:domain aas:SubmodelElementList ;
-    rdfs:range aas:AASSubmodelElements ;
+    rdfs:range aas:AasSubmodelElements ;
     rdfs:comment "The submodel element type of the submodel elements contained in the list."@en ;
 .
 
@@ -2017,7 +2017,7 @@ aas:SubmodelElementList rdf:type owl:Class ;
 <https://admin-shell.io/aas/3/0/SubmodelElementList/valueTypeListElement> rdf:type owl:ObjectProperty ;
     rdfs:label "has value type list element"^^xs:string ;
     rdfs:domain aas:SubmodelElementList ;
-    rdfs:range aas:DataTypeDefXSD ;
+    rdfs:range aas:DataTypeDefXsd ;
     rdfs:comment "The value type of the submodel element contained in the list."@en ;
 .
 
@@ -2046,11 +2046,11 @@ aas:ValueReferencePair rdf:type owl:Class ;
     rdfs:label "has value"^^xs:string ;
     rdfs:domain aas:ValueReferencePair ;
     rdfs:range xs:string ;
-    rdfs:comment "The value of the referenced concept definition of the value in 'valueID'."@en ;
+    rdfs:comment "The value of the referenced concept definition of the value in 'valueId'."@en ;
 .
 
-###  https://admin-shell.io/aas/3/0/ValueReferencePair/valueID
-<https://admin-shell.io/aas/3/0/ValueReferencePair/valueID> rdf:type owl:ObjectProperty ;
+###  https://admin-shell.io/aas/3/0/ValueReferencePair/valueId
+<https://admin-shell.io/aas/3/0/ValueReferencePair/valueId> rdf:type owl:ObjectProperty ;
     rdfs:label "has value ID"^^xs:string ;
     rdfs:domain aas:ValueReferencePair ;
     rdfs:range aas:Reference ;

--- a/test_data/rdf_shacl/test_main/expected/aas_core_meta.v3/expected_output/shacl-schema.ttl
+++ b/test_data/rdf_shacl/test_main/expected/aas_core_meta.v3/expected_output/shacl-schema.ttl
@@ -83,7 +83,7 @@ aas:AdministrativeInformationShape a sh:NodeShape ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/AdministrativeInformation/templateID> ;
+        sh:path <https://admin-shell.io/aas/3/0/AdministrativeInformation/templateId> ;
         sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
@@ -141,7 +141,7 @@ aas:AssetInformationShape a sh:NodeShape ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/AssetInformation/globalAssetID> ;
+        sh:path <https://admin-shell.io/aas/3/0/AssetInformation/globalAssetId> ;
         sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
@@ -152,7 +152,7 @@ aas:AssetInformationShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <https://admin-shell.io/aas/3/0/AssetInformation/specificAssetIds> ;
-        sh:class aas:SpecificAssetID ;
+        sh:class aas:SpecificAssetId ;
         sh:minCount 0 ;
     ] ;
     sh:property [
@@ -314,24 +314,24 @@ aas:DataSpecificationContentShape a sh:NodeShape ;
     ] ;
 .
 
-aas:DataSpecificationIEC61360Shape a sh:NodeShape ;
-    sh:targetClass aas:DataSpecificationIEC61360 ;
+aas:DataSpecificationIec61360Shape a sh:NodeShape ;
+    sh:targetClass aas:DataSpecificationIec61360 ;
     rdfs:subClassOf aas:DataSpecificationContentShape ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/preferredName> ;
-        sh:class aas:LangStringPreferredNameTypeIEC61360 ;
+        sh:path <https://admin-shell.io/aas/3/0/DataSpecificationIec61360/preferredName> ;
+        sh:class aas:LangStringPreferredNameTypeIec61360 ;
         sh:minCount 1 ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/shortName> ;
-        sh:class aas:LangStringShortNameTypeIEC61360 ;
+        sh:path <https://admin-shell.io/aas/3/0/DataSpecificationIec61360/shortName> ;
+        sh:class aas:LangStringShortNameTypeIec61360 ;
         sh:minCount 0 ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/unit> ;
+        sh:path <https://admin-shell.io/aas/3/0/DataSpecificationIec61360/unit> ;
         sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
@@ -340,14 +340,14 @@ aas:DataSpecificationIEC61360Shape a sh:NodeShape ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/unitID> ;
+        sh:path <https://admin-shell.io/aas/3/0/DataSpecificationIec61360/unitId> ;
         sh:class aas:Reference ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/sourceOfDefinition> ;
+        sh:path <https://admin-shell.io/aas/3/0/DataSpecificationIec61360/sourceOfDefinition> ;
         sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
@@ -356,7 +356,7 @@ aas:DataSpecificationIEC61360Shape a sh:NodeShape ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/symbol> ;
+        sh:path <https://admin-shell.io/aas/3/0/DataSpecificationIec61360/symbol> ;
         sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
@@ -365,20 +365,20 @@ aas:DataSpecificationIEC61360Shape a sh:NodeShape ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/dataType> ;
-        sh:class aas:DataTypeIEC61360 ;
+        sh:path <https://admin-shell.io/aas/3/0/DataSpecificationIec61360/dataType> ;
+        sh:class aas:DataTypeIec61360 ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/definition> ;
-        sh:class aas:LangStringDefinitionTypeIEC61360 ;
+        sh:path <https://admin-shell.io/aas/3/0/DataSpecificationIec61360/definition> ;
+        sh:class aas:LangStringDefinitionTypeIec61360 ;
         sh:minCount 0 ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/valueFormat> ;
+        sh:path <https://admin-shell.io/aas/3/0/DataSpecificationIec61360/valueFormat> ;
         sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
@@ -387,14 +387,14 @@ aas:DataSpecificationIEC61360Shape a sh:NodeShape ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/valueList> ;
+        sh:path <https://admin-shell.io/aas/3/0/DataSpecificationIec61360/valueList> ;
         sh:class aas:ValueList ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/value> ;
+        sh:path <https://admin-shell.io/aas/3/0/DataSpecificationIec61360/value> ;
         sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
@@ -404,7 +404,7 @@ aas:DataSpecificationIEC61360Shape a sh:NodeShape ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/DataSpecificationIEC61360/levelType> ;
+        sh:path <https://admin-shell.io/aas/3/0/DataSpecificationIec61360/levelType> ;
         sh:class aas:LevelType ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
@@ -447,7 +447,7 @@ aas:EntityShape a sh:NodeShape ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/Entity/globalAssetID> ;
+        sh:path <https://admin-shell.io/aas/3/0/Entity/globalAssetId> ;
         sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
@@ -458,7 +458,7 @@ aas:EntityShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <https://admin-shell.io/aas/3/0/Entity/specificAssetIds> ;
-        sh:class aas:SpecificAssetID ;
+        sh:class aas:SpecificAssetId ;
         sh:minCount 0 ;
     ] ;
 .
@@ -513,7 +513,7 @@ aas:EventPayloadShape a sh:NodeShape ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/EventPayload/sourceSemanticID> ;
+        sh:path <https://admin-shell.io/aas/3/0/EventPayload/sourceSemanticId> ;
         sh:class aas:Reference ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
@@ -527,7 +527,7 @@ aas:EventPayloadShape a sh:NodeShape ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/EventPayload/observableSemanticID> ;
+        sh:path <https://admin-shell.io/aas/3/0/EventPayload/observableSemanticId> ;
         sh:class aas:Reference ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
@@ -544,7 +544,7 @@ aas:EventPayloadShape a sh:NodeShape ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/EventPayload/subjectID> ;
+        sh:path <https://admin-shell.io/aas/3/0/EventPayload/subjectId> ;
         sh:class aas:Reference ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
@@ -582,7 +582,7 @@ aas:ExtensionShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <https://admin-shell.io/aas/3/0/Extension/valueType> ;
-        sh:class aas:DataTypeDefXSD ;
+        sh:class aas:DataTypeDefXsd ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
     ] ;
@@ -711,7 +711,7 @@ aas:HasSemanticsShape a sh:NodeShape ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/HasSemantics/semanticID> ;
+        sh:path <https://admin-shell.io/aas/3/0/HasSemantics/semanticId> ;
         sh:class aas:Reference ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
@@ -779,12 +779,12 @@ aas:KeyShape a sh:NodeShape ;
     ] ;
 .
 
-aas:LangStringDefinitionTypeIEC61360Shape a sh:NodeShape ;
-    sh:targetClass aas:LangStringDefinitionTypeIEC61360 ;
+aas:LangStringDefinitionTypeIec61360Shape a sh:NodeShape ;
+    sh:targetClass aas:LangStringDefinitionTypeIec61360 ;
     rdfs:subClassOf aas:AbstractLangStringShape ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/LangStringDefinitionTypeIEC61360/text> ;
+        sh:path <https://admin-shell.io/aas/3/0/LangStringDefinitionTypeIec61360/text> ;
         sh:datatype xs:string ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
@@ -805,12 +805,12 @@ aas:LangStringNameTypeShape a sh:NodeShape ;
     ] ;
 .
 
-aas:LangStringPreferredNameTypeIEC61360Shape a sh:NodeShape ;
-    sh:targetClass aas:LangStringPreferredNameTypeIEC61360 ;
+aas:LangStringPreferredNameTypeIec61360Shape a sh:NodeShape ;
+    sh:targetClass aas:LangStringPreferredNameTypeIec61360 ;
     rdfs:subClassOf aas:AbstractLangStringShape ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/LangStringPreferredNameTypeIEC61360/text> ;
+        sh:path <https://admin-shell.io/aas/3/0/LangStringPreferredNameTypeIec61360/text> ;
         sh:datatype xs:string ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
@@ -818,12 +818,12 @@ aas:LangStringPreferredNameTypeIEC61360Shape a sh:NodeShape ;
     ] ;
 .
 
-aas:LangStringShortNameTypeIEC61360Shape a sh:NodeShape ;
-    sh:targetClass aas:LangStringShortNameTypeIEC61360 ;
+aas:LangStringShortNameTypeIec61360Shape a sh:NodeShape ;
+    sh:targetClass aas:LangStringShortNameTypeIec61360 ;
     rdfs:subClassOf aas:AbstractLangStringShape ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/LangStringShortNameTypeIEC61360/text> ;
+        sh:path <https://admin-shell.io/aas/3/0/LangStringShortNameTypeIec61360/text> ;
         sh:datatype xs:string ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
@@ -887,7 +887,7 @@ aas:MultiLanguagePropertyShape a sh:NodeShape ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/MultiLanguageProperty/valueID> ;
+        sh:path <https://admin-shell.io/aas/3/0/MultiLanguageProperty/valueId> ;
         sh:class aas:Reference ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
@@ -934,7 +934,7 @@ aas:PropertyShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <https://admin-shell.io/aas/3/0/Property/valueType> ;
-        sh:class aas:DataTypeDefXSD ;
+        sh:class aas:DataTypeDefXsd ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
     ] ;
@@ -947,7 +947,7 @@ aas:PropertyShape a sh:NodeShape ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/Property/valueID> ;
+        sh:path <https://admin-shell.io/aas/3/0/Property/valueId> ;
         sh:class aas:Reference ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
@@ -999,7 +999,7 @@ aas:QualifierShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <https://admin-shell.io/aas/3/0/Qualifier/valueType> ;
-        sh:class aas:DataTypeDefXSD ;
+        sh:class aas:DataTypeDefXsd ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
     ] ;
@@ -1012,7 +1012,7 @@ aas:QualifierShape a sh:NodeShape ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/Qualifier/valueID> ;
+        sh:path <https://admin-shell.io/aas/3/0/Qualifier/valueId> ;
         sh:class aas:Reference ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
@@ -1025,7 +1025,7 @@ aas:RangeShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <https://admin-shell.io/aas/3/0/Range/valueType> ;
-        sh:class aas:DataTypeDefXSD ;
+        sh:class aas:DataTypeDefXsd ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
     ] ;
@@ -1106,7 +1106,7 @@ aas:ReferenceShape a sh:NodeShape ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/Reference/referredSemanticID> ;
+        sh:path <https://admin-shell.io/aas/3/0/Reference/referredSemanticId> ;
         sh:class aas:Reference ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
@@ -1176,12 +1176,12 @@ aas:ResourceShape a sh:NodeShape ;
     ] ;
 .
 
-aas:SpecificAssetIDShape a sh:NodeShape ;
-    sh:targetClass aas:SpecificAssetID ;
+aas:SpecificAssetIdShape a sh:NodeShape ;
+    sh:targetClass aas:SpecificAssetId ;
     rdfs:subClassOf aas:HasSemanticsShape ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/SpecificAssetID/name> ;
+        sh:path <https://admin-shell.io/aas/3/0/SpecificAssetId/name> ;
         sh:datatype xs:string ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
@@ -1191,7 +1191,7 @@ aas:SpecificAssetIDShape a sh:NodeShape ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/SpecificAssetID/value> ;
+        sh:path <https://admin-shell.io/aas/3/0/SpecificAssetId/value> ;
         sh:datatype xs:string ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
@@ -1201,7 +1201,7 @@ aas:SpecificAssetIDShape a sh:NodeShape ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/SpecificAssetID/externalSubjectID> ;
+        sh:path <https://admin-shell.io/aas/3/0/SpecificAssetId/externalSubjectId> ;
         sh:class aas:Reference ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
@@ -1266,7 +1266,7 @@ aas:SubmodelElementListShape a sh:NodeShape ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/SubmodelElementList/semanticIDListElement> ;
+        sh:path <https://admin-shell.io/aas/3/0/SubmodelElementList/semanticIdListElement> ;
         sh:class aas:Reference ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
@@ -1274,14 +1274,14 @@ aas:SubmodelElementListShape a sh:NodeShape ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <https://admin-shell.io/aas/3/0/SubmodelElementList/typeValueListElement> ;
-        sh:class aas:AASSubmodelElements ;
+        sh:class aas:AasSubmodelElements ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
         sh:path <https://admin-shell.io/aas/3/0/SubmodelElementList/valueTypeListElement> ;
-        sh:class aas:DataTypeDefXSD ;
+        sh:class aas:DataTypeDefXsd ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
     ] ;
@@ -1317,7 +1317,7 @@ aas:ValueReferencePairShape a sh:NodeShape ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/ValueReferencePair/valueID> ;
+        sh:path <https://admin-shell.io/aas/3/0/ValueReferencePair/valueId> ;
         sh:class aas:Reference ;
         sh:minCount 1 ;
         sh:maxCount 1 ;


### PR DESCRIPTION
We change naming in V3 for RDF & SHACL to be consistent with XSD, and also to make life easier for downstream clients.

See: https://github.com/admin-shell-io/aas-specs/issues/263