### PR TITLE
Remove redundant initilaizations with None

### DIFF
--- a/.idea/aas-core-csharp-codegen.iml
+++ b/.idea/aas-core-csharp-codegen.iml
@@ -12,8 +12,9 @@
       <excludeFolder url="file://$MODULE_DIR$/venv" />
       <excludeFolder url="file://$MODULE_DIR$/venv310" />
       <excludeFolder url="file://$MODULE_DIR$/venv39" />
+      <excludeFolder url="file://$MODULE_DIR$/venv38" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.8 (aas-core-codegen)" jdkType="Python SDK" />
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="Black">
+    <option name="sdkName" value="Python 3.8 (aas-core-codegen)" />
+  </component>
   <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.8 (aas-core-codegen)" project-jdk-type="Python SDK" />
 </project>

--- a/aas_core_codegen/cpp/constants/_generate.py
+++ b/aas_core_codegen/cpp/constants/_generate.py
@@ -198,8 +198,7 @@ def _generate_constant_set_of_primitives_definition(
             writer.write(comment)
             writer.write("\n")
 
-    # noinspection PyUnusedLocal
-    set_type = None  # type: Optional[str]
+    set_type: Optional[str]
 
     if constant.a_type is intermediate.PrimitiveType.BOOL:
         set_type = "std::unordered_set<bool>"
@@ -220,8 +219,6 @@ def _generate_constant_set_of_primitives_definition(
         assert_never(constant.a_type)
         raise AssertionError("Unexpected execution path")
 
-    assert set_type is not None
-
     constant_name = cpp_naming.constant_name(constant.name)
 
     writer.write(
@@ -239,8 +236,7 @@ def _generate_constant_set_of_primitives_implementation(
     """Generate the implementation of a constant set of primitives."""
     literal_codes = []  # type: List[str]
 
-    # noinspection PyUnusedLocal
-    set_type = None  # type: Optional[str]
+    set_type: str
 
     if constant.a_type is intermediate.PrimitiveType.BOOL:
         set_type = "std::unordered_set<bool>"
@@ -289,8 +285,6 @@ std::unordered_set<
     else:
         assert_never(constant.a_type)
         raise AssertionError("Unexpected execution path")
-
-    assert set_type is not None
 
     literals_joined = ",\n".join(literal_codes)
 
@@ -431,8 +425,9 @@ struct HashBytes {{
     ]
 
     for constant in symbol_table.constants:
-        block = None  # type: Optional[Stripped]
-        error = None  # type: Optional[Error]
+        block: Optional[Stripped]
+        error: Optional[Error]
+
         if isinstance(constant, intermediate.ConstantPrimitive):
             block, error = _generate_constant_primitive_definition(constant=constant)
         elif isinstance(constant, intermediate.ConstantSetOfPrimitives):
@@ -524,8 +519,9 @@ std::size_t HashBytes::operator()(
     ]
 
     for constant in symbol_table.constants:
-        block = None  # type: Optional[Stripped]
-        error = None  # type: Optional[Error]
+        block: Optional[Stripped]
+        error: Optional[Error]
+
         if isinstance(constant, intermediate.ConstantPrimitive):
             block, error = _generate_constant_primitive_implementation(
                 constant=constant

--- a/aas_core_codegen/cpp/description.py
+++ b/aas_core_codegen/cpp/description.py
@@ -181,7 +181,7 @@ class _ElementRenderer(intermediate_doc.DocutilsElementTransformer[str]):
     def transform_reference_to_our_type_in_doc(
         self, element: intermediate_doc.ReferenceToOurType
     ) -> Tuple[Optional[str], Optional[List[str]]]:
-        result = None  # type: Optional[str]
+        result: str
 
         if isinstance(
             element.our_type,
@@ -191,7 +191,7 @@ class _ElementRenderer(intermediate_doc.DocutilsElementTransformer[str]):
                 intermediate.ConcreteClass,
             ),
         ):
-            name = None  # type: Optional[str]
+            name: str
 
             if isinstance(element.our_type, intermediate.Enumeration):
                 name = cpp_naming.enum_name(element.our_type.name)
@@ -207,8 +207,6 @@ class _ElementRenderer(intermediate_doc.DocutilsElementTransformer[str]):
 
             else:
                 assert_never(element.our_type)
-
-            assert name is not None
 
             if self.context.namespace == cpp_common.TYPES_NAMESPACE:
                 result = f"{name}"
@@ -226,13 +224,12 @@ class _ElementRenderer(intermediate_doc.DocutilsElementTransformer[str]):
         else:
             assert_never(element.our_type)
 
-        assert result is not None
         return result, None
 
     def transform_reference_to_attribute_in_doc(
         self, element: intermediate_doc.ReferenceToAttribute
     ) -> Tuple[Optional[str], Optional[List[str]]]:
-        result = None  # type: Optional[str]
+        result: str
 
         if isinstance(element.reference, intermediate_doc.ReferenceToProperty):
             interface_name = cpp_naming.interface_name(element.reference.cls.name)
@@ -257,8 +254,6 @@ class _ElementRenderer(intermediate_doc.DocutilsElementTransformer[str]):
                 result = f"{cpp_common.TYPES_NAMESPACE}::{enum_name}::{literal_name}"
         else:
             assert_never(element.reference)
-
-        assert result is not None
 
         return result, None
 

--- a/aas_core_codegen/cpp/jsonization/_generate.py
+++ b/aas_core_codegen/cpp/jsonization/_generate.py
@@ -1278,7 +1278,7 @@ def _generate_deserialize_property(
     """
     type_anno = intermediate.beneath_optional(prop.type_annotation)
 
-    code = None  # type: Optional[Stripped]
+    code: Stripped
 
     if isinstance(type_anno, intermediate.PrimitiveTypeAnnotation):
         code = _generate_deserialize_primitive_property(prop=prop, ok_type=ok_type)
@@ -1314,8 +1314,6 @@ def _generate_deserialize_property(
         code = _generate_deserialize_list_property(prop=prop, ok_type=ok_type)
     else:
         assert_never(type_anno)
-
-    assert code is not None
 
     if isinstance(prop.type_annotation, intermediate.OptionalTypeAnnotation):
         json_prop_literal = cpp_common.string_literal(naming.json_property(prop.name))

--- a/aas_core_codegen/cpp/optionaling.py
+++ b/aas_core_codegen/cpp/optionaling.py
@@ -470,8 +470,7 @@ class Inferrer(parse_tree.Transformer[Optional[Error]]):
         return None
 
     def transform_for_range(self, node: parse_tree.ForRange) -> Optional[Error]:
-        # noinspection PyUnusedLocal
-        error = None  # type: Optional[Error]
+        error: Optional[Error]
 
         variable_type_in_env = self._environment.find(node.variable.identifier)
         if variable_type_in_env is not None:

--- a/aas_core_codegen/cpp/structure/_generate.py
+++ b/aas_core_codegen/cpp/structure/_generate.py
@@ -59,7 +59,7 @@ def _human_readable_identifier(
     # code was nigh unreadable. So we preferred a little bit of copying to a little
     # bit of complexity.
 
-    result = None  # type: Optional[str]
+    result: str
 
     if isinstance(something, intermediate.Enumeration):
         result = f"meta-model enumeration {something.name!r}"
@@ -72,7 +72,6 @@ def _human_readable_identifier(
     else:
         assert_never(something)
 
-    assert result is not None
     return result
 
 
@@ -94,7 +93,7 @@ def _verify_structure_name_collisions(
     # region Inter-structure collisions
 
     for enum_or_cls in itertools.chain(symbol_table.enumerations, symbol_table.classes):
-        names = None  # type: Optional[List[Identifier]]
+        names: List[Identifier]
 
         if isinstance(enum_or_cls, intermediate.Enumeration):
             names = [cpp_naming.enum_name(enum_or_cls.name)]
@@ -1246,7 +1245,8 @@ def _generate_method_implementation(
     spec_impls: specific_implementations.SpecificImplementations,
 ) -> Tuple[Optional[Stripped], Optional[Error]]:
     """Generate the implementation of the method."""
-    body = None  # type: Optional[Stripped]
+    body: Optional[Stripped]
+
     if isinstance(method, intermediate.ImplementationSpecificMethod):
         implementation_key = specific_implementations.ImplementationKey(
             f"types/{method.specified_for.name}/{method.name}.body.cpp"

--- a/aas_core_codegen/cpp/transpilation.py
+++ b/aas_core_codegen/cpp/transpilation.py
@@ -377,8 +377,7 @@ class Transpiler(
         member_type = self.type_map[node]
         member_type_beneath = intermediate_type_inference.beneath_optional(member_type)
 
-        # noinspection PyUnusedLocal
-        member_accessor = None  # type: Optional[str]
+        member_accessor: str
 
         if isinstance(
             instance_type_beneath, intermediate_type_inference.OurTypeAnnotation
@@ -445,8 +444,6 @@ class Transpiler(
                 f"was {member_type}. However, we do not know how to resolve "
                 f"the member {node.name!r} in {instance_type}.",
             )
-
-        assert member_accessor is not None
 
         assert isinstance(
             instance_type_beneath, intermediate_type_inference.OurTypeAnnotation
@@ -638,8 +635,7 @@ common::{contains_function}(
         for arg_node in node.args:
             arg_type = self.type_map[arg_node]
 
-            # noinspection PyUnusedLocal
-            arg = None  # type: Optional[Stripped]
+            arg: Optional[Stripped]
             if isinstance(arg_type, intermediate_type_inference.OptionalTypeAnnotation):
                 arg, error = self.transform(arg_node)
             else:
@@ -684,8 +680,7 @@ common::{contains_function}(
         for arg_node in node.args:
             arg_type = self.type_map[arg_node]
 
-            # noinspection PyUnusedLocal
-            arg = None  # type: Optional[Stripped]
+            arg: Optional[Stripped]
             if isinstance(arg_type, intermediate_type_inference.OptionalTypeAnnotation):
                 arg, error = self.transform(arg_node)
             else:
@@ -986,7 +981,7 @@ common::{contains_function}(
             errors.append(error)
 
         if len(errors) > 0:
-            operation_name = None  # type: Optional[str]
+            operation_name: str
             if isinstance(node, parse_tree.Add):
                 operation_name = "the addition"
             elif isinstance(node, parse_tree.Sub):
@@ -1175,15 +1170,13 @@ common::{concat}(
         if isinstance(node.generator, parse_tree.ForEach):
             assert iteration is not None
 
-            qualifier_function = None  # type: Optional[str]
+            qualifier_function: str
             if isinstance(node, parse_tree.Any):
                 qualifier_function = cpp_naming.function_name(Identifier("Some"))
             elif isinstance(node, parse_tree.All):
                 qualifier_function = cpp_naming.function_name(Identifier("All"))
             else:
                 assert_never(node)
-
-            assert qualifier_function is not None
 
             no_parentheses_types_in_this_context = (
                 parse_tree.Member,
@@ -1221,15 +1214,12 @@ common::{qualifier_function}(
             )
 
         elif isinstance(node.generator, parse_tree.ForRange):
-            qualifier_function = None
             if isinstance(node, parse_tree.Any):
                 qualifier_function = "SomeRange"
             elif isinstance(node, parse_tree.All):
                 qualifier_function = "AllRange"
             else:
                 assert_never(node)
-
-            assert qualifier_function is not None
 
             assert start is not None
             assert end is not None
@@ -1304,8 +1294,7 @@ common::{qualifier_function}(
         assert target is not None
         assert target_type is not None
 
-        # noinspection PyUnusedLocal
-        value = None  # type: Optional[Stripped]
+        value: Optional[Stripped]
 
         if isinstance(
             target_type, intermediate_type_inference.OptionalTypeAnnotation

--- a/aas_core_codegen/cpp/visitation/_generate.py
+++ b/aas_core_codegen/cpp/visitation/_generate.py
@@ -315,7 +315,7 @@ def _generate_recursive_visit_for_property(
     else:
         get_expr = Stripped(f"that->{getter}()")
 
-    code = None  # type: Optional[Stripped]
+    code: Stripped
 
     if isinstance(type_anno, intermediate.PrimitiveTypeAnnotation):
         # No visits to primitive values.
@@ -370,8 +370,6 @@ for (
 
     else:
         assert_never(type_anno)
-
-    assert code is not None
 
     if not isinstance(prop.type_annotation, intermediate.OptionalTypeAnnotation):
         return Stripped(

--- a/aas_core_codegen/csharp/constants/_generate.py
+++ b/aas_core_codegen/csharp/constants/_generate.py
@@ -336,8 +336,9 @@ private class ByteArrayComparer
     errors = []  # type: List[Error]
 
     for constant in symbol_table.constants:
-        constants_block = None  # type: Optional[Stripped]
-        error = None  # type: Optional[Error]
+        constants_block: Optional[Stripped]
+        error: Optional[Error]
+
         if isinstance(constant, intermediate.ConstantPrimitive):
             constants_block, error = _generate_constant_primitive(constant=constant)
         elif isinstance(constant, intermediate.ConstantSetOfPrimitives):

--- a/aas_core_codegen/csharp/description.py
+++ b/aas_core_codegen/csharp/description.py
@@ -163,7 +163,7 @@ class _ElementRenderer(intermediate_doc.DocutilsElementTransformer[_NodeUnion]):
     def transform_reference_to_our_type_in_doc(
         self, element: intermediate_doc.ReferenceToOurType
     ) -> Tuple[Optional[_NodeUnion], Optional[List[str]]]:
-        name = None  # type: Optional[str]
+        name: str
 
         if isinstance(element.our_type, intermediate.Enumeration):
             name = csharp_naming.enum_name(element.our_type.name)
@@ -204,8 +204,6 @@ class _ElementRenderer(intermediate_doc.DocutilsElementTransformer[_NodeUnion]):
 
             assert_never(element.our_type)
 
-        assert name is not None
-
         # NOTE (mristin, 2022-06-19):
         # We need to prefix the cref in case there are naming conflicts.
         prefixed_name = f"Aas.{name}"
@@ -220,10 +218,10 @@ class _ElementRenderer(intermediate_doc.DocutilsElementTransformer[_NodeUnion]):
     def transform_reference_to_attribute_in_doc(
         self, element: intermediate_doc.ReferenceToAttribute
     ) -> Tuple[Optional[_NodeUnion], Optional[List[str]]]:
-        cref = None  # type: Optional[str]
+        cref: str
 
         if isinstance(element.reference, intermediate_doc.ReferenceToProperty):
-            name_of_our_type = None  # type: Optional[str]
+            name_of_our_type: str
 
             if isinstance(element.reference.cls, intermediate.AbstractClass):
                 # We do not generate C# code for abstract classes, so we have to refer
@@ -244,7 +242,6 @@ class _ElementRenderer(intermediate_doc.DocutilsElementTransformer[_NodeUnion]):
 
             prop_name = csharp_naming.property_name(element.reference.prop.name)
 
-            assert name_of_our_type is not None
             cref = f"{name_of_our_type}.{prop_name}"
         elif isinstance(
             element.reference, intermediate_doc.ReferenceToEnumerationLiteral
@@ -272,8 +269,6 @@ class _ElementRenderer(intermediate_doc.DocutilsElementTransformer[_NodeUnion]):
                 ]
 
             assert_never(element.reference)
-
-        assert cref is not None
 
         # NOTE (mristin, 2022-06-19):
         # We need to prefix the cref in case there are naming conflicts.

--- a/aas_core_codegen/csharp/enhancing/_generate.py
+++ b/aas_core_codegen/csharp/enhancing/_generate.py
@@ -236,7 +236,7 @@ if (that is Enhanced<TEnhancement>)
         type_anno = intermediate.beneath_optional(prop.type_annotation)
         prop_name = csharp_naming.property_name(prop.name)
 
-        wrap_stmt = None  # type: Optional[Stripped]
+        wrap_stmt: Stripped
 
         if isinstance(type_anno, intermediate.PrimitiveTypeAnnotation):
             # We can not enhance primitive types; nothing to do here.
@@ -319,8 +319,6 @@ that.{prop_name} = (
             )
         else:
             assert_never(type_anno.our_type)
-
-        assert wrap_stmt is not None
 
         if isinstance(prop.type_annotation, intermediate.OptionalTypeAnnotation):
             wrap_stmt = Stripped(

--- a/aas_core_codegen/csharp/jsonization/_generate.py
+++ b/aas_core_codegen/csharp/jsonization/_generate.py
@@ -193,7 +193,7 @@ def _parse_method_for_atomic_value(
     type_annotation: intermediate.AtomicTypeAnnotation,
 ) -> Stripped:
     """Determine the parse method for deserializing an atomic non-optional value."""
-    parse_method = None  # type: Optional[str]
+    parse_method: str
 
     if isinstance(type_annotation, intermediate.PrimitiveTypeAnnotation):
         parse_method = _PARSE_METHOD_BY_PRIMITIVE_TYPE[type_annotation.a_type]
@@ -240,7 +240,8 @@ def _generate_deserialize_constructor_argument(
 
     json_literal = csharp_common.string_literal(json_name)
 
-    parse_block = None  # type: Optional[Stripped]
+    parse_block: Stripped
+
     if isinstance(
         type_anno,
         (intermediate.PrimitiveTypeAnnotation, intermediate.OurTypeAnnotation),
@@ -946,7 +947,8 @@ def _generate_deserialize(
     )  # type: Optional[intermediate.ClassUnion]
 
     if first_cls is not None:
-        cls_name = None  # type: Optional[str]
+        cls_name: str
+
         if isinstance(first_cls, intermediate.AbstractClass):
             cls_name = csharp_naming.interface_name(first_cls.name)
         elif isinstance(first_cls, intermediate.ConcreteClass):
@@ -1376,7 +1378,8 @@ public static Nodes.JsonValue {name}ToJsonValue(Aas.{name} that)
     )  # type: Optional[intermediate.ClassUnion]
 
     if first_cls is not None:
-        cls_name = None  # type: Optional[str]
+        cls_name: str
+
         if isinstance(first_cls, intermediate.AbstractClass):
             cls_name = csharp_naming.interface_name(first_cls.name)
         elif isinstance(first_cls, intermediate.ConcreteClass):

--- a/aas_core_codegen/csharp/structure/_generate.py
+++ b/aas_core_codegen/csharp/structure/_generate.py
@@ -51,7 +51,7 @@ def _human_readable_identifier(
 
     The reader should be able to trace ``something`` back to the meta-model.
     """
-    result = None  # type: Optional[str]
+    result: str
 
     if isinstance(something, intermediate.Enumeration):
         result = f"meta-model enumeration {something.name!r}"
@@ -62,7 +62,6 @@ def _human_readable_identifier(
     else:
         assert_never(something)
 
-    assert result is not None
     return result
 
 

--- a/aas_core_codegen/csharp/transpilation.py
+++ b/aas_core_codegen/csharp/transpilation.py
@@ -68,8 +68,7 @@ class Transpiler(
         )
         member_type = intermediate_type_inference.beneath_optional(self.type_map[node])
 
-        # noinspection PyUnusedLocal
-        member_name = None  # type: Optional[str]
+        member_name: str
 
         if isinstance(
             instance_type, intermediate_type_inference.OurTypeAnnotation
@@ -111,8 +110,6 @@ class Transpiler(
                 f"was {member_type}. However, we do not know how to resolve "
                 f"the member {node.name!r} in {instance_type}.",
             )
-
-        assert member_name is not None
 
         return Stripped(f"{instance}.{member_name}"), None
 
@@ -679,7 +676,8 @@ class Transpiler(
             errors.append(error)
 
         if len(errors) > 0:
-            operation_name = None  # type: Optional[str]
+            operation_name: str
+
             if isinstance(node, parse_tree.Add):
                 operation_name = "the addition"
             elif isinstance(node, parse_tree.Sub):
@@ -838,7 +836,8 @@ class Transpiler(
         assert variable is not None
         assert condition is not None
 
-        qualifier_function = None  # type: Optional[str]
+        qualifier_function: str
+
         if isinstance(node, parse_tree.Any):
             qualifier_function = "Any"
         elif isinstance(node, parse_tree.All):
@@ -846,7 +845,8 @@ class Transpiler(
         else:
             assert_never(node)
 
-        source = None  # type: Optional[Stripped]
+        source: Stripped
+
         if isinstance(node.generator, parse_tree.ForEach):
             no_parentheses_types_in_this_context = (
                 parse_tree.Member,
@@ -862,6 +862,7 @@ class Transpiler(
             ):
                 source = Stripped(f"({iteration})")
             else:
+                assert iteration is not None
                 source = iteration
         elif isinstance(node.generator, parse_tree.ForRange):
             assert start is not None

--- a/aas_core_codegen/csharp/verification/_generate.py
+++ b/aas_core_codegen/csharp/verification/_generate.py
@@ -1417,7 +1417,8 @@ namespace {namespace}
     )  # type: Optional[intermediate.ClassUnion]
 
     if first_cls is not None:
-        cls_name = None  # type: Optional[str]
+        cls_name: str
+
         if isinstance(first_cls, intermediate.AbstractClass):
             cls_name = csharp_naming.interface_name(first_cls.name)
         elif isinstance(first_cls, intermediate.ConcreteClass):

--- a/aas_core_codegen/csharp/xmlization/_generate.py
+++ b/aas_core_codegen/csharp/xmlization/_generate.py
@@ -117,7 +117,7 @@ def _generate_deserialize_primitive_property(
     a_type = intermediate.try_primitive_type(type_anno)
     assert a_type is not None, f"Unexpected type annotation: {prop.type_annotation}"
 
-    deserialization_expr = None  # type: Optional[str]
+    deserialization_expr: str
     if a_type is intermediate.PrimitiveType.BOOL:
         deserialization_expr = "reader.ReadContentAsBoolean()"
     elif a_type is intermediate.PrimitiveType.INT:
@@ -132,8 +132,6 @@ DeserializeImplementation.ReadWholeContentAsBase64(
 {I}reader)"""
     else:
         assert_never(a_type)
-
-    assert deserialization_expr is not None
 
     target_var = csharp_naming.variable_name(Identifier(f"the_{prop.name}"))
 
@@ -1271,7 +1269,7 @@ def _generate_deserialize(symbol_table: intermediate.SymbolTable) -> Stripped:
     first_cls = symbol_table.classes[0] if len(symbol_table.classes) > 0 else None
 
     if first_cls is not None:
-        cls_name = None  # type: Optional[str]
+        cls_name: str
         if isinstance(first_cls, intermediate.AbstractClass):
             cls_name = csharp_naming.interface_name(first_cls.name)
         elif isinstance(first_cls, intermediate.ConcreteClass):
@@ -1335,7 +1333,7 @@ def _generate_serialize_primitive_property_as_content(
     prop_name = csharp_naming.property_name(prop.name)
     xml_prop_name_literal = csharp_common.string_literal(naming.xml_property(prop.name))
 
-    write_value_block = None  # type: Optional[Stripped]
+    write_value_block: Stripped
 
     if (
         a_type is intermediate.PrimitiveType.BOOL
@@ -1358,8 +1356,6 @@ writer.WriteBase64(
         )
     else:
         assert_never(a_type)
-
-    assert write_value_block is not None
 
     # NOTE (mristin, 2022-06-21):
     # Wrap the write_value_block with property even if we discard it below
@@ -1804,7 +1800,7 @@ public static void To(
     )  # type: Optional[intermediate.ClassUnion]
 
     if first_cls is not None:
-        cls_name = None  # type: Optional[str]
+        cls_name: str
         if isinstance(first_cls, intermediate.AbstractClass):
             cls_name = csharp_naming.interface_name(first_cls.name)
         elif isinstance(first_cls, intermediate.ConcreteClass):

--- a/aas_core_codegen/golang/common.py
+++ b/aas_core_codegen/golang/common.py
@@ -118,9 +118,6 @@ def bytes_literal(value: bytes) -> Tuple[Stripped, bool]:
 
     writer = io.StringIO()
 
-    # noinspection PyUnusedLocal
-    multi_line = None  # type: Optional[bool]
-
     if len(value) <= 8:
         items_joined = ", ".join(f"0x{byte:02x}" for byte in value)
         return Stripped(f"[...]byte{{{items_joined}}}"), False
@@ -147,9 +144,8 @@ def bytes_literal(value: bytes) -> Tuple[Stripped, bool]:
                 writer.write(f"0x{byte:02x}")
 
         writer.write("\n}")
-        multi_line = True
 
-        return Stripped(writer.getvalue()), multi_line
+        return Stripped(writer.getvalue()), True
 
 
 PRIMITIVE_TYPE_MAP = {

--- a/aas_core_codegen/golang/constants/_generate.py
+++ b/aas_core_codegen/golang/constants/_generate.py
@@ -157,7 +157,7 @@ def _generate_constant_set_of_primitives(
             writer.write("\n")
 
     literal_codes = []  # type: List[str]
-    set_type = None  # type: Optional[str]
+    set_type: str
 
     if constant.a_type is intermediate.PrimitiveType.BOOL:
         set_type = "map[bool]struct{}"
@@ -200,8 +200,6 @@ def _generate_constant_set_of_primitives(
     else:
         assert_never(constant.a_type)
         raise AssertionError("Unexpected execution path")
-
-    assert set_type is not None
 
     literals_joined = ",\n".join(literal_codes)
 
@@ -302,8 +300,9 @@ import (
     ]  # type: List[Stripped]
 
     for constant in symbol_table.constants:
-        block = None  # type: Optional[Stripped]
-        error = None  # type: Optional[Error]
+        block: Optional[Stripped]
+        error: Optional[Error]
+
         if isinstance(constant, intermediate.ConstantPrimitive):
             block, error = _generate_constant_primitive(constant=constant)
         elif isinstance(constant, intermediate.ConstantSetOfPrimitives):

--- a/aas_core_codegen/golang/description.py
+++ b/aas_core_codegen/golang/description.py
@@ -70,7 +70,7 @@ class _ElementRenderer(intermediate_doc.DocutilsElementTransformer[str]):
     def transform_reference_to_our_type_in_doc(
         self, element: intermediate_doc.ReferenceToOurType
     ) -> Tuple[Optional[str], Optional[List[str]]]:
-        result = None  # type: Optional[str]
+        result: str
 
         if isinstance(
             element.our_type,
@@ -80,7 +80,7 @@ class _ElementRenderer(intermediate_doc.DocutilsElementTransformer[str]):
                 intermediate.ConcreteClass,
             ),
         ):
-            name = None  # type: Optional[str]
+            name: str
 
             if isinstance(element.our_type, intermediate.Enumeration):
                 name = golang_naming.enum_name(element.our_type.name)
@@ -96,8 +96,6 @@ class _ElementRenderer(intermediate_doc.DocutilsElementTransformer[str]):
 
             else:
                 assert_never(element.our_type)
-
-            assert name is not None
 
             if self.context.package == golang_common.TYPES_PACKAGE:
                 result = f"[{name}]"
@@ -115,13 +113,12 @@ class _ElementRenderer(intermediate_doc.DocutilsElementTransformer[str]):
         else:
             assert_never(element.our_type)
 
-        assert result is not None
         return result, None
 
     def transform_reference_to_attribute_in_doc(
         self, element: intermediate_doc.ReferenceToAttribute
     ) -> Tuple[Optional[str], Optional[List[str]]]:
-        result = None  # type: Optional[str]
+        result: str
 
         if isinstance(element.reference, intermediate_doc.ReferenceToProperty):
             interface_name = golang_naming.interface_name(element.reference.cls.name)
@@ -147,8 +144,6 @@ class _ElementRenderer(intermediate_doc.DocutilsElementTransformer[str]):
                 result = f"[{golang_common.TYPES_PACKAGE}.{literal_name}]"
         else:
             assert_never(element.reference)
-
-        assert result is not None
 
         return result, None
 

--- a/aas_core_codegen/golang/enhancing/_generate.py
+++ b/aas_core_codegen/golang/enhancing/_generate.py
@@ -195,7 +195,7 @@ def _generate_wrap_for_cls(cls: intermediate.ConcreteClass) -> Stripped:
 
     recurse_blocks = []  # type: List[Stripped]
     for prop in cls.properties:
-        recurse_block = None  # type: Optional[Stripped]
+        recurse_block: Stripped
 
         type_anno = intermediate.beneath_optional(prop.type_annotation)
 
@@ -266,8 +266,6 @@ for i, v := range {prop_var} {{
 
         else:
             assert_never(type_anno)
-
-        assert recurse_block is not None
 
         if isinstance(prop.type_annotation, intermediate.OptionalTypeAnnotation):
             recurse_block = Stripped(

--- a/aas_core_codegen/golang/jsonization/_generate.py
+++ b/aas_core_codegen/golang/jsonization/_generate.py
@@ -476,7 +476,7 @@ def _determine_parse_function_for_atomic_value(
     type_annotation: intermediate.AtomicTypeAnnotation,
 ) -> Stripped:
     """Determine the parse function for deserializing an atomic non-optional value."""
-    function_name = None  # type: Optional[str]
+    function_name: str
 
     if isinstance(type_annotation, intermediate.PrimitiveTypeAnnotation):
         function_name = _PARSE_FUNCTION_BY_PRIMITIVE_TYPE[type_annotation.a_type]
@@ -543,7 +543,7 @@ def _generate_deserialization_switch_statement(
             naming.json_property(prop.name)
         )
 
-        case_body = None  # type: Optional[Stripped]
+        case_body: Stripped
 
         primitive_type = intermediate.try_primitive_type(type_anno)
 
@@ -684,8 +684,6 @@ for i, itemJsonable := range jsonableArray {{
 
         else:
             assert_never(type_anno)
-
-        assert case_body is not None
 
         if not optional:
             found_var = golang_naming.variable_name(Identifier(f"found_{prop.name}"))
@@ -1201,8 +1199,7 @@ def _generate_cls_to_map(cls: intermediate.ConcreteClass) -> Stripped:
             Identifier(f"jsonable_{prop.name}")
         )
 
-        # noinspection PyUnusedLocal
-        block = None  # type: Optional[Stripped]
+        block: Stripped
 
         if isinstance(type_anno, intermediate.ListTypeAnnotation):
             assert isinstance(

--- a/aas_core_codegen/golang/structure/_generate.py
+++ b/aas_core_codegen/golang/structure/_generate.py
@@ -56,7 +56,7 @@ def _human_readable_identifier(
     # code was nigh unreadable. So we preferred a little bit of copying to a little
     # bit of complexity.
 
-    result = None  # type: Optional[str]
+    result: str
 
     if isinstance(something, intermediate.Enumeration):
         result = f"meta-model enumeration {something.name!r}"
@@ -92,7 +92,7 @@ def _verify_structure_name_collisions(
     # region Inter-structure collisions
 
     for enum_or_cls in itertools.chain(symbol_table.enumerations, symbol_table.classes):
-        names = None  # type: Optional[List[Identifier]]
+        names: List[Identifier]
 
         if isinstance(enum_or_cls, intermediate.Enumeration):
             names = [golang_naming.enum_name(enum_or_cls.name)]

--- a/aas_core_codegen/golang/transpilation.py
+++ b/aas_core_codegen/golang/transpilation.py
@@ -232,8 +232,7 @@ class Transpiler(
 
         member_type = self.type_map[node]
 
-        # noinspection PyUnusedLocal
-        member_accessor = None  # type: Optional[str]
+        member_accessor: str
 
         if isinstance(
             instance_type, intermediate_type_inference.OurTypeAnnotation
@@ -296,8 +295,6 @@ class Transpiler(
                 f"was {member_type}. However, we do not know how to resolve "
                 f"the member {node.name!r} in {instance_type}.",
             )
-
-        assert member_accessor is not None
 
         return Stripped(f"{instance}.{member_accessor}"), None
 
@@ -833,7 +830,7 @@ len(
             errors.append(error)
 
         if len(errors) > 0:
-            operation_name = None  # type: Optional[str]
+            operation_name: str
             if isinstance(node, parse_tree.Add):
                 operation_name = "the addition"
             elif isinstance(node, parse_tree.Sub):
@@ -1010,7 +1007,7 @@ fmt.Sprintf(
         if isinstance(node.generator, parse_tree.ForEach):
             assert iteration is not None
 
-            qualifier_function = None  # type: Optional[str]
+            qualifier_function: str
             if isinstance(node, parse_tree.Any):
                 qualifier_function = "Some"
             elif isinstance(node, parse_tree.All):
@@ -1052,15 +1049,12 @@ aascommon.{qualifier_function}(
             )
 
         elif isinstance(node.generator, parse_tree.ForRange):
-            qualifier_function = None
             if isinstance(node, parse_tree.Any):
                 qualifier_function = "SomeRange"
             elif isinstance(node, parse_tree.All):
                 qualifier_function = "AllRange"
             else:
                 assert_never(node)
-
-            assert qualifier_function is not None
 
             assert start is not None
             assert end is not None

--- a/aas_core_codegen/intermediate/_types.py
+++ b/aas_core_codegen/intermediate/_types.py
@@ -2782,7 +2782,7 @@ def map_descendability(
             return False
 
         elif isinstance(a_type_annotation, OurTypeAnnotation):
-            result = None  # type: Optional[bool]
+            result: bool
             if isinstance(a_type_annotation.our_type, Enumeration):
                 result = False
             elif isinstance(a_type_annotation.our_type, ConstrainedPrimitive):
@@ -2792,7 +2792,6 @@ def map_descendability(
             else:
                 assert_never(a_type_annotation.our_type)
 
-            assert result is not None
             mapping[a_type_annotation] = result
             return result
 

--- a/aas_core_codegen/intermediate/type_inference.py
+++ b/aas_core_codegen/intermediate/type_inference.py
@@ -747,15 +747,13 @@ class Canonicalizer(parse_tree.RestrictedTransformer[str]):
         if not Canonicalizer._needs_no_brackets(node.right):
             right_repr = f"({right_repr})"
 
-        result = None  # type: Optional[str]
+        result: str
         if isinstance(node, parse_tree.Add):
             result = f"{left_repr} + {right_repr}"
         elif isinstance(node, parse_tree.Sub):
             result = f"{left_repr} - {right_repr}"
         else:
             assert_never(node)
-
-        assert result is not None
 
         self.representation_map[node] = result
         return result
@@ -812,7 +810,7 @@ class Canonicalizer(parse_tree.RestrictedTransformer[str]):
         if not Canonicalizer._needs_no_brackets(node.condition):
             condition = f"({condition})"
 
-        result = None  # type: Optional[str]
+        result: str
 
         if isinstance(node, parse_tree.Any):
             result = f"any({condition} {generator})"
@@ -821,7 +819,6 @@ class Canonicalizer(parse_tree.RestrictedTransformer[str]):
         else:
             assert_never(node)
 
-        assert result is not None
         self.representation_map[node] = result
         return result
 
@@ -1340,15 +1337,12 @@ class Inferrer(parse_tree.RestrictedTransformer[Optional["TypeAnnotationUnion"]]
             )
             return None
 
-        # noinspection PyUnusedLocal
-        result = None  # type: Optional[TypeAnnotationUnion]
+        result: TypeAnnotationUnion
 
         if member_type.method.returns is None:
             result = PrimitiveTypeAnnotation(a_type=PrimitiveType.NONE)
         else:
             result = convert_type_annotation(member_type.method.returns)
-
-        assert result is not None
 
         result = self._strip_optional_if_non_null(node=node, type_annotation=result)
         self.type_map[node] = result
@@ -1431,7 +1425,7 @@ class Inferrer(parse_tree.RestrictedTransformer[Optional["TypeAnnotationUnion"]]
     def transform_constant(
         self, node: parse_tree.Constant
     ) -> Optional["TypeAnnotationUnion"]:
-        result = None  # type: Optional[TypeAnnotationUnion]
+        result: TypeAnnotationUnion
 
         if isinstance(node.value, bool):
             result = PrimitiveTypeAnnotation(PrimitiveType.BOOL)
@@ -1443,8 +1437,6 @@ class Inferrer(parse_tree.RestrictedTransformer[Optional["TypeAnnotationUnion"]]
             result = PrimitiveTypeAnnotation(PrimitiveType.STR)
         else:
             assert_never(node.value)
-
-        assert result is not None
 
         self.type_map[node] = result
         return result
@@ -1717,8 +1709,7 @@ class Inferrer(parse_tree.RestrictedTransformer[Optional["TypeAnnotationUnion"]]
             return None
 
         # fmt: off
-        # noinspection PyUnusedLocal
-        result_type = None  # type: Optional[PrimitiveType]
+        result_type: PrimitiveType
         if (
             (
                 left_type.a_type is PrimitiveType.LENGTH
@@ -1746,8 +1737,6 @@ class Inferrer(parse_tree.RestrictedTransformer[Optional["TypeAnnotationUnion"]]
                 f"Unhandled execution path: {left_type=}, {right_type=}"
             )
         # fmt: on
-
-        assert result_type is not None
 
         result = PrimitiveTypeAnnotation(a_type=result_type)
         self.type_map[node] = result
@@ -1927,8 +1916,7 @@ class Inferrer(parse_tree.RestrictedTransformer[Optional["TypeAnnotationUnion"]]
             PrimitiveType.LENGTH,
         )
 
-        # noinspection PyUnusedLocal
-        loop_variable_type = None  # type: Optional[PrimitiveTypeAnnotation]
+        loop_variable_type: PrimitiveTypeAnnotation
         if (
             start_type.a_type is PrimitiveType.LENGTH
             or end_type.a_type is PrimitiveType.LENGTH
@@ -1940,8 +1928,6 @@ class Inferrer(parse_tree.RestrictedTransformer[Optional["TypeAnnotationUnion"]]
                 and end_type.a_type is PrimitiveType.INT
             )
             loop_variable_type = PrimitiveTypeAnnotation(a_type=PrimitiveType.INT)
-
-        assert loop_variable_type is not None
 
         # endregion
 
@@ -2000,8 +1986,7 @@ class Inferrer(parse_tree.RestrictedTransformer[Optional["TypeAnnotationUnion"]]
     ) -> Optional["TypeAnnotationUnion"]:
         is_new_variable = False
 
-        # noinspection PyUnusedLocal
-        target_type = None  # type: Optional[TypeAnnotationUnion]
+        target_type: Optional[TypeAnnotationUnion]
 
         if isinstance(node.target, parse_tree.Name):
             target_type = self._environment.find(node.target.identifier)

--- a/aas_core_codegen/jsonschema/main.py
+++ b/aas_core_codegen/jsonschema/main.py
@@ -542,15 +542,13 @@ def _generate_inheritable_definition(
     if len(definition) > 0:
         all_of.append(definition)
 
-    definition_name = None  # type: Optional[str]
+    definition_name: str
     if isinstance(cls, intermediate.AbstractClass):
         definition_name = naming.json_model_type(cls.name)
     elif isinstance(cls, intermediate.ConcreteClass):
         definition_name = f"{naming.json_model_type(cls.name)}_abstract"
     else:
         assert_never(cls)
-
-    assert definition_name is not None
 
     result = collections.OrderedDict()  # type: MutableMapping[str, Any]
 
@@ -733,8 +731,7 @@ def _generate(
             )
         ]
 
-    # noinspection PyUnusedLocal
-    schema = None  # type: Optional[MutableMapping[str, Any]]
+    schema: MutableMapping[str, Any]
 
     try:
         # noinspection PyTypeChecker
@@ -745,8 +742,6 @@ def _generate(
                 None, f"Failed to parse the base schema from {schema_base_key}: {err}"
             )
         ]
-
-    assert schema is not None
 
     if "$id" in schema:
         return None, [

--- a/aas_core_codegen/parse/_rules.py
+++ b/aas_core_codegen/parse/_rules.py
@@ -179,8 +179,7 @@ class _ParseAnyOrAll(_Parse):
 
         # region Parse the generator
 
-        # noinspection PyUnusedLocal
-        our_generator = None  # type: Optional[tree.ForUnion]
+        our_generator: tree.ForUnion
 
         if (
             isinstance(generator.iter, ast.Call)
@@ -227,12 +226,10 @@ class _ParseAnyOrAll(_Parse):
                 variable=our_variable, iteration=our_iteration, original_node=generator
             )
 
-        assert our_generator is not None
-
         # endregion
 
         # noinspection PyUnusedLocal
-        factory_to_use = None  # type: Optional[Union[Type[tree.Any], Type[tree.All]]]
+        factory_to_use: Union[Type[tree.Any], Type[tree.All]]
         if node.func.id == "any":
             factory_to_use = tree.Any
         elif node.func.id == "all":

--- a/aas_core_codegen/parse/_translate.py
+++ b/aas_core_codegen/parse/_translate.py
@@ -255,8 +255,7 @@ def _type_annotation(
 
         # NOTE (mristin, 2022-01-22):
         # Please see the note about the deprecation of ``ast.Index`` above.
-        # noinspection PyUnusedLocal
-        index_node = None  # type: Optional[ast.AST]
+        index_node: ast.AST
         if sys.version_info < (3, 9):
             # noinspection PyUnresolvedReferences
             if isinstance(node.slice, ast.Index):
@@ -272,8 +271,6 @@ def _type_annotation(
                 )
         else:
             index_node = node.slice
-
-        assert index_node is not None
 
         subscripts = []  # type: List[TypeAnnotation]
 
@@ -1565,8 +1562,8 @@ def _ast_constant_string_to_description(
     dedented = textwrap.dedent(text)
 
     warnings = io.StringIO()
-    # noinspection PyUnusedLocal
-    document = None  # type: Optional[docutils.nodes.document]
+
+    document: docutils.nodes.document
     try:
         document = docutils.core.publish_doctree(
             dedented, settings_overrides={"warning_stream": warnings}
@@ -1698,7 +1695,6 @@ def _class_decorator_to_invariant(
     condition_node = None  # type: Optional[ast.AST]
     description_node = None  # type: Optional[ast.AST]
 
-    # BEFORE-RELEASE (mristin, 2021-12-13): test parsing of args and kwargs
     if len(decorator.args) >= 1:
         condition_node = decorator.args[0]
 

--- a/aas_core_codegen/parse/retree/_parse.py
+++ b/aas_core_codegen/parse/retree/_parse.py
@@ -661,11 +661,10 @@ def _parse_char_literal(cursor: Cursor) -> Tuple[Optional[Char], Optional[Error]
     For example, if there is a quantifier (such as ``*``, ``+`` or ``?``) following
     a literal. In those cases, return ``None`` and no error.
     """
-    # noinspection PyUnusedLocal
-    result = None  # type: Optional[Char]
-
     if cursor.done():
         return None, None
+
+    result: Char
 
     if cursor.try_literal("\\x"):
         substring = cursor.try_substring(length=2)
@@ -838,7 +837,6 @@ def _parse_char_literal(cursor: Cursor) -> Tuple[Optional[Char], Optional[Error]
         )
         result = Char(character=character)
 
-    assert result is not None
     return result, None
 
 
@@ -869,8 +867,7 @@ def _parse_concatenation(
         if cursor.peek_literal("|"):
             break
 
-        # noinspection PyUnusedLocal
-        value = None  # type: Optional[TermValueUnion]
+        value: Optional[TermValueUnion]
 
         # noinspection GrazieInspection
         if cursor.try_literal("^"):

--- a/aas_core_codegen/parse/retree/_render.py
+++ b/aas_core_codegen/parse/retree/_render.py
@@ -168,8 +168,7 @@ class Renderer(Transformer[List[Union[str, FormattedValue]]]):
         self, node: Quantifier
     ) -> List[Union[str, FormattedValue]]:
         """Transform the ``quantifier``."""
-        # noinspection PyUnusedLocal
-        quantifier = None  # type: Optional[str]
+        quantifier: str
 
         if node.maximum is not None:
             if node.minimum == node.maximum:
@@ -189,8 +188,6 @@ class Renderer(Transformer[List[Union[str, FormattedValue]]]):
                 quantifier = "+"
             else:
                 quantifier = f"{{{node.minimum},}}"
-
-        assert quantifier is not None
 
         if node.non_greedy:
             quantifier += "?"

--- a/aas_core_codegen/python/common.py
+++ b/aas_core_codegen/python/common.py
@@ -96,11 +96,8 @@ def string_literal(
     If ``duplicate_curly_brackets`` is set, all the opening and closing curly brackets
     (``{`` and ``}``) are duplicated (``{{`` and ``}}``, respectively).
     """
-    # noinspection PyUnusedLocal
-    mapping = None  # type: Optional[Mapping[str, str]]
-
-    # noinspection PyUnusedLocal
-    enclosing = None  # type: Optional[str]
+    mapping: Mapping[str, str]
+    enclosing: str
 
     if quoting is None:
         if text.count("'") <= text.count('"'):
@@ -121,8 +118,6 @@ def string_literal(
     else:
         assert_never(quoting)
         raise AssertionError("Unexpected execution path")
-
-    assert mapping is not None
 
     if duplicate_curly_brackets:
         if mapping is _ESCAPING_IN_PYTHON_INCLUDING_DOUBLE_QUOTES:
@@ -173,8 +168,7 @@ def bytes_literal(value: bytes) -> Tuple[Stripped, bool]:
     """
     writer = io.StringIO()
 
-    # noinspection PyUnusedLocal
-    multi_line = None  # type: Optional[bool]
+    multi_line: bool
 
     if len(value) <= 8:
         writer.write('b"')

--- a/aas_core_codegen/python/constants/_generate.py
+++ b/aas_core_codegen/python/constants/_generate.py
@@ -334,8 +334,9 @@ import {aas_module}.types as aas_types"""
     ]  # type: List[Stripped]
 
     for constant in symbol_table.constants:
-        block = None  # type: Optional[Stripped]
-        error = None  # type: Optional[Error]
+        block: Optional[Stripped]
+        error: Optional[Error]
+
         if isinstance(constant, intermediate.ConstantPrimitive):
             block, error = _generate_constant_primitive(
                 constant=constant, aas_module=aas_module

--- a/aas_core_codegen/python/description.py
+++ b/aas_core_codegen/python/description.py
@@ -76,7 +76,7 @@ class _ElementRenderer(intermediate_doc.DocutilsElementTransformer[str]):
     def transform_reference_to_our_type_in_doc(
         self, element: intermediate_doc.ReferenceToOurType
     ) -> Tuple[Optional[str], Optional[List[str]]]:
-        result = None  # type: Optional[str]
+        result: str
 
         name = python_naming.class_name(element.our_type.name)
 
@@ -102,13 +102,12 @@ class _ElementRenderer(intermediate_doc.DocutilsElementTransformer[str]):
         else:
             assert_never(element.our_type)
 
-        assert result is not None
         return result, None
 
     def transform_reference_to_attribute_in_doc(
         self, element: intermediate_doc.ReferenceToAttribute
     ) -> Tuple[Optional[str], Optional[List[str]]]:
-        result = None  # type: Optional[str]
+        result: str
 
         if isinstance(element.reference, intermediate_doc.ReferenceToProperty):
             cls_name = python_naming.class_name(element.reference.cls.name)
@@ -139,8 +138,6 @@ class _ElementRenderer(intermediate_doc.DocutilsElementTransformer[str]):
                 result = f":py:attr:`.types.{cls_name}.{literal_name}`"
         else:
             assert_never(element.reference)
-
-        assert result is not None
 
         return result, None
 

--- a/aas_core_codegen/python/jsonization/_generate.py
+++ b/aas_core_codegen/python/jsonization/_generate.py
@@ -360,7 +360,7 @@ def _parse_function_for_atomic_value(
     type_annotation: intermediate.AtomicTypeAnnotation,
 ) -> Stripped:
     """Determine the parse function for deserializing an atomic non-optional value."""
-    function_name = None  # type: Optional[str]
+    function_name: str
 
     if isinstance(type_annotation, intermediate.PrimitiveTypeAnnotation):
         function_name = _PARSE_FUNCTION_BY_PRIMITIVE_TYPE[type_annotation.a_type]
@@ -883,7 +883,7 @@ def _generate_transform(cls: intermediate.ConcreteClass) -> Stripped:
 
         type_anno = intermediate.beneath_optional(prop.type_annotation)
 
-        block = None  # type: Optional[Stripped]
+        block: Stripped
 
         if isinstance(
             type_anno,
@@ -927,8 +927,6 @@ jsonable[{key_literal}] = [
 
         else:
             assert_never(type_anno)
-
-        assert block is not None
 
         if isinstance(prop.type_annotation, intermediate.OptionalTypeAnnotation):
             block = Stripped(

--- a/aas_core_codegen/python/structure/_generate.py
+++ b/aas_core_codegen/python/structure/_generate.py
@@ -53,7 +53,7 @@ def _human_readable_identifier(
 
     The reader should be able to trace ``something`` back to the meta-model.
     """
-    result = None  # type: Optional[str]
+    result: str
 
     if isinstance(something, intermediate.Enumeration):
         result = f"meta-model enumeration {something.name!r}"
@@ -64,7 +64,6 @@ def _human_readable_identifier(
     else:
         assert_never(something)
 
-    assert result is not None
     return result
 
 
@@ -603,33 +602,31 @@ def descend(self) -> Iterator[Class]:
 
 def _generate_default_value(default: intermediate.Default) -> Stripped:
     """Generate the Python code representing the default value of an argument."""
-    code = None  # type: Optional[str]
+    code: str
 
-    if default is not None:
-        if isinstance(default, intermediate.DefaultPrimitive):
-            if default.value is None:
-                code = "None"
-            elif isinstance(default.value, bool):
-                code = "True" if default.value else "False"
-            elif isinstance(default.value, str):
-                code = python_common.string_literal(default.value)
-            elif isinstance(default.value, int):
-                code = str(default.value)
-            elif isinstance(default.value, float):
-                code = f"{default}"
-            else:
-                assert_never(default.value)
-        elif isinstance(default, intermediate.DefaultEnumerationLiteral):
-            code = ".".join(
-                [
-                    python_naming.enum_name(default.enumeration.name),
-                    python_naming.enum_literal_name(default.literal.name),
-                ]
-            )
+    if isinstance(default, intermediate.DefaultPrimitive):
+        if default.value is None:
+            code = "None"
+        elif isinstance(default.value, bool):
+            code = "True" if default.value else "False"
+        elif isinstance(default.value, str):
+            code = python_common.string_literal(default.value)
+        elif isinstance(default.value, int):
+            code = str(default.value)
+        elif isinstance(default.value, float):
+            code = f"{default}"
         else:
-            assert_never(default)
+            assert_never(default.value)
+    elif isinstance(default, intermediate.DefaultEnumerationLiteral):
+        code = ".".join(
+            [
+                python_naming.enum_name(default.enumeration.name),
+                python_naming.enum_literal_name(default.literal.name),
+            ]
+        )
+    else:
+        assert_never(default)
 
-    assert code is not None
     return Stripped(code)
 
 
@@ -1714,7 +1711,7 @@ class Class(abc.ABC):
     )
 
     for our_type in symbol_table.our_types:
-        error = None  # type: Optional[Error]
+        error: Optional[Error]
 
         if isinstance(our_type, intermediate.Enumeration):
             block, error = _generate_enum(enum=our_type, aas_module=aas_module)

--- a/aas_core_codegen/python/transpilation.py
+++ b/aas_core_codegen/python/transpilation.py
@@ -70,8 +70,7 @@ class Transpiler(
         )
         member_type = intermediate_type_inference.beneath_optional(self.type_map[node])
 
-        # noinspection PyUnusedLocal
-        member_name = None  # type: Optional[str]
+        member_name: str
 
         if isinstance(
             instance_type, intermediate_type_inference.OurTypeAnnotation
@@ -113,8 +112,6 @@ class Transpiler(
                 f"was {member_type}. However, we do not know how to resolve "
                 f"the member {node.name!r} in {instance_type}.",
             )
-
-        assert member_name is not None
 
         return Stripped(f"{instance}.{member_name}"), None
 
@@ -631,7 +628,7 @@ not (
             errors.append(error)
 
         if len(errors) > 0:
-            operation_name = None  # type: Optional[str]
+            operation_name: str
             if isinstance(node, parse_tree.Add):
                 operation_name = "the addition"
             elif isinstance(node, parse_tree.Sub):
@@ -820,7 +817,7 @@ not (
         assert variable is not None
         assert condition is not None
 
-        qualifier_function = None  # type: Optional[str]
+        qualifier_function: str
         if isinstance(node, parse_tree.Any):
             qualifier_function = "any"
         elif isinstance(node, parse_tree.All):
@@ -828,7 +825,7 @@ not (
         else:
             assert_never(node)
 
-        source = None  # type: Optional[Stripped]
+        source: Stripped
         if isinstance(node.generator, parse_tree.ForEach):
             no_parentheses_types_in_this_context = (
                 parse_tree.Member,
@@ -843,6 +840,7 @@ not (
             ):
                 source = Stripped(f"({iteration})")
             else:
+                assert iteration is not None
                 source = iteration
         elif isinstance(node.generator, parse_tree.ForRange):
             assert start is not None
@@ -858,8 +856,6 @@ range(
 
         else:
             assert_never(node.generator)
-
-        assert source is not None
 
         return (
             Stripped(

--- a/aas_core_codegen/python/xmlization/_generate.py
+++ b/aas_core_codegen/python/xmlization/_generate.py
@@ -578,7 +578,7 @@ def __init__(self) -> None:
 
         prop_name = python_naming.property_name(prop.name)
 
-        method_body = None  # type: Optional[Stripped]
+        method_body: Stripped
 
         if isinstance(type_anno, intermediate.PrimitiveTypeAnnotation) or (
             isinstance(type_anno, intermediate.OurTypeAnnotation)
@@ -746,8 +746,6 @@ self.{prop_name} = result"""
         else:
             assert_never(type_anno)
             raise AssertionError("Unexpected execution path")
-
-        assert method_body is not None
 
         method_name = python_naming.method_name(Identifier(f"read_and_set_{prop.name}"))
         methods.append(
@@ -1292,9 +1290,9 @@ return"""
 
             type_anno = intermediate.beneath_optional(prop.type_annotation)
 
-            write_prop = None  # type: Optional[Stripped]
-
             primitive_type = intermediate.try_primitive_type(type_anno)
+
+            write_prop: Stripped
 
             if primitive_type is not None:
                 write_method = _WRITE_METHOD_BY_PRIMITIVE_TYPE[primitive_type]
@@ -1377,8 +1375,6 @@ else:
                     )
                 else:
                     assert_never(type_anno)
-
-            assert write_prop is not None
 
             if isinstance(prop.type_annotation, intermediate.OptionalTypeAnnotation):
                 write_prop = Stripped(

--- a/aas_core_codegen/rdf_shacl/common.py
+++ b/aas_core_codegen/rdf_shacl/common.py
@@ -106,15 +106,15 @@ def rdfs_range_for_type_annotation(
     """Determine the ``rdfs:range`` corresponding to the ``type_annotation``."""
     type_anno = intermediate.beneath_optional(type_annotation)
 
-    rdfs_range = None  # type: Optional[str]
+    rdfs_range: str
 
     if isinstance(type_anno, intermediate.PrimitiveTypeAnnotation):
         rdfs_range = PRIMITIVE_MAP[type_anno.a_type]
 
     elif isinstance(type_anno, intermediate.OurTypeAnnotation):
-        rdfs_range = our_type_to_rdfs_range.get(type_anno.our_type, None)
+        maybe_rdfs_range = our_type_to_rdfs_range.get(type_anno.our_type, None)
 
-        if rdfs_range is None:
+        if maybe_rdfs_range is None:
             if isinstance(
                 type_anno.our_type,
                 (
@@ -130,6 +130,8 @@ def rdfs_range_for_type_annotation(
                 rdfs_range = PRIMITIVE_MAP[type_anno.our_type.constrainee]
             else:
                 assert_never(type_anno.our_type)
+        else:
+            rdfs_range = maybe_rdfs_range
 
     elif isinstance(type_anno, intermediate.ListTypeAnnotation):
         rdfs_range = rdfs_range_for_type_annotation(
@@ -138,8 +140,6 @@ def rdfs_range_for_type_annotation(
         )
     else:
         assert_never(type_anno)
-
-    assert rdfs_range is not None
 
     return Stripped(rdfs_range)
 

--- a/aas_core_codegen/rdf_shacl/shacl.py
+++ b/aas_core_codegen/rdf_shacl/shacl.py
@@ -381,8 +381,7 @@ def generate(
             # on why we hard-wire ``Lang_string`` here.
             continue
 
-        # noinspection PyUnusedLocal
-        block = None  # type: Optional[Stripped]
+        block: Optional[Stripped]
 
         if isinstance(our_type, intermediate.Enumeration):
             continue

--- a/aas_core_codegen/typescript/common.py
+++ b/aas_core_codegen/typescript/common.py
@@ -119,9 +119,6 @@ def bytes_literal(value: bytes) -> Tuple[Stripped, bool]:
 
     writer = io.StringIO()
 
-    # noinspection PyUnusedLocal
-    multi_line = None  # type: Optional[bool]
-
     if len(value) <= 8:
         items_joined = ", ".join(f"0x{byte:02x}" for byte in value)
         return Stripped(f"new Uint8Array([{items_joined}])"), False
@@ -149,9 +146,8 @@ new Uint8Array(
                 writer.write(f"0x{byte:02x}")
 
         writer.write(f"\n{INDENT}]\n)")
-        multi_line = True
 
-        return Stripped(writer.getvalue()), multi_line
+        return Stripped(writer.getvalue()), True
 
 
 def needs_escaping(text: str, in_backticks: bool = False) -> bool:
@@ -240,8 +236,7 @@ def generate_type(
     elif isinstance(type_annotation, intermediate.OurTypeAnnotation):
         our_type = type_annotation.our_type
 
-        # noinspection PyUnusedLocal
-        name = None  # type: Optional[Identifier]
+        name: Identifier
 
         if isinstance(our_type, intermediate.Enumeration):
             name = typescript_naming.enum_name(type_annotation.our_type.name)

--- a/aas_core_codegen/typescript/constants/_generate.py
+++ b/aas_core_codegen/typescript/constants/_generate.py
@@ -161,7 +161,7 @@ def _generate_constant_set_of_primitives(
             writer.write("\n")
 
     literal_codes = []  # type: List[str]
-    set_type = None  # type: Optional[str]
+    set_type: str
 
     if constant.a_type is intermediate.PrimitiveType.BOOL:
         set_type = "boolean"
@@ -217,8 +217,6 @@ def _generate_constant_set_of_primitives(
     else:
         assert_never(constant.a_type)
         raise AssertionError("Unexpected execution path")
-
-    assert set_type is not None
 
     literals_joined = ",\n".join(literal_codes)
 
@@ -309,8 +307,9 @@ def generate(
     ]  # type: List[Stripped]
 
     for constant in symbol_table.constants:
-        block = None  # type: Optional[Stripped]
-        error = None  # type: Optional[Error]
+        block: Optional[Stripped]
+        error: Optional[Error]
+
         if isinstance(constant, intermediate.ConstantPrimitive):
             block, error = _generate_constant_primitive(constant=constant)
         elif isinstance(constant, intermediate.ConstantSetOfPrimitives):

--- a/aas_core_codegen/typescript/jsonization/_generate.py
+++ b/aas_core_codegen/typescript/jsonization/_generate.py
@@ -396,7 +396,7 @@ def _parse_function_for_atomic_value(
     type_annotation: intermediate.AtomicTypeAnnotation,
 ) -> Stripped:
     """Determine the parse function for deserializing an atomic non-optional value."""
-    function_name = None  # type: Optional[str]
+    function_name: str
 
     if isinstance(type_annotation, intermediate.PrimitiveTypeAnnotation):
         function_name = _PARSE_FUNCTION_BY_PRIMITIVE_TYPE[type_annotation.a_type]
@@ -997,7 +997,7 @@ def _generate_transform(cls: intermediate.ConcreteClass) -> Stripped:
 
         type_anno = intermediate.beneath_optional(prop.type_annotation)
 
-        block = None  # type: Optional[Stripped]
+        block: Stripped
 
         if isinstance(
             type_anno,
@@ -1041,8 +1041,6 @@ jsonable[{key_literal}] = {var_name};"""
 
         else:
             assert_never(type_anno)
-
-        assert block is not None
 
         if isinstance(prop.type_annotation, intermediate.OptionalTypeAnnotation):
             block = Stripped(

--- a/aas_core_codegen/typescript/structure/_generate.py
+++ b/aas_core_codegen/typescript/structure/_generate.py
@@ -58,7 +58,7 @@ def _human_readable_identifier(
     # code was nigh unreadable. So we preferred a little bit of copying to a little
     # bit of complexity.
 
-    result = None  # type: Optional[str]
+    result: str
 
     if isinstance(something, intermediate.Enumeration):
         result = f"meta-model enumeration {something.name!r}"
@@ -69,7 +69,6 @@ def _human_readable_identifier(
     else:
         assert_never(something)
 
-    assert result is not None
     return result
 
 
@@ -654,39 +653,37 @@ def _generate_default_value(
     default: intermediate.Default,
 ) -> Tuple[Optional[Stripped], Optional[Error]]:
     """Generate the TypeScript code representing the default value of an argument."""
-    code = None  # type: Optional[str]
+    code: str
 
-    if default is not None:
-        if isinstance(default, intermediate.DefaultPrimitive):
-            if default.value is None:
-                code = "null"
-            elif isinstance(default.value, bool):
-                code = typescript_common.boolean_literal(default.value)
-            elif isinstance(default.value, int):
-                if not typescript_common.representable_as_number(default.value):
-                    return None, Error(
-                        default.parsed.node,
-                        f"The value is not representable as a double-precision "
-                        f"floating point number: {default.value}",
-                    )
-                code = typescript_common.numeric_literal(default.value)
-            elif isinstance(default.value, float):
-                code = typescript_common.numeric_literal(default.value)
-            elif isinstance(default.value, str):
-                code = typescript_common.string_literal(default.value)
-            else:
-                assert_never(default.value)
-        elif isinstance(default, intermediate.DefaultEnumerationLiteral):
-            code = ".".join(
-                [
-                    typescript_naming.enum_name(default.enumeration.name),
-                    typescript_naming.enum_literal_name(default.literal.name),
-                ]
-            )
+    if isinstance(default, intermediate.DefaultPrimitive):
+        if default.value is None:
+            code = "null"
+        elif isinstance(default.value, bool):
+            code = typescript_common.boolean_literal(default.value)
+        elif isinstance(default.value, int):
+            if not typescript_common.representable_as_number(default.value):
+                return None, Error(
+                    default.parsed.node,
+                    f"The value is not representable as a double-precision "
+                    f"floating point number: {default.value}",
+                )
+            code = typescript_common.numeric_literal(default.value)
+        elif isinstance(default.value, float):
+            code = typescript_common.numeric_literal(default.value)
+        elif isinstance(default.value, str):
+            code = typescript_common.string_literal(default.value)
         else:
-            assert_never(default)
+            assert_never(default.value)
+    elif isinstance(default, intermediate.DefaultEnumerationLiteral):
+        code = ".".join(
+            [
+                typescript_naming.enum_name(default.enumeration.name),
+                typescript_naming.enum_literal_name(default.literal.name),
+            ]
+        )
+    else:
+        assert_never(default)
 
-    assert code is not None
     return Stripped(code), None
 
 

--- a/aas_core_codegen/typescript/transpilation.py
+++ b/aas_core_codegen/typescript/transpilation.py
@@ -72,8 +72,7 @@ class Transpiler(
         )
         member_type = intermediate_type_inference.beneath_optional(self.type_map[node])
 
-        # noinspection PyUnusedLocal
-        member_name = None  # type: Optional[str]
+        member_name: str
 
         if isinstance(
             instance_type, intermediate_type_inference.OurTypeAnnotation
@@ -115,8 +114,6 @@ class Transpiler(
                 f"was {member_type}. However, we do not know how to resolve "
                 f"the member {node.name!r} in {instance_type}.",
             )
-
-        assert member_name is not None
 
         return Stripped(f"{instance}.{member_name}"), None
 
@@ -748,7 +745,7 @@ AasCommon.at(
             errors.append(error)
 
         if len(errors) > 0:
-            operation_name = None  # type: Optional[str]
+            operation_name: str
             if isinstance(node, parse_tree.Add):
                 operation_name = "the addition"
             elif isinstance(node, parse_tree.Sub):
@@ -909,7 +906,7 @@ AasCommon.at(
         assert variable is not None
         assert condition is not None
 
-        qualifier_function = None  # type: Optional[str]
+        qualifier_function: str
         if isinstance(node, parse_tree.Any):
             qualifier_function = "AasCommon.some"
         elif isinstance(node, parse_tree.All):
@@ -917,7 +914,7 @@ AasCommon.at(
         else:
             assert_never(node)
 
-        source = None  # type: Optional[Stripped]
+        source: Stripped
         if isinstance(node.generator, parse_tree.ForEach):
             no_parentheses_types_in_this_context = (
                 parse_tree.Member,
@@ -932,7 +929,9 @@ AasCommon.at(
             ):
                 source = Stripped(f"({iteration})")
             else:
+                assert iteration is not None
                 source = iteration
+
         elif isinstance(node.generator, parse_tree.ForRange):
             assert start is not None
             assert end is not None
@@ -948,7 +947,6 @@ AasCommon.range(
         else:
             assert_never(node.generator)
 
-        assert source is not None
         return (
             Stripped(
                 f"""\

--- a/aas_core_codegen/xsd/main.py
+++ b/aas_core_codegen/xsd/main.py
@@ -226,8 +226,7 @@ def _generate_xs_restriction(
         ]
 
     if patterns_relevant_for_xsd is not None and len(patterns_relevant_for_xsd) > 0:
-        # noinspection PyUnusedLocal
-        translated_pattern = None  # type: Optional[str]
+        translated_pattern: Optional[str]
 
         if len(patterns_relevant_for_xsd) == 1:
             translated_pattern, error = _translate_pattern(
@@ -358,8 +357,7 @@ def _generate_xs_element_for_a_primitive_property(
     # NOTE (mristin, 2022-06-18):
     # xs_restriction may be None here if there are no constraints.
 
-    # noinspection PyUnusedLocal
-    xs_element = None  # type: Optional[ET.Element]
+    xs_element: ET.Element
 
     if xs_restriction is None:
         xs_element = ET.Element(
@@ -376,7 +374,6 @@ def _generate_xs_element_for_a_primitive_property(
         xs_element = ET.Element("xs:element", {"name": naming.xml_property(prop.name)})
         xs_element.append(xs_simple_type)
 
-    assert xs_element is not None
     return xs_element, None
 
 
@@ -402,7 +399,7 @@ def _generate_xs_element_for_a_list_property(
         if len_constraint.max_value is not None:
             max_occurs = str(len_constraint.max_value)
 
-    xs_element = None  # type: Optional[ET.Element]
+    xs_element: ET.Element
 
     if isinstance(type_anno.items, intermediate.OurTypeAnnotation):
         # NOTE (mristin, 2021-11-13):
@@ -494,7 +491,6 @@ def _generate_xs_element_for_a_list_property(
             f"in the XSD with the type: {type_anno}",
         )
 
-    assert xs_element is not None
     return xs_element, None
 
 
@@ -507,7 +503,7 @@ def _generate_xs_element_for_a_property(
     """Generate the definition of an ``xs:element`` for a property."""
     type_anno = intermediate.beneath_optional(prop.type_annotation)
 
-    xs_element = None  # type: Optional[ET.Element]
+    xs_element: Optional[ET.Element]
 
     if isinstance(type_anno, intermediate.PrimitiveTypeAnnotation):
         xs_element, error = _generate_xs_element_for_a_primitive_property(
@@ -758,8 +754,7 @@ def _retrieve_implementation_specific_elements(
             )
         ]
 
-    # noinspection PyUnusedLocal
-    implementation_root = None  # type: Optional[ET.Element]
+    implementation_root: ET.Element
 
     try:
         implementation_root = ET.fromstring(text)
@@ -771,8 +766,6 @@ def _retrieve_implementation_specific_elements(
                 f"the specific implementation {implementation_key}: {err}",
             )
         ]
-
-    assert implementation_root is not None
 
     errors = []  # type: List[Error]
     for descendant in implementation_root.iter():
@@ -884,8 +877,7 @@ def _generate(
             )
         ]
 
-    # noinspection PyUnusedLocal
-    root = None  # type: Optional[ET.Element]
+    root: ET.Element
     try:
         root = ET.fromstring(root_element_as_text)
     except ET.ParseError as err:
@@ -1060,7 +1052,7 @@ def _generate(
             # for the explanation why we hard-wire the ``Value_data_type`` here
             continue
 
-        elements = None  # type: Optional[List[ET.Element]]
+        elements: Optional[List[ET.Element]]
 
         if (
             isinstance(


### PR DESCRIPTION
I (@mristin) was not aware of the syntax such as `name: str` where mypy forces name to be initialized in all the execution paths. Hence, I previously always wrote:

```python
name = None  # type: Optional[str]

...

assert name is not None
```

which is unnecessarily verbose and includes a redundant is-not-None check at the end.