### PR TITLE
Fix `AUTHORS` for Logilab

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,5 +1,5 @@
-Elodie Thiéblin (contact@logilab.fr) for Logilab
-Fabien Amarger (contact@logilab.fr) for Siemens AG
+Elodie Thiéblin (contact@logilab.fr, elodie.thieblin@logilab.fr) for Logilab and Siemens AG
+Fabien Amarger (contact@logilab.fr, fabien.amarger@logilab.fr) for Logilab and Siemens AG
 Igor Garmaev (i.garmaev@iat.rwth-aachen.de) for RWTH Aachen
 Marko Ristin (marko@ristin.ch, marko.ristin@gmail.com, rist@zhaw.ch) for Zurich University of Applied Sciences (ZHAW)
 Sebastian Heppner (s.heppner@iat.rwth-aachen.de) for RWTH Aachen


### PR DESCRIPTION
We specify that Logilab contributors also contributed in the name of Siemens AG as it was a joint project.