### PR TITLE
Disable linting double negations in TypeScript

### DIFF
--- a/aas_core_codegen/typescript/verification/_generate.py
+++ b/aas_core_codegen/typescript/verification/_generate.py
@@ -1385,6 +1385,13 @@ import * as AasTypes from "./types";"""
         ),
         Stripped(
             f"""\
+// The generated code might contain deliberately double negations. For example,
+// when the constraint is formulated as a NAND and we check that the constraint
+// is not fulfilled. Therefore, we disable this linting rule.
+/* eslint no-extra-boolean-cast: 0 */"""
+        ),
+        Stripped(
+            f"""\
 /**
  * Represent a property access on a path to an erroneous value.
  */

--- a/test_data/typescript/test_main/aas_core_meta.v3/expected_output/verification.ts
+++ b/test_data/typescript/test_main/aas_core_meta.v3/expected_output/verification.ts
@@ -24,6 +24,11 @@ import * as AasCommon from "./common";
 import * as AasConstants from "./constants";
 import * as AasTypes from "./types";
 
+// The generated code might contain deliberately double negations. For example,
+// when the constraint is formulated as a NAND and we check that the constraint
+// is not fulfilled. Therefore, we disable this linting rule.
+/* eslint no-extra-boolean-cast: 0 */
+
 /**
  * Represent a property access on a path to an erroneous value.
  */


### PR DESCRIPTION
We disable the linter rule for double negations in the generated verification module since double negations are deliberately generated. Namely, we do check if a constraint is violated with "if not constraint fulfilled". If the constraint is formulated as a NAND, it will result in a (desired) double negation.