### PR TITLE
Remove redundant curly bracked in C++

### DIFF
--- a/test_data/cpp/test_main/aas_core_meta.v3/expected_output/enhancing.hpp
+++ b/test_data/cpp/test_main/aas_core_meta.v3/expected_output/enhancing.hpp
@@ -18,7 +18,7 @@ namespace aas_3_0 {
 
 /**
  * \defgroup enhancing Enhance instances of the model with your custom enhancements.
- * @{{
+ * @{
  */
 namespace enhancing {
 


### PR DESCRIPTION
We mistakenly forgot to remove a curly bracket when removing string interpolation in C++ generator.