### PR TITLE
Fix `assert_never` import in JSON-LD generator

### DIFF
--- a/aas_core_codegen/jsonld/main.py
+++ b/aas_core_codegen/jsonld/main.py
@@ -27,14 +27,13 @@ from typing import (
 )
 
 from icontract import require
-from typing_extensions import assert_never
 
 from aas_core_codegen import (
     naming,
     intermediate,
     run,
 )
-from aas_core_codegen.common import Error, Stripped, Identifier
+from aas_core_codegen.common import Error, Stripped, Identifier, assert_never
 from aas_core_codegen.rdf_shacl import (
     naming as rdf_shacl_naming,
     common as rdf_shacl_common,


### PR DESCRIPTION
We import `assert_never` from `common` module for compatibility with other Python versions.