### PR TITLE
Fix C++ to pass jsonization of concrete classes

### DIFF
--- a/aas_core_codegen/cpp/aas_common/_generate.py
+++ b/aas_core_codegen/cpp/aas_common/_generate.py
@@ -610,6 +610,10 @@ std::wstring Utf8ToWstring(
 {I}const char* utf8_text,
 {I}size_t utf8_text_size
 ) {{
+{I}if (utf8_text_size == 0) {{
+{II}return std::wstring();
+{I}}}
+
 {I}#ifdef _WIN32
 {I}// NOTE (mristin):
 {I}// We have to use MultiByteToWideChar from <windows.h> on Windows

--- a/dev_scripts/replace-curly-brackets-backslashes-and-two-space-indent.html
+++ b/dev_scripts/replace-curly-brackets-backslashes-and-two-space-indent.html
@@ -1,0 +1,39 @@
+<html>
+<head>
+<title>Replace curly brackets, backslashes and indent</title>
+<script>
+    function processInput() {
+        var input = document.getElementById("input");
+        var output = document.getElementById("output");
+
+        var text = input.value
+            .replaceAll("{", "{{")
+            .replaceAll("}", "}}")
+            .replaceAll(/^          /gm, "{IIIII}")
+            .replaceAll(/^        /gm, "{IIII}")
+            .replaceAll(/^      /gm, "{III}")
+            .replaceAll(/^    /gm, "{II}")
+            .replaceAll(/^  /gm, "{I}")
+            .replaceAll("\\", "\\\\");
+
+        output.value = text;
+    }
+
+    function copyOutput() {
+        var output = document.getElementById("output");
+        output.select();
+        document.execCommand("copy");
+    }
+
+    window.onload = function() {
+        processInput();
+    }
+</script>
+</head>
+<body>
+<textarea id="input" cols="120" rows="10" oninput="processInput()"></textarea>
+<br/><br/><br/>
+<textarea id="output" cols="120" rows="10" readonly></textarea>
+<br/><br/><br/>
+<button onclick="copyOutput()">Copy</button>
+</body>

--- a/test_data/cpp/test_main/aas_core_meta.v3/expected_output/common.cpp
+++ b/test_data/cpp/test_main/aas_core_meta.v3/expected_output/common.cpp
@@ -13976,6 +13976,10 @@ std::wstring Utf8ToWstring(
   const char* utf8_text,
   size_t utf8_text_size
 ) {
+  if (utf8_text_size == 0) {
+    return std::wstring();
+  }
+
   #ifdef _WIN32
   // NOTE (mristin):
   // We have to use MultiByteToWideChar from <windows.h> on Windows


### PR DESCRIPTION
We fix the C++ generator so that the generator code passes all the tests related to jsonization of concrete classes.