### PR TITLE
Upgrade greenery to 4.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ icontract>=2.5.2,<3
 sortedcontainers>=2.4.0,<3
 docutils>=0.18.1,<1
 more-itertools>=8,<9
-greenery==4.0.0
+greenery==4.1.0


### PR DESCRIPTION
We need to upgrade greenery to 4.1.0 so that we can merge regex patterns using character classes.

See: https://github.com/qntm/greenery/issues/81