### PR TITLE
Indicate runtime model type in TypeScript

### DIFF
--- a/test_data/typescript/test_main/aas_core_meta.v3/expected_output/stringification.ts
+++ b/test_data/typescript/test_main/aas_core_meta.v3/expected_output/stringification.ts
@@ -7,6 +7,364 @@
 
 import * as AasTypes from "./types";
 
+const MODEL_TYPE_FROM_STRING = new Map<string, AasTypes.ModelType>([
+  [
+    "Extension",
+    AasTypes.ModelType.Extension
+  ],
+  [
+    "AdministrativeInformation",
+    AasTypes.ModelType.AdministrativeInformation
+  ],
+  [
+    "Qualifier",
+    AasTypes.ModelType.Qualifier
+  ],
+  [
+    "AssetAdministrationShell",
+    AasTypes.ModelType.AssetAdministrationShell
+  ],
+  [
+    "AssetInformation",
+    AasTypes.ModelType.AssetInformation
+  ],
+  [
+    "Resource",
+    AasTypes.ModelType.Resource
+  ],
+  [
+    "SpecificAssetId",
+    AasTypes.ModelType.SpecificAssetId
+  ],
+  [
+    "Submodel",
+    AasTypes.ModelType.Submodel
+  ],
+  [
+    "RelationshipElement",
+    AasTypes.ModelType.RelationshipElement
+  ],
+  [
+    "SubmodelElementList",
+    AasTypes.ModelType.SubmodelElementList
+  ],
+  [
+    "SubmodelElementCollection",
+    AasTypes.ModelType.SubmodelElementCollection
+  ],
+  [
+    "Property",
+    AasTypes.ModelType.Property
+  ],
+  [
+    "MultiLanguageProperty",
+    AasTypes.ModelType.MultiLanguageProperty
+  ],
+  [
+    "Range",
+    AasTypes.ModelType.Range
+  ],
+  [
+    "ReferenceElement",
+    AasTypes.ModelType.ReferenceElement
+  ],
+  [
+    "Blob",
+    AasTypes.ModelType.Blob
+  ],
+  [
+    "File",
+    AasTypes.ModelType.File
+  ],
+  [
+    "AnnotatedRelationshipElement",
+    AasTypes.ModelType.AnnotatedRelationshipElement
+  ],
+  [
+    "Entity",
+    AasTypes.ModelType.Entity
+  ],
+  [
+    "EventPayload",
+    AasTypes.ModelType.EventPayload
+  ],
+  [
+    "BasicEventElement",
+    AasTypes.ModelType.BasicEventElement
+  ],
+  [
+    "Operation",
+    AasTypes.ModelType.Operation
+  ],
+  [
+    "OperationVariable",
+    AasTypes.ModelType.OperationVariable
+  ],
+  [
+    "Capability",
+    AasTypes.ModelType.Capability
+  ],
+  [
+    "ConceptDescription",
+    AasTypes.ModelType.ConceptDescription
+  ],
+  [
+    "Reference",
+    AasTypes.ModelType.Reference
+  ],
+  [
+    "Key",
+    AasTypes.ModelType.Key
+  ],
+  [
+    "LangStringNameType",
+    AasTypes.ModelType.LangStringNameType
+  ],
+  [
+    "LangStringTextType",
+    AasTypes.ModelType.LangStringTextType
+  ],
+  [
+    "Environment",
+    AasTypes.ModelType.Environment
+  ],
+  [
+    "EmbeddedDataSpecification",
+    AasTypes.ModelType.EmbeddedDataSpecification
+  ],
+  [
+    "LevelType",
+    AasTypes.ModelType.LevelType
+  ],
+  [
+    "ValueReferencePair",
+    AasTypes.ModelType.ValueReferencePair
+  ],
+  [
+    "ValueList",
+    AasTypes.ModelType.ValueList
+  ],
+  [
+    "LangStringPreferredNameTypeIec61360",
+    AasTypes.ModelType.LangStringPreferredNameTypeIec61360
+  ],
+  [
+    "LangStringShortNameTypeIec61360",
+    AasTypes.ModelType.LangStringShortNameTypeIec61360
+  ],
+  [
+    "LangStringDefinitionTypeIec61360",
+    AasTypes.ModelType.LangStringDefinitionTypeIec61360
+  ],
+  [
+    "DataSpecificationIec61360",
+    AasTypes.ModelType.DataSpecificationIec61360
+  ]
+]);
+
+/**
+ * Parse `text` as a string representation of {@link types!ModelType}.
+ *
+ * @param text - string representation of {@link types!ModelType}
+ * @returns literal of {@link types!ModelType}, if valid, and `null` otherwise
+ */
+export function modelTypeFromString(
+  text: string
+): AasTypes.ModelType | null {
+  const result = MODEL_TYPE_FROM_STRING.get(text);
+  return result !== undefined ? result : null;
+}
+
+const MODEL_TYPE_TO_STRING = new Map<AasTypes.ModelType, string>([
+  [
+    AasTypes.ModelType.Extension,
+    "Extension"
+  ],
+  [
+    AasTypes.ModelType.AdministrativeInformation,
+    "AdministrativeInformation"
+  ],
+  [
+    AasTypes.ModelType.Qualifier,
+    "Qualifier"
+  ],
+  [
+    AasTypes.ModelType.AssetAdministrationShell,
+    "AssetAdministrationShell"
+  ],
+  [
+    AasTypes.ModelType.AssetInformation,
+    "AssetInformation"
+  ],
+  [
+    AasTypes.ModelType.Resource,
+    "Resource"
+  ],
+  [
+    AasTypes.ModelType.SpecificAssetId,
+    "SpecificAssetId"
+  ],
+  [
+    AasTypes.ModelType.Submodel,
+    "Submodel"
+  ],
+  [
+    AasTypes.ModelType.RelationshipElement,
+    "RelationshipElement"
+  ],
+  [
+    AasTypes.ModelType.SubmodelElementList,
+    "SubmodelElementList"
+  ],
+  [
+    AasTypes.ModelType.SubmodelElementCollection,
+    "SubmodelElementCollection"
+  ],
+  [
+    AasTypes.ModelType.Property,
+    "Property"
+  ],
+  [
+    AasTypes.ModelType.MultiLanguageProperty,
+    "MultiLanguageProperty"
+  ],
+  [
+    AasTypes.ModelType.Range,
+    "Range"
+  ],
+  [
+    AasTypes.ModelType.ReferenceElement,
+    "ReferenceElement"
+  ],
+  [
+    AasTypes.ModelType.Blob,
+    "Blob"
+  ],
+  [
+    AasTypes.ModelType.File,
+    "File"
+  ],
+  [
+    AasTypes.ModelType.AnnotatedRelationshipElement,
+    "AnnotatedRelationshipElement"
+  ],
+  [
+    AasTypes.ModelType.Entity,
+    "Entity"
+  ],
+  [
+    AasTypes.ModelType.EventPayload,
+    "EventPayload"
+  ],
+  [
+    AasTypes.ModelType.BasicEventElement,
+    "BasicEventElement"
+  ],
+  [
+    AasTypes.ModelType.Operation,
+    "Operation"
+  ],
+  [
+    AasTypes.ModelType.OperationVariable,
+    "OperationVariable"
+  ],
+  [
+    AasTypes.ModelType.Capability,
+    "Capability"
+  ],
+  [
+    AasTypes.ModelType.ConceptDescription,
+    "ConceptDescription"
+  ],
+  [
+    AasTypes.ModelType.Reference,
+    "Reference"
+  ],
+  [
+    AasTypes.ModelType.Key,
+    "Key"
+  ],
+  [
+    AasTypes.ModelType.LangStringNameType,
+    "LangStringNameType"
+  ],
+  [
+    AasTypes.ModelType.LangStringTextType,
+    "LangStringTextType"
+  ],
+  [
+    AasTypes.ModelType.Environment,
+    "Environment"
+  ],
+  [
+    AasTypes.ModelType.EmbeddedDataSpecification,
+    "EmbeddedDataSpecification"
+  ],
+  [
+    AasTypes.ModelType.LevelType,
+    "LevelType"
+  ],
+  [
+    AasTypes.ModelType.ValueReferencePair,
+    "ValueReferencePair"
+  ],
+  [
+    AasTypes.ModelType.ValueList,
+    "ValueList"
+  ],
+  [
+    AasTypes.ModelType.LangStringPreferredNameTypeIec61360,
+    "LangStringPreferredNameTypeIec61360"
+  ],
+  [
+    AasTypes.ModelType.LangStringShortNameTypeIec61360,
+    "LangStringShortNameTypeIec61360"
+  ],
+  [
+    AasTypes.ModelType.LangStringDefinitionTypeIec61360,
+    "LangStringDefinitionTypeIec61360"
+  ],
+  [
+    AasTypes.ModelType.DataSpecificationIec61360,
+    "DataSpecificationIec61360"
+  ]
+]);
+
+/**
+ * Translate {@link types!ModelType} to a string.
+ *
+ * @param value - to be stringified
+ * @returns string representation of {@link types!ModelType},
+ * if `value` valid, and `null` otherwise
+ */
+export function modelTypeToString(
+  value: AasTypes.ModelType
+): string | null {
+  const result = MODEL_TYPE_TO_STRING.get(value);
+  return result !== undefined ? result : null;
+}
+
+/**
+ * Translate {@link types!ModelType} to a string.
+ *
+ * @param value - to be stringified
+ * @returns string representation of {@link types!ModelType}
+ * @throws
+ * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error|Error}
+ * if the `value` is invalid
+ */
+export function mustModelTypeToString(
+  value: AasTypes.ModelType
+): string {
+  const result = MODEL_TYPE_TO_STRING.get(value);
+  if (result === undefined) {
+    throw new Error(
+      `Invalid literal of ModelType: ${value}`
+    );
+  }
+  return result;
+}
+
 const MODELLING_KIND_FROM_STRING = new Map<string, AasTypes.ModellingKind>([
   ["Template", AasTypes.ModellingKind.Template],
   ["Instance", AasTypes.ModellingKind.Instance]

--- a/test_data/typescript/test_main/aas_core_meta.v3/expected_output/types.ts
+++ b/test_data/typescript/test_main/aas_core_meta.v3/expected_output/types.ts
@@ -93,9 +93,112 @@
 // Do NOT edit or append.
 
 /**
+ * Represent runtime model type of an instance.
+ */
+export enum ModelType {
+  Extension = 0,
+  AdministrativeInformation = 1,
+  Qualifier = 2,
+  AssetAdministrationShell = 3,
+  AssetInformation = 4,
+  Resource = 5,
+  SpecificAssetId = 6,
+  Submodel = 7,
+  RelationshipElement = 8,
+  SubmodelElementList = 9,
+  SubmodelElementCollection = 10,
+  Property = 11,
+  MultiLanguageProperty = 12,
+  Range = 13,
+  ReferenceElement = 14,
+  Blob = 15,
+  File = 16,
+  AnnotatedRelationshipElement = 17,
+  Entity = 18,
+  EventPayload = 19,
+  BasicEventElement = 20,
+  Operation = 21,
+  OperationVariable = 22,
+  Capability = 23,
+  ConceptDescription = 24,
+  Reference = 25,
+  Key = 26,
+  LangStringNameType = 27,
+  LangStringTextType = 28,
+  Environment = 29,
+  EmbeddedDataSpecification = 30,
+  LevelType = 31,
+  ValueReferencePair = 32,
+  ValueList = 33,
+  LangStringPreferredNameTypeIec61360 = 34,
+  LangStringShortNameTypeIec61360 = 35,
+  LangStringDefinitionTypeIec61360 = 36,
+  DataSpecificationIec61360 = 37
+}
+
+/**
+ * Iterate over the literals of {@link ModelType}.
+ *
+ * @remark
+ * TypeScript does not provide an elegant way to iterate over the literals, so
+ * this function helps you avoid common errors and pitfalls.
+ *
+ * @return iterator over the literals
+ */
+export function *overModelType (
+): Iterable<ModelType> {
+  // NOTE (mristin, 2022-12-03):
+  // We yield numbers instead of literals to avoid name lookups on platforms
+  // which do not provide JIT compilation of hot paths.
+  yield <ModelType>0;  // Extension
+  yield <ModelType>1;  // AdministrativeInformation
+  yield <ModelType>2;  // Qualifier
+  yield <ModelType>3;  // AssetAdministrationShell
+  yield <ModelType>4;  // AssetInformation
+  yield <ModelType>5;  // Resource
+  yield <ModelType>6;  // SpecificAssetId
+  yield <ModelType>7;  // Submodel
+  yield <ModelType>8;  // RelationshipElement
+  yield <ModelType>9;  // SubmodelElementList
+  yield <ModelType>10;  // SubmodelElementCollection
+  yield <ModelType>11;  // Property
+  yield <ModelType>12;  // MultiLanguageProperty
+  yield <ModelType>13;  // Range
+  yield <ModelType>14;  // ReferenceElement
+  yield <ModelType>15;  // Blob
+  yield <ModelType>16;  // File
+  yield <ModelType>17;  // AnnotatedRelationshipElement
+  yield <ModelType>18;  // Entity
+  yield <ModelType>19;  // EventPayload
+  yield <ModelType>20;  // BasicEventElement
+  yield <ModelType>21;  // Operation
+  yield <ModelType>22;  // OperationVariable
+  yield <ModelType>23;  // Capability
+  yield <ModelType>24;  // ConceptDescription
+  yield <ModelType>25;  // Reference
+  yield <ModelType>26;  // Key
+  yield <ModelType>27;  // LangStringNameType
+  yield <ModelType>28;  // LangStringTextType
+  yield <ModelType>29;  // Environment
+  yield <ModelType>30;  // EmbeddedDataSpecification
+  yield <ModelType>31;  // LevelType
+  yield <ModelType>32;  // ValueReferencePair
+  yield <ModelType>33;  // ValueList
+  yield <ModelType>34;  // LangStringPreferredNameTypeIec61360
+  yield <ModelType>35;  // LangStringShortNameTypeIec61360
+  yield <ModelType>36;  // LangStringDefinitionTypeIec61360
+  yield <ModelType>37;  // DataSpecificationIec61360
+}
+
+/**
  * Represent the most general class of an AAS model.
  */
 export abstract class Class {
+  /**
+   * Indicate the runtime model type of an instance.
+   */
+  abstract modelType(): ModelType;
+
   /**
    * Iterate over all the instances referenced from this one.
    */
@@ -189,6 +292,16 @@ export interface IHasSemantics extends Class {
 export class Extension
   extends Class
   implements IHasSemantics {
+  /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>0;  // Extension
+  }
+
   /**
    * Identifier of the semantic definition of the element. It is called semantic ID
    * of the element or also main semantic ID of the element.
@@ -584,6 +697,16 @@ export class AdministrativeInformation
   extends Class
   implements IHasDataSpecification {
   /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>1;  // AdministrativeInformation
+  }
+
+  /**
    * Embedded data specification.
    */
   embeddedDataSpecifications: Array<EmbeddedDataSpecification> | null;
@@ -837,6 +960,16 @@ export class Qualifier
   extends Class
   implements IHasSemantics {
   /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>2;  // Qualifier
+  }
+
+  /**
    * Identifier of the semantic definition of the element. It is called semantic ID
    * of the element or also main semantic ID of the element.
    *
@@ -1036,6 +1169,16 @@ export class AssetAdministrationShell
   extends Class
   implements IIdentifiable,
   IHasDataSpecification {
+  /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>3;  // AssetAdministrationShell
+  }
+
   /**
    * An extension of the element.
    */
@@ -1402,6 +1545,16 @@ export class AssetAdministrationShell
  */
 export class AssetInformation extends Class {
   /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>4;  // AssetInformation
+  }
+
+  /**
    * Denotes whether the Asset is of kind {@link AssetKind.Type} or
    * {@link AssetKind.Instance}.
    */
@@ -1570,6 +1723,16 @@ export class AssetInformation extends Class {
  */
 export class Resource extends Class {
   /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>5;  // Resource
+  }
+
+  /**
    * Path and name of the resource (with file extension).
    *
    * @remarks
@@ -1718,6 +1881,16 @@ export function *overAssetKind(
 export class SpecificAssetId
   extends Class
   implements IHasSemantics {
+  /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>6;  // SpecificAssetId
+  }
+
   /**
    * Identifier of the semantic definition of the element. It is called semantic ID
    * of the element or also main semantic ID of the element.
@@ -1899,6 +2072,16 @@ export class Submodel
   IHasSemantics,
   IQualifiable,
   IHasDataSpecification {
+  /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>7;  // Submodel
+  }
+
   /**
    * An extension of the element.
    */
@@ -2346,6 +2529,16 @@ export class RelationshipElement
   extends Class
   implements IRelationshipElement {
   /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>8;  // RelationshipElement
+  }
+
+  /**
    * An extension of the element.
    */
   extensions: Array<Extension> | null;
@@ -2785,6 +2978,16 @@ export class SubmodelElementList
   extends Class
   implements ISubmodelElement {
   /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>9;  // SubmodelElementList
+  }
+
+  /**
    * An extension of the element.
    */
   extensions: Array<Extension> | null;
@@ -3201,6 +3404,16 @@ export class SubmodelElementCollection
   extends Class
   implements ISubmodelElement {
   /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>10;  // SubmodelElementCollection
+  }
+
+  /**
    * An extension of the element.
    */
   extensions: Array<Extension> | null;
@@ -3582,6 +3795,16 @@ export class Property
   extends Class
   implements IDataElement {
   /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>11;  // Property
+  }
+
+  /**
    * An extension of the element.
    */
   extensions: Array<Extension> | null;
@@ -3958,6 +4181,16 @@ export class Property
 export class MultiLanguageProperty
   extends Class
   implements IDataElement {
+  /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>12;  // MultiLanguageProperty
+  }
+
   /**
    * An extension of the element.
    */
@@ -4346,6 +4579,16 @@ export class Range
   extends Class
   implements IDataElement {
   /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>13;  // Range
+  }
+
+  /**
    * An extension of the element.
    */
   extensions: Array<Extension> | null;
@@ -4712,6 +4955,16 @@ export class ReferenceElement
   extends Class
   implements IDataElement {
   /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>14;  // ReferenceElement
+  }
+
+  /**
    * An extension of the element.
    */
   extensions: Array<Extension> | null;
@@ -5068,6 +5321,16 @@ export class ReferenceElement
 export class Blob
   extends Class
   implements IDataElement {
+  /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>15;  // Blob
+  }
+
   /**
    * An extension of the element.
    */
@@ -5436,6 +5699,16 @@ export class File
   extends Class
   implements IDataElement {
   /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>16;  // File
+  }
+
+  /**
    * An extension of the element.
    */
   extensions: Array<Extension> | null;
@@ -5793,6 +6066,16 @@ export class File
 export class AnnotatedRelationshipElement
   extends Class
   implements IRelationshipElement {
+  /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>17;  // AnnotatedRelationshipElement
+  }
+
   /**
    * An extension of the element.
    */
@@ -6182,6 +6465,16 @@ export class AnnotatedRelationshipElement
 export class Entity
   extends Class
   implements ISubmodelElement {
+  /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>18;  // Entity
+  }
+
   /**
    * An extension of the element.
    */
@@ -6705,6 +6998,16 @@ export function *overStateOfEvent(
  */
 export class EventPayload extends Class {
   /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>19;  // EventPayload
+  }
+
+  /**
    * Reference to the source event element, including identification of
    * {@link AssetAdministrationShell}, {@link Submodel},
    * {@link ISubmodelElement}'s.
@@ -6921,6 +7224,16 @@ export interface IEventElement
 export class BasicEventElement
   extends Class
   implements IEventElement {
+  /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>20;  // BasicEventElement
+  }
+
   /**
    * An extension of the element.
    */
@@ -7365,6 +7678,16 @@ export class Operation
   extends Class
   implements ISubmodelElement {
   /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>21;  // Operation
+  }
+
+  /**
    * An extension of the element.
    */
   extensions: Array<Extension> | null;
@@ -7779,6 +8102,16 @@ export class Operation
  */
 export class OperationVariable extends Class {
   /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>22;  // OperationVariable
+  }
+
+  /**
    * Describes an argument or result of an operation via a submodel element
    */
   value: ISubmodelElement;
@@ -7875,6 +8208,16 @@ export class OperationVariable extends Class {
 export class Capability
   extends Class
   implements ISubmodelElement {
+  /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>23;  // Capability
+  }
+
   /**
    * An extension of the element.
    */
@@ -8266,6 +8609,16 @@ export class ConceptDescription
   extends Class
   implements IIdentifiable,
   IHasDataSpecification {
+  /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>24;  // ConceptDescription
+  }
+
   /**
    * An extension of the element.
    */
@@ -8674,6 +9027,16 @@ export function *overReferenceTypes(
  */
 export class Reference extends Class {
   /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>25;  // Reference
+  }
+
+  /**
    * Type of the reference.
    *
    * @remarks
@@ -8800,6 +9163,16 @@ export class Reference extends Class {
  * A key is a reference to an element by its ID.
  */
 export class Key extends Class {
+  /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>26;  // Key
+  }
+
   /**
    * Denotes which kind of entity is referenced.
    *
@@ -9134,6 +9507,16 @@ export class LangStringNameType
   extends Class
   implements IAbstractLangString {
   /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>27;  // LangStringNameType
+  }
+
+  /**
    * Language tag conforming to BCP 47
    */
   language: string;
@@ -9231,6 +9614,16 @@ export class LangStringNameType
 export class LangStringTextType
   extends Class
   implements IAbstractLangString {
+  /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>28;  // LangStringTextType
+  }
+
   /**
    * Language tag conforming to BCP 47
    */
@@ -9333,6 +9726,16 @@ export class LangStringTextType
  * shall be no element with the same identifier in two different files.
  */
 export class Environment extends Class {
+  /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>29;  // Environment
+  }
+
   /**
    * Asset administration shell
    */
@@ -9516,6 +9919,16 @@ export interface IDataSpecificationContent extends Class {
  * Embed the content of a data specification.
  */
 export class EmbeddedDataSpecification extends Class {
+  /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>30;  // EmbeddedDataSpecification
+  }
+
   /**
    * Reference to the data specification
    */
@@ -9821,6 +10234,16 @@ export function *overDataTypeIec61360(
  */
 export class LevelType extends Class {
   /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>31;  // LevelType
+  }
+
+  /**
    * Minimum of the value
    */
   min: boolean;
@@ -9932,6 +10355,16 @@ export class LevelType extends Class {
  */
 export class ValueReferencePair extends Class {
   /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>32;  // ValueReferencePair
+  }
+
+  /**
    * The value of the referenced concept definition of the value in {@link valueId}.
    */
   value: string;
@@ -10034,6 +10467,16 @@ export class ValueReferencePair extends Class {
  */
 export class ValueList extends Class {
   /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>33;  // ValueList
+  }
+
+  /**
    * A pair of a value together with its global unique id.
    */
   valueReferencePairs: Array<ValueReferencePair>;
@@ -10130,6 +10573,16 @@ export class ValueList extends Class {
 export class LangStringPreferredNameTypeIec61360
   extends Class
   implements IAbstractLangString {
+  /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>34;  // LangStringPreferredNameTypeIec61360
+  }
+
   /**
    * Language tag conforming to BCP 47
    */
@@ -10229,6 +10682,16 @@ export class LangStringShortNameTypeIec61360
   extends Class
   implements IAbstractLangString {
   /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>35;  // LangStringShortNameTypeIec61360
+  }
+
+  /**
    * Language tag conforming to BCP 47
    */
   language: string;
@@ -10326,6 +10789,16 @@ export class LangStringShortNameTypeIec61360
 export class LangStringDefinitionTypeIec61360
   extends Class
   implements IAbstractLangString {
+  /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>36;  // LangStringDefinitionTypeIec61360
+  }
+
   /**
    * Language tag conforming to BCP 47
    */
@@ -10467,6 +10940,16 @@ export class LangStringDefinitionTypeIec61360
 export class DataSpecificationIec61360
   extends Class
   implements IDataSpecificationContent {
+  /**
+   * Indicate the runtime model type of the instance.
+   */
+  modelType(): ModelType {
+    // NOTE (mristin, 2022-12-03):
+    // We yield numbers instead of literals to avoid name lookups on platforms
+    // which do not provide JIT compilation of hot paths.
+    return <ModelType>37;  // DataSpecificationIec61360
+  }
+
   /**
    * Preferred name
    *


### PR DESCRIPTION
We add a function `modelType` to `Class` interface in TypeScript so that users can retrieve the runtime type of an instance.

Fixes https://github.com/aas-core-works/aas-core3.0-typescript/issues/15.