### PR TITLE
Remove `BEFORE-RELEASE` comments

### DIFF
--- a/aas_core_codegen/csharp/common.py
+++ b/aas_core_codegen/csharp/common.py
@@ -124,7 +124,6 @@ def generate_type(
     ``our_type_prefix`` is appended to all our types, if specified.
     """
     our_type_prefix = "" if our_type_qualifier is None else f"{our_type_qualifier}."
-    # BEFORE-RELEASE (mristin, 2021-12-13): test in isolation
     if isinstance(type_annotation, intermediate.PrimitiveTypeAnnotation):
         return PRIMITIVE_TYPE_MAP[type_annotation.a_type]
 

--- a/aas_core_codegen/csharp/structure/_generate.py
+++ b/aas_core_codegen/csharp/structure/_generate.py
@@ -183,7 +183,6 @@ def _verify_intra_structure_collisions(
         for prop in our_type.properties:
             prop_name = csharp_naming.property_name(prop.name)
             if prop_name in observed_member_names:
-                # BEFORE-RELEASE (mristin, 2021-12-13): test
                 errors.append(
                     Error(
                         prop.parsed.node,
@@ -202,7 +201,6 @@ def _verify_intra_structure_collisions(
             method_name = csharp_naming.method_name(method.name)
 
             if method_name in observed_member_names:
-                # BEFORE-RELEASE (mristin, 2021-12-13): test
                 errors.append(
                     Error(
                         method.parsed.node,

--- a/aas_core_codegen/intermediate/_translate.py
+++ b/aas_core_codegen/intermediate/_translate.py
@@ -1341,7 +1341,6 @@ def _determine_constrained_primitives_by_name(
 
     # region Check the inheritances of all the constrained primitive types
 
-    # BEFORE-RELEASE (mristin, 2021-12-23): test this
     for identifier in extended_map.keys():
         # We know for sure that the initial set is valid, so we can skip it in
         # the check.
@@ -1387,7 +1386,6 @@ def _determine_constrained_primitives_by_name(
 
     # region Check that primitive types do not have unexpected specification
 
-    # BEFORE-RELEASE (mristin, 2021-12-23): test this
     for identifier in result:
         parsed_cls = parsed_symbol_table.must_find_class(identifier)
         if len(parsed_cls.methods) > 0 or len(parsed_cls.properties) > 0:
@@ -3563,8 +3561,6 @@ def _second_pass_to_resolve_references_to_attributes_in_the_descriptions_in_plac
     for attr_ref_in_doc, description, our_type in _find_all_in_descriptions(
         element_type=doc.ReferenceToAttribute, symbol_table=symbol_table
     ):
-        # BEFORE-RELEASE (mristin, 2021-12-13):
-        #  test this, especially the failure cases
         if isinstance(attr_ref_in_doc.reference, _PlaceholderReferenceToAttribute):
             pth = attr_ref_in_doc.reference.path
 
@@ -3823,8 +3819,6 @@ class _ContractChecker(parse_tree.Visitor):
         )
 
         if verification_function is not None:
-            # BEFORE-RELEASE (mristin, 2021-12-19):
-            #  test failure case
             expected_argument_count = len(verification_function.arguments)
         elif node.name.identifier == "len":
             expected_argument_count = 1

--- a/aas_core_codegen/intermediate/pattern_verification.py
+++ b/aas_core_codegen/intermediate/pattern_verification.py
@@ -229,7 +229,6 @@ def try_to_understand(
             None,
         )
 
-    # BEFORE-RELEASE (mristin, 2021-12-19): test this
     if (
         isinstance(return_node.value, parse_tree.FunctionCall)
         and return_node.value.name.identifier == "match"
@@ -288,7 +287,6 @@ def try_to_understand(
     assert isinstance(match_call, parse_tree.FunctionCall)
     assert match_call.name.identifier == "match"
 
-    # BEFORE-RELEASE (mristin, 2021-12-19): test this
     if len(match_call.args) < 2:
         return (
             None,
@@ -301,7 +299,6 @@ def try_to_understand(
             ),
         )
 
-    # BEFORE-RELEASE (mristin, 2021-12-19): test this
     if len(match_call.args) > 2:
         return (
             None,

--- a/aas_core_codegen/main.py
+++ b/aas_core_codegen/main.py
@@ -57,24 +57,20 @@ class Parameters:
 def execute(params: Parameters, stdout: TextIO, stderr: TextIO) -> int:
     """Run the program."""
     # region Basic checks
-    # BEFORE-RELEASE (mristin, 2021-12-13): test this failure case
     if not params.model_path.exists():
         stderr.write(f"The --model_path does not exist: {params.model_path}\n")
         return 1
 
-    # BEFORE-RELEASE (mristin, 2021-12-13): test this failure case
     if not params.model_path.is_file():
         stderr.write(
             f"The --model_path does not point to a file: {params.model_path}\n"
         )
         return 1
 
-    # BEFORE-RELEASE (mristin, 2021-12-13): test this failure case
     if not params.snippets_dir.exists():
         stderr.write(f"The --snippets_dir does not exist: {params.snippets_dir}\n")
         return 1
 
-    # BEFORE-RELEASE (mristin, 2021-12-13): test this failure case
     if not params.snippets_dir.is_dir():
         stderr.write(
             f"The --snippets_dir does not point to a directory: "
@@ -82,11 +78,9 @@ def execute(params: Parameters, stdout: TextIO, stderr: TextIO) -> int:
         )
         return 1
 
-    # BEFORE-RELEASE (mristin, 2021-12-13): test the happy path
     if not params.output_dir.exists():
         params.output_dir.mkdir(parents=True, exist_ok=True)
     else:
-        # BEFORE-RELEASE (mristin, 2021-12-13): test this failure case
         if not params.output_dir.is_dir():
             stderr.write(
                 f"The --output_dir does not point to a directory: "

--- a/aas_core_codegen/parse/_translate.py
+++ b/aas_core_codegen/parse/_translate.py
@@ -920,12 +920,6 @@ def _args_to_arguments(
         # region Default
         default = None  # type: Optional[Default]
 
-        # BEFORE-RELEASE (mristin, 2021-12-16):
-        #  test the defaults in verification function
-        #
-        # BEFORE-RELEASE (mristin, 2021-12-16):
-        #  test the defaults in a class method
-
         # NOTE (mristin, 2021-12-16):
         # A simple hypothetical test calculation:
         # 5 args
@@ -1137,13 +1131,6 @@ def _parse_snapshot(
         None,
     )
 
-
-# BEFORE-RELEASE (mristin, 2021-12-13):
-#  include severity levels for contracts in the metamodel and
-#  consider them in the imports
-
-# BEFORE-RELEASE (mristin, 2021-12-13):
-#  test for unknown severity level
 
 # fmt: off
 # noinspection PyTypeChecker,PyUnresolvedReferences
@@ -3374,7 +3361,6 @@ def _verify_symbol_table(
             if isinstance(method, UnderstoodMethod)
         ),
     ):
-        # BEFORE-RELEASE (mristin, 2021-12-19): test
         for stmt in understood_method.body:
             if (
                 isinstance(stmt, tree.Assignment)
@@ -3395,7 +3381,6 @@ def _verify_symbol_table(
 
     # region Check that no class methods are used in verification
 
-    # BEFORE-RELEASE (mristin, 2021-12-16): test
     for our_type in symbol_table.our_types:
         if not isinstance(our_type, Class):
             continue
@@ -3569,7 +3554,6 @@ def _verify_symbol_table(
             if error is not None:
                 errors.append(error)
             else:
-                # BEFORE-RELEASE (mristin, 2021-12-13): test
                 if isinstance(prop.type_annotation, SubscriptedTypeAnnotation):
                     error = _verify_arity_of_type_annotation_subscript(
                         prop.type_annotation
@@ -3587,7 +3571,6 @@ def _verify_symbol_table(
                 if error is not None:
                     errors.append(error)
                 else:
-                    # BEFORE-RELEASE (mristin, 2021-12-13): test
                     if isinstance(arg.type_annotation, SubscriptedTypeAnnotation):
                         error = _verify_arity_of_type_annotation_subscript(
                             arg.type_annotation
@@ -3597,14 +3580,12 @@ def _verify_symbol_table(
                             errors.append(error)
 
             if method.returns is not None:
-                # BEFORE-RELEASE (mristin, 2021-12-13): test
                 error = verify_no_dangling_references_in_type_annotation(
                     type_annotation=method.returns
                 )
                 if error is not None:
                     errors.append(error)
                 else:
-                    # BEFORE-RELEASE (mristin, 2021-12-13): test
                     if isinstance(method.returns, SubscriptedTypeAnnotation):
                         error = _verify_arity_of_type_annotation_subscript(
                             method.returns

--- a/aas_core_codegen/smoke/main.py
+++ b/aas_core_codegen/smoke/main.py
@@ -91,8 +91,6 @@ def execute(model_path: pathlib.Path, stderr: TextIO) -> int:
     """Run the smoke test."""
     text = model_path.read_text(encoding="utf-8")
 
-    # BEFORE-RELEASE (mristin, 2021-12-13):
-    #  test all the following individual failure cases
     atok, parse_exception = parse.source_to_atok(source=text)
     if parse_exception:
         if isinstance(parse_exception, SyntaxError):


### PR DESCRIPTION
As we have long released the aas-core-codegen in the wild, there is no point of keeping a todo comments. At this point in time, we deprioritize tests that we planned in the beginning.