### PR TITLE
Make visitation dispatches virtual in C#

### DIFF
--- a/aas_core_codegen/csharp/visitation/_generate.py
+++ b/aas_core_codegen/csharp/visitation/_generate.py
@@ -303,7 +303,7 @@ def _generate_abstract_visitor_with_context(
     blocks = [
         Stripped(
             f"""\
-public void Visit(IClass that, TContext context)
+public virtual void Visit(IClass that, TContext context)
 {{
 {I}that.Accept(this, context);
 }}"""
@@ -439,7 +439,7 @@ def _generate_abstract_transformer(symbol_table: intermediate.SymbolTable) -> St
     blocks = [
         Stripped(
             f"""\
-public T Transform(IClass that)
+public virtual T Transform(IClass that)
 {{
 {I}return that.Transform(this);
 }}"""
@@ -581,7 +581,7 @@ def _generate_abstract_transformer_with_context(
     blocks = [
         Stripped(
             f"""\
-public T Transform(IClass that, TContext context)
+public virtual T Transform(IClass that, TContext context)
 {{
 {I}return that.Transform(this, context);
 }}"""

--- a/test_data/csharp/test_main/aas_core_meta.v3/expected_output/visitation.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3/expected_output/visitation.cs
@@ -867,7 +867,7 @@ namespace AasCore.Aas3_0
         public abstract class AbstractVisitorWithContext<TContext>
             : IVisitorWithContext<TContext>
         {
-            public void Visit(IClass that, TContext context)
+            public virtual void Visit(IClass that, TContext context)
             {
                 that.Accept(this, context);
             }
@@ -1161,7 +1161,7 @@ namespace AasCore.Aas3_0
         /// <typeparam name="T">The type of the transformation result</typeparam>
         public abstract class AbstractTransformer<T> : ITransformer<T>
         {
-            public T Transform(IClass that)
+            public virtual T Transform(IClass that)
             {
                 return that.Transform(this);
             }
@@ -1501,7 +1501,7 @@ namespace AasCore.Aas3_0
         public abstract class AbstractTransformerWithContext<TContext, T>
             : ITransformerWithContext<TContext, T>
         {
-            public T Transform(IClass that, TContext context)
+            public virtual T Transform(IClass that, TContext context)
             {
                 return that.Transform(this, context);
             }


### PR DESCRIPTION
We eventually noticed that the `Visit` and `Transform` methods can not be overridden in the implementors of the respective visitors and transformers as they were not marked as `virtual`.

This patch fixes the issue.