### PR TITLE
Fix paths in JSON-LD tests

### DIFF
--- a/tests/jsonld_context/test_main.py
+++ b/tests/jsonld_context/test_main.py
@@ -14,21 +14,18 @@ from tests.rdf_shacl.test_main import REPO_DIR
 
 class Test_jsonld_context(unittest.TestCase):
     def test_jsonld_context_generation(self) -> None:
-        expected_jsonld_context_file = (
-            REPO_DIR / "test_data" / "jsonld_context" / "context.jsonld"
-        )
-        expected_jsonld_context = expected_jsonld_context_file.read_text()
-
-        test_case = REPO_DIR / "test_data" / "jsonld_context"
-
         for module in [aas_core_meta.v3]:
-            case_dir = test_case / module.__name__
+            case_dir = REPO_DIR / "test_data" / "jsonld_context" / module.__name__
             expected_output_dir = case_dir / "output"
             assert (
                 module.__file__ is not None
             ), f"Expected the module {module!r} to have a __file__, but it has None"
             model_pth = pathlib.Path(module.__file__)
             assert model_pth.exists() and model_pth.is_file(), model_pth
+
+            expected_jsonld_context_path = expected_output_dir / "context.jsonld"
+            expected_jsonld_context = expected_jsonld_context_path.read_text()
+
             with contextlib.ExitStack() as exit_stack:
                 if tests.common.RERECORD:
                     output_dir = expected_output_dir
@@ -62,9 +59,17 @@ class Test_jsonld_context(unittest.TestCase):
                 self.assertEqual(
                     0, return_code, "Expected 0 return code on valid models"
                 )
-                generated_jsonld_context = (output_dir / "context.jsonld").read_text()
+                generated_jsonld_context_path = output_dir / "context.jsonld"
+                generated_jsonld_context = generated_jsonld_context_path.read_text()
 
-                self.assertEqual(generated_jsonld_context, expected_jsonld_context)
+                self.assertEqual(
+                    generated_jsonld_context,
+                    expected_jsonld_context,
+                    f"The generated and the expected context differ. "
+                    f"The expected JSON-LD context lives "
+                    f"at: {expected_jsonld_context_path}, while the generated one "
+                    f"at: {generated_jsonld_context_path}",
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We wrongly wired the expected paths in the tests related to the generation of JSON-LD context. The update script then never updated the context properly.

This patch fixes the issue.