### PR TITLE
Expose `intermediate.Constant`

### DIFF
--- a/aas_core_codegen/intermediate/__init__.py
+++ b/aas_core_codegen/intermediate/__init__.py
@@ -43,6 +43,7 @@ ConcreteClass = _types.ConcreteClass
 AbstractClass = _types.AbstractClass
 ConstantPrimitive = _types.ConstantPrimitive
 PrimitiveSetLiteral = _types.PrimitiveSetLiteral
+Constant = _types.Constant
 ConstantSetOfPrimitives = _types.ConstantSetOfPrimitives
 ConstantSetOfEnumerationLiterals = _types.ConstantSetOfEnumerationLiterals
 ConstantSetUnion = _types.ConstantSetUnion


### PR DESCRIPTION
We forgot to include `intermediate._types.Constant` in `intermediate` due to an unintentional omission.