### PR TITLE
Introduce `ssort` in CI

### DIFF
--- a/aas_core_codegen/common.py
+++ b/aas_core_codegen/common.py
@@ -182,10 +182,6 @@ class Lines(DBC):
         """
         return cast(Lines, lines)
 
-    def __add__(self, other: "Lines") -> "Lines":
-        """Concatenate two list of lines."""
-        raise NotImplementedError("Only for type annotations")
-
     # pylint: disable=function-redefined
 
     @overload
@@ -202,12 +198,16 @@ class Lines(DBC):
         """Get the line(s) at the given index."""
         raise NotImplementedError("Only for type annotations")
 
+    def __iter__(self) -> Iterator[str]:
+        """Iterate over the lines."""
+        raise NotImplementedError("Only for type annotations")
+
     def __len__(self) -> int:
         """Return the number of the lines."""
         raise NotImplementedError("Only for type annotations")
 
-    def __iter__(self) -> Iterator[str]:
-        """Iterate over the lines."""
+    def __add__(self, other: "Lines") -> "Lines":
+        """Concatenate two list of lines."""
         raise NotImplementedError("Only for type annotations")
 
 

--- a/aas_core_codegen/cpp/description.py
+++ b/aas_core_codegen/cpp/description.py
@@ -453,6 +453,18 @@ class _ElementRenderer(intermediate_doc.DocutilsElementTransformer[str]):
         )
 
 
+def documentation_comment(text: Stripped) -> Stripped:
+    """Generate the documentation comment with the given ``text``."""
+    commented_lines = []  # type: List[str]
+    for line in text.splitlines():
+        if len(line.strip()) == 0:
+            commented_lines.append("///")
+        else:
+            commented_lines.append(f"/// {line}")
+
+    return Stripped("\n".join(commented_lines))
+
+
 def generate_comment_for_summary_remarks(
     description: intermediate.SummaryRemarksDescription, context: Context
 ) -> Tuple[Optional[Stripped], Optional[List[Error]]]:
@@ -546,18 +558,6 @@ Constraint {constraint_id}:\\n
         ]
 
     return documentation_comment(Stripped("\n\n".join(blocks))), None
-
-
-def documentation_comment(text: Stripped) -> Stripped:
-    """Generate the documentation comment with the given ``text``."""
-    commented_lines = []  # type: List[str]
-    for line in text.splitlines():
-        if len(line.strip()) == 0:
-            commented_lines.append("///")
-        else:
-            commented_lines.append(f"/// {line}")
-
-    return Stripped("\n".join(commented_lines))
 
 
 def generate_comment_for_signature(

--- a/aas_core_codegen/cpp/transpilation.py
+++ b/aas_core_codegen/cpp/transpilation.py
@@ -292,6 +292,15 @@ class Transpiler(
 ):
     """Transpile a node of our AST to C++ code, or return an error."""
 
+    _CPP_COMPARISON_MAP = {
+        parse_tree.Comparator.LT: "<",
+        parse_tree.Comparator.LE: "<=",
+        parse_tree.Comparator.GT: ">",
+        parse_tree.Comparator.GE: ">=",
+        parse_tree.Comparator.EQ: "==",
+        parse_tree.Comparator.NE: "!=",
+    }
+
     def __init__(
         self,
         type_map: Mapping[
@@ -494,15 +503,6 @@ class Transpiler(
             )
 
         return Stripped(f"{collection}.at({index})"), None
-
-    _CPP_COMPARISON_MAP = {
-        parse_tree.Comparator.LT: "<",
-        parse_tree.Comparator.LE: "<=",
-        parse_tree.Comparator.GT: ">",
-        parse_tree.Comparator.GE: ">=",
-        parse_tree.Comparator.EQ: "==",
-        parse_tree.Comparator.NE: "!=",
-    }
 
     @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
     def transform_comparison(

--- a/aas_core_codegen/cpp/unrolling.py
+++ b/aas_core_codegen/cpp/unrolling.py
@@ -58,6 +58,50 @@ def render(node: Node) -> str:
 class AbstractUnroller(DBC):
     """Generate code to unroll recursion into generic types."""
 
+    @abc.abstractmethod
+    def _unroll_primitive_type_annotation(
+        self,
+        unrollee_expr: str,
+        type_annotation: intermediate.PrimitiveTypeAnnotation,
+        path: List[str],
+        list_loop_level: int,
+    ) -> List[Node]:
+        """Generate code for the given specific ``type_annotation``."""
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def _unroll_our_type_annotation(
+        self,
+        unrollee_expr: str,
+        type_annotation: intermediate.OurTypeAnnotation,
+        path: List[str],
+        list_loop_level: int,
+    ) -> List[Node]:
+        """Generate code for the given specific ``type_annotation``."""
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def _unroll_list_type_annotation(
+        self,
+        unrollee_expr: str,
+        type_annotation: intermediate.ListTypeAnnotation,
+        path: List[str],
+        list_loop_level: int,
+    ) -> List[Node]:
+        """Generate code for the given specific ``type_annotation``."""
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def _unroll_optional_type_annotation(
+        self,
+        unrollee_expr: str,
+        type_annotation: intermediate.OptionalTypeAnnotation,
+        path: List[str],
+        list_loop_level: int,
+    ) -> List[Node]:
+        """Generate code for the given specific ``type_annotation``."""
+        raise NotImplementedError()
+
     @require(lambda list_loop_level: list_loop_level >= 0)
     def unroll(
         self,
@@ -113,47 +157,3 @@ class AbstractUnroller(DBC):
             assert_never(type_annotation)
 
         raise AssertionError("Should not have gotten here")
-
-    @abc.abstractmethod
-    def _unroll_primitive_type_annotation(
-        self,
-        unrollee_expr: str,
-        type_annotation: intermediate.PrimitiveTypeAnnotation,
-        path: List[str],
-        list_loop_level: int,
-    ) -> List[Node]:
-        """Generate code for the given specific ``type_annotation``."""
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def _unroll_our_type_annotation(
-        self,
-        unrollee_expr: str,
-        type_annotation: intermediate.OurTypeAnnotation,
-        path: List[str],
-        list_loop_level: int,
-    ) -> List[Node]:
-        """Generate code for the given specific ``type_annotation``."""
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def _unroll_list_type_annotation(
-        self,
-        unrollee_expr: str,
-        type_annotation: intermediate.ListTypeAnnotation,
-        path: List[str],
-        list_loop_level: int,
-    ) -> List[Node]:
-        """Generate code for the given specific ``type_annotation``."""
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def _unroll_optional_type_annotation(
-        self,
-        unrollee_expr: str,
-        type_annotation: intermediate.OptionalTypeAnnotation,
-        path: List[str],
-        list_loop_level: int,
-    ) -> List[Node]:
-        """Generate code for the given specific ``type_annotation``."""
-        raise NotImplementedError()

--- a/aas_core_codegen/csharp/structure/_generate.py
+++ b/aas_core_codegen/csharp/structure/_generate.py
@@ -65,6 +65,71 @@ def _human_readable_identifier(
     return result
 
 
+def _verify_intra_structure_collisions(
+    our_type: intermediate.OurType,
+) -> Optional[Error]:
+    """Verify that no member names collide in the C# structure of our type."""
+    errors = []  # type: List[Error]
+
+    if isinstance(our_type, intermediate.Enumeration):
+        pass
+
+    elif isinstance(our_type, intermediate.ConstrainedPrimitive):
+        pass
+
+    elif isinstance(our_type, intermediate.Class):
+        observed_member_names = {}  # type: Dict[Identifier, str]
+
+        for prop in our_type.properties:
+            prop_name = csharp_naming.property_name(prop.name)
+            if prop_name in observed_member_names:
+                errors.append(
+                    Error(
+                        prop.parsed.node,
+                        f"C# property {prop_name!r} corresponding "
+                        f"to the meta-model property {prop.name!r} collides with "
+                        f"the {observed_member_names[prop_name]}",
+                    )
+                )
+            else:
+                observed_member_names[prop_name] = (
+                    f"C# property {prop_name!r} corresponding to "
+                    f"the meta-model property {prop.name!r}"
+                )
+
+        for method in our_type.methods:
+            method_name = csharp_naming.method_name(method.name)
+
+            if method_name in observed_member_names:
+                errors.append(
+                    Error(
+                        method.parsed.node,
+                        f"C# method {method_name!r} corresponding "
+                        f"to the meta-model method {method.name!r} collides with "
+                        f"the {observed_member_names[method_name]}",
+                    )
+                )
+            else:
+                observed_member_names[method_name] = (
+                    f"C# method {method_name!r} corresponding to "
+                    f"the meta-model method {method.name!r}"
+                )
+
+    else:
+        assert_never(our_type)
+
+    if len(errors) > 0:
+        errors.append(
+            Error(
+                our_type.parsed.node,
+                f"Naming collision(s) in C# code for our type {our_type.name!r}",
+                underlying=errors,
+            )
+        )
+
+    return None
+
+
 def _verify_structure_name_collisions(
     symbol_table: intermediate.SymbolTable,
 ) -> List[Error]:
@@ -162,71 +227,6 @@ def _verify_structure_name_collisions(
     # endregion
 
     return errors
-
-
-def _verify_intra_structure_collisions(
-    our_type: intermediate.OurType,
-) -> Optional[Error]:
-    """Verify that no member names collide in the C# structure of our type."""
-    errors = []  # type: List[Error]
-
-    if isinstance(our_type, intermediate.Enumeration):
-        pass
-
-    elif isinstance(our_type, intermediate.ConstrainedPrimitive):
-        pass
-
-    elif isinstance(our_type, intermediate.Class):
-        observed_member_names = {}  # type: Dict[Identifier, str]
-
-        for prop in our_type.properties:
-            prop_name = csharp_naming.property_name(prop.name)
-            if prop_name in observed_member_names:
-                errors.append(
-                    Error(
-                        prop.parsed.node,
-                        f"C# property {prop_name!r} corresponding "
-                        f"to the meta-model property {prop.name!r} collides with "
-                        f"the {observed_member_names[prop_name]}",
-                    )
-                )
-            else:
-                observed_member_names[prop_name] = (
-                    f"C# property {prop_name!r} corresponding to "
-                    f"the meta-model property {prop.name!r}"
-                )
-
-        for method in our_type.methods:
-            method_name = csharp_naming.method_name(method.name)
-
-            if method_name in observed_member_names:
-                errors.append(
-                    Error(
-                        method.parsed.node,
-                        f"C# method {method_name!r} corresponding "
-                        f"to the meta-model method {method.name!r} collides with "
-                        f"the {observed_member_names[method_name]}",
-                    )
-                )
-            else:
-                observed_member_names[method_name] = (
-                    f"C# method {method_name!r} corresponding to "
-                    f"the meta-model method {method.name!r}"
-                )
-
-    else:
-        assert_never(our_type)
-
-    if len(errors) > 0:
-        errors.append(
-            Error(
-                our_type.parsed.node,
-                f"Naming collision(s) in C# code for our type {our_type.name!r}",
-                underlying=errors,
-            )
-        )
-
-    return None
 
 
 class VerifiedIntermediateSymbolTable(intermediate.SymbolTable):

--- a/aas_core_codegen/csharp/transpilation.py
+++ b/aas_core_codegen/csharp/transpilation.py
@@ -37,6 +37,15 @@ class Transpiler(
 ):
     """Transpile a node of our AST to C# code, or return an error."""
 
+    _CSHARP_COMPARISON_MAP = {
+        parse_tree.Comparator.LT: "<",
+        parse_tree.Comparator.LE: "<=",
+        parse_tree.Comparator.GT: ">",
+        parse_tree.Comparator.GE: ">=",
+        parse_tree.Comparator.EQ: "==",
+        parse_tree.Comparator.NE: "!=",
+    }
+
     def __init__(
         self,
         type_map: Mapping[
@@ -150,15 +159,6 @@ class Transpiler(
             collection = Stripped(f"({collection})")
 
         return Stripped(f"{collection}[{index}]"), None
-
-    _CSHARP_COMPARISON_MAP = {
-        parse_tree.Comparator.LT: "<",
-        parse_tree.Comparator.LE: "<=",
-        parse_tree.Comparator.GT: ">",
-        parse_tree.Comparator.GE: ">=",
-        parse_tree.Comparator.EQ: "==",
-        parse_tree.Comparator.NE: "!=",
-    }
 
     @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
     def transform_comparison(

--- a/aas_core_codegen/csharp/unrolling.py
+++ b/aas_core_codegen/csharp/unrolling.py
@@ -96,6 +96,54 @@ class AbstractUnroller(DBC):
         else:
             return Identifier("yet" + "Yet" * (level - 1) + f"another{suffix}")
 
+    @abc.abstractmethod
+    def _unroll_primitive_type_annotation(
+        self,
+        unrollee_expr: str,
+        type_annotation: intermediate.PrimitiveTypeAnnotation,
+        path: List[str],
+        item_level: int,
+        key_value_level: int,
+    ) -> List[Node]:
+        """Generate code for the given specific ``type_annotation``."""
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def _unroll_our_type_annotation(
+        self,
+        unrollee_expr: str,
+        type_annotation: intermediate.OurTypeAnnotation,
+        path: List[str],
+        item_level: int,
+        key_value_level: int,
+    ) -> List[Node]:
+        """Generate code for the given specific ``type_annotation``."""
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def _unroll_list_type_annotation(
+        self,
+        unrollee_expr: str,
+        type_annotation: intermediate.ListTypeAnnotation,
+        path: List[str],
+        item_level: int,
+        key_value_level: int,
+    ) -> List[Node]:
+        """Generate code for the given specific ``type_annotation``."""
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def _unroll_optional_type_annotation(
+        self,
+        unrollee_expr: str,
+        type_annotation: intermediate.OptionalTypeAnnotation,
+        path: List[str],
+        item_level: int,
+        key_value_level: int,
+    ) -> List[Node]:
+        """Generate code for the given specific ``type_annotation``."""
+        raise NotImplementedError()
+
     @require(lambda item_level: item_level >= 0)
     @require(lambda key_value_level: key_value_level >= 0)
     def unroll(
@@ -161,51 +209,3 @@ class AbstractUnroller(DBC):
             assert_never(type_annotation)
 
         raise AssertionError("Should not have gotten here")
-
-    @abc.abstractmethod
-    def _unroll_primitive_type_annotation(
-        self,
-        unrollee_expr: str,
-        type_annotation: intermediate.PrimitiveTypeAnnotation,
-        path: List[str],
-        item_level: int,
-        key_value_level: int,
-    ) -> List[Node]:
-        """Generate code for the given specific ``type_annotation``."""
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def _unroll_our_type_annotation(
-        self,
-        unrollee_expr: str,
-        type_annotation: intermediate.OurTypeAnnotation,
-        path: List[str],
-        item_level: int,
-        key_value_level: int,
-    ) -> List[Node]:
-        """Generate code for the given specific ``type_annotation``."""
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def _unroll_list_type_annotation(
-        self,
-        unrollee_expr: str,
-        type_annotation: intermediate.ListTypeAnnotation,
-        path: List[str],
-        item_level: int,
-        key_value_level: int,
-    ) -> List[Node]:
-        """Generate code for the given specific ``type_annotation``."""
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def _unroll_optional_type_annotation(
-        self,
-        unrollee_expr: str,
-        type_annotation: intermediate.OptionalTypeAnnotation,
-        path: List[str],
-        item_level: int,
-        key_value_level: int,
-    ) -> List[Node]:
-        """Generate code for the given specific ``type_annotation``."""
-        raise NotImplementedError()

--- a/aas_core_codegen/csharp/verification/_generate.py
+++ b/aas_core_codegen/csharp/verification/_generate.py
@@ -90,44 +90,6 @@ class _PatternVerificationTranspiler(
         self.defined_variables = defined_variables
 
     @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
-    def transform_constant(
-        self, node: parse_tree.Constant
-    ) -> Tuple[Optional[Stripped], Optional[Error]]:
-        if isinstance(node.value, str):
-            # NOTE (mristin, 2022-06-11):
-            # We assume that all the string constants are valid regular expressions.
-
-            regex, parse_error = parse_retree.parse(values=[node.value])
-            if parse_error is not None:
-                regex_line, pointer_line = parse_retree.render_pointer(
-                    parse_error.cursor
-                )
-
-                return (
-                    None,
-                    Error(
-                        node.original_node,
-                        f"The string constant could not be parsed "
-                        f"as a regular expression: \n"
-                        f"{parse_error.message}\n"
-                        f"{regex_line}\n"
-                        f"{pointer_line}",
-                    ),
-                )
-
-            assert regex is not None
-            parse_retree.fix_for_utf16_regex_in_place(regex)
-
-            # NOTE (mristin, 2022-06-11):
-            # Strictly speaking, this is a joined string with a single value, a string
-            # literal.
-            return self._transform_joined_str_values(
-                values=parse_retree.render(regex=regex)
-            )
-        else:
-            raise AssertionError(f"Unexpected {node=}")
-
-    @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
     def _transform_joined_str_values(
         self, values: Sequence[Union[str, parse_tree.FormattedValue]]
     ) -> Tuple[Optional[Stripped], Optional[Error]]:
@@ -183,6 +145,44 @@ class _PatternVerificationTranspiler(
         writer.write('"')
 
         return Stripped(writer.getvalue()), None
+
+    @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
+    def transform_constant(
+        self, node: parse_tree.Constant
+    ) -> Tuple[Optional[Stripped], Optional[Error]]:
+        if isinstance(node.value, str):
+            # NOTE (mristin, 2022-06-11):
+            # We assume that all the string constants are valid regular expressions.
+
+            regex, parse_error = parse_retree.parse(values=[node.value])
+            if parse_error is not None:
+                regex_line, pointer_line = parse_retree.render_pointer(
+                    parse_error.cursor
+                )
+
+                return (
+                    None,
+                    Error(
+                        node.original_node,
+                        f"The string constant could not be parsed "
+                        f"as a regular expression: \n"
+                        f"{parse_error.message}\n"
+                        f"{regex_line}\n"
+                        f"{pointer_line}",
+                    ),
+                )
+
+            assert regex is not None
+            parse_retree.fix_for_utf16_regex_in_place(regex)
+
+            # NOTE (mristin, 2022-06-11):
+            # Strictly speaking, this is a joined string with a single value, a string
+            # literal.
+            return self._transform_joined_str_values(
+                values=parse_retree.render(regex=regex)
+            )
+        else:
+            raise AssertionError(f"Unexpected {node=}")
 
     @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
     def transform_name(

--- a/aas_core_codegen/golang/common.py
+++ b/aas_core_codegen/golang/common.py
@@ -104,6 +104,11 @@ def float_literal(value: float) -> Stripped:
         return Stripped(str(value))
 
 
+# NOTE (mristin, 2023-01-13):
+# See: https://stackoverflow.com/questions/19094704/indentation-in-go-tabs-or-spaces
+INDENT = "\t"
+
+
 def bytes_literal(value: bytes) -> Tuple[Stripped, bool]:
     """
     Generate an expression representing the ``value``.
@@ -253,9 +258,6 @@ def generate_type(
     raise AssertionError("Should not have gotten here")
 
 
-# NOTE (mristin, 2023-01-13):
-# See: https://stackoverflow.com/questions/19094704/indentation-in-go-tabs-or-spaces
-INDENT = "\t"
 INDENT2 = INDENT * 2
 INDENT3 = INDENT * 3
 INDENT4 = INDENT * 4

--- a/aas_core_codegen/golang/description.py
+++ b/aas_core_codegen/golang/description.py
@@ -329,6 +329,18 @@ class _ElementRenderer(intermediate_doc.DocutilsElementTransformer[str]):
         )
 
 
+def documentation_comment(text: Stripped) -> Stripped:
+    """Generate the documentation comment with the given ``text``."""
+    commented_lines = []  # type: List[str]
+    for line in text.splitlines():
+        if len(line.strip()) == 0:
+            commented_lines.append("//")
+        else:
+            commented_lines.append(f"// {line}")
+
+    return Stripped("\n".join(commented_lines))
+
+
 def generate_comment_for_summary_remarks(
     description: intermediate.SummaryRemarksDescription, context: Context
 ) -> Tuple[Optional[Stripped], Optional[List[Error]]]:
@@ -404,18 +416,6 @@ def generate_comment_for_summary_remarks_constraints(
         ]
 
     return documentation_comment(Stripped("\n\n".join(blocks))), None
-
-
-def documentation_comment(text: Stripped) -> Stripped:
-    """Generate the documentation comment with the given ``text``."""
-    commented_lines = []  # type: List[str]
-    for line in text.splitlines():
-        if len(line.strip()) == 0:
-            commented_lines.append("//")
-        else:
-            commented_lines.append(f"// {line}")
-
-    return Stripped("\n".join(commented_lines))
 
 
 def generate_comment_for_signature(

--- a/aas_core_codegen/golang/transpilation.py
+++ b/aas_core_codegen/golang/transpilation.py
@@ -140,6 +140,15 @@ class Transpiler(
 ):
     """Transpile a node of our AST to Go code, or return an error."""
 
+    _GOLANG_COMPARISON_MAP = {
+        parse_tree.Comparator.LT: "<",
+        parse_tree.Comparator.LE: "<=",
+        parse_tree.Comparator.GT: ">",
+        parse_tree.Comparator.GE: ">=",
+        parse_tree.Comparator.EQ: "==",
+        parse_tree.Comparator.NE: "!=",
+    }
+
     def __init__(
         self,
         type_map: Mapping[
@@ -353,15 +362,6 @@ len(
         # all the index access.
 
         return Stripped(f"{collection}[{index}]"), None
-
-    _GOLANG_COMPARISON_MAP = {
-        parse_tree.Comparator.LT: "<",
-        parse_tree.Comparator.LE: "<=",
-        parse_tree.Comparator.GT: ">",
-        parse_tree.Comparator.GE: ">=",
-        parse_tree.Comparator.EQ: "==",
-        parse_tree.Comparator.NE: "!=",
-    }
 
     @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
     def transform_comparison(

--- a/aas_core_codegen/golang/unrolling.py
+++ b/aas_core_codegen/golang/unrolling.py
@@ -58,6 +58,50 @@ def render(node: Node) -> str:
 class AbstractUnroller(DBC):
     """Generate code to unroll recursion into generic types."""
 
+    @abc.abstractmethod
+    def _unroll_primitive_type_annotation(
+        self,
+        unrollee_expr: str,
+        type_annotation: intermediate.PrimitiveTypeAnnotation,
+        path: List[str],
+        list_loop_level: int,
+    ) -> List[Node]:
+        """Generate code for the given specific ``type_annotation``."""
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def _unroll_our_type_annotation(
+        self,
+        unrollee_expr: str,
+        type_annotation: intermediate.OurTypeAnnotation,
+        path: List[str],
+        list_loop_level: int,
+    ) -> List[Node]:
+        """Generate code for the given specific ``type_annotation``."""
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def _unroll_list_type_annotation(
+        self,
+        unrollee_expr: str,
+        type_annotation: intermediate.ListTypeAnnotation,
+        path: List[str],
+        list_loop_level: int,
+    ) -> List[Node]:
+        """Generate code for the given specific ``type_annotation``."""
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def _unroll_optional_type_annotation(
+        self,
+        unrollee_expr: str,
+        type_annotation: intermediate.OptionalTypeAnnotation,
+        path: List[str],
+        list_loop_level: int,
+    ) -> List[Node]:
+        """Generate code for the given specific ``type_annotation``."""
+        raise NotImplementedError()
+
     @require(lambda list_loop_level: list_loop_level >= 0)
     def unroll(
         self,
@@ -113,47 +157,3 @@ class AbstractUnroller(DBC):
             assert_never(type_annotation)
 
         raise AssertionError("Should not have gotten here")
-
-    @abc.abstractmethod
-    def _unroll_primitive_type_annotation(
-        self,
-        unrollee_expr: str,
-        type_annotation: intermediate.PrimitiveTypeAnnotation,
-        path: List[str],
-        list_loop_level: int,
-    ) -> List[Node]:
-        """Generate code for the given specific ``type_annotation``."""
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def _unroll_our_type_annotation(
-        self,
-        unrollee_expr: str,
-        type_annotation: intermediate.OurTypeAnnotation,
-        path: List[str],
-        list_loop_level: int,
-    ) -> List[Node]:
-        """Generate code for the given specific ``type_annotation``."""
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def _unroll_list_type_annotation(
-        self,
-        unrollee_expr: str,
-        type_annotation: intermediate.ListTypeAnnotation,
-        path: List[str],
-        list_loop_level: int,
-    ) -> List[Node]:
-        """Generate code for the given specific ``type_annotation``."""
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def _unroll_optional_type_annotation(
-        self,
-        unrollee_expr: str,
-        type_annotation: intermediate.OptionalTypeAnnotation,
-        path: List[str],
-        list_loop_level: int,
-    ) -> List[Node]:
-        """Generate code for the given specific ``type_annotation``."""
-        raise NotImplementedError()

--- a/aas_core_codegen/infer_for_schema/_pattern.py
+++ b/aas_core_codegen/infer_for_schema/_pattern.py
@@ -21,18 +21,6 @@ from aas_core_codegen.parse import tree as parse_tree
 class PatternVerificationsByName(Mapping[Identifier, intermediate.PatternVerification]):
     """Map verification functions based on patterns by their names."""
 
-    def __getitem__(self, k: Identifier) -> intermediate.PatternVerification:
-        # Only for type annotation
-        raise NotImplementedError()
-
-    def __len__(self) -> int:
-        # Only for type annotation
-        raise NotImplementedError()
-
-    def __iter__(self) -> Iterator[Identifier]:
-        # Only for type annotation
-        raise NotImplementedError()
-
     # fmt: off
     # noinspection PyAbstractClass
     @require(
@@ -47,6 +35,18 @@ class PatternVerificationsByName(Mapping[Identifier, intermediate.PatternVerific
         cls, mapping: Mapping[Identifier, intermediate.PatternVerification]
     ) -> "PatternVerificationsByName":
         return cast(PatternVerificationsByName, mapping)
+
+    def __getitem__(self, k: Identifier) -> intermediate.PatternVerification:
+        # Only for type annotation
+        raise NotImplementedError()
+
+    def __iter__(self) -> Iterator[Identifier]:
+        # Only for type annotation
+        raise NotImplementedError()
+
+    def __len__(self) -> int:
+        # Only for type annotation
+        raise NotImplementedError()
 
 
 def map_pattern_verifications_by_name(

--- a/aas_core_codegen/parse/_types.py
+++ b/aas_core_codegen/parse/_types.py
@@ -36,15 +36,15 @@ class AtomicTypeAnnotation:
         self.identifier = identifier
         self.node = node
 
-    def __str__(self) -> str:
-        return self.identifier
-
     def __repr__(self) -> str:
         """Represent the instance as a string for debugging."""
         return (
             f"<{_MODULE_NAME}.{self.__class__.__name__} "
             f"{self.identifier} at 0x{id(self):x}>"
         )
+
+    def __str__(self) -> str:
+        return self.identifier
 
 
 class SelfTypeAnnotation:
@@ -68,14 +68,6 @@ class SubscriptedTypeAnnotation:
         self.subscripts = subscripts
         self.node = node
 
-    def __str__(self) -> str:
-        """Represent by reconstructing the type annotation heuristically."""
-        return "".join(
-            [self.identifier, "["]
-            + [", ".join([str(subscript) for subscript in self.subscripts])]
-            + ["]"]
-        )
-
     def __repr__(self) -> str:
         """Represent the instance as a string for debugging."""
         subscripts_str = ", ".join(repr(subscript) for subscript in self.subscripts)
@@ -83,6 +75,14 @@ class SubscriptedTypeAnnotation:
             f"<{_MODULE_NAME}.{self.__class__.__name__} "
             f"{self.identifier} at 0x{id(self):x} "
             f"subscripts={subscripts_str}>"
+        )
+
+    def __str__(self) -> str:
+        """Represent by reconstructing the type annotation heuristically."""
+        return "".join(
+            [self.identifier, "["]
+            + [", ".join([str(subscript) for subscript in self.subscripts])]
+            + ["]"]
         )
 
 

--- a/aas_core_codegen/parse/tree.py
+++ b/aas_core_codegen/parse/tree.py
@@ -19,10 +19,6 @@ class Node(abc.ABC):
         """Initialize with the given values."""
         self.original_node = original_node
 
-    def __str__(self) -> str:
-        """Provide a human-readable representation of the instance."""
-        return dump(self)
-
     @abc.abstractmethod
     def transform(self, transformer: "Transformer[T]") -> T:
         """Accept the transformer."""
@@ -32,6 +28,10 @@ class Node(abc.ABC):
     def visit(self, visitor: "Visitor") -> None:
         """Accept the transformer."""
         raise NotImplementedError()
+
+    def __str__(self) -> str:
+        """Provide a human-readable representation of the instance."""
+        return dump(self)
 
 
 class Statement(Node):
@@ -796,111 +796,6 @@ class Transformer(Generic[T], DBC):
         raise NotImplementedError(f"{node=}")
 
 
-class RestrictedTransformer(Transformer[T]):
-    """
-    Transform our AST into something where only a part of the tree is handled.
-
-    This class is helpful for cases where you are sure that certain nodes *can not*
-    appear.
-    """
-
-    def transform_member(self, node: Member) -> T:
-        """Transform a member to something."""
-        raise AssertionError(f"Unexpected node: {dump(node)}")
-
-    def transform_index(self, node: Index) -> T:
-        """Transform an index access to something."""
-        raise AssertionError(f"Unexpected node: {dump(node)}")
-
-    def transform_comparison(self, node: Comparison) -> T:
-        """Transform a comparison to something."""
-        raise AssertionError(f"Unexpected node: {dump(node)}")
-
-    def transform_is_in(self, node: IsIn) -> T:
-        """Transform a membership relation to something."""
-        raise NotImplementedError(f"{node=}")
-
-    def transform_implication(self, node: Implication) -> T:
-        """Transform an implication to something."""
-        raise AssertionError(f"Unexpected node: {dump(node)}")
-
-    def transform_method_call(self, node: MethodCall) -> T:
-        """Transform a method call into something."""
-        raise AssertionError(f"Unexpected node: {dump(node)}")
-
-    def transform_function_call(self, node: FunctionCall) -> T:
-        """Transform a function call into something."""
-        raise AssertionError(f"Unexpected node: {dump(node)}")
-
-    def transform_constant(self, node: Constant) -> T:
-        """Transform a constant into something."""
-        raise AssertionError(f"Unexpected node: {dump(node)}")
-
-    def transform_is_none(self, node: IsNone) -> T:
-        """Transform an is-none check into something."""
-        raise AssertionError(f"Unexpected node: {dump(node)}")
-
-    def transform_is_not_none(self, node: IsNotNone) -> T:
-        """Transform an is-not-none check into something."""
-        raise AssertionError(f"Unexpected node: {dump(node)}")
-
-    def transform_name(self, node: Name) -> T:
-        """Transform variable access into something."""
-        raise AssertionError(f"Unexpected node: {dump(node)}")
-
-    def transform_not(self, node: Not) -> T:
-        """Transform a negation into something."""
-        raise AssertionError(f"Unexpected node: {dump(node)}")
-
-    def transform_and(self, node: And) -> T:
-        """Transform a conjunction into something."""
-        raise AssertionError(f"Unexpected node: {dump(node)}")
-
-    def transform_or(self, node: Or) -> T:
-        """Transform a disjunction into something."""
-        raise AssertionError(f"Unexpected node: {dump(node)}")
-
-    def transform_add(self, node: Add) -> T:
-        """Transform an addition into something."""
-        raise NotImplementedError(f"{node=}")
-
-    def transform_sub(self, node: Sub) -> T:
-        """Transform a subtraction into something."""
-        raise NotImplementedError(f"{node=}")
-
-    def transform_formatted_value(self, node: FormattedValue) -> T:
-        """Transform a formatted value in a joined string into something."""
-        raise AssertionError(f"Unexpected node: {dump(node)}")
-
-    def transform_joined_str(self, node: JoinedStr) -> T:
-        """Transform a string interpolation into something."""
-        raise AssertionError(f"Unexpected node: {dump(node)}")
-
-    def transform_for_each(self, node: ForEach) -> T:
-        """Transform a for-each in a generator expression into something."""
-        raise AssertionError(f"Unexpected node: {dump(node)}")
-
-    def transform_for_range(self, node: ForRange) -> T:
-        """Transform a for-range in a generator expression into something."""
-        raise AssertionError(f"Unexpected node: {dump(node)}")
-
-    def transform_any(self, node: Any) -> T:
-        """Transform an ``any(...)`` expression into something."""
-        raise AssertionError(f"Unexpected node: {dump(node)}")
-
-    def transform_all(self, node: All) -> T:
-        """Transform an ``all(...)`` expression into something."""
-        raise AssertionError(f"Unexpected node: {dump(node)}")
-
-    def transform_assignment(self, node: Assignment) -> T:
-        """Transform an assignment into something."""
-        raise AssertionError(f"Unexpected node: {dump(node)}")
-
-    def transform_return(self, node: Return) -> T:
-        """Transform a return statement into something."""
-        raise AssertionError(f"Unexpected node: {dump(node)}")
-
-
 class _StringifyTransformer(Transformer[stringify.Entity]):
     """Transform a node into a stringifiable representation."""
 
@@ -1166,6 +1061,111 @@ def dump(node: Node) -> str:
     """Produce a string representation of the tree."""
     transformer = _StringifyTransformer()
     return stringify.dump(transformer.transform(node=node))
+
+
+class RestrictedTransformer(Transformer[T]):
+    """
+    Transform our AST into something where only a part of the tree is handled.
+
+    This class is helpful for cases where you are sure that certain nodes *can not*
+    appear.
+    """
+
+    def transform_member(self, node: Member) -> T:
+        """Transform a member to something."""
+        raise AssertionError(f"Unexpected node: {dump(node)}")
+
+    def transform_index(self, node: Index) -> T:
+        """Transform an index access to something."""
+        raise AssertionError(f"Unexpected node: {dump(node)}")
+
+    def transform_comparison(self, node: Comparison) -> T:
+        """Transform a comparison to something."""
+        raise AssertionError(f"Unexpected node: {dump(node)}")
+
+    def transform_is_in(self, node: IsIn) -> T:
+        """Transform a membership relation to something."""
+        raise NotImplementedError(f"{node=}")
+
+    def transform_implication(self, node: Implication) -> T:
+        """Transform an implication to something."""
+        raise AssertionError(f"Unexpected node: {dump(node)}")
+
+    def transform_method_call(self, node: MethodCall) -> T:
+        """Transform a method call into something."""
+        raise AssertionError(f"Unexpected node: {dump(node)}")
+
+    def transform_function_call(self, node: FunctionCall) -> T:
+        """Transform a function call into something."""
+        raise AssertionError(f"Unexpected node: {dump(node)}")
+
+    def transform_constant(self, node: Constant) -> T:
+        """Transform a constant into something."""
+        raise AssertionError(f"Unexpected node: {dump(node)}")
+
+    def transform_is_none(self, node: IsNone) -> T:
+        """Transform an is-none check into something."""
+        raise AssertionError(f"Unexpected node: {dump(node)}")
+
+    def transform_is_not_none(self, node: IsNotNone) -> T:
+        """Transform an is-not-none check into something."""
+        raise AssertionError(f"Unexpected node: {dump(node)}")
+
+    def transform_name(self, node: Name) -> T:
+        """Transform variable access into something."""
+        raise AssertionError(f"Unexpected node: {dump(node)}")
+
+    def transform_not(self, node: Not) -> T:
+        """Transform a negation into something."""
+        raise AssertionError(f"Unexpected node: {dump(node)}")
+
+    def transform_and(self, node: And) -> T:
+        """Transform a conjunction into something."""
+        raise AssertionError(f"Unexpected node: {dump(node)}")
+
+    def transform_or(self, node: Or) -> T:
+        """Transform a disjunction into something."""
+        raise AssertionError(f"Unexpected node: {dump(node)}")
+
+    def transform_add(self, node: Add) -> T:
+        """Transform an addition into something."""
+        raise NotImplementedError(f"{node=}")
+
+    def transform_sub(self, node: Sub) -> T:
+        """Transform a subtraction into something."""
+        raise NotImplementedError(f"{node=}")
+
+    def transform_formatted_value(self, node: FormattedValue) -> T:
+        """Transform a formatted value in a joined string into something."""
+        raise AssertionError(f"Unexpected node: {dump(node)}")
+
+    def transform_joined_str(self, node: JoinedStr) -> T:
+        """Transform a string interpolation into something."""
+        raise AssertionError(f"Unexpected node: {dump(node)}")
+
+    def transform_for_each(self, node: ForEach) -> T:
+        """Transform a for-each in a generator expression into something."""
+        raise AssertionError(f"Unexpected node: {dump(node)}")
+
+    def transform_for_range(self, node: ForRange) -> T:
+        """Transform a for-range in a generator expression into something."""
+        raise AssertionError(f"Unexpected node: {dump(node)}")
+
+    def transform_any(self, node: Any) -> T:
+        """Transform an ``any(...)`` expression into something."""
+        raise AssertionError(f"Unexpected node: {dump(node)}")
+
+    def transform_all(self, node: All) -> T:
+        """Transform an ``all(...)`` expression into something."""
+        raise AssertionError(f"Unexpected node: {dump(node)}")
+
+    def transform_assignment(self, node: Assignment) -> T:
+        """Transform an assignment into something."""
+        raise AssertionError(f"Unexpected node: {dump(node)}")
+
+    def transform_return(self, node: Return) -> T:
+        """Transform a return statement into something."""
+        raise AssertionError(f"Unexpected node: {dump(node)}")
 
 
 class _IterationTransformer(Transformer[Iterator[Node]]):

--- a/aas_core_codegen/python/naming.py
+++ b/aas_core_codegen/python/naming.py
@@ -7,25 +7,6 @@ from aas_core_codegen import intermediate, naming
 from aas_core_codegen.common import Identifier, assert_never
 
 
-def name_of(
-    something: Union[
-        intermediate.Enumeration, intermediate.AbstractClass, intermediate.ConcreteClass
-    ]
-) -> Identifier:
-    """Dispatch the name based on the run-time type of ``something``."""
-    if isinstance(something, intermediate.Enumeration):
-        return enum_name(something.name)
-
-    elif isinstance(
-        something, (intermediate.AbstractClass, intermediate.ConcreteClass)
-    ):
-        return class_name(something.name)
-
-    else:
-        assert_never(something)
-        raise AssertionError("Unexpected execution path")  # for mypy
-
-
 # fmt: off
 @require(
     lambda identifier: identifier[0].isupper(),
@@ -47,16 +28,55 @@ def enum_name(identifier: Identifier) -> Identifier:
     """
     parts = identifier.split("_")
 
-    # fmt: off
     return Identifier(
-        "".join(
-            part
-            if part.upper() == part
-            else part.capitalize()
-            for part in parts
-        )
+        "".join(part if part.upper() == part else part.capitalize() for part in parts)
     )
-    # fmt: on
+
+
+# fmt: off
+@require(
+    lambda identifier:
+    identifier[0].isupper(),
+    "Class names must start with a capital letter"
+)
+# fmt: on
+def class_name(identifier: Identifier) -> Identifier:
+    """
+    Generate a name for a class based on its meta-model ``identifier``.
+
+    >>> class_name(Identifier("Something"))
+    'Something'
+
+    >>> class_name(Identifier("URL_to_something"))
+    'URLToSomething'
+
+    >>> class_name(Identifier("Something_to_URL"))
+    'SomethingToURL'
+    """
+    parts = identifier.split("_")
+
+    return Identifier(
+        "".join(part if part == part.upper() else part.capitalize() for part in parts)
+    )
+
+
+def name_of(
+    something: Union[
+        intermediate.Enumeration, intermediate.AbstractClass, intermediate.ConcreteClass
+    ]
+) -> Identifier:
+    """Dispatch the name based on the run-time type of ``something``."""
+    if isinstance(something, intermediate.Enumeration):
+        return enum_name(something.name)
+
+    elif isinstance(
+        something, (intermediate.AbstractClass, intermediate.ConcreteClass)
+    ):
+        return class_name(something.name)
+
+    else:
+        assert_never(something)
+        raise AssertionError("Unexpected execution path")  # for mypy
 
 
 def enum_literal_name(identifier: Identifier) -> Identifier:
@@ -117,51 +137,10 @@ def private_class_name(identifier: Identifier) -> Identifier:
     """
     parts = identifier.split("_")
 
-    # fmt: off
     return Identifier(
         "_"
-        + "".join(
-            part
-            if part.upper() == part
-            else part.capitalize()
-            for part in parts
-        )
+        + "".join(part if part.upper() == part else part.capitalize() for part in parts)
     )
-    # fmt: on
-
-
-# fmt: off
-@require(
-    lambda identifier:
-    identifier[0].isupper(),
-    "Class names must start with a capital letter"
-)
-# fmt: on
-def class_name(identifier: Identifier) -> Identifier:
-    """
-    Generate a name for a class based on its meta-model ``identifier``.
-
-    >>> class_name(Identifier("Something"))
-    'Something'
-
-    >>> class_name(Identifier("URL_to_something"))
-    'URLToSomething'
-
-    >>> class_name(Identifier("Something_to_URL"))
-    'SomethingToURL'
-    """
-    parts = identifier.split("_")
-
-    # fmt: off
-    return Identifier(
-        "".join(
-            part
-            if part == part.upper()
-            else part.capitalize()
-            for part in parts
-        )
-    )
-    # fmt: on
 
 
 def property_name(identifier: Identifier) -> Identifier:

--- a/aas_core_codegen/python/structure/_generate.py
+++ b/aas_core_codegen/python/structure/_generate.py
@@ -67,56 +67,6 @@ def _human_readable_identifier(
     return result
 
 
-def _verify_structure_name_collisions(
-    symbol_table: intermediate.SymbolTable,
-) -> List[Error]:
-    """Verify that the Python names of the structures do not collide."""
-    observed_structure_names: Dict[
-        Identifier,
-        Union[
-            intermediate.Enumeration,
-            intermediate.AbstractClass,
-            intermediate.ConcreteClass,
-        ],
-    ] = dict()
-
-    errors = []  # type: List[Error]
-
-    # region Inter-structure collisions
-
-    for enum_or_cls in itertools.chain(symbol_table.enumerations, symbol_table.classes):
-        name = python_naming.name_of(enum_or_cls)
-
-        other = observed_structure_names.get(name, None)
-
-        if other is not None:
-            errors.append(
-                Error(
-                    enum_or_cls.parsed.node,
-                    f"The Python name {name!r} "
-                    f"of the {_human_readable_identifier(enum_or_cls)} "
-                    f"collides with the Python name "
-                    f"of the {_human_readable_identifier(other)}",
-                )
-            )
-        else:
-            observed_structure_names[name] = enum_or_cls
-
-    # endregion
-
-    # region Intra-structure collisions
-
-    for our_type in symbol_table.our_types:
-        collision_error = _verify_intra_structure_collisions(our_type=our_type)
-
-        if collision_error is not None:
-            errors.append(collision_error)
-
-    # endregion
-
-    return errors
-
-
 def _verify_intra_structure_collisions(
     our_type: intermediate.OurType,
 ) -> Optional[Error]:
@@ -198,6 +148,56 @@ def _verify_intra_structure_collisions(
         )
 
     return None
+
+
+def _verify_structure_name_collisions(
+    symbol_table: intermediate.SymbolTable,
+) -> List[Error]:
+    """Verify that the Python names of the structures do not collide."""
+    observed_structure_names: Dict[
+        Identifier,
+        Union[
+            intermediate.Enumeration,
+            intermediate.AbstractClass,
+            intermediate.ConcreteClass,
+        ],
+    ] = dict()
+
+    errors = []  # type: List[Error]
+
+    # region Inter-structure collisions
+
+    for enum_or_cls in itertools.chain(symbol_table.enumerations, symbol_table.classes):
+        name = python_naming.name_of(enum_or_cls)
+
+        other = observed_structure_names.get(name, None)
+
+        if other is not None:
+            errors.append(
+                Error(
+                    enum_or_cls.parsed.node,
+                    f"The Python name {name!r} "
+                    f"of the {_human_readable_identifier(enum_or_cls)} "
+                    f"collides with the Python name "
+                    f"of the {_human_readable_identifier(other)}",
+                )
+            )
+        else:
+            observed_structure_names[name] = enum_or_cls
+
+    # endregion
+
+    # region Intra-structure collisions
+
+    for our_type in symbol_table.our_types:
+        collision_error = _verify_intra_structure_collisions(our_type=our_type)
+
+        if collision_error is not None:
+            errors.append(collision_error)
+
+    # endregion
+
+    return errors
 
 
 class VerifiedIntermediateSymbolTable(intermediate.SymbolTable):

--- a/aas_core_codegen/python/transpilation.py
+++ b/aas_core_codegen/python/transpilation.py
@@ -36,6 +36,15 @@ class Transpiler(
 ):
     """Transpile a node of our AST to Python code, or return an error."""
 
+    _PYTHON_COMPARISON_MAP = {
+        parse_tree.Comparator.LT: "<",
+        parse_tree.Comparator.LE: "<=",
+        parse_tree.Comparator.GT: ">",
+        parse_tree.Comparator.GE: ">=",
+        parse_tree.Comparator.EQ: "==",
+        parse_tree.Comparator.NE: "!=",
+    }
+
     def __init__(
         self,
         type_map: Mapping[
@@ -141,15 +150,6 @@ class Transpiler(
             collection = Stripped(f"({collection})")
 
         return Stripped(f"{collection}[{index}]"), None
-
-    _PYTHON_COMPARISON_MAP = {
-        parse_tree.Comparator.LT: "<",
-        parse_tree.Comparator.LE: "<=",
-        parse_tree.Comparator.GT: ">",
-        parse_tree.Comparator.GE: ">=",
-        parse_tree.Comparator.EQ: "==",
-        parse_tree.Comparator.NE: "!=",
-    }
 
     @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
     def transform_comparison(

--- a/aas_core_codegen/python/unrolling.py
+++ b/aas_core_codegen/python/unrolling.py
@@ -55,6 +55,50 @@ def render(node: Node) -> str:
 class AbstractUnroller(DBC):
     """Generate code to unroll recursion into generic types."""
 
+    @abc.abstractmethod
+    def _unroll_primitive_type_annotation(
+        self,
+        unrollee_expr: str,
+        type_annotation: intermediate.PrimitiveTypeAnnotation,
+        path: List[str],
+        list_loop_level: int,
+    ) -> List[Node]:
+        """Generate code for the given specific ``type_annotation``."""
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def _unroll_our_type_annotation(
+        self,
+        unrollee_expr: str,
+        type_annotation: intermediate.OurTypeAnnotation,
+        path: List[str],
+        list_loop_level: int,
+    ) -> List[Node]:
+        """Generate code for the given specific ``type_annotation``."""
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def _unroll_list_type_annotation(
+        self,
+        unrollee_expr: str,
+        type_annotation: intermediate.ListTypeAnnotation,
+        path: List[str],
+        list_loop_level: int,
+    ) -> List[Node]:
+        """Generate code for the given specific ``type_annotation``."""
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def _unroll_optional_type_annotation(
+        self,
+        unrollee_expr: str,
+        type_annotation: intermediate.OptionalTypeAnnotation,
+        path: List[str],
+        list_loop_level: int,
+    ) -> List[Node]:
+        """Generate code for the given specific ``type_annotation``."""
+        raise NotImplementedError()
+
     @require(lambda list_loop_level: list_loop_level >= 0)
     def unroll(
         self,
@@ -110,47 +154,3 @@ class AbstractUnroller(DBC):
             assert_never(type_annotation)
 
         raise AssertionError("Should not have gotten here")
-
-    @abc.abstractmethod
-    def _unroll_primitive_type_annotation(
-        self,
-        unrollee_expr: str,
-        type_annotation: intermediate.PrimitiveTypeAnnotation,
-        path: List[str],
-        list_loop_level: int,
-    ) -> List[Node]:
-        """Generate code for the given specific ``type_annotation``."""
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def _unroll_our_type_annotation(
-        self,
-        unrollee_expr: str,
-        type_annotation: intermediate.OurTypeAnnotation,
-        path: List[str],
-        list_loop_level: int,
-    ) -> List[Node]:
-        """Generate code for the given specific ``type_annotation``."""
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def _unroll_list_type_annotation(
-        self,
-        unrollee_expr: str,
-        type_annotation: intermediate.ListTypeAnnotation,
-        path: List[str],
-        list_loop_level: int,
-    ) -> List[Node]:
-        """Generate code for the given specific ``type_annotation``."""
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def _unroll_optional_type_annotation(
-        self,
-        unrollee_expr: str,
-        type_annotation: intermediate.OptionalTypeAnnotation,
-        path: List[str],
-        list_loop_level: int,
-    ) -> List[Node]:
-        """Generate code for the given specific ``type_annotation``."""
-        raise NotImplementedError()

--- a/aas_core_codegen/python/verification/_generate.py
+++ b/aas_core_codegen/python/verification/_generate.py
@@ -79,43 +79,6 @@ class _PatternVerificationTranspiler(
     """Transpile a statement of a pattern verification into Python."""
 
     @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
-    def transform_constant(
-        self, node: parse_tree.Constant
-    ) -> Tuple[Optional[Stripped], Optional[Error]]:
-        if isinstance(node.value, str):
-            # NOTE (mristin, 2022-06-11):
-            # We assume that all the string constants are valid regular expressions.
-
-            regex, parse_error = parse_retree.parse(values=[node.value])
-            if parse_error is not None:
-                regex_line, pointer_line = parse_retree.render_pointer(
-                    parse_error.cursor
-                )
-
-                return (
-                    None,
-                    Error(
-                        node.original_node,
-                        f"The string constant could not be parsed "
-                        f"as a regular expression: \n"
-                        f"{parse_error.message}\n"
-                        f"{regex_line}\n"
-                        f"{pointer_line}",
-                    ),
-                )
-
-            assert regex is not None
-
-            # NOTE (mristin, 2022-09-30):
-            # Strictly speaking, this is a joined string with a single value, a string
-            # literal.
-            return self._transform_joined_str_values(
-                values=parse_retree.render(regex=regex)
-            )
-        else:
-            raise AssertionError(f"Unexpected {node=}")
-
-    @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
     def _transform_joined_str_values(
         self, values: Sequence[Union[str, parse_tree.FormattedValue]]
     ) -> Tuple[Optional[Stripped], Optional[Error]]:
@@ -195,6 +158,43 @@ class _PatternVerificationTranspiler(
         writer.write(enclosing)
 
         return Stripped(writer.getvalue()), None
+
+    @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
+    def transform_constant(
+        self, node: parse_tree.Constant
+    ) -> Tuple[Optional[Stripped], Optional[Error]]:
+        if isinstance(node.value, str):
+            # NOTE (mristin, 2022-06-11):
+            # We assume that all the string constants are valid regular expressions.
+
+            regex, parse_error = parse_retree.parse(values=[node.value])
+            if parse_error is not None:
+                regex_line, pointer_line = parse_retree.render_pointer(
+                    parse_error.cursor
+                )
+
+                return (
+                    None,
+                    Error(
+                        node.original_node,
+                        f"The string constant could not be parsed "
+                        f"as a regular expression: \n"
+                        f"{parse_error.message}\n"
+                        f"{regex_line}\n"
+                        f"{pointer_line}",
+                    ),
+                )
+
+            assert regex is not None
+
+            # NOTE (mristin, 2022-09-30):
+            # Strictly speaking, this is a joined string with a single value, a string
+            # literal.
+            return self._transform_joined_str_values(
+                values=parse_retree.render(regex=regex)
+            )
+        else:
+            raise AssertionError(f"Unexpected {node=}")
 
     @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
     def transform_name(

--- a/aas_core_codegen/rdf_shacl/common.py
+++ b/aas_core_codegen/rdf_shacl/common.py
@@ -30,6 +30,56 @@ def string_literal(text: str) -> Stripped:
 OurTypeToRdfsRange = MutableMapping[intermediate.OurType, Stripped]
 
 
+EXPLANATION_ABOUT_WHY_WE_EXPECT_LANG_STRING = (
+    "(mristin, 2022-09-01) "
+    "We hard-wire the langString's to rdf:langString. Admittedly, this is "
+    "hacky. We could have made the class ``Lang_string`` "
+    "implementation-specific and defined its ``rdfs:range`` manually as "
+    "a snippet.\n\n"
+    "However, we decided against that as such a design would force us to "
+    "define langString for every language and schema which do not natively "
+    "support it, write custom data generation methods *etc.* Given that "
+    "RDF+SHACL codegen is one out of many code generators we leave the "
+    "other code generators and test data generators as simple as possible, "
+    "and make this code generator a bit hacky in return."
+)
+
+
+@ensure(
+    lambda result: not (result[1] is not None) or (result[0] is None),
+    "If there is an error, the class must not be found.",
+)
+def get_lang_string_as_expected(
+    symbol_table: intermediate.SymbolTable,
+) -> Tuple[Optional[intermediate.ConcreteClass], Optional[Error]]:
+    """
+    Try to retrieve the ``Lang_string`` as a concrete class.
+
+    In some metamodels, we do define ``Lang_string`` and can hard-wire schema generation
+    in RDF and SHACL with it. However, in other models, we dispensed of ``Lang_string``.
+    Therefore, this function is not guaranteed to return a class. If there is no
+    ``Lang_string`` in the symbol table, no error will be returned!
+
+    However, if ``Lang_string`` exists as a class, it must be a concrete class. If it
+    does not fulfill the expectations, an error will be returned.
+    """
+    lang_string_cls = symbol_table.find_our_type(Identifier("Lang_string"))
+    if lang_string_cls is not None:
+        if not isinstance(lang_string_cls, intermediate.ConcreteClass):
+            return (
+                None,
+                Error(
+                    None,
+                    f"Expected ``Lang_string`` to be specified as "
+                    f"a concrete class in the meta model, but it has been defined "
+                    f"as: {type(lang_string_cls)}.\n\n"
+                    + EXPLANATION_ABOUT_WHY_WE_EXPECT_LANG_STRING,
+                ),
+            )
+
+    return lang_string_cls, None
+
+
 @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
 def map_our_type_to_rdfs_range(
     symbol_table: intermediate.SymbolTable,
@@ -99,6 +149,15 @@ def map_our_type_to_rdfs_range(
     return our_type_to_rdfs_range, None
 
 
+PRIMITIVE_MAP = {
+    intermediate.PrimitiveType.BOOL: "xs:boolean",
+    intermediate.PrimitiveType.INT: "xs:long",
+    intermediate.PrimitiveType.FLOAT: "xs:double",
+    intermediate.PrimitiveType.STR: "xs:string",
+    intermediate.PrimitiveType.BYTEARRAY: "xs:base64Binary",
+}
+
+
 def rdfs_range_for_type_annotation(
     type_annotation: intermediate.TypeAnnotationUnion,
     our_type_to_rdfs_range: OurTypeToRdfsRange,
@@ -144,61 +203,4 @@ def rdfs_range_for_type_annotation(
     return Stripped(rdfs_range)
 
 
-EXPLANATION_ABOUT_WHY_WE_EXPECT_LANG_STRING = (
-    "(mristin, 2022-09-01) "
-    "We hard-wire the langString's to rdf:langString. Admittedly, this is "
-    "hacky. We could have made the class ``Lang_string`` "
-    "implementation-specific and defined its ``rdfs:range`` manually as "
-    "a snippet.\n\n"
-    "However, we decided against that as such a design would force us to "
-    "define langString for every language and schema which do not natively "
-    "support it, write custom data generation methods *etc.* Given that "
-    "RDF+SHACL codegen is one out of many code generators we leave the "
-    "other code generators and test data generators as simple as possible, "
-    "and make this code generator a bit hacky in return."
-)
-
-
-@ensure(
-    lambda result: not (result[1] is not None) or (result[0] is None),
-    "If there is an error, the class must not be found.",
-)
-def get_lang_string_as_expected(
-    symbol_table: intermediate.SymbolTable,
-) -> Tuple[Optional[intermediate.ConcreteClass], Optional[Error]]:
-    """
-    Try to retrieve the ``Lang_string`` as a concrete class.
-
-    In some metamodels, we do define ``Lang_string`` and can hard-wire schema generation
-    in RDF and SHACL with it. However, in other models, we dispensed of ``Lang_string``.
-    Therefore, this function is not guaranteed to return a class. If there is no
-    ``Lang_string`` in the symbol table, no error will be returned!
-
-    However, if ``Lang_string`` exists as a class, it must be a concrete class. If it
-    does not fulfill the expectations, an error will be returned.
-    """
-    lang_string_cls = symbol_table.find_our_type(Identifier("Lang_string"))
-    if lang_string_cls is not None:
-        if not isinstance(lang_string_cls, intermediate.ConcreteClass):
-            return (
-                None,
-                Error(
-                    None,
-                    f"Expected ``Lang_string`` to be specified as "
-                    f"a concrete class in the meta model, but it has been defined "
-                    f"as: {type(lang_string_cls)}.\n\n"
-                    + EXPLANATION_ABOUT_WHY_WE_EXPECT_LANG_STRING,
-                ),
-            )
-
-    return lang_string_cls, None
-
-
-PRIMITIVE_MAP = {
-    intermediate.PrimitiveType.BOOL: "xs:boolean",
-    intermediate.PrimitiveType.INT: "xs:long",
-    intermediate.PrimitiveType.FLOAT: "xs:double",
-    intermediate.PrimitiveType.STR: "xs:string",
-    intermediate.PrimitiveType.BYTEARRAY: "xs:base64Binary",
-}
 assert all(literal in PRIMITIVE_MAP for literal in intermediate.PrimitiveType)

--- a/aas_core_codegen/typescript/common.py
+++ b/aas_core_codegen/typescript/common.py
@@ -105,6 +105,10 @@ def string_literal(
             return Stripped(f"`{escaped}`")
 
 
+INDENT = "  "
+INDENT2 = INDENT * 2
+
+
 def bytes_literal(value: bytes) -> Tuple[Stripped, bool]:
     """
     Generate an expression representing the ``value``.
@@ -275,8 +279,6 @@ def generate_type(
     raise AssertionError("Should not have gotten here")
 
 
-INDENT = "  "
-INDENT2 = INDENT * 2
 INDENT3 = INDENT * 3
 INDENT4 = INDENT * 4
 INDENT5 = INDENT * 5

--- a/aas_core_codegen/typescript/naming.py
+++ b/aas_core_codegen/typescript/naming.py
@@ -8,25 +8,6 @@ from aas_core_codegen import intermediate
 from aas_core_codegen.common import Identifier, assert_never
 
 
-def name_of(
-    something: Union[
-        intermediate.Enumeration, intermediate.AbstractClass, intermediate.ConcreteClass
-    ]
-) -> Identifier:
-    """Dispatch the name based on the run-time type of ``something``."""
-    if isinstance(something, intermediate.Enumeration):
-        return enum_name(something.name)
-
-    elif isinstance(
-        something, (intermediate.AbstractClass, intermediate.ConcreteClass)
-    ):
-        return class_name(something.name)
-
-    else:
-        assert_never(something)
-        raise AssertionError("Unexpected execution path")  # for mypy
-
-
 # fmt: off
 @require(
     lambda identifier: identifier[0].isupper(),
@@ -47,6 +28,48 @@ def enum_name(identifier: Identifier) -> Identifier:
     'SomethingToUrl'
     """
     return aas_core_codegen.naming.capitalized_camel_case(identifier)
+
+
+# fmt: off
+@require(
+    lambda identifier:
+    identifier[0].isupper(),
+    "Class names must start with a capital letter"
+)
+# fmt: on
+def class_name(identifier: Identifier) -> Identifier:
+    """
+    Generate a name for a class based on its meta-model ``identifier``.
+
+    >>> class_name(Identifier("Something"))
+    'Something'
+
+    >>> class_name(Identifier("URL_to_something"))
+    'UrlToSomething'
+
+    >>> class_name(Identifier("Something_to_URL"))
+    'SomethingToUrl'
+    """
+    return aas_core_codegen.naming.capitalized_camel_case(identifier)
+
+
+def name_of(
+    something: Union[
+        intermediate.Enumeration, intermediate.AbstractClass, intermediate.ConcreteClass
+    ]
+) -> Identifier:
+    """Dispatch the name based on the run-time type of ``something``."""
+    if isinstance(something, intermediate.Enumeration):
+        return enum_name(something.name)
+
+    elif isinstance(
+        something, (intermediate.AbstractClass, intermediate.ConcreteClass)
+    ):
+        return class_name(something.name)
+
+    else:
+        assert_never(something)
+        raise AssertionError("Unexpected execution path")  # for mypy
 
 
 def enum_literal_name(identifier: Identifier) -> Identifier:
@@ -74,29 +97,6 @@ def constant_name(identifier: Identifier) -> Identifier:
     """
     parts = identifier.split("_")
     return Identifier("_".join(part.upper() for part in parts))
-
-
-# fmt: off
-@require(
-    lambda identifier:
-    identifier[0].isupper(),
-    "Class names must start with a capital letter"
-)
-# fmt: on
-def class_name(identifier: Identifier) -> Identifier:
-    """
-    Generate a name for a class based on its meta-model ``identifier``.
-
-    >>> class_name(Identifier("Something"))
-    'Something'
-
-    >>> class_name(Identifier("URL_to_something"))
-    'UrlToSomething'
-
-    >>> class_name(Identifier("Something_to_URL"))
-    'SomethingToUrl'
-    """
-    return aas_core_codegen.naming.capitalized_camel_case(identifier)
 
 
 # fmt: off

--- a/aas_core_codegen/typescript/stringification/_generate.py
+++ b/aas_core_codegen/typescript/stringification/_generate.py
@@ -20,17 +20,17 @@ from aas_core_codegen import naming
 
 
 def _generate_model_type_from_string(
-        symbol_table: intermediate.SymbolTable
+    symbol_table: intermediate.SymbolTable,
 ) -> List[Stripped]:
     """Generate the function to de-serialize model type from a string."""
     model_type_enum = typescript_naming.enum_name(Identifier("Model_type"))
 
     keys_values = []  # type: List[Stripped]
-    for i, concrete_cls in enumerate(symbol_table.concrete_classes):
+    for concrete_cls in symbol_table.concrete_classes:
         json_model_type = naming.json_model_type(concrete_cls.name)
         model_type_literal = typescript_naming.enum_literal_name(concrete_cls.name)
 
-        assert (json_model_type == model_type_literal), (
+        assert json_model_type == model_type_literal, (
             f"Expected the JSON model type for class {concrete_cls.name!r}, "
             f"{json_model_type!r}, to equal the literal in the enumeration "
             f"{model_type_enum!r}, but it does not. "
@@ -78,22 +78,22 @@ export function {from_string}(
 {I}const result = {map_name}.get(text);
 {I}return result !== undefined ? result : null;
 }}"""
-        )
+        ),
     ]
 
 
 def _generate_model_type_to_string(
-        symbol_table: intermediate.SymbolTable
+    symbol_table: intermediate.SymbolTable,
 ) -> List[Stripped]:
     """Generate the function to serialize a runtime model type to a string."""
     model_type_enum = typescript_naming.enum_name(Identifier("Model_type"))
 
     keys_values = []  # type: List[Stripped]
-    for i, concrete_cls in enumerate(symbol_table.concrete_classes):
+    for concrete_cls in symbol_table.concrete_classes:
         json_model_type = naming.json_model_type(concrete_cls.name)
         model_type_literal = typescript_naming.enum_literal_name(concrete_cls.name)
 
-        assert (json_model_type == model_type_literal), (
+        assert json_model_type == model_type_literal, (
             f"Expected the JSON model type for class {concrete_cls.name!r}, "
             f"{json_model_type!r}, to equal the literal in the enumeration "
             f"{model_type_enum!r}, but it does not. "
@@ -333,7 +333,7 @@ export function {must_to_str_name}(
 )
 # fmt: on
 def generate(
-        symbol_table: intermediate.SymbolTable,
+    symbol_table: intermediate.SymbolTable,
 ) -> Tuple[Optional[str], Optional[List[Error]]]:
     """Generate the TypeScript code for the de/serialization of strings."""
     blocks = [

--- a/aas_core_codegen/typescript/transpilation.py
+++ b/aas_core_codegen/typescript/transpilation.py
@@ -38,6 +38,15 @@ class Transpiler(
 ):
     """Transpile a node of our AST to TypeScript code, or return an error."""
 
+    _TYPESCRIPT_COMPARISON_MAP = {
+        parse_tree.Comparator.LT: "<",
+        parse_tree.Comparator.LE: "<=",
+        parse_tree.Comparator.GT: ">",
+        parse_tree.Comparator.GE: ">=",
+        parse_tree.Comparator.EQ: "==",
+        parse_tree.Comparator.NE: "!=",
+    }
+
     def __init__(
         self,
         type_map: Mapping[
@@ -161,15 +170,6 @@ AasCommon.at(
             ),
             None,
         )
-
-    _TYPESCRIPT_COMPARISON_MAP = {
-        parse_tree.Comparator.LT: "<",
-        parse_tree.Comparator.LE: "<=",
-        parse_tree.Comparator.GT: ">",
-        parse_tree.Comparator.GE: ">=",
-        parse_tree.Comparator.EQ: "==",
-        parse_tree.Comparator.NE: "!=",
-    }
 
     @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
     def transform_comparison(

--- a/aas_core_codegen/typescript/unrolling.py
+++ b/aas_core_codegen/typescript/unrolling.py
@@ -58,6 +58,50 @@ def render(node: Node) -> str:
 class AbstractUnroller(DBC):
     """Generate code to unroll recursion into generic types."""
 
+    @abc.abstractmethod
+    def _unroll_primitive_type_annotation(
+        self,
+        unrollee_expr: str,
+        type_annotation: intermediate.PrimitiveTypeAnnotation,
+        path: List[str],
+        list_loop_level: int,
+    ) -> List[Node]:
+        """Generate code for the given specific ``type_annotation``."""
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def _unroll_our_type_annotation(
+        self,
+        unrollee_expr: str,
+        type_annotation: intermediate.OurTypeAnnotation,
+        path: List[str],
+        list_loop_level: int,
+    ) -> List[Node]:
+        """Generate code for the given specific ``type_annotation``."""
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def _unroll_list_type_annotation(
+        self,
+        unrollee_expr: str,
+        type_annotation: intermediate.ListTypeAnnotation,
+        path: List[str],
+        list_loop_level: int,
+    ) -> List[Node]:
+        """Generate code for the given specific ``type_annotation``."""
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def _unroll_optional_type_annotation(
+        self,
+        unrollee_expr: str,
+        type_annotation: intermediate.OptionalTypeAnnotation,
+        path: List[str],
+        list_loop_level: int,
+    ) -> List[Node]:
+        """Generate code for the given specific ``type_annotation``."""
+        raise NotImplementedError()
+
     @require(lambda list_loop_level: list_loop_level >= 0)
     def unroll(
         self,
@@ -113,47 +157,3 @@ class AbstractUnroller(DBC):
             assert_never(type_annotation)
 
         raise AssertionError("Should not have gotten here")
-
-    @abc.abstractmethod
-    def _unroll_primitive_type_annotation(
-        self,
-        unrollee_expr: str,
-        type_annotation: intermediate.PrimitiveTypeAnnotation,
-        path: List[str],
-        list_loop_level: int,
-    ) -> List[Node]:
-        """Generate code for the given specific ``type_annotation``."""
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def _unroll_our_type_annotation(
-        self,
-        unrollee_expr: str,
-        type_annotation: intermediate.OurTypeAnnotation,
-        path: List[str],
-        list_loop_level: int,
-    ) -> List[Node]:
-        """Generate code for the given specific ``type_annotation``."""
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def _unroll_list_type_annotation(
-        self,
-        unrollee_expr: str,
-        type_annotation: intermediate.ListTypeAnnotation,
-        path: List[str],
-        list_loop_level: int,
-    ) -> List[Node]:
-        """Generate code for the given specific ``type_annotation``."""
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def _unroll_optional_type_annotation(
-        self,
-        unrollee_expr: str,
-        type_annotation: intermediate.OptionalTypeAnnotation,
-        path: List[str],
-        list_loop_level: int,
-    ) -> List[Node]:
-        """Generate code for the given specific ``type_annotation``."""
-        raise NotImplementedError()

--- a/aas_core_codegen/typescript/verification/_generate.py
+++ b/aas_core_codegen/typescript/verification/_generate.py
@@ -109,46 +109,6 @@ class _PatternVerificationTranspiler(
     """Transpile a statement of a pattern verification into TypeScript."""
 
     @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
-    def transform_constant(
-        self, node: parse_tree.Constant
-    ) -> Tuple[Optional[Stripped], Optional[Error]]:
-        if isinstance(node.value, str):
-            # NOTE (mristin, 2022-06-11):
-            # We assume that all the string constants are valid regular expressions.
-
-            regex, parse_error = parse_retree.parse(values=[node.value])
-            if parse_error is not None:
-                regex_line, pointer_line = parse_retree.render_pointer(
-                    parse_error.cursor
-                )
-
-                return (
-                    None,
-                    Error(
-                        node.original_node,
-                        f"The string constant could not be parsed "
-                        f"as a regular expression: \n"
-                        f"{parse_error.message}\n"
-                        f"{regex_line}\n"
-                        f"{pointer_line}",
-                    ),
-                )
-
-            assert regex is not None
-
-            # NOTE (mristin, 2022-11-04):
-            # Strictly speaking, this is a joined string with a single value, a string
-            # literal. Thus, do not be confused by the name of the function —
-            # this function treats both joined formatted values *and* string literals.
-            return self._transform_joined_str_values(
-                values=parse_retree.render(
-                    regex=regex, renderer=_REGEX_RENDERER_FOR_JAVASCRIPT
-                )
-            )
-        else:
-            raise AssertionError(f"Unexpected {node=}")
-
-    @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
     def _transform_joined_str_values(
         self, values: Sequence[Union[str, parse_tree.FormattedValue]]
     ) -> Tuple[Optional[Stripped], Optional[Error]]:
@@ -197,6 +157,46 @@ class _PatternVerificationTranspiler(
 
         parts_joined = "".join(parts)
         return Stripped(f"`{parts_joined}`"), None
+
+    @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
+    def transform_constant(
+        self, node: parse_tree.Constant
+    ) -> Tuple[Optional[Stripped], Optional[Error]]:
+        if isinstance(node.value, str):
+            # NOTE (mristin, 2022-06-11):
+            # We assume that all the string constants are valid regular expressions.
+
+            regex, parse_error = parse_retree.parse(values=[node.value])
+            if parse_error is not None:
+                regex_line, pointer_line = parse_retree.render_pointer(
+                    parse_error.cursor
+                )
+
+                return (
+                    None,
+                    Error(
+                        node.original_node,
+                        f"The string constant could not be parsed "
+                        f"as a regular expression: \n"
+                        f"{parse_error.message}\n"
+                        f"{regex_line}\n"
+                        f"{pointer_line}",
+                    ),
+                )
+
+            assert regex is not None
+
+            # NOTE (mristin, 2022-11-04):
+            # Strictly speaking, this is a joined string with a single value, a string
+            # literal. Thus, do not be confused by the name of the function —
+            # this function treats both joined formatted values *and* string literals.
+            return self._transform_joined_str_values(
+                values=parse_retree.render(
+                    regex=regex, renderer=_REGEX_RENDERER_FOR_JAVASCRIPT
+                )
+            )
+        else:
+            raise AssertionError(f"Unexpected {node=}")
 
     @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
     def transform_name(

--- a/aas_core_codegen/yielding/linear.py
+++ b/aas_core_codegen/yielding/linear.py
@@ -674,22 +674,6 @@ def _fix_labels_in_place(statements: List[StatementUnion]) -> None:
 class Subroutine(Sequence[StatementUnion]):
     """Capture a subroutine which can execute between the yields."""
 
-    @overload
-    def __getitem__(self, index: int) -> StatementUnion:
-        raise NotImplementedError("Only for type annotations")
-
-    @overload
-    def __getitem__(self, index: slice) -> "Subroutine":
-        raise NotImplementedError("Only for type annotations")
-
-    def __getitem__(
-        self, index: Union[int, slice]
-    ) -> Union[StatementUnion, "Subroutine"]:
-        raise NotImplementedError("Only for type annotations")
-
-    def __len__(self) -> int:
-        raise NotImplementedError("Only for type annotations")
-
     # fmt: off
     @require(
         lambda statements:
@@ -708,6 +692,22 @@ class Subroutine(Sequence[StatementUnion]):
     # fmt: on
     def __new__(cls, statements: Sequence[StatementUnion]) -> "Subroutine":
         return cast(Subroutine, statements)
+
+    @overload
+    def __getitem__(self, index: int) -> StatementUnion:
+        raise NotImplementedError("Only for type annotations")
+
+    @overload
+    def __getitem__(self, index: slice) -> "Subroutine":
+        raise NotImplementedError("Only for type annotations")
+
+    def __getitem__(
+        self, index: Union[int, slice]
+    ) -> Union[StatementUnion, "Subroutine"]:
+        raise NotImplementedError("Only for type annotations")
+
+    def __len__(self) -> int:
+        raise NotImplementedError("Only for type annotations")
 
 
 def _split_in_subroutines(statements: Sequence[StatementUnion]) -> List[Subroutine]:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ https://github.com/pypa/sampleproject
 """
 import os
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 # pylint: disable=redefined-builtin
 
@@ -51,6 +51,7 @@ setup(
             "jsonschema==3.2.0",
             "xmlschema==1.10.0",
             "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@4d7e59e#egg=aas-core-meta",
+            "ssort==0.12.3",
         ]
     },
     # fmt: on


### PR DESCRIPTION
We use `ssort` to sort the definitions in the source files in a systematic way, so that we do not have to that manually anymore.