### PR TITLE
Fix missed code emitting in C# enhancer

### DIFF
--- a/aas_core_codegen/csharp/enhancing/_generate.py
+++ b/aas_core_codegen/csharp/enhancing/_generate.py
@@ -487,6 +487,9 @@ public abstract class Enhanced<TEnhancement> where TEnhancement : class
                     )
                 )
                 continue
+
+            assert code is not None
+            enhancing_blocks.append(code)
         else:
             code, error = _generate_enhanced_class(cls=cls)
             if error is not None:


### PR DESCRIPTION
We omitted by mistake to emit the specific implementation for the enhanced class code.