### PR TITLE
Remove breakpoint in json-ld tests

### DIFF
--- a/tests/jsonld_context/test_main.py
+++ b/tests/jsonld_context/test_main.py
@@ -64,7 +64,6 @@ class Test_jsonld_context(unittest.TestCase):
                 )
                 generated_jsonld_context = (output_dir / "context.jsonld").read_text()
 
-                breakpoint()
                 self.assertEqual(generated_jsonld_context, expected_jsonld_context)
 
 


### PR DESCRIPTION
A `breakpoint()` has been mistakenly left in the json-ld test. In particular, the breakpoint put the update script for aas-core-meta on hold.

In this patch, we remove the breakpoint so that the tests can run again.