### PR TITLE
Update test data to aas-core-meta 6d5411b

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
             "twine",
             "jsonschema==3.2.0",
             "xmlschema==1.10.0",
-            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@cb28d18#egg=aas-core-meta",
+            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@6d5411b#egg=aas-core-meta",
             "ssort==0.12.3",
         ]
     },

--- a/test_data/cpp/test_main/aas_core_meta.v3/expected_output/enhancing.hpp
+++ b/test_data/cpp/test_main/aas_core_meta.v3/expected_output/enhancing.hpp
@@ -7104,20 +7104,6 @@ class EnhancedEmbeddedDataSpecification
     return types::ModelType::kEmbeddedDataSpecification;
   }
 
-  const std::shared_ptr<types::IReference>& data_specification() const override {
-    return instance_->data_specification();
-  }
-
-  std::shared_ptr<types::IReference>& mutable_data_specification() override {
-    return instance_->mutable_data_specification();
-  }
-
-  void set_data_specification(
-    std::shared_ptr<types::IReference> value
-  ) override {
-    instance_->set_data_specification(value);
-  }
-
   const std::shared_ptr<types::IDataSpecificationContent>& data_specification_content() const override {
     return instance_->data_specification_content();
   }
@@ -7130,6 +7116,26 @@ class EnhancedEmbeddedDataSpecification
     std::shared_ptr<types::IDataSpecificationContent> value
   ) override {
     instance_->set_data_specification_content(value);
+  }
+
+  const common::optional<
+    std::shared_ptr<types::IReference>
+  >& data_specification() const override {
+    return instance_->data_specification();
+  }
+
+  common::optional<
+    std::shared_ptr<types::IReference>
+  >& mutable_data_specification() override {
+    return instance_->mutable_data_specification();
+  }
+
+  void set_data_specification(
+    common::optional<
+      std::shared_ptr<types::IReference>
+    > value
+  ) override {
+    instance_->set_data_specification(value);
   }
 
   const std::shared_ptr<E>& enhancement() const {
@@ -13524,19 +13530,33 @@ std::shared_ptr<types::IEmbeddedDataSpecification> WrapEmbeddedDataSpecification
   // We assume that we already checked whether `that` has been enhanced
   // in the caller.
 
-  that->set_data_specification(
-    Wrap<E>(
-      that->data_specification(),
-      factory
-    )
-  );
-
   that->set_data_specification_content(
     Wrap<E>(
       that->data_specification_content(),
       factory
     )
   );
+
+  if (that->data_specification().has_value()) {
+    const std::shared_ptr<types::IReference>& value(
+      that->data_specification().value()
+    );
+
+    std::shared_ptr<
+      types::IReference
+    > wrapped(
+      Wrap<E>(
+        value,
+        factory
+      )
+    );
+
+    that->set_data_specification(
+      common::make_optional(
+        std::move(wrapped)
+      )
+    );
+  }
 
   std::shared_ptr<E> enh(
     factory(that)

--- a/test_data/cpp/test_main/aas_core_meta.v3/expected_output/iteration.cpp
+++ b/test_data/cpp/test_main/aas_core_meta.v3/expected_output/iteration.cpp
@@ -11300,10 +11300,10 @@ void IteratorOverEmbeddedDataSpecification::Execute() {
         index_ = -1;
         done_ = false;
 
-        property_ = Property::kDataSpecification;
+        property_ = Property::kDataSpecificationContent;
         item_ = std::move(
           std::static_pointer_cast<types::IClass>(
-            casted_->data_specification()
+            casted_->data_specification_content()
           )
         );
         ++index_;
@@ -11313,10 +11313,15 @@ void IteratorOverEmbeddedDataSpecification::Execute() {
       }
 
       case 1: {
-        property_ = Property::kDataSpecificationContent;
+        if (!(casted_->data_specification().has_value())) {
+          state_ = 2;
+          continue;
+        }
+
+        property_ = Property::kDataSpecification;
         item_ = std::move(
           std::static_pointer_cast<types::IClass>(
-            casted_->data_specification_content()
+            *(casted_->data_specification())
           )
         );
         ++index_;

--- a/test_data/cpp/test_main/aas_core_meta.v3/expected_output/jsonization.cpp
+++ b/test_data/cpp/test_main/aas_core_meta.v3/expected_output/jsonization.cpp
@@ -22421,8 +22421,8 @@ std::pair<
 }
 
 std::set<std::string> kPropertiesInEmbeddedDataSpecification = {
-  "dataSpecification",
-  "dataSpecificationContent"
+  "dataSpecificationContent",
+  "dataSpecification"
 };
 
 std::pair<
@@ -22477,18 +22477,6 @@ std::pair<
 
   // region Check required properties
 
-  if (!json.contains("dataSpecification")) {
-    return std::make_pair<
-      common::optional<std::shared_ptr<types::IEmbeddedDataSpecification> >,
-      common::optional<DeserializationError>
-    >(
-      common::nullopt,
-      common::make_optional<DeserializationError>(
-        L"The required property dataSpecification is missing"
-      )
-    );
-  }
-
   if (!json.contains("dataSpecificationContent")) {
     return std::make_pair<
       common::optional<std::shared_ptr<types::IEmbeddedDataSpecification> >,
@@ -22507,39 +22495,13 @@ std::pair<
 
   common::optional<DeserializationError> error;
 
-  common::optional<std::shared_ptr<types::IReference> > the_data_specification;
-
   common::optional<std::shared_ptr<types::IDataSpecificationContent> > the_data_specification_content;
 
+  common::optional<
+    std::shared_ptr<types::IReference>
+  > the_data_specification;
+
   // endregion Initialization
-
-  // region De-serialize dataSpecification
-
-  std::tie(
-    the_data_specification,
-    error
-  ) = DeserializeReference(
-    json["dataSpecification"],
-    additional_properties
-  );
-
-  if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<PropertySegment>(
-        L"dataSpecification"
-      )
-    );
-
-    return std::make_pair<
-      common::optional<std::shared_ptr<types::IEmbeddedDataSpecification> >,
-      common::optional<DeserializationError>
-    >(
-      common::nullopt,
-      std::move(error)
-    );
-  }
-
-  // endregion De-serialize dataSpecification
 
   // region De-serialize dataSpecificationContent
 
@@ -22569,6 +22531,36 @@ std::pair<
 
   // endregion De-serialize dataSpecificationContent
 
+  // region De-serialize dataSpecification
+
+  if (json.contains("dataSpecification")) {
+    std::tie(
+      the_data_specification,
+      error
+    ) = DeserializeReference(
+      json["dataSpecification"],
+      additional_properties
+    );
+
+    if (error.has_value()) {
+      error->path.segments.emplace_front(
+        common::make_unique<PropertySegment>(
+          L"dataSpecification"
+        )
+      );
+
+      return std::make_pair<
+        common::optional<std::shared_ptr<types::IEmbeddedDataSpecification> >,
+        common::optional<DeserializationError>
+      >(
+        common::nullopt,
+        std::move(error)
+      );
+    }
+  }
+
+  // endregion De-serialize dataSpecification
+
   return std::make_pair(
     common::make_optional<
       std::shared_ptr<types::IEmbeddedDataSpecification>
@@ -22577,8 +22569,8 @@ std::pair<
       // We deliberately do not use std::make_shared here to avoid an unnecessary
       // upcast.
       new types::EmbeddedDataSpecification(
-        std::move(*the_data_specification),
-        std::move(*the_data_specification_content)
+        std::move(*the_data_specification_content),
+        std::move(the_data_specification)
       )
     ),
     common::nullopt
@@ -35748,33 +35740,6 @@ std::pair<
 
   common::optional<SerializationError> error;
 
-  common::optional<nlohmann::json> json_data_specification;
-  std::tie(
-    json_data_specification,
-    error
-  ) = SerializeIClass(
-    *that.data_specification()
-  );
-  if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kDataSpecification
-      )
-    );
-
-    return std::make_pair<
-      common::optional<nlohmann::json>,
-      common::optional<SerializationError>
-    >(
-      common::nullopt,
-      std::move(error)
-    );
-  }
-
-  result["dataSpecification"] = std::move(
-    *json_data_specification
-  );
-
   common::optional<nlohmann::json> json_data_specification_content;
   std::tie(
     json_data_specification_content,
@@ -35801,6 +35766,40 @@ std::pair<
   result["dataSpecificationContent"] = std::move(
     *json_data_specification_content
   );
+
+  const common::optional<
+    std::shared_ptr<types::IReference>
+  >& maybe_data_specification(
+    that.data_specification()
+  );
+  if (maybe_data_specification.has_value()) {
+    common::optional<nlohmann::json> json_data_specification;
+    std::tie(
+      json_data_specification,
+      error
+    ) = SerializeIClass(
+      **maybe_data_specification
+    );
+    if (error.has_value()) {
+      error->path.segments.emplace_front(
+        common::make_unique<iteration::PropertySegment>(
+          iteration::Property::kDataSpecification
+        )
+      );
+
+      return std::make_pair<
+        common::optional<nlohmann::json>,
+        common::optional<SerializationError>
+      >(
+        common::nullopt,
+        std::move(error)
+      );
+    }
+
+    result["dataSpecification"] = std::move(
+      *json_data_specification
+    );
+  }
 
   return std::make_pair<
     common::optional<nlohmann::json>,

--- a/test_data/cpp/test_main/aas_core_meta.v3/expected_output/types.cpp
+++ b/test_data/cpp/test_main/aas_core_meta.v3/expected_output/types.cpp
@@ -6911,30 +6911,18 @@ void Environment::set_concept_descriptions(
 // region EmbeddedDataSpecification
 
 EmbeddedDataSpecification::EmbeddedDataSpecification(
-  std::shared_ptr<IReference> data_specification,
-  std::shared_ptr<IDataSpecificationContent> data_specification_content
+  std::shared_ptr<IDataSpecificationContent> data_specification_content,
+  common::optional<
+    std::shared_ptr<IReference>
+  > data_specification
 ) {
-  data_specification_ = std::move(data_specification);
-
   data_specification_content_ = std::move(data_specification_content);
+
+  data_specification_ = std::move(data_specification);
 }
 
 ModelType EmbeddedDataSpecification::model_type() const {
   return ModelType::kEmbeddedDataSpecification;
-}
-
-const std::shared_ptr<IReference>& EmbeddedDataSpecification::data_specification() const {
-  return data_specification_;
-}
-
-std::shared_ptr<IReference>& EmbeddedDataSpecification::mutable_data_specification() {
-  return data_specification_;
-}
-
-void EmbeddedDataSpecification::set_data_specification(
-  std::shared_ptr<IReference> value
-) {
-  data_specification_ = value;
 }
 
 const std::shared_ptr<IDataSpecificationContent>& EmbeddedDataSpecification::data_specification_content() const {
@@ -6949,6 +6937,26 @@ void EmbeddedDataSpecification::set_data_specification_content(
   std::shared_ptr<IDataSpecificationContent> value
 ) {
   data_specification_content_ = value;
+}
+
+const common::optional<
+  std::shared_ptr<IReference>
+>& EmbeddedDataSpecification::data_specification() const {
+  return data_specification_;
+}
+
+common::optional<
+  std::shared_ptr<IReference>
+>& EmbeddedDataSpecification::mutable_data_specification() {
+  return data_specification_;
+}
+
+void EmbeddedDataSpecification::set_data_specification(
+  common::optional<
+    std::shared_ptr<IReference>
+  > value
+) {
+  data_specification_ = value;
 }
 
 // endregion EmbeddedDataSpecification

--- a/test_data/cpp/test_main/aas_core_meta.v3/expected_output/types.hpp
+++ b/test_data/cpp/test_main/aas_core_meta.v3/expected_output/types.hpp
@@ -2927,19 +2927,6 @@ class IEmbeddedDataSpecification
     : virtual public IClass {
  public:
   ///@{
-  /// \brief Reference to the data specification
-
-  virtual const std::shared_ptr<IReference>& data_specification() const = 0;
-
-  virtual std::shared_ptr<IReference>& mutable_data_specification() = 0;
-
-  virtual void set_data_specification(
-    std::shared_ptr<IReference> value
-  ) = 0;
-
-  ///@}
-
-  ///@{
   /// \brief Actual content of the data specification
 
   virtual const std::shared_ptr<IDataSpecificationContent>& data_specification_content() const = 0;
@@ -2948,6 +2935,25 @@ class IEmbeddedDataSpecification
 
   virtual void set_data_specification_content(
     std::shared_ptr<IDataSpecificationContent> value
+  ) = 0;
+
+  ///@}
+
+  ///@{
+  /// \brief Reference to the data specification
+
+  virtual const common::optional<
+    std::shared_ptr<IReference>
+  >& data_specification() const = 0;
+
+  virtual common::optional<
+    std::shared_ptr<IReference>
+  >& mutable_data_specification() = 0;
+
+  virtual void set_data_specification(
+    common::optional<
+      std::shared_ptr<IReference>
+    > value
   ) = 0;
 
   ///@}
@@ -10269,24 +10275,14 @@ class Environment
 class EmbeddedDataSpecification
     : public IEmbeddedDataSpecification {
  public:
-  EmbeddedDataSpecification(
-    std::shared_ptr<IReference> data_specification,
-    std::shared_ptr<IDataSpecificationContent> data_specification_content
+  explicit EmbeddedDataSpecification(
+    std::shared_ptr<IDataSpecificationContent> data_specification_content,
+    common::optional<
+      std::shared_ptr<IReference>
+    > data_specification = common::nullopt
   );
 
   ModelType model_type() const override;
-
-  // region Get and set data_specification_
-
-  const std::shared_ptr<IReference>& data_specification() const override;
-
-  std::shared_ptr<IReference>& mutable_data_specification() override;
-
-  void set_data_specification(
-    std::shared_ptr<IReference> value
-  ) override;
-
-  // endregion
 
   // region Get and set data_specification_content_
 
@@ -10300,12 +10296,32 @@ class EmbeddedDataSpecification
 
   // endregion
 
+  // region Get and set data_specification_
+
+  const common::optional<
+    std::shared_ptr<IReference>
+  >& data_specification() const override;
+
+  common::optional<
+    std::shared_ptr<IReference>
+  >& mutable_data_specification() override;
+
+  void set_data_specification(
+    common::optional<
+      std::shared_ptr<IReference>
+    > value
+  ) override;
+
+  // endregion
+
   ~EmbeddedDataSpecification() override = default;
 
  private:
-  std::shared_ptr<IReference> data_specification_;
-
   std::shared_ptr<IDataSpecificationContent> data_specification_content_;
+
+  common::optional<
+    std::shared_ptr<IReference>
+  > data_specification_;
 };
 
 class LevelType

--- a/test_data/cpp/test_main/aas_core_meta.v3/expected_output/visitation.cpp
+++ b/test_data/cpp/test_main/aas_core_meta.v3/expected_output/visitation.cpp
@@ -3090,15 +3090,23 @@ void PassThroughVisitor::VisitEnvironment(
 void PassThroughVisitor::VisitEmbeddedDataSpecification(
   const std::shared_ptr<types::IEmbeddedDataSpecification>& that
 ) {
-  // mutable_data_specification
-  Visit(
-    that->mutable_data_specification()
-  );
-
   // mutable_data_specification_content
   Visit(
     that->mutable_data_specification_content()
   );
+
+  // region mutable_data_specification
+  const common::optional<
+    std::shared_ptr<types::IReference>
+  >& maybe_data_specification(
+    that->mutable_data_specification()
+  );
+  if (maybe_data_specification.has_value()) {
+    Visit(
+      maybe_data_specification.value()
+    );
+  }
+  // endregion
 }
 
 void PassThroughVisitor::VisitLevelType(

--- a/test_data/cpp/test_main/aas_core_meta.v3/expected_output/xmlization.cpp
+++ b/test_data/cpp/test_main/aas_core_meta.v3/expected_output/xmlization.cpp
@@ -14216,8 +14216,8 @@ enum class OfEnvironment : std::uint32_t {
 };  // enum class OfEnvironment
 
 enum class OfEmbeddedDataSpecification : std::uint32_t {
-  kDataSpecification = 0,
-  kDataSpecificationContent = 1
+  kDataSpecificationContent = 0,
+  kDataSpecification = 1
 };  // enum class OfEmbeddedDataSpecification
 
 enum class OfLevelType : std::uint32_t {
@@ -15447,12 +15447,12 @@ const std::unordered_map<
   OfEmbeddedDataSpecification
 > kMapOfEmbeddedDataSpecification = {
   {
-    "dataSpecification",
-    OfEmbeddedDataSpecification::kDataSpecification
-  },
-  {
     "dataSpecificationContent",
     OfEmbeddedDataSpecification::kDataSpecificationContent
+  },
+  {
+    "dataSpecification",
+    OfEmbeddedDataSpecification::kDataSpecification
   }
 };
 
@@ -31505,9 +31505,11 @@ std::pair<
 
   // region Initialization
 
-  common::optional<std::shared_ptr<types::IReference> > the_data_specification;
-
   common::optional<std::shared_ptr<types::IDataSpecificationContent> > the_data_specification_content;
+
+  common::optional<
+    std::shared_ptr<types::IReference>
+  > the_data_specification;
 
   // endregion Initialization
 
@@ -31586,6 +31588,12 @@ std::pair<
     );
 
     switch (property) {
+      case properties::OfEmbeddedDataSpecification::kDataSpecificationContent:
+        std::tie(
+          the_data_specification_content,
+          error
+        ) = DataSpecificationContentFromElement(reader);
+        break;
       case properties::OfEmbeddedDataSpecification::kDataSpecification:
         std::tie(
           the_data_specification,
@@ -31593,12 +31601,6 @@ std::pair<
         ) = ReferenceFromSequence<
           types::IReference
         >(reader);
-        break;
-      case properties::OfEmbeddedDataSpecification::kDataSpecificationContent:
-        std::tie(
-          the_data_specification_content,
-          error
-        ) = DataSpecificationContentFromElement(reader);
         break;
       default:
         throw std::logic_error(
@@ -31684,14 +31686,6 @@ std::pair<
 
   // region Check required properties
 
-  if (!the_data_specification.has_value()) {
-    return NoInstanceAndDeserializationErrorWithCause<
-      std::shared_ptr<T>
-    >(
-      L"The required property dataSpecification is missing"
-    );
-  }
-
   if (!the_data_specification_content.has_value()) {
     return NoInstanceAndDeserializationErrorWithCause<
       std::shared_ptr<T>
@@ -31710,8 +31704,8 @@ std::pair<
       // We deliberately do not use std::make_shared here to avoid an unnecessary
       // upcast.
       new types::EmbeddedDataSpecification(
-        std::move(*the_data_specification),
-        std::move(*the_data_specification_content)
+        std::move(*the_data_specification_content),
+        std::move(the_data_specification)
       )
     ),
     common::nullopt
@@ -53744,43 +53738,6 @@ common::optional<SerializationError> SerializeEmbeddedDataSpecificationAsSequenc
 ) {
   common::optional<SerializationError> error;
 
-  const std::shared_ptr<types::IReference>& the_data_specification(
-    that.data_specification()
-  );
-  writer.StartElement(
-    "dataSpecification"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeReferenceAsSequence(
-    *the_data_specification,
-    writer
-  );
-  if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kDataSpecification
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "dataSpecification"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kDataSpecification
-      )
-    );
-
-    return error;
-  }
-
   const std::shared_ptr<types::IDataSpecificationContent>& the_data_specification_content(
     that.data_specification_content()
   );
@@ -53816,6 +53773,48 @@ common::optional<SerializationError> SerializeEmbeddedDataSpecificationAsSequenc
     );
 
     return error;
+  }
+
+  const auto& maybe_data_specification(
+    that.data_specification()
+  );
+  if (maybe_data_specification.has_value()) {
+    const std::shared_ptr<types::IReference>& the_data_specification(
+      *maybe_data_specification
+    );
+    writer.StartElement(
+      "dataSpecification"
+    );
+    if (writer.error().has_value()) {
+      return writer.move_error();
+    }
+    error = SerializeReferenceAsSequence(
+      *the_data_specification,
+      writer
+    );
+    if (error.has_value()) {
+      error->path.segments.emplace_front(
+        common::make_unique<iteration::PropertySegment>(
+          iteration::Property::kDataSpecification
+        )
+      );
+
+      return error;
+    }
+    writer.StopElement(
+      "dataSpecification"
+    );
+    if (writer.error().has_value()) {
+      error = writer.move_error();
+
+      error->path.segments.emplace_front(
+        common::make_unique<iteration::PropertySegment>(
+          iteration::Property::kDataSpecification
+        )
+      );
+
+      return error;
+    }
   }
 
   writer.Finish();

--- a/test_data/csharp/test_main/aas_core_meta.v3/expected_output/copying.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3/expected_output/copying.cs
@@ -502,8 +502,8 @@ namespace AasCore.Aas3_0
             )
             {
                 return new Aas.EmbeddedDataSpecification(
-                    that.DataSpecification,
-                    that.DataSpecificationContent);
+                    that.DataSpecificationContent,
+                    that.DataSpecification);
             }
 
             public override Aas.IClass TransformLevelType(
@@ -2456,8 +2456,10 @@ namespace AasCore.Aas3_0
             )
             {
                 return new Aas.EmbeddedDataSpecification(
-                    Deep(that.DataSpecification),
-                    Deep(that.DataSpecificationContent)
+                    Deep(that.DataSpecificationContent),
+                    (that.DataSpecification != null)
+                        ? Deep(that.DataSpecification)
+                        : null
                 );
             }
 

--- a/test_data/csharp/test_main/aas_core_meta.v3/expected_output/enhancing.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3/expected_output/enhancing.cs
@@ -3713,16 +3713,16 @@ namespace AasCore.Aas3_0
                 _instance = instance;
             }
 
-            public IReference DataSpecification
-            {
-                get => _instance.DataSpecification;
-                set => _instance.DataSpecification = value;
-            }
-
             public IDataSpecificationContent DataSpecificationContent
             {
                 get => _instance.DataSpecificationContent;
                 set => _instance.DataSpecificationContent = value;
+            }
+
+            public IReference? DataSpecification
+            {
+                get => _instance.DataSpecification;
+                set => _instance.DataSpecification = value;
             }
 
             public IEnumerable<Aas.IClass> DescendOnce()
@@ -7649,17 +7649,6 @@ namespace AasCore.Aas3_0
                     );
                 }
 
-                var transformedDataSpecification = Transform(
-                    that.DataSpecification
-                );
-                var castedDataSpecification = (
-                    transformedDataSpecification as Aas.IReference
-                ) ?? throw new System.InvalidOperationException(
-                    "Expected the transformed value to be a IReference, " +
-                    $"but got: {transformedDataSpecification}"
-                );
-                that.DataSpecification = castedDataSpecification;
-
                 var transformedDataSpecificationContent = Transform(
                     that.DataSpecificationContent
                 );
@@ -7670,6 +7659,20 @@ namespace AasCore.Aas3_0
                     $"but got: {transformedDataSpecificationContent}"
                 );
                 that.DataSpecificationContent = castedDataSpecificationContent;
+
+                if (that.DataSpecification != null)
+                {
+                    var transformedDataSpecification = Transform(
+                        that.DataSpecification
+                    );
+                    var castedDataSpecification = (
+                        transformedDataSpecification as Aas.IReference
+                    ) ?? throw new System.InvalidOperationException(
+                        "Expected the transformed value to be a IReference, " +
+                        $"but got: {transformedDataSpecification}"
+                    );
+                    that.DataSpecification = castedDataSpecification;
+                }
 
                 var enhancement = _enhancementFactory(that);
                 return (enhancement == null)

--- a/test_data/csharp/test_main/aas_core_meta.v3/expected_output/jsonization.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3/expected_output/jsonization.cs
@@ -13160,37 +13160,13 @@ namespace AasCore.Aas3_0
                     return null;
                 }
 
-                IReference? theDataSpecification = null;
                 IDataSpecificationContent? theDataSpecificationContent = null;
+                IReference? theDataSpecification = null;
 
                 foreach (var keyValue in obj)
                 {
                     switch (keyValue.Key)
                     {
-                        case "dataSpecification":
-                        {
-                            if (keyValue.Value == null)
-                            {
-                                continue;
-                            }
-
-                            theDataSpecification = DeserializeImplementation.ReferenceFrom(
-                                keyValue.Value,
-                                out error);
-                            if (error != null)
-                            {
-                                error.PrependSegment(
-                                    new Reporting.NameSegment(
-                                        "dataSpecification"));
-                                return null;
-                            }
-                            if (theDataSpecification == null)
-                            {
-                                throw new System.InvalidOperationException(
-                                    "Unexpected theDataSpecification null when error is also null");
-                            }
-                            break;
-                        }
                         case "dataSpecificationContent":
                         {
                             if (keyValue.Value == null)
@@ -13215,18 +13191,35 @@ namespace AasCore.Aas3_0
                             }
                             break;
                         }
+                        case "dataSpecification":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                continue;
+                            }
+
+                            theDataSpecification = DeserializeImplementation.ReferenceFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "dataSpecification"));
+                                return null;
+                            }
+                            if (theDataSpecification == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theDataSpecification null when error is also null");
+                            }
+                            break;
+                        }
                         default:
                             error = new Reporting.Error(
                                 $"Unexpected property: {keyValue.Key}");
                             return null;
                     }
-                }
-
-                if (theDataSpecification == null)
-                {
-                    error = new Reporting.Error(
-                        "Required property \"dataSpecification\" is missing");
-                    return null;
                 }
 
                 if (theDataSpecificationContent == null)
@@ -13237,12 +13230,10 @@ namespace AasCore.Aas3_0
                 }
 
                 return new Aas.EmbeddedDataSpecification(
-                    theDataSpecification
-                         ?? throw new System.InvalidOperationException(
-                            "Unexpected null, had to be handled before"),
                     theDataSpecificationContent
                          ?? throw new System.InvalidOperationException(
-                            "Unexpected null, had to be handled before"));
+                            "Unexpected null, had to be handled before"),
+                    theDataSpecification);
             }  // internal static EmbeddedDataSpecificationFrom
 
             /// <summary>
@@ -18462,11 +18453,14 @@ namespace AasCore.Aas3_0
             {
                 var result = new Nodes.JsonObject();
 
-                result["dataSpecification"] = Transform(
-                    that.DataSpecification);
-
                 result["dataSpecificationContent"] = Transform(
                     that.DataSpecificationContent);
+
+                if (that.DataSpecification != null)
+                {
+                    result["dataSpecification"] = Transform(
+                        that.DataSpecification);
+                }
 
                 return result;
             }

--- a/test_data/csharp/test_main/aas_core_meta.v3/expected_output/types.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3/expected_output/types.cs
@@ -11887,14 +11887,14 @@ namespace AasCore.Aas3_0
     public interface IEmbeddedDataSpecification : IClass
     {
         /// <summary>
-        /// Reference to the data specification
-        /// </summary>
-        public IReference DataSpecification { get; set; }
-
-        /// <summary>
         /// Actual content of the data specification
         /// </summary>
         public IDataSpecificationContent DataSpecificationContent { get; set; }
+
+        /// <summary>
+        /// Reference to the data specification
+        /// </summary>
+        public IReference? DataSpecification { get; set; }
     }
 
     /// <summary>
@@ -11903,14 +11903,14 @@ namespace AasCore.Aas3_0
     public class EmbeddedDataSpecification : IEmbeddedDataSpecification
     {
         /// <summary>
-        /// Reference to the data specification
-        /// </summary>
-        public IReference DataSpecification { get; set; }
-
-        /// <summary>
         /// Actual content of the data specification
         /// </summary>
         public IDataSpecificationContent DataSpecificationContent { get; set; }
+
+        /// <summary>
+        /// Reference to the data specification
+        /// </summary>
+        public IReference? DataSpecification { get; set; }
 
         /// <summary>
         /// Iterate over all the class instances referenced from this instance
@@ -11918,9 +11918,12 @@ namespace AasCore.Aas3_0
         /// </summary>
         public IEnumerable<IClass> DescendOnce()
         {
-            yield return DataSpecification;
-
             yield return DataSpecificationContent;
+
+            if (DataSpecification != null)
+            {
+                yield return DataSpecification;
+            }
         }
 
         /// <summary>
@@ -11928,20 +11931,23 @@ namespace AasCore.Aas3_0
         /// </summary>
         public IEnumerable<IClass> Descend()
         {
-            yield return DataSpecification;
-
-            // Recurse
-            foreach (var anItem in DataSpecification.Descend())
-            {
-                yield return anItem;
-            }
-
             yield return DataSpecificationContent;
 
             // Recurse
             foreach (var anItem in DataSpecificationContent.Descend())
             {
                 yield return anItem;
+            }
+
+            if (DataSpecification != null)
+            {
+                yield return DataSpecification;
+
+                // Recurse
+                foreach (var anItem in DataSpecification.Descend())
+                {
+                    yield return anItem;
+                }
             }
         }
 
@@ -11986,11 +11992,11 @@ namespace AasCore.Aas3_0
         }
 
         public EmbeddedDataSpecification(
-            IReference dataSpecification,
-            IDataSpecificationContent dataSpecificationContent)
+            IDataSpecificationContent dataSpecificationContent,
+            IReference? dataSpecification = null)
         {
-            DataSpecification = dataSpecification;
             DataSpecificationContent = dataSpecificationContent;
+            DataSpecification = dataSpecification;
         }
     }
 

--- a/test_data/csharp/test_main/aas_core_meta.v3/expected_output/verification.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3/expected_output/verification.cs
@@ -9111,20 +9111,23 @@ namespace AasCore.Aas3_0
                 Aas.IEmbeddedDataSpecification that
             )
             {
-                foreach (var error in Verification.Verify(that.DataSpecification))
-                {
-                    error.PrependSegment(
-                        new Reporting.NameSegment(
-                            "dataSpecification"));
-                    yield return error;
-                }
-
                 foreach (var error in Verification.Verify(that.DataSpecificationContent))
                 {
                     error.PrependSegment(
                         new Reporting.NameSegment(
                             "dataSpecificationContent"));
                     yield return error;
+                }
+
+                if (that.DataSpecification != null)
+                {
+                    foreach (var error in Verification.Verify(that.DataSpecification))
+                    {
+                        error.PrependSegment(
+                            new Reporting.NameSegment(
+                                "dataSpecification"));
+                        yield return error;
+                    }
                 }
             }
 

--- a/test_data/csharp/test_main/aas_core_meta.v3/expected_output/xmlization.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3/expected_output/xmlization.cs
@@ -16958,8 +16958,8 @@ namespace AasCore.Aas3_0
             {
                 error = null;
 
-                IReference? theDataSpecification = null;
                 IDataSpecificationContent? theDataSpecificationContent = null;
+                IReference? theDataSpecification = null;
 
                 if (!isEmptySequence)
                 {
@@ -17005,20 +17005,6 @@ namespace AasCore.Aas3_0
 
                         switch (elementName)
                         {
-                            case "dataSpecification":
-                            {
-                                theDataSpecification = ReferenceFromSequence(
-                                    reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "dataSpecification"));
-                                    return null;
-                                }
-                                break;
-                            }
                             case "dataSpecificationContent":
                             {
                                 if (isEmptyProperty)
@@ -17068,6 +17054,20 @@ namespace AasCore.Aas3_0
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
                                             "dataSpecificationContent"));
+                                    return null;
+                                }
+                                break;
+                            }
+                            case "dataSpecification":
+                            {
+                                theDataSpecification = ReferenceFromSequence(
+                                    reader, isEmptyProperty, out error);
+
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "dataSpecification"));
                                     return null;
                                 }
                                 break;
@@ -17125,14 +17125,6 @@ namespace AasCore.Aas3_0
                     }
                 }
 
-                if (theDataSpecification == null)
-                {
-                    error = new Reporting.Error(
-                        "The required property DataSpecification has not been given " +
-                        "in the XML representation of an instance of class EmbeddedDataSpecification");
-                    return null;
-                }
-
                 if (theDataSpecificationContent == null)
                 {
                     error = new Reporting.Error(
@@ -17142,12 +17134,10 @@ namespace AasCore.Aas3_0
                 }
 
                 return new Aas.EmbeddedDataSpecification(
-                    theDataSpecification
-                         ?? throw new System.InvalidOperationException(
-                            "Unexpected null, had to be handled before"),
                     theDataSpecificationContent
                          ?? throw new System.InvalidOperationException(
-                            "Unexpected null, had to be handled before"));
+                            "Unexpected null, had to be handled before"),
+                    theDataSpecification);
             }  // internal static Aas.EmbeddedDataSpecification? EmbeddedDataSpecificationFromSequence
 
             /// <summary>
@@ -25823,16 +25813,6 @@ namespace AasCore.Aas3_0
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "dataSpecification",
-                    NS);
-
-                this.ReferenceToSequence(
-                    that.DataSpecification,
-                    writer);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
                     "dataSpecificationContent",
                     NS);
 
@@ -25841,6 +25821,19 @@ namespace AasCore.Aas3_0
                     writer);
 
                 writer.WriteEndElement();
+
+                if (that.DataSpecification != null)
+                {
+                    writer.WriteStartElement(
+                        "dataSpecification",
+                        NS);
+
+                    this.ReferenceToSequence(
+                        that.DataSpecification,
+                        writer);
+
+                    writer.WriteEndElement();
+                }
             }  // private void EmbeddedDataSpecificationToSequence
 
             public override void VisitEmbeddedDataSpecification(

--- a/test_data/golang/test_main/aas_core_meta.v3/expected_output/enhancing/enhancing.go
+++ b/test_data/golang/test_main/aas_core_meta.v3/expected_output/enhancing/enhancing.go
@@ -6148,17 +6148,6 @@ func (eeds *enhancedEmbeddedDataSpecification[E]) Descend(
 	return eeds.instance.Descend(action)
 }
 
-func (eeds *enhancedEmbeddedDataSpecification[E]) DataSpecification(
-) aastypes.IReference {
-	return eeds.instance.DataSpecification()
-}
-
-func (eeds *enhancedEmbeddedDataSpecification[E]) SetDataSpecification(
-	value aastypes.IReference,
-) {
-	eeds.instance.SetDataSpecification(value)
-}
-
 func (eeds *enhancedEmbeddedDataSpecification[E]) DataSpecificationContent(
 ) aastypes.IDataSpecificationContent {
 	return eeds.instance.DataSpecificationContent()
@@ -6168,6 +6157,17 @@ func (eeds *enhancedEmbeddedDataSpecification[E]) SetDataSpecificationContent(
 	value aastypes.IDataSpecificationContent,
 ) {
 	eeds.instance.SetDataSpecificationContent(value)
+}
+
+func (eeds *enhancedEmbeddedDataSpecification[E]) DataSpecification(
+) aastypes.IReference {
+	return eeds.instance.DataSpecification()
+}
+
+func (eeds *enhancedEmbeddedDataSpecification[E]) SetDataSpecification(
+	value aastypes.IReference,
+) {
+	eeds.instance.SetDataSpecification(value)
 }
 
 func (eeds *enhancedEmbeddedDataSpecification[E]) getEnhancement(
@@ -6198,14 +6198,6 @@ func wrapEmbeddedDataSpecification[E any](
 		result = that
 	}
 
-	theDataSpecification := that.DataSpecification()
-	that.SetDataSpecification(
-		Wrap[E](
-			theDataSpecification,
-			factory,
-		).(aastypes.IReference),
-	)
-
 	theDataSpecificationContent := that.DataSpecificationContent()
 	that.SetDataSpecificationContent(
 		Wrap[E](
@@ -6213,6 +6205,16 @@ func wrapEmbeddedDataSpecification[E any](
 			factory,
 		).(aastypes.IDataSpecificationContent),
 	)
+
+	theDataSpecification := that.DataSpecification()
+	if theDataSpecification != nil {
+		that.SetDataSpecification(
+			Wrap[E](
+				theDataSpecification,
+				factory,
+			).(aastypes.IReference),
+		)
+	}
 
 	return
 }

--- a/test_data/golang/test_main/aas_core_meta.v3/expected_output/jsonization/jsonization.go
+++ b/test_data/golang/test_main/aas_core_meta.v3/expected_output/jsonization/jsonization.go
@@ -11692,28 +11692,13 @@ func embeddedDataSpecificationFromMapWithoutDispatch(
 	result aastypes.IEmbeddedDataSpecification,
 	err *DeserializationError,
 ) {
-	var theDataSpecification aastypes.IReference
 	var theDataSpecificationContent aastypes.IDataSpecificationContent
+	var theDataSpecification aastypes.IReference
 
-	foundDataSpecification := false
 	foundDataSpecificationContent := false
 
 	for k, v := range m {
 		switch k {
-		case "dataSpecification":
-			theDataSpecification, err = ReferenceFromJsonable(
-				v,
-			)
-			if err != nil {
-				err.Path.PrependName(
-					&aasreporting.NameSegment{
-						Name: "dataSpecification",
-					},
-				)
-				return
-			}
-			foundDataSpecification = true
-
 		case "dataSpecificationContent":
 			theDataSpecificationContent, err = DataSpecificationContentFromJsonable(
 				v,
@@ -11728,6 +11713,19 @@ func embeddedDataSpecificationFromMapWithoutDispatch(
 			}
 			foundDataSpecificationContent = true
 
+		case "dataSpecification":
+			theDataSpecification, err = ReferenceFromJsonable(
+				v,
+			)
+			if err != nil {
+				err.Path.PrependName(
+					&aasreporting.NameSegment{
+						Name: "dataSpecification",
+					},
+				)
+				return
+			}
+
 		default:
 			err = newDeserializationError(
 				fmt.Sprintf(
@@ -11739,13 +11737,6 @@ func embeddedDataSpecificationFromMapWithoutDispatch(
 		}
 	}
 
-	if !foundDataSpecification {
-		err = newDeserializationError(
-			"The required property 'dataSpecification' is missing",
-		)
-		return
-	}
-
 	if !foundDataSpecificationContent {
 		err = newDeserializationError(
 			"The required property 'dataSpecificationContent' is missing",
@@ -11754,8 +11745,10 @@ func embeddedDataSpecificationFromMapWithoutDispatch(
 	}
 
 	result = aastypes.NewEmbeddedDataSpecification(
-		theDataSpecification,
 		theDataSpecificationContent,
+	)
+	result.SetDataSpecification(
+		theDataSpecification,
 	)
 
 	return
@@ -19308,21 +19301,6 @@ func embeddedDataSpecificationToMap(
 ) (result map[string]interface{}, err *SerializationError) {
 	result = make(map[string]interface{})
 
-	var jsonableDataSpecification interface{}
-	jsonableDataSpecification, err = ToJsonable(
-		that.DataSpecification(),
-	)
-	if err != nil {
-		err.Path.PrependName(
-			&aasreporting.NameSegment{
-				Name: "DataSpecification()",
-			},
-		)
-
-		return
-	}
-	result["dataSpecification"] = jsonableDataSpecification
-
 	var jsonableDataSpecificationContent interface{}
 	jsonableDataSpecificationContent, err = ToJsonable(
 		that.DataSpecificationContent(),
@@ -19337,6 +19315,23 @@ func embeddedDataSpecificationToMap(
 		return
 	}
 	result["dataSpecificationContent"] = jsonableDataSpecificationContent
+
+	if that.DataSpecification() != nil {
+		var jsonableDataSpecification interface{}
+		jsonableDataSpecification, err = ToJsonable(
+			that.DataSpecification(),
+		)
+		if err != nil {
+			err.Path.PrependName(
+				&aasreporting.NameSegment{
+					Name: "DataSpecification()",
+				},
+			)
+
+			return
+		}
+		result["dataSpecification"] = jsonableDataSpecification
+	}
 
 	return
 }

--- a/test_data/golang/test_main/aas_core_meta.v3/expected_output/types/types.go
+++ b/test_data/golang/test_main/aas_core_meta.v3/expected_output/types/types.go
@@ -11426,18 +11426,18 @@ func IsDataSpecificationContent(
 type IEmbeddedDataSpecification interface {
 	IClass
 
-	// Reference to the data specification
-	DataSpecification() IReference;
-
-	SetDataSpecification(
-		value IReference,
-	);
-
 	// Actual content of the data specification
 	DataSpecificationContent() IDataSpecificationContent;
 
 	SetDataSpecificationContent(
 		value IDataSpecificationContent,
+	);
+
+	// Reference to the data specification
+	DataSpecification() IReference;
+
+	SetDataSpecification(
+		value IReference,
 	);
 }
 
@@ -11455,19 +11455,8 @@ func IsEmbeddedDataSpecification(
 
 // Implements IEmbeddedDataSpecification.
 type EmbeddedDataSpecification struct {
-	dataSpecification IReference
 	dataSpecificationContent IDataSpecificationContent
-}
-
-func (eds *EmbeddedDataSpecification) DataSpecification(
-) IReference {
-	return eds.dataSpecification
-}
-
-func (eds *EmbeddedDataSpecification) SetDataSpecification(
-	value IReference,
-) {
-	eds.dataSpecification = value
+	dataSpecification IReference
 }
 
 func (eds *EmbeddedDataSpecification) DataSpecificationContent(
@@ -11479,6 +11468,17 @@ func (eds *EmbeddedDataSpecification) SetDataSpecificationContent(
 	value IDataSpecificationContent,
 ) {
 	eds.dataSpecificationContent = value
+}
+
+func (eds *EmbeddedDataSpecification) DataSpecification(
+) IReference {
+	return eds.dataSpecification
+}
+
+func (eds *EmbeddedDataSpecification) SetDataSpecification(
+	value IReference,
+) {
+	eds.dataSpecification = value
 }
 
 func (eds *EmbeddedDataSpecification) ModelType(
@@ -11498,17 +11498,19 @@ func (eds *EmbeddedDataSpecification) DescendOnce(
 	action func(IClass) bool,
 ) (abort bool) {
 	abort = action(
-		eds.dataSpecification,
+		eds.dataSpecificationContent,
 	)
 	if abort {
 		return
 	}
 
-	abort = action(
-		eds.dataSpecificationContent,
-	)
-	if abort {
-		return
+	if eds.dataSpecification != nil {
+		abort = action(
+			eds.dataSpecification,
+		)
+		if abort {
+			return
+		}
 	}
 
 	return
@@ -11524,19 +11526,6 @@ func (eds *EmbeddedDataSpecification) Descend(
 	action func(IClass) bool,
 ) (abort bool) {
 	abort = action(
-		eds.dataSpecification,
-	)
-	if abort {
-		return
-	}
-	abort = eds.dataSpecification.Descend(
-		action,
-	)
-	if abort {
-		return
-	}
-
-	abort = action(
 		eds.dataSpecificationContent,
 	)
 	if abort {
@@ -11549,18 +11538,32 @@ func (eds *EmbeddedDataSpecification) Descend(
 		return
 	}
 
+	if eds.dataSpecification != nil {
+		abort = action(
+			eds.dataSpecification,
+		)
+		if abort {
+			return
+		}
+		abort = eds.dataSpecification.Descend(
+			action,
+		)
+		if abort {
+			return
+		}
+	}
+
 	return
 }
 
 // Create a new instance of EmbeddedDataSpecification with
 // the given properties.
 func NewEmbeddedDataSpecification(
-	dataSpecification IReference,
 	dataSpecificationContent IDataSpecificationContent,
 ) *EmbeddedDataSpecification {
 	return &EmbeddedDataSpecification{
-		dataSpecification: dataSpecification,
 		dataSpecificationContent: dataSpecificationContent,
+		dataSpecification: nil,
 	}
 }
 

--- a/test_data/golang/test_main/aas_core_meta.v3/expected_output/verification/verification.go
+++ b/test_data/golang/test_main/aas_core_meta.v3/expected_output/verification/verification.go
@@ -12325,32 +12325,6 @@ func VerifyEmbeddedDataSpecification(
 ) (abort bool) {
 	abort = false
 
-	if that.DataSpecification() == nil {
-		abort = onError(
-			newVerificationError(
-				"Required property not set: DataSpecification",
-			),
-		)
-		if abort {
-			return
-		}
-	} else {
-		abort = Verify(
-			that.DataSpecification(),
-			func(err *VerificationError) bool {
-				err.Path.PrependName(
-					&aasreporting.NameSegment{
-						Name: "DataSpecification",
-					},
-				)
-				return onError(err)
-			},
-		)
-		if abort {
-			return
-		}
-	}
-
 	if that.DataSpecificationContent() == nil {
 		abort = onError(
 			newVerificationError(
@@ -12367,6 +12341,23 @@ func VerifyEmbeddedDataSpecification(
 				err.Path.PrependName(
 					&aasreporting.NameSegment{
 						Name: "DataSpecificationContent",
+					},
+				)
+				return onError(err)
+			},
+		)
+		if abort {
+			return
+		}
+	}
+
+	if that.DataSpecification() != nil {
+		abort = Verify(
+			that.DataSpecification(),
+			func(err *VerificationError) bool {
+				err.Path.PrependName(
+					&aasreporting.NameSegment{
+						Name: "DataSpecification",
 					},
 				)
 				return onError(err)

--- a/test_data/golang/test_main/aas_core_meta.v3/expected_output/xmlization/xmlization.go
+++ b/test_data/golang/test_main/aas_core_meta.v3/expected_output/xmlization/xmlization.go
@@ -10755,10 +10755,9 @@ func readEmbeddedDataSpecificationAsSequence(
 	next xml.Token,
 	err error,
 ) {
-	var theDataSpecification aastypes.IReference
 	var theDataSpecificationContent aastypes.IDataSpecificationContent
+	var theDataSpecification aastypes.IReference
 
-	foundDataSpecification := false
 	foundDataSpecificationContent := false
 
 	for {
@@ -10801,13 +10800,6 @@ func readEmbeddedDataSpecificationAsSequence(
 
 		var valueErr error
 		switch local {
-		case "dataSpecification":
-			theDataSpecification, current, valueErr =  readReferenceAsSequence(
-				decoder,
-				current,
-			)
-			foundDataSpecification = true
-
 		case "dataSpecificationContent":
 			theDataSpecificationContent, valueErr =  unmarshalDataSpecificationContent(
 				decoder,
@@ -10818,6 +10810,12 @@ func readEmbeddedDataSpecificationAsSequence(
 				current, valueErr = readNext(decoder, current)
 			}
 			foundDataSpecificationContent = true
+
+		case "dataSpecification":
+			theDataSpecification, current, valueErr =  readReferenceAsSequence(
+				decoder,
+				current,
+			)
 
 		default:
 			valueErr = newDeserializationError(
@@ -10863,13 +10861,6 @@ func readEmbeddedDataSpecificationAsSequence(
 
 	next = current
 
-	if !foundDataSpecification {
-		err = newDeserializationError(
-			"The required property 'dataSpecification' is missing",
-		)
-		return
-	}
-
 	if !foundDataSpecificationContent {
 		err = newDeserializationError(
 			"The required property 'dataSpecificationContent' is missing",
@@ -10878,8 +10869,10 @@ func readEmbeddedDataSpecificationAsSequence(
 	}
 
 	instance = aastypes.NewEmbeddedDataSpecification(
-		theDataSpecification,
 		theDataSpecificationContent,
+	)
+	instance.SetDataSpecification(
+		theDataSpecification,
 	)
 	return
 }
@@ -22955,46 +22948,6 @@ func writeEmbeddedDataSpecificationAsSequence(
 	encoder *xml.Encoder,
 	that aastypes.IEmbeddedDataSpecification,
 ) (err error) {
-	// region DataSpecification
-
-	err = writeStartElement(
-		encoder,
-		"dataSpecification",
-		false,
-	)
-	if err != nil {
-		return
-	}
-	err = writeReferenceAsSequence(
-		encoder,
-		that.DataSpecification(),
-	)
-	if err != nil {
-		if seriaErr, ok := err.(*SerializationError); ok {
-			seriaErr.Path.PrependName(
-				&aasreporting.NameSegment{
-					Name: "DataSpecification()",
-				},
-			)
-		}
-		return
-	}
-	err = writeEndElement(
-		encoder,
-		"dataSpecification",
-		false,
-	)
-	if err != nil {
-		return
-	}
-
-	err = encoder.Flush()
-	if err != nil {
-		return err
-	}
-
-	// endregion
-
 	// region DataSpecificationContent
 
 	err = writeStartElement(
@@ -23027,6 +22980,50 @@ func writeEmbeddedDataSpecificationAsSequence(
 	)
 	if err != nil {
 		return
+	}
+
+	err = encoder.Flush()
+	if err != nil {
+		return err
+	}
+
+	// endregion
+
+	// region DataSpecification
+
+	theDataSpecification := that.DataSpecification()
+
+	if theDataSpecification != nil {
+		err = writeStartElement(
+			encoder,
+			"dataSpecification",
+			false,
+		)
+		if err != nil {
+			return
+		}
+		err = writeReferenceAsSequence(
+			encoder,
+			theDataSpecification,
+		)
+		if err != nil {
+			if seriaErr, ok := err.(*SerializationError); ok {
+				seriaErr.Path.PrependName(
+					&aasreporting.NameSegment{
+						Name: "DataSpecification()",
+					},
+				)
+			}
+			return
+		}
+		err = writeEndElement(
+			encoder,
+			"dataSpecification",
+			false,
+		)
+		if err != nil {
+			return
+		}
 	}
 
 	err = encoder.Flush()

--- a/test_data/intermediate/real_meta_models/aas_core_meta.v3/expected_symbol_table.txt
+++ b/test_data/intermediate/real_meta_models/aas_core_meta.v3/expected_symbol_table.txt
@@ -25625,18 +25625,6 @@ SymbolTable(
       concrete_descendants=[],
       properties=[
         Property(
-          name='data_specification',
-          type_annotation=OurTypeAnnotation(
-            our_type='Reference to our type Reference',
-            parsed=...),
-          description=DescriptionOfProperty(
-            summary='<paragraph>Reference to the data specification</paragraph>',
-            remarks=[],
-            constraints_by_identifier=[],
-            parsed=...),
-          specified_for='Reference to ConcreteClass Embedded_data_specification',
-          parsed=...),
-        Property(
           name='data_specification_content',
           type_annotation=OurTypeAnnotation(
             our_type='Reference to our type Data_specification_content',
@@ -25647,24 +25635,42 @@ SymbolTable(
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to ConcreteClass Embedded_data_specification',
+          parsed=...),
+        Property(
+          name='data_specification',
+          type_annotation=OptionalTypeAnnotation(
+            value=OurTypeAnnotation(
+              our_type='Reference to our type Reference',
+              parsed=...),
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>Reference to the data specification</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Embedded_data_specification',
           parsed=...)],
       methods=[],
       constructor=Constructor(
         name='__init__',
         arguments=[
           Argument(
-            name='data_specification',
-            type_annotation=OurTypeAnnotation(
-              our_type='Reference to our type Reference',
-              parsed=...),
-            default=None,
-            parsed=...),
-          Argument(
             name='data_specification_content',
             type_annotation=OurTypeAnnotation(
               our_type='Reference to our type Data_specification_content',
               parsed=...),
             default=None,
+            parsed=...),
+          Argument(
+            name='data_specification',
+            type_annotation=OptionalTypeAnnotation(
+              value=OurTypeAnnotation(
+                our_type='Reference to our type Reference',
+                parsed=...),
+              parsed=...),
+            default=DefaultPrimitive(
+              value=None,
+              parsed=...),
             parsed=...)],
         returns=None,
         description=None,
@@ -25678,24 +25684,24 @@ SymbolTable(
         statements=[
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specification',
-              argument='data_specification',
+              name='data_specification_content',
+              argument='data_specification_content',
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specification_content',
-              argument='data_specification_content',
+              name='data_specification',
+              argument='data_specification',
               default=None)""")],
         inlined_statements=[
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specification',
-              argument='data_specification',
+              name='data_specification_content',
+              argument='data_specification_content',
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specification_content',
-              argument='data_specification_content',
+              name='data_specification',
+              argument='data_specification',
               default=None)""")]),
       invariants=[],
       serialization=Serialization(

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/copying/Copying.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/copying/Copying.java
@@ -506,8 +506,8 @@ public class Copying
             IEmbeddedDataSpecification that
         ) {
             return new EmbeddedDataSpecification(
-                that.getDataSpecification(),
-                that.getDataSpecificationContent());
+                that.getDataSpecificationContent(),
+                that.getDataSpecification().orElse(null));
         }
 
         @Override
@@ -2512,8 +2512,8 @@ public class Copying
             IEmbeddedDataSpecification that
         ) {
             return new EmbeddedDataSpecification(
-                deep(that.getDataSpecification()),
-                deep(that.getDataSpecificationContent())
+                deep(that.getDataSpecificationContent()),
+                that.getDataSpecification().orElse(null)
             );
         }
 

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/enhancing/EnhancedEmbeddedDataSpecification.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/enhancing/EnhancedEmbeddedDataSpecification.java
@@ -30,16 +30,6 @@ public class EnhancedEmbeddedDataSpecification<EnhancementT>
   }
 
   @Override
-  public IReference getDataSpecification() {
-    return instance.getDataSpecification();
-  }
-
-  @Override
-  public void setDataSpecification(IReference dataSpecification) {
-    instance.setDataSpecification(dataSpecification);
-  }
-
-  @Override
   public IDataSpecificationContent getDataSpecificationContent() {
     return instance.getDataSpecificationContent();
   }
@@ -47,6 +37,16 @@ public class EnhancedEmbeddedDataSpecification<EnhancementT>
   @Override
   public void setDataSpecificationContent(IDataSpecificationContent dataSpecificationContent) {
     instance.setDataSpecificationContent(dataSpecificationContent);
+  }
+
+  @Override
+  public Optional<IReference> getDataSpecification() {
+    return instance.getDataSpecification();
+  }
+
+  @Override
+  public void setDataSpecification(IReference dataSpecification) {
+    instance.setDataSpecification(dataSpecification);
   }
 
   public Iterable<IClass> descendOnce() {

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/enhancing/Wrapper.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/enhancing/Wrapper.java
@@ -3105,17 +3105,6 @@ class Wrapper<EnhancementT> extends AbstractTransformer<IClass> {
       );
     }
 
-    IReference dataSpecification = that.getDataSpecification();
-    IClass transformedDataSpecification = transform(dataSpecification);
-    if (!(transformedDataSpecification instanceof IReference)) {
-      throw new UnsupportedOperationException(
-        "Expected the transformed value to be a IReference " +
-        ", but got: " + transformedDataSpecification
-      );
-    }
-    IReference castedDataSpecification = (IReference) transformedDataSpecification;
-    that.setDataSpecification(castedDataSpecification);
-
     IDataSpecificationContent dataSpecificationContent = that.getDataSpecificationContent();
     IClass transformedDataSpecificationContent = transform(dataSpecificationContent);
     if (!(transformedDataSpecificationContent instanceof IDataSpecificationContent)) {
@@ -3126,6 +3115,19 @@ class Wrapper<EnhancementT> extends AbstractTransformer<IClass> {
     }
     IDataSpecificationContent castedDataSpecificationContent = (IDataSpecificationContent) transformedDataSpecificationContent;
     that.setDataSpecificationContent(castedDataSpecificationContent);
+
+    if (that.getDataSpecification().isPresent()) {
+      IReference dataSpecification = that.getDataSpecification().get();
+      IClass transformedDataSpecification = transform(dataSpecification);
+      if (!(transformedDataSpecification instanceof IReference)) {
+        throw new UnsupportedOperationException(
+          "Expected the transformed value to be a IReference " +
+          ", but got: " + transformedDataSpecification
+        );
+      }
+      IReference castedDataSpecification = (IReference) transformedDataSpecification;
+      that.setDataSpecification(castedDataSpecification);
+    }
 
     Optional<EnhancementT> enhancement = enhancementFactory.apply(that);
     return !enhancement.isPresent()

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/EmbeddedDataSpecificationBuilder.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/EmbeddedDataSpecificationBuilder.java
@@ -1,0 +1,40 @@
+package aas_core.aas3_0.generation;
+
+import aas_core.aas3_0.types.enums.*;
+import aas_core.aas3_0.types.impl.*;
+import aas_core.aas3_0.types.model.*;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Builder for the EmbeddedDataSpecification type.
+ */
+public class EmbeddedDataSpecificationBuilder {
+  /**
+   * Actual content of the data specification
+   */
+  private IDataSpecificationContent dataSpecificationContent;
+
+  /**
+   * Reference to the data specification
+   */
+  private IReference dataSpecification;
+
+  public EmbeddedDataSpecificationBuilder(IDataSpecificationContent dataSpecificationContent) {
+    this.dataSpecificationContent = Objects.requireNonNull(
+      dataSpecificationContent,
+      "Argument \"dataSpecificationContent\" must be non-null.");
+  }
+
+  public EmbeddedDataSpecificationBuilder setDataspecification(IReference dataSpecification) {
+    this.dataSpecification = dataSpecification;
+    return this;
+  }
+
+  public EmbeddedDataSpecification build() {
+    return new EmbeddedDataSpecification(
+      this.dataSpecificationContent,
+      this.dataSpecification);
+  }
+}

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/jsonization/Jsonization.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/jsonization/Jsonization.java
@@ -10436,27 +10436,13 @@ public class Jsonization {
           return Result.failure(error);
         }
 
-        IReference theDataSpecification = null;
         IDataSpecificationContent theDataSpecificationContent = null;
+        IReference theDataSpecification = null;
 
         for (Iterator<Map.Entry<String, JsonNode>> iterator = node.fields(); iterator.hasNext(); ) {
           Map.Entry<String, JsonNode> currentNode = iterator.next();
 
           switch (currentNode.getKey()) {
-            case "dataSpecification": {
-              if (currentNode.getValue() == null) {
-                continue;
-              }
-
-              final Result<? extends IReference> theDataSpecificationResult = tryReferenceFrom(currentNode.getValue());
-              if (theDataSpecificationResult.isError()) {
-                theDataSpecificationResult.getError()
-                  .prependSegment(new Reporting.NameSegment("dataSpecification"));
-                return theDataSpecificationResult.castTo(EmbeddedDataSpecification.class);
-              }
-              theDataSpecification = theDataSpecificationResult.getResult();
-              break;
-            }
             case "dataSpecificationContent": {
               if (currentNode.getValue() == null) {
                 continue;
@@ -10471,18 +10457,26 @@ public class Jsonization {
               theDataSpecificationContent = theDataSpecificationContentResult.getResult();
               break;
             }
+            case "dataSpecification": {
+              if (currentNode.getValue() == null) {
+                continue;
+              }
+
+              final Result<? extends IReference> theDataSpecificationResult = tryReferenceFrom(currentNode.getValue());
+              if (theDataSpecificationResult.isError()) {
+                theDataSpecificationResult.getError()
+                  .prependSegment(new Reporting.NameSegment("dataSpecification"));
+                return theDataSpecificationResult.castTo(EmbeddedDataSpecification.class);
+              }
+              theDataSpecification = theDataSpecificationResult.getResult();
+              break;
+            }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
               return Result.failure(error);
             }
           }
-        }
-
-        if (theDataSpecification == null) {
-          final Reporting.Error error = new Reporting.Error(
-            "Required property \"dataSpecification\" is missing");
-          return Result.failure(error);
         }
 
         if (theDataSpecificationContent == null) {
@@ -10492,8 +10486,8 @@ public class Jsonization {
         }
 
         return Result.success(new EmbeddedDataSpecification(
-          theDataSpecification,
-          theDataSpecificationContent));
+          theDataSpecificationContent,
+          theDataSpecification));
       }
 
       /**
@@ -14599,11 +14593,13 @@ public class Jsonization {
       ) {
         final ObjectNode result = JsonNodeFactory.instance.objectNode();
 
-        result.set("dataSpecification", transform(
-          that.getDataSpecification()));
-
         result.set("dataSpecificationContent", transform(
           that.getDataSpecificationContent()));
+
+        if (that.getDataSpecification().isPresent()) {
+          result.set("dataSpecification", transform(
+            that.getDataSpecification().get()));
+        }
 
         return result;
       }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/types/impl/EmbeddedDataSpecification.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/types/impl/EmbeddedDataSpecification.java
@@ -31,36 +31,28 @@ import java.util.Objects;
  */
 public class EmbeddedDataSpecification implements IEmbeddedDataSpecification {
   /**
-   * Reference to the data specification
-   */
-  private IReference dataSpecification;
-
-  /**
    * Actual content of the data specification
    */
   private IDataSpecificationContent dataSpecificationContent;
 
-  public EmbeddedDataSpecification(
-    IReference dataSpecification,
-    IDataSpecificationContent dataSpecificationContent) {
-    this.dataSpecification = Objects.requireNonNull(
-      dataSpecification,
-      "Argument \"dataSpecification\" must be non-null.");
+  /**
+   * Reference to the data specification
+   */
+  private IReference dataSpecification;
+
+  public EmbeddedDataSpecification(IDataSpecificationContent dataSpecificationContent) {
     this.dataSpecificationContent = Objects.requireNonNull(
       dataSpecificationContent,
       "Argument \"dataSpecificationContent\" must be non-null.");
   }
 
-  @Override
-  public IReference getDataSpecification() {
-    return dataSpecification;
-  }
-
-  @Override
-  public void setDataSpecification(IReference dataSpecification) {
-    this.dataSpecification = Objects.requireNonNull(
-      dataSpecification,
-      "Argument \"dataSpecification\" must be non-null.");
+  public EmbeddedDataSpecification(
+    IDataSpecificationContent dataSpecificationContent,
+    IReference dataSpecification) {
+    this.dataSpecificationContent = Objects.requireNonNull(
+      dataSpecificationContent,
+      "Argument \"dataSpecificationContent\" must be non-null.");
+    this.dataSpecification = dataSpecification;
   }
 
   @Override
@@ -73,6 +65,16 @@ public class EmbeddedDataSpecification implements IEmbeddedDataSpecification {
     this.dataSpecificationContent = Objects.requireNonNull(
       dataSpecificationContent,
       "Argument \"dataSpecificationContent\" must be non-null.");
+  }
+
+  @Override
+  public Optional<IReference> getDataSpecification() {
+    return Optional.ofNullable(dataSpecification);
+  }
+
+  @Override
+  public void setDataSpecification(IReference dataSpecification) {
+    this.dataSpecification = dataSpecification;
   }
 
   /**
@@ -152,14 +154,14 @@ public class EmbeddedDataSpecification implements IEmbeddedDataSpecification {
     private Stream<IClass> stream() {
       Stream<IClass> memberStream = Stream.empty();
 
-      if (dataSpecification != null) {
-        memberStream = Stream.concat(memberStream,
-          Stream.<IClass>of(EmbeddedDataSpecification.this.dataSpecification));
-      }
-
       if (dataSpecificationContent != null) {
         memberStream = Stream.concat(memberStream,
           Stream.<IClass>of(EmbeddedDataSpecification.this.dataSpecificationContent));
+      }
+
+      if (dataSpecification != null) {
+        memberStream = Stream.concat(memberStream,
+          Stream.<IClass>of(EmbeddedDataSpecification.this.dataSpecification));
       }
 
       return memberStream;
@@ -191,16 +193,16 @@ public class EmbeddedDataSpecification implements IEmbeddedDataSpecification {
     private Stream<IClass> stream() {
       Stream<IClass> memberStream = Stream.empty();
 
-      if (dataSpecification != null) {
-        memberStream = Stream.concat(memberStream,
-          Stream.concat(Stream.<IClass>of(EmbeddedDataSpecification.this.dataSpecification),
-            StreamSupport.stream(EmbeddedDataSpecification.this.dataSpecification.descend().spliterator(), false)));
-      }
-
       if (dataSpecificationContent != null) {
         memberStream = Stream.concat(memberStream,
           Stream.concat(Stream.<IClass>of(EmbeddedDataSpecification.this.dataSpecificationContent),
             StreamSupport.stream(EmbeddedDataSpecification.this.dataSpecificationContent.descend().spliterator(), false)));
+      }
+
+      if (dataSpecification != null) {
+        memberStream = Stream.concat(memberStream,
+          Stream.concat(Stream.<IClass>of(EmbeddedDataSpecification.this.dataSpecification),
+            StreamSupport.stream(EmbeddedDataSpecification.this.dataSpecification.descend().spliterator(), false)));
       }
 
       return memberStream;

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/types/model/IEmbeddedDataSpecification.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/types/model/IEmbeddedDataSpecification.java
@@ -17,18 +17,18 @@ import java.util.Optional;
  */
 public interface IEmbeddedDataSpecification extends IClass {
   /**
-   * Reference to the data specification
-   */
-  IReference getDataSpecification();
-
-  void setDataSpecification(IReference dataSpecification);
-
-  /**
    * Actual content of the data specification
    */
   IDataSpecificationContent getDataSpecificationContent();
 
   void setDataSpecificationContent(IDataSpecificationContent dataSpecificationContent);
+
+  /**
+   * Reference to the data specification
+   */
+  Optional<IReference> getDataSpecification();
+
+  void setDataSpecification(IReference dataSpecification);
 }
 
 /*

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/verification/Verification.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/verification/Verification.java
@@ -8871,15 +8871,6 @@ public class Verification {
       Stream<Reporting.Error> errorStream = Stream.empty();
 
       errorStream = Stream.<Reporting.Error>concat(errorStream,
-        Stream.of(that.getDataSpecification())
-          .flatMap(Verification::verifyToErrorStream)
-            .map(error -> {
-              error.prependSegment(
-                new Reporting.NameSegment("dataSpecification"));
-              return error;
-            }));
-
-      errorStream = Stream.<Reporting.Error>concat(errorStream,
         Stream.of(that.getDataSpecificationContent())
           .flatMap(Verification::verifyToErrorStream)
             .map(error -> {
@@ -8887,6 +8878,17 @@ public class Verification {
                 new Reporting.NameSegment("dataSpecificationContent"));
               return error;
             }));
+
+      if (that.getDataSpecification().isPresent()) {
+        errorStream = Stream.<Reporting.Error>concat(errorStream,
+          Stream.of(that.getDataSpecification().get())
+            .flatMap(Verification::verifyToErrorStream)
+              .map(error -> {
+                error.prependSegment(
+                  new Reporting.NameSegment("dataSpecification"));
+                return error;
+              }));
+      }
 
       return errorStream;
     }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/xmlization/Xmlization.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/xmlization/Xmlization.java
@@ -13199,8 +13199,8 @@ public class Xmlization {
     private static Result<EmbeddedDataSpecification> tryEmbeddedDataSpecificationFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
-      IReference theDataSpecification = null;
       IDataSpecificationContent theDataSpecificationContent = null;
+      IReference theDataSpecification = null;
 
       if (!isEmptySequence) {
         skipWhitespaceAndComments(reader);
@@ -13236,22 +13236,6 @@ public class Xmlization {
           final String elementName = tryElementName.getResult();
 
           switch (tryElementName.getResult()) {
-            case "dataSpecification":
-            {
-              Result<Reference> tryDataSpecification = tryReferenceFromSequence(
-                reader, isEmptyProperty);
-
-              if (tryDataSpecification.isError()) {
-                tryDataSpecification.getError()
-                  .prependSegment(
-                    new Reporting.NameSegment(
-                      "dataSpecification"));
-                return tryDataSpecification.castTo(EmbeddedDataSpecification.class);
-              }
-
-              theDataSpecification = tryDataSpecification.getResult();
-              break;
-            }
             case "dataSpecificationContent":
             {
               if (isEmptyProperty) {
@@ -13305,6 +13289,22 @@ public class Xmlization {
               theDataSpecificationContent = tryDataSpecificationContent.getResult();
               break;
             }
+            case "dataSpecification":
+            {
+              Result<Reference> tryDataSpecification = tryReferenceFromSequence(
+                reader, isEmptyProperty);
+
+              if (tryDataSpecification.isError()) {
+                tryDataSpecification.getError()
+                  .prependSegment(
+                    new Reporting.NameSegment(
+                      "dataSpecification"));
+                return tryDataSpecification.castTo(EmbeddedDataSpecification.class);
+              }
+
+              theDataSpecification = tryDataSpecification.getResult();
+              break;
+            }
             default:
               final Reporting.Error error = new Reporting.Error(
                 "We expected properties of the class EmbeddedDataSpecification, " +
@@ -13325,13 +13325,6 @@ public class Xmlization {
         }
       }
 
-      if (theDataSpecification == null) {
-        final Reporting.Error error = new Reporting.Error(
-          "The required property dataSpecification has not been given " +
-          "in the XML representation of an instance of class EmbeddedDataSpecification");
-        return Result.failure(error);
-      }
-
       if (theDataSpecificationContent == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property dataSpecificationContent has not been given " +
@@ -13340,8 +13333,8 @@ public class Xmlization {
       }
 
       return Result.success(new EmbeddedDataSpecification(
-        theDataSpecification,
-        theDataSpecificationContent));
+        theDataSpecificationContent,
+        theDataSpecification));
     }
 
     /**
@@ -21716,23 +21709,6 @@ public class Xmlization {
       XMLStreamWriter writer) {
       try {
         writer.writeStartElement(
-          "dataSpecification");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-
-        this.referenceToSequence(
-          that.getDataSpecification(),
-          writer);
-
-        writer.writeEndElement();
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        writer.writeStartElement(
           "dataSpecificationContent");
         if (topLevel) {
           writer.writeNamespace("xmlns", AAS_NAME_SPACE);
@@ -21744,6 +21720,25 @@ public class Xmlization {
           writer);
 
         writer.writeEndElement();
+      } catch (XMLStreamException exception) {
+        throw new SerializeException("",exception.getMessage());
+      }
+
+      try {
+        if (that.getDataSpecification().isPresent()) {
+          writer.writeStartElement(
+            "dataSpecification");
+          if (topLevel) {
+            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
+            topLevel = false;
+          }
+
+          this.referenceToSequence(
+            that.getDataSpecification().get(),
+            writer);
+
+          writer.writeEndElement();
+        }
       } catch (XMLStreamException exception) {
         throw new SerializeException("",exception.getMessage());
       }

--- a/test_data/jsonld_context/aas_core_meta.v3/output/context.jsonld
+++ b/test_data/jsonld_context/aas_core_meta.v3/output/context.jsonld
@@ -679,6 +679,11 @@
       "@type": "@id",
       "@context": {}
     },
+    "dataSpecificationContent": {
+      "@id": "aas:EmbeddedDataSpecification/dataSpecificationContent",
+      "@type": "@id",
+      "@context": {}
+    },
     "dataSpecification": {
       "@id": "aas:EmbeddedDataSpecification/dataSpecification",
       "@type": "@id",
@@ -691,11 +696,6 @@
           "@type": "@vocab"
         }
       }
-    },
-    "dataSpecificationContent": {
-      "@id": "aas:EmbeddedDataSpecification/dataSpecificationContent",
-      "@type": "@id",
-      "@context": {}
     },
     "nom": {
       "@id": "aas:LevelType/nom"

--- a/test_data/jsonschema/test_main/aas_core_meta.v3/expected_output/schema.json
+++ b/test_data/jsonschema/test_main/aas_core_meta.v3/expected_output/schema.json
@@ -505,15 +505,14 @@
     "EmbeddedDataSpecification": {
       "type": "object",
       "properties": {
-        "dataSpecification": {
-          "$ref": "#/definitions/Reference"
-        },
         "dataSpecificationContent": {
           "$ref": "#/definitions/DataSpecificationContent_choice"
+        },
+        "dataSpecification": {
+          "$ref": "#/definitions/Reference"
         }
       },
       "required": [
-        "dataSpecification",
         "dataSpecificationContent"
       ]
     },

--- a/test_data/parse/real_meta_models/aas_core_meta.v3/expected_symbol_table.txt
+++ b/test_data/parse/real_meta_models/aas_core_meta.v3/expected_symbol_table.txt
@@ -10833,18 +10833,22 @@ UnverifiedSymbolTable(
       inheritances=[],
       properties=[
         Property(
-          name='data_specification',
+          name='data_specification_content',
           type_annotation=AtomicTypeAnnotation(
-            identifier='Reference',
+            identifier='Data_specification_content',
             node=...),
           description=Description(
             document=...,
             node=...),
           node=...),
         Property(
-          name='data_specification_content',
-          type_annotation=AtomicTypeAnnotation(
-            identifier='Data_specification_content',
+          name='data_specification',
+          type_annotation=SubscriptedTypeAnnotation(
+            identifier='Optional',
+            subscripts=[
+              AtomicTypeAnnotation(
+                identifier='Reference',
+                node=...)],
             node=...),
           description=Description(
             document=...,
@@ -10861,18 +10865,23 @@ UnverifiedSymbolTable(
               default=None,
               node=...),
             Argument(
-              name='data_specification',
-              type_annotation=AtomicTypeAnnotation(
-                identifier='Reference',
-                node=...),
-              default=None,
-              node=...),
-            Argument(
               name='data_specification_content',
               type_annotation=AtomicTypeAnnotation(
                 identifier='Data_specification_content',
                 node=...),
               default=None,
+              node=...),
+            Argument(
+              name='data_specification',
+              type_annotation=SubscriptedTypeAnnotation(
+                identifier='Optional',
+                subscripts=[
+                  AtomicTypeAnnotation(
+                    identifier='Reference',
+                    node=...)],
+                node=...),
+              default=Default(
+                node=...),
               node=...)],
           returns=None,
           description=None,

--- a/test_data/python/test_main/aas_core_meta.v3/expected_output/jsonization.py
+++ b/test_data/python/test_main/aas_core_meta.v3/expected_output/jsonization.py
@@ -9137,25 +9137,12 @@ class _SetterForEmbeddedDataSpecification:
 
     def __init__(self) -> None:
         """Initialize with all the properties unset."""
-        self.data_specification: Optional[aas_types.Reference] = None
         self.data_specification_content: Optional[aas_types.DataSpecificationContent] = None
+        self.data_specification: Optional[aas_types.Reference] = None
 
     def ignore(self, jsonable: Jsonable) -> None:
         """Ignore :paramref:`jsonable` and do not set anything."""
         pass
-
-    def set_data_specification_from_jsonable(
-            self,
-            jsonable: Jsonable
-    ) -> None:
-        """
-        Parse :paramref:`jsonable` as the value of :py:attr:`~data_specification`.
-
-        :param jsonable: input to be parsed
-        """
-        self.data_specification = reference_from_jsonable(
-            jsonable
-        )
 
     def set_data_specification_content_from_jsonable(
             self,
@@ -9167,6 +9154,19 @@ class _SetterForEmbeddedDataSpecification:
         :param jsonable: input to be parsed
         """
         self.data_specification_content = data_specification_content_from_jsonable(
+            jsonable
+        )
+
+    def set_data_specification_from_jsonable(
+            self,
+            jsonable: Jsonable
+    ) -> None:
+        """
+        Parse :paramref:`jsonable` as the value of :py:attr:`~data_specification`.
+
+        :param jsonable: input to be parsed
+        """
+        self.data_specification = reference_from_jsonable(
             jsonable
         )
 
@@ -9209,19 +9209,14 @@ def embedded_data_specification_from_jsonable(
             )
             raise exception
 
-    if setter.data_specification is None:
-        raise DeserializationException(
-            "The required property 'dataSpecification' is missing"
-        )
-
     if setter.data_specification_content is None:
         raise DeserializationException(
             "The required property 'dataSpecificationContent' is missing"
         )
 
     return aas_types.EmbeddedDataSpecification(
-        setter.data_specification,
-        setter.data_specification_content
+        setter.data_specification_content,
+        setter.data_specification
     )
 
 
@@ -11229,10 +11224,10 @@ _SETTER_MAP_FOR_EMBEDDED_DATA_SPECIFICATION: Mapping[
         None
     ]
 ] = {
-    'dataSpecification':
-        _SetterForEmbeddedDataSpecification.set_data_specification_from_jsonable,
     'dataSpecificationContent':
         _SetterForEmbeddedDataSpecification.set_data_specification_content_from_jsonable,
+    'dataSpecification':
+        _SetterForEmbeddedDataSpecification.set_data_specification_from_jsonable,
     'modelType':
         _SetterForEmbeddedDataSpecification.ignore
 }
@@ -12793,13 +12788,14 @@ class _Serializer(
         """Serialize :paramref:`that` to a JSON-able representation."""
         jsonable: MutableMapping[str, MutableJsonable] = dict()
 
-        jsonable['dataSpecification'] = (
-            self.transform(that.data_specification)
-        )
-
         jsonable['dataSpecificationContent'] = (
             self.transform(that.data_specification_content)
         )
+
+        if that.data_specification is not None:
+            jsonable['dataSpecification'] = (
+                self.transform(that.data_specification)
+            )
 
         return jsonable
 

--- a/test_data/python/test_main/aas_core_meta.v3/expected_output/types.py
+++ b/test_data/python/test_main/aas_core_meta.v3/expected_output/types.py
@@ -5554,11 +5554,11 @@ class DataSpecificationContent(Class):
 class EmbeddedDataSpecification(Class):
     """Embed the content of a data specification."""
 
-    #: Reference to the data specification
-    data_specification: 'Reference'
-
     #: Actual content of the data specification
     data_specification_content: 'DataSpecificationContent'
+
+    #: Reference to the data specification
+    data_specification: Optional['Reference']
 
     def descend_once(self) -> Iterator[Class]:
         """
@@ -5568,9 +5568,10 @@ class EmbeddedDataSpecification(Class):
 
         :yield: instances directly referenced from this instance
         """
-        yield self.data_specification
-
         yield self.data_specification_content
+
+        if self.data_specification is not None:
+            yield self.data_specification
 
     def descend(self) -> Iterator[Class]:
         """
@@ -5578,13 +5579,14 @@ class EmbeddedDataSpecification(Class):
 
         :yield: instances recursively referenced from this instance
         """
-        yield self.data_specification
-
-        yield from self.data_specification.descend()
-
         yield self.data_specification_content
 
         yield from self.data_specification_content.descend()
+
+        if self.data_specification is not None:
+            yield self.data_specification
+
+            yield from self.data_specification.descend()
 
     def accept(self, visitor: "AbstractVisitor") -> None:
         """Dispatch the :paramref:`visitor` on this instance."""
@@ -5618,12 +5620,12 @@ class EmbeddedDataSpecification(Class):
 
     def __init__(
             self,
-            data_specification: 'Reference',
-            data_specification_content: 'DataSpecificationContent'
+            data_specification_content: 'DataSpecificationContent',
+            data_specification: Optional['Reference'] = None
     ) -> None:
         """Initialize with the given values."""
-        self.data_specification = data_specification
         self.data_specification_content = data_specification_content
+        self.data_specification = data_specification
 
 
 class DataTypeIEC61360(enum.Enum):

--- a/test_data/python/test_main/aas_core_meta.v3/expected_output/verification.py
+++ b/test_data/python/test_main/aas_core_meta.v3/expected_output/verification.py
@@ -7895,15 +7895,6 @@ class _Transformer(
             self,
             that: aas_types.EmbeddedDataSpecification
     ) -> Iterator[Error]:
-        for error in self.transform(that.data_specification):
-            error.path._prepend(
-                PropertySegment(
-                    that,
-                    'data_specification'
-                )
-            )
-            yield error
-
         for error in self.transform(that.data_specification_content):
             error.path._prepend(
                 PropertySegment(
@@ -7912,6 +7903,16 @@ class _Transformer(
                 )
             )
             yield error
+
+        if that.data_specification is not None:
+            for error in self.transform(that.data_specification):
+                error.path._prepend(
+                    PropertySegment(
+                        that,
+                        'data_specification'
+                    )
+                )
+                yield error
 
     # noinspection PyMethodMayBeStatic
     def transform_level_type(

--- a/test_data/python/test_main/aas_core_meta.v3/expected_output/xmlization.py
+++ b/test_data/python/test_main/aas_core_meta.v3/expected_output/xmlization.py
@@ -24043,22 +24043,8 @@ class _ReaderAndSetterForEmbeddedDataSpecification:
 
     def __init__(self) -> None:
         """Initialize with all the properties unset."""
-        self.data_specification: Optional[aas_types.Reference] = None
         self.data_specification_content: Optional[aas_types.DataSpecificationContent] = None
-
-    def read_and_set_data_specification(
-        self,
-        element: Element,
-        iterator: Iterator[Tuple[str, Element]]
-    ) -> None:
-        """
-        Read :paramref:`element` as the property
-        :py:attr:`.types.EmbeddedDataSpecification.data_specification` and set it.
-        """
-        self.data_specification = _read_reference_as_sequence(
-            element,
-            iterator
-        )
+        self.data_specification: Optional[aas_types.Reference] = None
 
     def read_and_set_data_specification_content(
         self,
@@ -24096,6 +24082,20 @@ class _ReaderAndSetterForEmbeddedDataSpecification:
         _read_end_element(element, iterator)
 
         self.data_specification_content = result
+
+    def read_and_set_data_specification(
+        self,
+        element: Element,
+        iterator: Iterator[Tuple[str, Element]]
+    ) -> None:
+        """
+        Read :paramref:`element` as the property
+        :py:attr:`.types.EmbeddedDataSpecification.data_specification` and set it.
+        """
+        self.data_specification = _read_reference_as_sequence(
+            element,
+            iterator
+        )
 
 
 def _read_embedded_data_specification_as_sequence(
@@ -24176,19 +24176,14 @@ def _read_embedded_data_specification_as_sequence(
             exception.path._prepend(ElementSegment(next_element))
             raise
 
-    if reader_and_setter.data_specification is None:
-        raise DeserializationException(
-            "The required property 'dataSpecification' is missing"
-        )
-
     if reader_and_setter.data_specification_content is None:
         raise DeserializationException(
             "The required property 'dataSpecificationContent' is missing"
         )
 
     return aas_types.EmbeddedDataSpecification(
-        reader_and_setter.data_specification,
-        reader_and_setter.data_specification_content
+        reader_and_setter.data_specification_content,
+        reader_and_setter.data_specification
     )
 
 
@@ -27070,10 +27065,10 @@ _READ_AND_SET_DISPATCH_FOR_EMBEDDED_DATA_SPECIFICATION: Mapping[
         None
     ]
 ] = {
-    'dataSpecification':
-        _ReaderAndSetterForEmbeddedDataSpecification.read_and_set_data_specification,
     'dataSpecificationContent':
         _ReaderAndSetterForEmbeddedDataSpecification.read_and_set_data_specification_content,
+    'dataSpecification':
+        _ReaderAndSetterForEmbeddedDataSpecification.read_and_set_data_specification,
 }
 
 
@@ -30473,15 +30468,16 @@ class _Serializer(aas_types.AbstractVisitor):
 
         :param that: instance to be serialized
         """
-        self._write_start_element('dataSpecification')
-        self._write_reference_as_sequence(
-            that.data_specification
-        )
-        self._write_end_element('dataSpecification')
-
         self._write_start_element('dataSpecificationContent')
         self.visit(that.data_specification_content)
         self._write_end_element('dataSpecificationContent')
+
+        if that.data_specification is not None:
+            self._write_start_element('dataSpecification')
+            self._write_reference_as_sequence(
+                that.data_specification
+            )
+            self._write_end_element('dataSpecification')
 
     def visit_embedded_data_specification(
         self,

--- a/test_data/rdf_shacl/test_main/expected/aas_core_meta.v3/expected_output/shacl-schema.ttl
+++ b/test_data/rdf_shacl/test_main/expected/aas_core_meta.v3/expected_output/shacl-schema.ttl
@@ -415,16 +415,16 @@ aas:EmbeddedDataSpecificationShape a sh:NodeShape ;
     sh:targetClass aas:EmbeddedDataSpecification ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/EmbeddedDataSpecification/dataSpecification> ;
-        sh:class aas:Reference ;
+        sh:path <https://admin-shell.io/aas/3/0/EmbeddedDataSpecification/dataSpecificationContent> ;
+        sh:class aas:DataSpecificationContent ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/EmbeddedDataSpecification/dataSpecificationContent> ;
-        sh:class aas:DataSpecificationContent ;
-        sh:minCount 1 ;
+        sh:path <https://admin-shell.io/aas/3/0/EmbeddedDataSpecification/dataSpecification> ;
+        sh:class aas:Reference ;
+        sh:minCount 0 ;
         sh:maxCount 1 ;
     ] ;
 .

--- a/test_data/typescript/test_main/aas_core_meta.v3/expected_output/jsonization.ts
+++ b/test_data/typescript/test_main/aas_core_meta.v3/expected_output/jsonization.ts
@@ -14132,9 +14132,9 @@ export function dataSpecificationContentFromJsonable(
  * of {@link types!EmbeddedDataSpecification}.
  */
 class SetterForEmbeddedDataSpecification {
-  dataSpecification: AasTypes.Reference | null = null;
-
   dataSpecificationContent: AasTypes.IDataSpecificationContent | null = null;
+
+  dataSpecification: AasTypes.Reference | null = null;
 
   /**
    * Ignore `jsonable` and do not set anything.
@@ -14146,26 +14146,6 @@ class SetterForEmbeddedDataSpecification {
   ignore(jsonable: JsonValue): DeserializationError | null {
     // Intentionally empty.
     return null;
-  }
-
-  /**
-   * Parse `jsonable` as the value of {@link dataSpecification}.
-   *
-   * @param jsonable - to be parsed
-   * @returns error, if any
-   */
-  setDataSpecificationFromJsonable(
-    jsonable: JsonValue
-  ): DeserializationError | null {
-    const parsedOrError = referenceFromJsonable(
-      jsonable
-    );
-    if (parsedOrError.error !== null) {
-      return parsedOrError.error;
-    } else {
-      this.dataSpecification = parsedOrError.mustValue();
-      return null;
-    }
   }
 
   /**
@@ -14184,6 +14164,26 @@ class SetterForEmbeddedDataSpecification {
       return parsedOrError.error;
     } else {
       this.dataSpecificationContent = parsedOrError.mustValue();
+      return null;
+    }
+  }
+
+  /**
+   * Parse `jsonable` as the value of {@link dataSpecification}.
+   *
+   * @param jsonable - to be parsed
+   * @returns error, if any
+   */
+  setDataSpecificationFromJsonable(
+    jsonable: JsonValue
+  ): DeserializationError | null {
+    const parsedOrError = referenceFromJsonable(
+      jsonable
+    );
+    if (parsedOrError.error !== null) {
+      return parsedOrError.error;
+    } else {
+      this.dataSpecification = parsedOrError.mustValue();
       return null;
     }
   }
@@ -14249,14 +14249,6 @@ export function embeddedDataSpecificationFromJsonable(
     }
   }
 
-  if (setter.dataSpecification === null) {
-    return newDeserializationError<
-      AasTypes.EmbeddedDataSpecification
-    >(
-      "The required property 'dataSpecification' is missing"
-    );
-  }
-
   if (setter.dataSpecificationContent === null) {
     return newDeserializationError<
       AasTypes.EmbeddedDataSpecification
@@ -14270,8 +14262,8 @@ export function embeddedDataSpecificationFromJsonable(
     DeserializationError
   >(
     new AasTypes.EmbeddedDataSpecification(
-      setter.dataSpecification,
-      setter.dataSpecificationContent
+      setter.dataSpecificationContent,
+      setter.dataSpecification
     ),
     null
   );
@@ -17833,12 +17825,12 @@ const SETTER_MAP_FOR_EMBEDDED_DATA_SPECIFICATION =
   >(
     [
       [
-        "dataSpecification",
-        SetterForEmbeddedDataSpecification.prototype.setDataSpecificationFromJsonable
-      ],
-      [
         "dataSpecificationContent",
         SetterForEmbeddedDataSpecification.prototype.setDataSpecificationContentFromJsonable
+      ],
+      [
+        "dataSpecification",
+        SetterForEmbeddedDataSpecification.prototype.setDataSpecificationFromJsonable
       ],
       [
         "modelType",
@@ -20328,11 +20320,13 @@ class Serializer extends AasTypes.AbstractTransformer<JsonObject> {
   ): JsonObject {
     const jsonable: JsonObject = {};
 
-    jsonable["dataSpecification"] =
-      this.transform(that.dataSpecification);
-
     jsonable["dataSpecificationContent"] =
       this.transform(that.dataSpecificationContent);
+
+    if (that.dataSpecification !== null) {
+      jsonable["dataSpecification"] =
+        this.transform(that.dataSpecification);
+    }
 
     return jsonable;
   }

--- a/test_data/typescript/test_main/aas_core_meta.v3/expected_output/types.ts
+++ b/test_data/typescript/test_main/aas_core_meta.v3/expected_output/types.ts
@@ -9934,14 +9934,14 @@ export class EmbeddedDataSpecification extends Class {
   }
 
   /**
-   * Reference to the data specification
-   */
-  dataSpecification: Reference;
-
-  /**
    * Actual content of the data specification
    */
   dataSpecificationContent: IDataSpecificationContent;
+
+  /**
+   * Reference to the data specification
+   */
+  dataSpecification: Reference | null;
 
   /**
    * Iterate over the instances referenced from this instance.
@@ -9951,9 +9951,11 @@ export class EmbeddedDataSpecification extends Class {
    * @returns Iterator over the referenced instances
    */
   *descendOnce(): IterableIterator<Class> {
-    yield this.dataSpecification;
-
     yield this.dataSpecificationContent;
+
+    if (this.dataSpecification !== null) {
+      yield this.dataSpecification;
+    }
   }
 
   /**
@@ -9962,13 +9964,15 @@ export class EmbeddedDataSpecification extends Class {
    * @returns Iterator over the referenced instances
    */
   *descend(): IterableIterator<Class> {
-    yield this.dataSpecification;
-
-    yield * this.dataSpecification.descend();
-
     yield this.dataSpecificationContent;
 
     yield * this.dataSpecificationContent.descend();
+
+    if (this.dataSpecification !== null) {
+      yield this.dataSpecification;
+
+      yield * this.dataSpecification.descend();
+    }
   }
 
   /**
@@ -10024,12 +10028,12 @@ export class EmbeddedDataSpecification extends Class {
   }
 
   constructor(
-    dataSpecification: Reference,
-    dataSpecificationContent: IDataSpecificationContent
+    dataSpecificationContent: IDataSpecificationContent,
+    dataSpecification: Reference | null = null
   ) {
     super();
-    this.dataSpecification = dataSpecification;
     this.dataSpecificationContent = dataSpecificationContent;
+    this.dataSpecification = dataSpecification;
   }
 }
 

--- a/test_data/typescript/test_main/aas_core_meta.v3/expected_output/verification.ts
+++ b/test_data/typescript/test_main/aas_core_meta.v3/expected_output/verification.ts
@@ -9280,18 +9280,6 @@ class Verifier
   ): IterableIterator<VerificationError> {
     if (context === true) {
       for (const error of this.transformWithContext(
-          that.dataSpecification, context)
-      ) {
-        error.path.prepend(
-          new PropertySegment(
-            that,
-            "dataSpecification"
-          )
-        );
-        yield error;
-      }
-
-      for (const error of this.transformWithContext(
           that.dataSpecificationContent, context)
       ) {
         error.path.prepend(
@@ -9301,6 +9289,20 @@ class Verifier
           )
         );
         yield error;
+      }
+
+      if (that.dataSpecification !== null) {
+        for (const error of this.transformWithContext(
+            that.dataSpecification, context)
+        ) {
+          error.path.prepend(
+            new PropertySegment(
+              that,
+              "dataSpecification"
+            )
+          );
+          yield error;
+        }
       }
     }
   }

--- a/test_data/xsd/test_main/aas_core_meta.v3/expected_output/schema.xsd
+++ b/test_data/xsd/test_main/aas_core_meta.v3/expected_output/schema.xsd
@@ -277,7 +277,6 @@
   </xs:group>
   <xs:group name="embeddedDataSpecification">
     <xs:sequence>
-      <xs:element name="dataSpecification" type="reference_t"/>
       <xs:element name="dataSpecificationContent">
         <xs:complexType>
           <xs:sequence>
@@ -285,6 +284,7 @@
           </xs:sequence>
         </xs:complexType>
       </xs:element>
+      <xs:element name="dataSpecification" type="reference_t" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="entity">


### PR DESCRIPTION
We update the development requirements to and re-record the test data for [aas-core-meta 6d5411b].

[aas-core-meta 6d5411b]: https://github.com/aas-core-works/aas-core-meta/commit/6d5411b

Notably, we propagat [the fix #328 on aas-core-meta] related to `Embedded_data_specification` where `data_specification` is made optional.

[the fix #328 on aas-core-meta]: https://github.com/aas-core-works/aas-core-meta/pull/328