### PR TITLE
Add `__repr__` to verification errors in Python

### DIFF
--- a/aas_core_codegen/python/verification/_generate.py
+++ b/aas_core_codegen/python/verification/_generate.py
@@ -1382,7 +1382,10 @@ class Error:
 {I}def __init__(self, cause: str) -> None:
 {II}\"\"\"Initialize as an error with an empty path.\"\"\"
 {II}self.cause = cause
-{II}self.path = Path()"""
+{II}self.path = Path()
+
+{I}def __repr__(self) -> str:
+{II}return f"Error(path={{self.path}}, cause={{self.cause}})\""""
         ),
     ]  # type: List[Stripped]
 

--- a/test_data/python/test_main/aas_core_meta.v3/expected_output/verification.py
+++ b/test_data/python/test_main/aas_core_meta.v3/expected_output/verification.py
@@ -130,6 +130,9 @@ class Error:
         self.cause = cause
         self.path = Path()
 
+    def __repr__(self) -> str:
+        return f"Error(path={self.path}, cause={self.cause})"
+
 
 # noinspection SpellCheckingInspection
 def _construct_matches_id_short() -> Pattern[str]:


### PR DESCRIPTION
We add the `__repr__` method to the verification error in order to facilitate debugging in the downstream applications.

See: https://github.com/aas-core-works/aas-core3.0-python/issues/11