### PR TITLE
Update pylint to 3.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         "dev": [
             "black==22.3.0",
             "mypy==0.950",
-            "pylint==2.12.2",
+            "pylint==3.1.0",
             "pydocstyle>=2.1.1, <3",
             "coverage>=4.5.1, <5",
             "pygments>=2, <3",


### PR DESCRIPTION
We need to update pylint to version 3.1.0 as some indirect dependencies introduced regressions, breaking the continuous integration scripts. With this update the continuous integration scripts work again.