### PR TITLE
Simplify iterations over our types using lists

### DIFF
--- a/aas_core_codegen/csharp/copying/_generate.py
+++ b/aas_core_codegen/csharp/copying/_generate.py
@@ -90,30 +90,27 @@ def _generate_shallow_copier(
 
     blocks = []  # type: List[Stripped]
 
-    for our_type in symbol_table.our_types:
-        if not isinstance(our_type, intermediate.ConcreteClass):
-            continue
-
-        if our_type.is_implementation_specific:
+    for cls in symbol_table.concrete_classes:
+        if cls.is_implementation_specific:
             implementation_key = specific_implementations.ImplementationKey(
-                f"Copying/ShallowCopier/transform_{our_type.name}.cs"
+                f"Copying/ShallowCopier/transform_{cls.name}.cs"
             )
 
             implementation = spec_impls.get(implementation_key, None)
             if implementation is None:
                 errors.append(
                     Error(
-                        our_type.parsed.node,
+                        cls.parsed.node,
                         f"The snippet for making shallow copies is missing "
                         f"for the implementation-specific "
-                        f"class {our_type.name}: {implementation_key}",
+                        f"class {cls.name}: {implementation_key}",
                     )
                 )
                 continue
 
             blocks.append(spec_impls[implementation_key])
         else:
-            blocks.append(_generate_shallow_copy_transform_method(cls=our_type))
+            blocks.append(_generate_shallow_copy_transform_method(cls=cls))
 
     writer = io.StringIO()
     writer.write(
@@ -313,30 +310,27 @@ def _generate_deep_copier(
 
     blocks = []  # type: List[Stripped]
 
-    for our_type in symbol_table.our_types:
-        if not isinstance(our_type, intermediate.ConcreteClass):
-            continue
-
-        if our_type.is_implementation_specific:
+    for cls in symbol_table.concrete_classes:
+        if cls.is_implementation_specific:
             implementation_key = specific_implementations.ImplementationKey(
-                f"Copying/DeepCopier/transform_{our_type.name}.cs"
+                f"Copying/DeepCopier/transform_{cls.name}.cs"
             )
 
             implementation = spec_impls.get(implementation_key, None)
             if implementation is None:
                 errors.append(
                     Error(
-                        our_type.parsed.node,
+                        cls.parsed.node,
                         f"The snippet for making deep copies is missing "
                         f"for the implementation-specific "
-                        f"class {our_type.name}: {implementation_key}",
+                        f"class {cls.name}: {implementation_key}",
                     )
                 )
                 continue
 
             blocks.append(spec_impls[implementation_key])
         else:
-            blocks.append(_generate_deep_copy_transform_method(cls=our_type))
+            blocks.append(_generate_deep_copy_transform_method(cls=cls))
 
     writer = io.StringIO()
     writer.write(

--- a/aas_core_codegen/csharp/enhancing/_generate.py
+++ b/aas_core_codegen/csharp/enhancing/_generate.py
@@ -387,20 +387,17 @@ internal Wrapper(
         ),
     ]  # type: List[Stripped]
 
-    for our_type in symbol_table.our_types:
-        if not isinstance(our_type, intermediate.ConcreteClass):
-            continue
-
-        if our_type.is_implementation_specific:
+    for cls in symbol_table.concrete_classes:
+        if cls.is_implementation_specific:
             implementation_key = specific_implementations.ImplementationKey(
-                f"Enhancing/Wrap/{our_type.name}.cs"
+                f"Enhancing/Wrap/{cls.name}.cs"
             )
 
             code = spec_impls.get(implementation_key, None)
             if code is None:
                 errors.append(
                     Error(
-                        our_type.parsed.node,
+                        cls.parsed.node,
                         f"The implementation is missing "
                         f"for the implementation-specific class: {implementation_key}",
                     )
@@ -410,7 +407,7 @@ internal Wrapper(
             blocks.append(code)
             continue
 
-        blocks.append(_generate_transform(cls=our_type))
+        blocks.append(_generate_transform(cls=cls))
 
     writer = io.StringIO()
     writer.write(
@@ -474,27 +471,24 @@ public abstract class Enhanced<TEnhancement> where TEnhancement : class
 
     errors = []  # type: List[Error]
 
-    for our_type in symbol_table.our_types:
-        if not isinstance(our_type, intermediate.ConcreteClass):
-            continue
-
-        if our_type.is_implementation_specific:
+    for cls in symbol_table.concrete_classes:
+        if cls.is_implementation_specific:
             implementation_key = specific_implementations.ImplementationKey(
-                f"Enhancing/Enhanced/{our_type.name}.cs"
+                f"Enhancing/Enhanced/{cls.name}.cs"
             )
 
             code = spec_impls.get(implementation_key, None)
             if code is None:
                 errors.append(
                     Error(
-                        our_type.parsed.node,
+                        cls.parsed.node,
                         f"The implementation is missing "
                         f"for the implementation-specific class: {implementation_key}",
                     )
                 )
                 continue
         else:
-            code, error = _generate_enhanced_class(cls=our_type)
+            code, error = _generate_enhanced_class(cls=cls)
             if error is not None:
                 errors.append(error)
                 continue

--- a/aas_core_codegen/csharp/jsonization/_generate.py
+++ b/aas_core_codegen/csharp/jsonization/_generate.py
@@ -941,13 +941,9 @@ def _generate_deserialize(
 """
     )
 
-    first_cls = None  # type: Optional[intermediate.ClassUnion]
-    for our_type in symbol_table.our_types:
-        if isinstance(
-            our_type, (intermediate.AbstractClass, intermediate.ConcreteClass)
-        ):
-            first_cls = our_type
-            break
+    first_cls = (
+        symbol_table.classes[0] if len(symbol_table.classes) > 0 else None
+    )  # type: Optional[intermediate.ClassUnion]
 
     if first_cls is not None:
         cls_name = None  # type: Optional[str]
@@ -1347,12 +1343,11 @@ public static Nodes.JsonObject ToJsonObject(Aas.IClass that)
         ),
     ]  # type: List[Stripped]
 
-    for our_type in symbol_table.our_types:
-        if isinstance(our_type, intermediate.Enumeration):
-            name = csharp_naming.enum_name(our_type.name)
-            blocks.append(
-                Stripped(
-                    f"""\
+    for enum in symbol_table.enumerations:
+        name = csharp_naming.enum_name(enum.name)
+        blocks.append(
+            Stripped(
+                f"""\
 /// <summary>
 /// Serialize a literal of {name} into a JSON string.
 /// </summary>
@@ -1363,8 +1358,8 @@ public static Nodes.JsonValue {name}ToJsonValue(Aas.{name} that)
 {II}?? throw new System.ArgumentException(
 {III}$"Invalid {name}: {{that}}");
 }}"""
-                )
             )
+        )
 
     writer = io.StringIO()
 
@@ -1376,13 +1371,9 @@ public static Nodes.JsonValue {name}ToJsonValue(Aas.{name} that)
 """
     )
 
-    first_cls = None  # type: Optional[intermediate.ClassUnion]
-    for our_type in symbol_table.our_types:
-        if isinstance(
-            our_type, (intermediate.AbstractClass, intermediate.ConcreteClass)
-        ):
-            first_cls = our_type
-            break
+    first_cls = (
+        symbol_table.classes[0] if len(symbol_table.classes) > 0 else None
+    )  # type: Optional[intermediate.ClassUnion]
 
     if first_cls is not None:
         cls_name = None  # type: Optional[str]

--- a/aas_core_codegen/csharp/stringification/_generate.py
+++ b/aas_core_codegen/csharp/stringification/_generate.py
@@ -201,12 +201,9 @@ using System.Collections.Generic;  // can't alias"""
 
     stringification_blocks = []  # type: List[Stripped]
 
-    for our_type in symbol_table.our_types:
-        if not isinstance(our_type, intermediate.Enumeration):
-            continue
-
+    for enum in symbol_table.enumerations:
         stringification_blocks.append(
-            _generate_enum_to_and_from_string(enumeration=our_type)
+            _generate_enum_to_and_from_string(enumeration=enum)
         )
 
     writer = io.StringIO()

--- a/aas_core_codegen/csharp/verification/_generate.py
+++ b/aas_core_codegen/csharp/verification/_generate.py
@@ -706,13 +706,10 @@ def _generate_enum_value_sets(symbol_table: intermediate.SymbolTable) -> Strippe
     """Generate a class that pre-computes the sets of allowed enumeration literals."""
     blocks = []  # type: List[Stripped]
 
-    for our_type in symbol_table.our_types:
-        if not isinstance(our_type, intermediate.Enumeration):
-            continue
+    for enum in symbol_table.enumerations:
+        enum_name = csharp_naming.enum_name(enum.name)
 
-        enum_name = csharp_naming.enum_name(our_type.name)
-
-        if len(our_type.literals) == 0:
+        if len(enum.literals) == 0:
             blocks.append(
                 Stripped(
                     f"""\
@@ -727,10 +724,10 @@ internal static readonly HashSet<int> For{enum_name} = new HashSet<int>\n{{\n
 """
             )
 
-            for i, literal in enumerate(our_type.literals):
+            for i, literal in enumerate(enum.literals):
                 literal_name = csharp_naming.enum_literal_name(literal.name)
                 hash_set_writer.write(f"{I}(int)Aas.{enum_name}.{literal_name}")
-                if i < len(our_type.literals) - 1:
+                if i < len(enum.literals) - 1:
                     hash_set_writer.write(",\n")
                 else:
                     hash_set_writer.write("\n")
@@ -1434,13 +1431,9 @@ namespace {namespace}
 
     # region Write an example usage
 
-    first_cls = None  # type: Optional[intermediate.ClassUnion]
-    for our_type in symbol_table.our_types:
-        if isinstance(
-            our_type, (intermediate.AbstractClass, intermediate.ConcreteClass)
-        ):
-            first_cls = our_type
-            break
+    first_cls = (
+        symbol_table.classes[0] if len(symbol_table.classes) > 0 else None
+    )  # type: Optional[intermediate.ClassUnion]
 
     if first_cls is not None:
         cls_name = None  # type: Optional[str]

--- a/aas_core_codegen/golang/jsonization/_generate.py
+++ b/aas_core_codegen/golang/jsonization/_generate.py
@@ -1551,14 +1551,14 @@ func (de *DeserializationError) PathString() string {{
     # NOTE (mristin, 2023-04-12):
     # We add all the dispatch mappings at the end as the functions might not have been
     # defined yet.
-    for our_type in symbol_table.our_types:
-        if isinstance(our_type, intermediate.AbstractClass):
-            blocks.append(_generate_class_from_map(cls=our_type))
-        elif isinstance(our_type, intermediate.ConcreteClass):
-            if len(our_type.concrete_descendants) > 0:
-                blocks.append(_generate_class_from_map(cls=our_type))
+    for cls in symbol_table.classes:
+        if isinstance(cls, intermediate.AbstractClass):
+            blocks.append(_generate_class_from_map(cls=cls))
+        elif isinstance(cls, intermediate.ConcreteClass):
+            if len(cls.concrete_descendants) > 0:
+                blocks.append(_generate_class_from_map(cls=cls))
         else:
-            pass
+            assert_never(cls)
 
     blocks.append(Stripped("// endregion"))
 

--- a/aas_core_codegen/golang/stringification/_generate.py
+++ b/aas_core_codegen/golang/stringification/_generate.py
@@ -376,12 +376,9 @@ import (
         _generate_model_type_to_string(symbol_table=symbol_table),
     ]
 
-    for our_type in symbol_table.our_types:
-        if not isinstance(our_type, intermediate.Enumeration):
-            continue
-
-        blocks.append(_generate_enum_from_string(enumeration=our_type))
-        blocks.append(_generate_enum_to_string(enumeration=our_type))
+    for enum in symbol_table.enumerations:
+        blocks.append(_generate_enum_from_string(enumeration=enum))
+        blocks.append(_generate_enum_to_string(enumeration=enum))
 
     blocks.append(golang_common.WARNING)
 

--- a/aas_core_codegen/jsonschema/main.py
+++ b/aas_core_codegen/jsonschema/main.py
@@ -923,12 +923,9 @@ def _generate(
         return None, errors
 
     model_types = sorted(
-        naming.json_model_type(our_type.name)
-        for our_type in symbol_table.our_types
-        if (
-            isinstance(our_type, intermediate.ConcreteClass)
-            and our_type.serialization.with_model_type
-        )
+        naming.json_model_type(cls.name)
+        for cls in symbol_table.concrete_classes
+        if cls.serialization.with_model_type
     )  # type: List[Identifier]
 
     definitions.update(

--- a/aas_core_codegen/python/stringification/_generate.py
+++ b/aas_core_codegen/python/stringification/_generate.py
@@ -110,12 +110,9 @@ import {aas_module}.types as aas_types"""
         ),
     ]
 
-    for our_type in symbol_table.our_types:
-        if not isinstance(our_type, intermediate.Enumeration):
-            continue
-
+    for enum in symbol_table.enumerations:
         blocks.append(
-            _generate_enum_from_string(enumeration=our_type, aas_module=aas_module)
+            _generate_enum_from_string(enumeration=enum, aas_module=aas_module)
         )
 
     blocks.append(python_common.WARNING)

--- a/aas_core_codegen/python/structure/_generate.py
+++ b/aas_core_codegen/python/structure/_generate.py
@@ -1,5 +1,6 @@
 """Generate the Python data structures from the intermediate representation."""
 import io
+import itertools
 import textwrap
 from typing import (
     Optional,
@@ -84,33 +85,23 @@ def _verify_structure_name_collisions(
 
     # region Inter-structure collisions
 
-    for our_type in symbol_table.our_types:
-        if not isinstance(
-            our_type,
-            (
-                intermediate.Enumeration,
-                intermediate.AbstractClass,
-                intermediate.ConcreteClass,
-            ),
-        ):
-            continue
-
-        name = python_naming.name_of(our_type)
+    for enum_or_cls in itertools.chain(symbol_table.enumerations, symbol_table.classes):
+        name = python_naming.name_of(enum_or_cls)
 
         other = observed_structure_names.get(name, None)
 
         if other is not None:
             errors.append(
                 Error(
-                    our_type.parsed.node,
+                    enum_or_cls.parsed.node,
                     f"The Python name {name!r} "
-                    f"of the {_human_readable_identifier(our_type)} "
+                    f"of the {_human_readable_identifier(enum_or_cls)} "
                     f"collides with the Python name "
                     f"of the {_human_readable_identifier(other)}",
                 )
             )
         else:
-            observed_structure_names[name] = our_type
+            observed_structure_names[name] = enum_or_cls
 
     # endregion
 
@@ -1124,12 +1115,9 @@ def visit(
         )
     ]  # type: List[Stripped]
 
-    for our_type in symbol_table.our_types:
-        if not isinstance(our_type, intermediate.ConcreteClass):
-            continue
-
-        visit_name = python_naming.method_name(Identifier(f"visit_{our_type.name}"))
-        cls_name = python_naming.class_name(our_type.name)
+    for cls in symbol_table.concrete_classes:
+        visit_name = python_naming.method_name(Identifier(f"visit_{cls.name}"))
+        cls_name = python_naming.class_name(cls.name)
 
         blocks.append(
             Stripped(
@@ -1178,14 +1166,11 @@ def visit_with_context(
         )
     ]  # type: List[Stripped]
 
-    for our_type in symbol_table.our_types:
-        if not isinstance(our_type, intermediate.ConcreteClass):
-            continue
-
+    for cls in symbol_table.concrete_classes:
         visit_with_context_name = python_naming.method_name(
-            Identifier(f"visit_{our_type.name}_with_context")
+            Identifier(f"visit_{cls.name}_with_context")
         )
-        cls_name = python_naming.class_name(our_type.name)
+        cls_name = python_naming.class_name(cls.name)
 
         blocks.append(
             Stripped(
@@ -1232,12 +1217,9 @@ def visit(
         )
     ]  # type: List[Stripped]
 
-    for our_type in symbol_table.our_types:
-        if not isinstance(our_type, intermediate.ConcreteClass):
-            continue
-
-        visit_name = python_naming.method_name(Identifier(f"visit_{our_type.name}"))
-        cls_name = python_naming.class_name(our_type.name)
+    for cls in symbol_table.concrete_classes:
+        visit_name = python_naming.method_name(Identifier(f"visit_{cls.name}"))
+        cls_name = python_naming.class_name(cls.name)
 
         blocks.append(
             Stripped(
@@ -1291,14 +1273,11 @@ def visit_with_context(
         )
     ]  # type: List[Stripped]
 
-    for our_type in symbol_table.our_types:
-        if not isinstance(our_type, intermediate.ConcreteClass):
-            continue
-
+    for cls in symbol_table.concrete_classes:
         visit_with_context_name = python_naming.method_name(
-            Identifier(f"visit_{our_type.name}_with_context")
+            Identifier(f"visit_{cls.name}_with_context")
         )
-        cls_name = python_naming.class_name(our_type.name)
+        cls_name = python_naming.class_name(cls.name)
 
         blocks.append(
             Stripped(
@@ -1352,15 +1331,10 @@ def transform(
         )
     ]  # type: List[Stripped]
 
-    for our_type in symbol_table.our_types:
-        if not isinstance(our_type, intermediate.ConcreteClass):
-            continue
+    for cls in symbol_table.concrete_classes:
+        transform_name = python_naming.method_name(Identifier(f"transform_{cls.name}"))
 
-        transform_name = python_naming.method_name(
-            Identifier(f"transform_{our_type.name}")
-        )
-
-        cls_name = python_naming.class_name(our_type.name)
+        cls_name = python_naming.class_name(cls.name)
 
         blocks.append(
             Stripped(
@@ -1409,15 +1383,12 @@ def transform_with_context(
         )
     ]  # type: List[Stripped]
 
-    for our_type in symbol_table.our_types:
-        if not isinstance(our_type, intermediate.ConcreteClass):
-            continue
-
+    for cls in symbol_table.concrete_classes:
         transform_with_context_name = python_naming.method_name(
-            Identifier(f"transform_{our_type.name}_with_context")
+            Identifier(f"transform_{cls.name}_with_context")
         )
 
-        cls_name = python_naming.class_name(our_type.name)
+        cls_name = python_naming.class_name(cls.name)
 
         blocks.append(
             Stripped(
@@ -1479,15 +1450,10 @@ def transform(
         ),
     ]  # type: List[Stripped]
 
-    for our_type in symbol_table.our_types:
-        if not isinstance(our_type, intermediate.ConcreteClass):
-            continue
+    for cls in symbol_table.concrete_classes:
+        transform_name = python_naming.method_name(Identifier(f"transform_{cls.name}"))
 
-        transform_name = python_naming.method_name(
-            Identifier(f"transform_{our_type.name}")
-        )
-
-        cls_name = python_naming.class_name(our_type.name)
+        cls_name = python_naming.class_name(cls.name)
 
         blocks.append(
             Stripped(
@@ -1551,15 +1517,12 @@ def transform_with_context(
         ),
     ]  # type: List[Stripped]
 
-    for our_type in symbol_table.our_types:
-        if not isinstance(our_type, intermediate.ConcreteClass):
-            continue
-
+    for cls in symbol_table.concrete_classes:
         transform_with_context_name = python_naming.method_name(
-            Identifier(f"transform_{our_type.name}_with_context")
+            Identifier(f"transform_{cls.name}_with_context")
         )
 
-        cls_name = python_naming.class_name(our_type.name)
+        cls_name = python_naming.class_name(cls.name)
 
         blocks.append(
             Stripped(

--- a/aas_core_codegen/python/verification/_generate.py
+++ b/aas_core_codegen/python/verification/_generate.py
@@ -1039,50 +1039,39 @@ def _generate_transformer(
 
     blocks = []  # type: List[Stripped]
 
-    for our_type in symbol_table.our_types:
-        if isinstance(our_type, intermediate.Enumeration):
-            continue
+    # The abstract classes are directly dispatched by the transformer,
+    # so we do not need to handle them separately.
 
-        elif isinstance(our_type, intermediate.ConstrainedPrimitive):
-            continue
+    for cls in symbol_table.concrete_classes:
+        if cls.is_implementation_specific:
+            transform_key = specific_implementations.ImplementationKey(
+                f"Verification/transform_{cls.name}.py"
+            )
 
-        elif isinstance(our_type, intermediate.AbstractClass):
-            # The abstract classes are directly dispatched by the transformer,
-            # so we do not need to handle them separately.
-            pass
-
-        elif isinstance(our_type, intermediate.ConcreteClass):
-            if our_type.is_implementation_specific:
-                transform_key = specific_implementations.ImplementationKey(
-                    f"Verification/transform_{our_type.name}.py"
-                )
-
-                implementation = spec_impls.get(transform_key, None)
-                if implementation is None:
-                    errors.append(
-                        Error(
-                            our_type.parsed.node,
-                            f"The transformation snippet is missing "
-                            f"for the implementation-specific "
-                            f"class {our_type.name}: {transform_key}",
-                        )
+            implementation = spec_impls.get(transform_key, None)
+            if implementation is None:
+                errors.append(
+                    Error(
+                        cls.parsed.node,
+                        f"The transformation snippet is missing "
+                        f"for the implementation-specific "
+                        f"class {cls.name}: {transform_key}",
                     )
-                    continue
-
-                blocks.append(spec_impls[transform_key])
-            else:
-                block, cls_errors = _generate_transform_for_class(
-                    cls=our_type,
-                    symbol_table=symbol_table,
-                    base_environment=base_environment,
                 )
-                if cls_errors is not None:
-                    errors.extend(cls_errors)
-                else:
-                    assert block is not None
-                    blocks.append(block)
+                continue
+
+            blocks.append(spec_impls[transform_key])
         else:
-            assert_never(our_type)
+            block, cls_errors = _generate_transform_for_class(
+                cls=cls,
+                symbol_table=symbol_table,
+                base_environment=base_environment,
+            )
+            if cls_errors is not None:
+                errors.extend(cls_errors)
+            else:
+                assert block is not None
+                blocks.append(block)
 
     if len(errors) > 0:
         return None, errors
@@ -1205,11 +1194,11 @@ def _generate_module_docstring(
         Stripped("Verify that the instances of the meta-model satisfy the invariants.")
     ]  # type: List[Stripped]
 
-    first_cls = None  # type: Optional[intermediate.ConcreteClass]
-    for our_type in symbol_table.our_types:
-        if isinstance(our_type, intermediate.ConcreteClass):
-            first_cls = our_type
-            break
+    first_cls = (
+        symbol_table.concrete_classes[0]
+        if len(symbol_table.concrete_classes) > 0
+        else None
+    )  # type: Optional[intermediate.ConcreteClass]
 
     if first_cls is not None:
         cls_name = python_naming.class_name(first_cls.name)

--- a/aas_core_codegen/smoke/main.py
+++ b/aas_core_codegen/smoke/main.py
@@ -48,21 +48,18 @@ def _smoke_transpile_to_csharp(symbol_table: intermediate.SymbolTable) -> List[E
 
     dummy_implementation = Stripped("DUMMY IMPLEMENTATION")
 
-    for our_type in symbol_table.our_types:
-        if not isinstance(our_type, intermediate.Class):
-            continue
-
-        if our_type.is_implementation_specific:
+    for cls in symbol_table.classes:
+        if cls.is_implementation_specific:
             key = specific_implementations.ImplementationKey(
                 "Types/{our_type.name}/{our_type.name}.cs"
             )
             spec_impls[key] = dummy_implementation
             continue
 
-        for method in our_type.methods:
+        for method in cls.methods:
             if isinstance(method, intermediate.ImplementationSpecificMethod):
                 key = specific_implementations.ImplementationKey(
-                    f"Types/{our_type.name}/{method.name}.cs"
+                    f"Types/{cls.name}/{method.name}.cs"
                 )
                 spec_impls[key] = dummy_implementation
 

--- a/aas_core_codegen/typescript/jsonization/_generate.py
+++ b/aas_core_codegen/typescript/jsonization/_generate.py
@@ -1095,9 +1095,8 @@ if (that.{prop_name} !== null) {{
 def _generate_transformer(symbol_table: intermediate.SymbolTable) -> Stripped:
     methods = []  # type: List[Stripped]
 
-    for our_type in symbol_table.our_types:
-        if isinstance(our_type, intermediate.ConcreteClass):
-            methods.append(_generate_transform(our_type))
+    for cls in symbol_table.concrete_classes:
+        methods.append(_generate_transform(cls))
 
     writer = io.StringIO()
     writer.write(
@@ -1363,26 +1362,24 @@ function newDeserializationError<T>(
     # NOTE (mristin, 2022-11-25):
     # We add all the dispatch mappings at the end as the functions might not have been
     # defined yet.
-    for our_type in symbol_table.our_types:
-        if isinstance(our_type, intermediate.AbstractClass):
-            blocks.append(
-                _generate_dispatch_map_for_interface(interface=our_type.interface)
-            )
-        elif isinstance(our_type, intermediate.ConcreteClass):
-            if len(our_type.concrete_descendants) > 0:
+    for cls in symbol_table.classes:
+        if isinstance(cls, intermediate.AbstractClass):
+            blocks.append(_generate_dispatch_map_for_interface(interface=cls.interface))
+        elif isinstance(cls, intermediate.ConcreteClass):
+            if len(cls.concrete_descendants) > 0:
                 assert (
-                    our_type.interface is not None
+                    cls.interface is not None
                 ), "Expected an interface on a class with concrete descendants"
 
                 blocks.append(
-                    _generate_dispatch_map_for_interface(interface=our_type.interface)
+                    _generate_dispatch_map_for_interface(interface=cls.interface)
                 )
 
-            if not our_type.is_implementation_specific:
-                blocks.append(_generate_setter_map(cls=our_type))
+            if not cls.is_implementation_specific:
+                blocks.append(_generate_setter_map(cls=cls))
 
         else:
-            pass
+            assert_never(cls)
 
     blocks.append(Stripped("// endregion"))
 

--- a/aas_core_codegen/typescript/stringification/_generate.py
+++ b/aas_core_codegen/typescript/stringification/_generate.py
@@ -193,12 +193,9 @@ def generate(
         Stripped('import * as AasTypes from "./types";'),
     ]
 
-    for our_type in symbol_table.our_types:
-        if not isinstance(our_type, intermediate.Enumeration):
-            continue
-
-        blocks.append(_generate_enum_from_string(enumeration=our_type))
-        blocks.append(_generate_enum_to_string(enumeration=our_type))
+    for enum in symbol_table.enumerations:
+        blocks.append(_generate_enum_from_string(enumeration=enum))
+        blocks.append(_generate_enum_to_string(enumeration=enum))
 
     blocks.append(typescript_common.WARNING)
 

--- a/aas_core_codegen/typescript/structure/_generate.py
+++ b/aas_core_codegen/typescript/structure/_generate.py
@@ -1071,7 +1071,6 @@ export interface {name}
 def _generate_class(
     cls: intermediate.ConcreteClass,
     spec_impls: specific_implementations.SpecificImplementations,
-    symbol_table: intermediate.SymbolTable,
 ) -> Tuple[Optional[Stripped], Optional[Error]]:
     """Generate TypeScript code for the given concrete class ``cls``."""
     # Code blocks of the class body separated by double newlines and indented once
@@ -1409,12 +1408,9 @@ visit(that: Class): void {{
         )
     ]  # type: List[Stripped]
 
-    for our_type in symbol_table.our_types:
-        if not isinstance(our_type, intermediate.ConcreteClass):
-            continue
-
-        visit_name = typescript_naming.method_name(Identifier(f"visit_{our_type.name}"))
-        cls_name = typescript_naming.class_name(our_type.name)
+    for cls in symbol_table.concrete_classes:
+        visit_name = typescript_naming.method_name(Identifier(f"visit_{cls.name}"))
+        cls_name = typescript_naming.class_name(cls.name)
 
         blocks.append(
             Stripped(
@@ -1473,14 +1469,11 @@ visitWithContext(
         )
     ]  # type: List[Stripped]
 
-    for our_type in symbol_table.our_types:
-        if not isinstance(our_type, intermediate.ConcreteClass):
-            continue
-
+    for cls in symbol_table.concrete_classes:
         visit_with_context_name = typescript_naming.method_name(
-            Identifier(f"visit_{our_type.name}_with_context")
+            Identifier(f"visit_{cls.name}_with_context")
         )
-        cls_name = typescript_naming.class_name(our_type.name)
+        cls_name = typescript_naming.class_name(cls.name)
 
         blocks.append(
             Stripped(
@@ -1525,12 +1518,9 @@ def _generate_pass_through_visitor(symbol_table: intermediate.SymbolTable) -> St
     """Generate the code for the pass-through visitor."""
     blocks = []  # type: List[Stripped]
 
-    for our_type in symbol_table.our_types:
-        if not isinstance(our_type, intermediate.ConcreteClass):
-            continue
-
-        visit_name = typescript_naming.method_name(Identifier(f"visit_{our_type.name}"))
-        cls_name = typescript_naming.class_name(our_type.name)
+    for cls in symbol_table.concrete_classes:
+        visit_name = typescript_naming.method_name(Identifier(f"visit_{cls.name}"))
+        cls_name = typescript_naming.class_name(cls.name)
 
         blocks.append(
             Stripped(
@@ -1594,14 +1584,11 @@ visitWithContext(
         )
     ]  # type: List[Stripped]
 
-    for our_type in symbol_table.our_types:
-        if not isinstance(our_type, intermediate.ConcreteClass):
-            continue
-
+    for cls in symbol_table.concrete_classes:
         visit_with_context_name = typescript_naming.method_name(
-            Identifier(f"visit_{our_type.name}_with_context")
+            Identifier(f"visit_{cls.name}_with_context")
         )
-        cls_name = typescript_naming.class_name(our_type.name)
+        cls_name = typescript_naming.class_name(cls.name)
 
         blocks.append(
             Stripped(
@@ -1663,15 +1650,12 @@ transform(that: Class): T {{
         )
     ]  # type: List[Stripped]
 
-    for our_type in symbol_table.our_types:
-        if not isinstance(our_type, intermediate.ConcreteClass):
-            continue
-
+    for cls in symbol_table.concrete_classes:
         transform_name = typescript_naming.method_name(
-            Identifier(f"transform_{our_type.name}")
+            Identifier(f"transform_{cls.name}")
         )
 
-        cls_name = typescript_naming.class_name(our_type.name)
+        cls_name = typescript_naming.class_name(cls.name)
 
         blocks.append(
             Stripped(
@@ -1734,15 +1718,12 @@ transformWithContext(
         )
     ]  # type: List[Stripped]
 
-    for our_type in symbol_table.our_types:
-        if not isinstance(our_type, intermediate.ConcreteClass):
-            continue
-
+    for cls in symbol_table.concrete_classes:
         transform_with_context_name = typescript_naming.method_name(
-            Identifier(f"transform_{our_type.name}_with_context")
+            Identifier(f"transform_{cls.name}_with_context")
         )
 
-        cls_name = typescript_naming.class_name(our_type.name)
+        cls_name = typescript_naming.class_name(cls.name)
 
         blocks.append(
             Stripped(
@@ -1811,15 +1792,12 @@ constructor(defaultResult: T) {{
         ),
     ]  # type: List[Stripped]
 
-    for our_type in symbol_table.our_types:
-        if not isinstance(our_type, intermediate.ConcreteClass):
-            continue
-
+    for cls in symbol_table.concrete_classes:
         transform_name = typescript_naming.method_name(
-            Identifier(f"transform_{our_type.name}")
+            Identifier(f"transform_{cls.name}")
         )
 
-        cls_name = typescript_naming.class_name(our_type.name)
+        cls_name = typescript_naming.class_name(cls.name)
 
         blocks.append(
             Stripped(
@@ -1893,15 +1871,12 @@ constructor(defaultResult: T) {{
         ),
     ]  # type: List[Stripped]
 
-    for our_type in symbol_table.our_types:
-        if not isinstance(our_type, intermediate.ConcreteClass):
-            continue
-
+    for cls in symbol_table.concrete_classes:
         transform_with_context_name = typescript_naming.method_name(
-            Identifier(f"transform_{our_type.name}_with_context")
+            Identifier(f"transform_{cls.name}_with_context")
         )
 
-        cls_name = typescript_naming.class_name(our_type.name)
+        cls_name = typescript_naming.class_name(cls.name)
 
         blocks.append(
             Stripped(
@@ -1984,17 +1959,14 @@ def _generate_as_interface_transformer(
 
     interface_name = typescript_naming.interface_name(interface.name)
 
-    for our_type in symbol_table.our_types:
-        if not isinstance(our_type, intermediate.ConcreteClass):
-            continue
-
+    for cls in symbol_table.concrete_classes:
         transform_name = typescript_naming.method_name(
-            Identifier(f"transform_{our_type.name}")
+            Identifier(f"transform_{cls.name}")
         )
 
-        cls_name = typescript_naming.class_name(our_type.name)
+        cls_name = typescript_naming.class_name(cls.name)
 
-        if our_type.is_subclass_of(interface.base):
+        if cls.is_subclass_of(interface.base):
             blocks.append(
                 Stripped(
                     f"""\
@@ -2047,17 +2019,14 @@ class {transformer_name}
 
 def _generate_type_matcher(symbol_table: intermediate.SymbolTable) -> Stripped:
     blocks = []  # type: List[Stripped]
-    for our_type in symbol_table.our_types:
-        if not isinstance(our_type, intermediate.ConcreteClass):
-            continue
-
+    for cls in symbol_table.concrete_classes:
         transform_name = typescript_naming.method_name(
-            Identifier(f"transform_{our_type.name}_with_context")
+            Identifier(f"transform_{cls.name}_with_context")
         )
 
-        cls_name = typescript_naming.class_name(our_type.name)
+        cls_name = typescript_naming.class_name(cls.name)
 
-        is_name = typescript_naming.function_name(Identifier(f"is_{our_type.name}"))
+        is_name = typescript_naming.function_name(Identifier(f"is_{cls.name}"))
 
         blocks.append(
             Stripped(
@@ -2245,7 +2214,6 @@ export abstract class Class {{
                     block, error = _generate_class(
                         cls=our_type,
                         spec_impls=spec_impls,
-                        symbol_table=symbol_table,
                     )
                     if error is not None:
                         errors.append(error)
@@ -2271,34 +2239,29 @@ export abstract class Class {{
         ]
     )
 
-    for our_type in symbol_table.our_types:
-        if not isinstance(
-            our_type, (intermediate.AbstractClass, intermediate.ConcreteClass)
-        ):
-            continue
-
-        if our_type.interface is not None:
+    for cls in symbol_table.classes:
+        if cls.interface is not None:
             transformer_name = typescript_naming.class_name(
-                Identifier(f"As_{our_type.interface.name}_transformer")
+                Identifier(f"As_{cls.interface.name}_transformer")
             )
             constant_transformer = typescript_naming.constant_name(
-                Identifier(f"As_{our_type.interface.name}_transformer")
+                Identifier(f"As_{cls.interface.name}_transformer")
             )
 
             as_interface = typescript_naming.function_name(
-                Identifier(f"as_{our_type.interface.name}")
+                Identifier(f"as_{cls.interface.name}")
             )
 
             is_interface = typescript_naming.function_name(
-                Identifier(f"is_{our_type.interface.name}")
+                Identifier(f"is_{cls.interface.name}")
             )
 
-            interface_name = typescript_naming.interface_name(our_type.interface.name)
+            interface_name = typescript_naming.interface_name(cls.interface.name)
 
             blocks.extend(
                 [
                     _generate_as_interface_transformer(
-                        interface=our_type.interface, symbol_table=symbol_table
+                        interface=cls.interface, symbol_table=symbol_table
                     ),
                     Stripped(
                         f"""\
@@ -2342,14 +2305,14 @@ export function {is_interface}(
         # Without these functions, the clients would have to refactor a lot once
         # the meta-model changes and a class gets descendants where it had none before.
         if (
-            isinstance(our_type, intermediate.ConcreteClass)
-            and len(our_type.concrete_descendants) == 0
+            isinstance(cls, intermediate.ConcreteClass)
+            and len(cls.concrete_descendants) == 0
         ):
-            cls_name = typescript_naming.class_name(our_type.name)
+            cls_name = typescript_naming.class_name(cls.name)
 
-            as_cls = typescript_naming.function_name(Identifier(f"as_{our_type.name}"))
+            as_cls = typescript_naming.function_name(Identifier(f"as_{cls.name}"))
 
-            is_cls = typescript_naming.function_name(Identifier(f"is_{our_type.name}"))
+            is_cls = typescript_naming.function_name(Identifier(f"is_{cls.name}"))
 
             blocks.extend(
                 [


### PR DESCRIPTION
We pre-compute lists for classes in #406, so we simplify the code in this patch to make it more correct by design and more readable.

However, we made no changes to the code which would change the order of iteration over the symbols, and consequently changing the test data. This would cause too many changes to the downstream code which we did not consider worthwhile just for the sake of code consistency.