### PR TITLE
Remove an unused import

### DIFF
--- a/aas_core_codegen/python/unrolling.py
+++ b/aas_core_codegen/python/unrolling.py
@@ -7,7 +7,7 @@ from typing import Sequence, List
 from icontract import DBC, require
 
 from aas_core_codegen import intermediate
-from aas_core_codegen.common import Identifier, assert_never
+from aas_core_codegen.common import assert_never
 from aas_core_codegen.python.common import INDENT as I
 
 

--- a/aas_core_codegen/typescript/unrolling.py
+++ b/aas_core_codegen/typescript/unrolling.py
@@ -7,7 +7,7 @@ from typing import Sequence, List
 from icontract import DBC, require
 
 from aas_core_codegen import intermediate
-from aas_core_codegen.common import Identifier, assert_never
+from aas_core_codegen.common import assert_never
 from aas_core_codegen.typescript.common import INDENT as I
 
 


### PR DESCRIPTION
Pylint does not accept unsude import and it is necessary for the GitHub actions.