### PR TITLE
Report unexpected text in XML sequences in C#

### DIFF
--- a/aas_core_codegen/csharp/xmlization/_generate.py
+++ b/aas_core_codegen/csharp/xmlization/_generate.py
@@ -622,8 +622,25 @@ default:
     blocks_for_non_empty.append(
         Stripped(
             f"""\
-while (reader.NodeType == Xml.XmlNodeType.Element)
+while (true)
 {{
+{I}SkipNoneWhitespaceAndComments(reader);
+
+{I}if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+{I}{{
+{II}break;
+{I}}}
+
+{I}if (reader.NodeType != Xml.XmlNodeType.Element)
+{I}{{
+{II}error = new Reporting.Error(
+{III}"Expected an XML start element representing " +
+{III}"a property of an instance of class {name}, " +
+{III}$"but got the node of type {{reader.NodeType}} " +
+{III}$"with the value {{reader.Value}}");
+{II}return null;
+{I}}}
+
 {I}string elementName = TryElementName(
 {II}reader, out error);
 {I}if (error != null)
@@ -682,13 +699,6 @@ while (reader.NodeType == Xml.XmlNodeType.Element)
 {II}}}
 {II}// Skip the expected end element
 {II}reader.Read();
-
-{II}SkipNoneWhitespaceAndComments(reader);
-{I}}}
-
-{I}if (reader.EOF)
-{I}{{
-{II}break;
 {I}}}
 }}"""
         )

--- a/test_data/csharp/test_main/aas_core_meta.v3/expected_output/xmlization.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3/expected_output/xmlization.cs
@@ -232,8 +232,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class Extension, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -518,13 +535,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -1067,8 +1077,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class AdministrativeInformation, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -1302,13 +1329,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -1543,8 +1563,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class Qualifier, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -1862,13 +1899,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -2040,8 +2070,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class AssetAdministrationShell, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -2447,13 +2494,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -2623,8 +2663,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class AssetInformation, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -2873,13 +2930,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -3030,8 +3080,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class Resource, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -3175,13 +3242,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -3332,8 +3392,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class SpecificAssetId, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -3541,13 +3618,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -3719,8 +3789,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class Submodel, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -4239,13 +4326,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -4499,8 +4579,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class RelationshipElement, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -4902,13 +4999,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -5137,8 +5227,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class SubmodelElementList, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -5719,13 +5826,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -5893,8 +5993,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class SubmodelElementCollection, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -6304,13 +6421,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -6528,8 +6638,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class Property, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -7012,13 +7139,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -7185,8 +7305,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class MultiLanguageProperty, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -7610,13 +7747,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -7773,8 +7903,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class Range, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -8283,13 +8430,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -8455,8 +8595,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class ReferenceElement, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -8844,13 +9001,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -9005,8 +9155,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class Blob, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -9468,13 +9635,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -9640,8 +9800,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class File, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -10095,13 +10272,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -10268,8 +10438,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class AnnotatedRelationshipElement, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -10707,13 +10894,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -10892,8 +11072,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class Entity, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -11434,13 +11631,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -11605,8 +11795,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class EventPayload, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -11868,13 +12075,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -12110,8 +12310,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class BasicEventElement, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -12783,13 +13000,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -12982,8 +13192,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class Operation, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -13465,13 +13692,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -13618,8 +13838,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class OperationVariable, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -13736,13 +13973,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -13896,8 +14126,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class Capability, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -14271,13 +14518,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -14429,8 +14669,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class ConceptDescription, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -14808,13 +15065,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -14970,8 +15220,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class Reference, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -15140,13 +15407,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -15305,8 +15565,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class Key, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -15465,13 +15742,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -15688,8 +15958,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class LangStringNameType, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -15833,13 +16120,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -15997,8 +16277,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class LangStringTextType, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -16142,13 +16439,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -16307,8 +16597,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class Environment, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -16480,13 +16787,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -16672,8 +16972,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class EmbeddedDataSpecification, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -16804,13 +17121,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -16970,8 +17280,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class LevelType, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -17223,13 +17550,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -17409,8 +17729,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class ValueReferencePair, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -17528,13 +17865,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -17691,8 +18021,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class ValueList, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -17792,13 +18139,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -17945,8 +18285,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class LangStringPreferredNameTypeIec61360, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -18090,13 +18447,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -18254,8 +18604,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class LangStringShortNameTypeIec61360, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -18399,13 +18766,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -18563,8 +18923,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class LangStringDefinitionTypeIec61360, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -18708,13 +19085,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }
@@ -18882,8 +19252,25 @@ namespace AasCore.Aas3_0
                             "but reached the end-of-file");
                         return null;
                     }
-                    while (reader.NodeType == Xml.XmlNodeType.Element)
+                    while (true)
                     {
+                        SkipNoneWhitespaceAndComments(reader);
+
+                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                        {
+                            break;
+                        }
+
+                        if (reader.NodeType != Xml.XmlNodeType.Element)
+                        {
+                            error = new Reporting.Error(
+                                "Expected an XML start element representing " +
+                                "a property of an instance of class DataSpecificationIec61360, " +
+                                $"but got the node of type {reader.NodeType} " +
+                                $"with the value {reader.Value}");
+                            return null;
+                        }
+
                         string elementName = TryElementName(
                             reader, out error);
                         if (error != null)
@@ -19352,13 +19739,6 @@ namespace AasCore.Aas3_0
                             }
                             // Skip the expected end element
                             reader.Read();
-
-                            SkipNoneWhitespaceAndComments(reader);
-                        }
-
-                        if (reader.EOF)
-                        {
-                            break;
                         }
                     }
                 }


### PR DESCRIPTION
Currently, we break out of the loop when parsing sequences of XML elements representing properties of an instances. This gives misleading error messages ("required property not set").

Instead, with this patch, we report that the text is unexpected, which is much clearer to the user.