### PR TITLE
Fix setter names for Java builder classes

### DIFF
--- a/aas_core_codegen/java/generation/_generate.py
+++ b/aas_core_codegen/java/generation/_generate.py
@@ -168,7 +168,7 @@ private {prop_type} {prop_name};"""
 
         arg_name = java_naming.argument_name(arg.name)
 
-        setter_name = java_naming.setter_name(arg_name)
+        setter_name = java_naming.setter_name(arg.name)
 
         setter_blocks.append(
             Stripped(

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/AdministrativeInformationBuilder.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/AdministrativeInformationBuilder.java
@@ -45,7 +45,7 @@ public class AdministrativeInformationBuilder {
    */
   private String templateId;
 
-  public AdministrativeInformationBuilder setEmbeddeddataspecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
+  public AdministrativeInformationBuilder setEmbeddedDataSpecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
     this.embeddedDataSpecifications = embeddedDataSpecifications;
     return this;
   }
@@ -65,7 +65,7 @@ public class AdministrativeInformationBuilder {
     return this;
   }
 
-  public AdministrativeInformationBuilder setTemplateid(String templateId) {
+  public AdministrativeInformationBuilder setTemplateId(String templateId) {
     this.templateId = templateId;
     return this;
   }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/AnnotatedRelationshipElementBuilder.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/AnnotatedRelationshipElementBuilder.java
@@ -131,12 +131,12 @@ public class AnnotatedRelationshipElementBuilder {
     return this;
   }
 
-  public AnnotatedRelationshipElementBuilder setIdshort(String idShort) {
+  public AnnotatedRelationshipElementBuilder setIdShort(String idShort) {
     this.idShort = idShort;
     return this;
   }
 
-  public AnnotatedRelationshipElementBuilder setDisplayname(List<ILangStringNameType> displayName) {
+  public AnnotatedRelationshipElementBuilder setDisplayName(List<ILangStringNameType> displayName) {
     this.displayName = displayName;
     return this;
   }
@@ -146,12 +146,12 @@ public class AnnotatedRelationshipElementBuilder {
     return this;
   }
 
-  public AnnotatedRelationshipElementBuilder setSemanticid(IReference semanticId) {
+  public AnnotatedRelationshipElementBuilder setSemanticId(IReference semanticId) {
     this.semanticId = semanticId;
     return this;
   }
 
-  public AnnotatedRelationshipElementBuilder setSupplementalsemanticids(List<IReference> supplementalSemanticIds) {
+  public AnnotatedRelationshipElementBuilder setSupplementalSemanticIds(List<IReference> supplementalSemanticIds) {
     this.supplementalSemanticIds = supplementalSemanticIds;
     return this;
   }
@@ -161,7 +161,7 @@ public class AnnotatedRelationshipElementBuilder {
     return this;
   }
 
-  public AnnotatedRelationshipElementBuilder setEmbeddeddataspecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
+  public AnnotatedRelationshipElementBuilder setEmbeddedDataSpecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
     this.embeddedDataSpecifications = embeddedDataSpecifications;
     return this;
   }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/AssetAdministrationShellBuilder.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/AssetAdministrationShellBuilder.java
@@ -120,12 +120,12 @@ public class AssetAdministrationShellBuilder {
     return this;
   }
 
-  public AssetAdministrationShellBuilder setIdshort(String idShort) {
+  public AssetAdministrationShellBuilder setIdShort(String idShort) {
     this.idShort = idShort;
     return this;
   }
 
-  public AssetAdministrationShellBuilder setDisplayname(List<ILangStringNameType> displayName) {
+  public AssetAdministrationShellBuilder setDisplayName(List<ILangStringNameType> displayName) {
     this.displayName = displayName;
     return this;
   }
@@ -140,12 +140,12 @@ public class AssetAdministrationShellBuilder {
     return this;
   }
 
-  public AssetAdministrationShellBuilder setEmbeddeddataspecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
+  public AssetAdministrationShellBuilder setEmbeddedDataSpecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
     this.embeddedDataSpecifications = embeddedDataSpecifications;
     return this;
   }
 
-  public AssetAdministrationShellBuilder setDerivedfrom(IReference derivedFrom) {
+  public AssetAdministrationShellBuilder setDerivedFrom(IReference derivedFrom) {
     this.derivedFrom = derivedFrom;
     return this;
   }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/AssetInformationBuilder.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/AssetInformationBuilder.java
@@ -59,22 +59,22 @@ public class AssetInformationBuilder {
       "Argument \"assetKind\" must be non-null.");
   }
 
-  public AssetInformationBuilder setGlobalassetid(String globalAssetId) {
+  public AssetInformationBuilder setGlobalAssetId(String globalAssetId) {
     this.globalAssetId = globalAssetId;
     return this;
   }
 
-  public AssetInformationBuilder setSpecificassetids(List<ISpecificAssetId> specificAssetIds) {
+  public AssetInformationBuilder setSpecificAssetIds(List<ISpecificAssetId> specificAssetIds) {
     this.specificAssetIds = specificAssetIds;
     return this;
   }
 
-  public AssetInformationBuilder setAssettype(String assetType) {
+  public AssetInformationBuilder setAssetType(String assetType) {
     this.assetType = assetType;
     return this;
   }
 
-  public AssetInformationBuilder setDefaultthumbnail(IResource defaultThumbnail) {
+  public AssetInformationBuilder setDefaultThumbnail(IResource defaultThumbnail) {
     this.defaultThumbnail = defaultThumbnail;
     return this;
   }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/BasicEventElementBuilder.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/BasicEventElementBuilder.java
@@ -189,12 +189,12 @@ public class BasicEventElementBuilder {
     return this;
   }
 
-  public BasicEventElementBuilder setIdshort(String idShort) {
+  public BasicEventElementBuilder setIdShort(String idShort) {
     this.idShort = idShort;
     return this;
   }
 
-  public BasicEventElementBuilder setDisplayname(List<ILangStringNameType> displayName) {
+  public BasicEventElementBuilder setDisplayName(List<ILangStringNameType> displayName) {
     this.displayName = displayName;
     return this;
   }
@@ -204,12 +204,12 @@ public class BasicEventElementBuilder {
     return this;
   }
 
-  public BasicEventElementBuilder setSemanticid(IReference semanticId) {
+  public BasicEventElementBuilder setSemanticId(IReference semanticId) {
     this.semanticId = semanticId;
     return this;
   }
 
-  public BasicEventElementBuilder setSupplementalsemanticids(List<IReference> supplementalSemanticIds) {
+  public BasicEventElementBuilder setSupplementalSemanticIds(List<IReference> supplementalSemanticIds) {
     this.supplementalSemanticIds = supplementalSemanticIds;
     return this;
   }
@@ -219,32 +219,32 @@ public class BasicEventElementBuilder {
     return this;
   }
 
-  public BasicEventElementBuilder setEmbeddeddataspecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
+  public BasicEventElementBuilder setEmbeddedDataSpecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
     this.embeddedDataSpecifications = embeddedDataSpecifications;
     return this;
   }
 
-  public BasicEventElementBuilder setMessagetopic(String messageTopic) {
+  public BasicEventElementBuilder setMessageTopic(String messageTopic) {
     this.messageTopic = messageTopic;
     return this;
   }
 
-  public BasicEventElementBuilder setMessagebroker(IReference messageBroker) {
+  public BasicEventElementBuilder setMessageBroker(IReference messageBroker) {
     this.messageBroker = messageBroker;
     return this;
   }
 
-  public BasicEventElementBuilder setLastupdate(String lastUpdate) {
+  public BasicEventElementBuilder setLastUpdate(String lastUpdate) {
     this.lastUpdate = lastUpdate;
     return this;
   }
 
-  public BasicEventElementBuilder setMininterval(String minInterval) {
+  public BasicEventElementBuilder setMinInterval(String minInterval) {
     this.minInterval = minInterval;
     return this;
   }
 
-  public BasicEventElementBuilder setMaxinterval(String maxInterval) {
+  public BasicEventElementBuilder setMaxInterval(String maxInterval) {
     this.maxInterval = maxInterval;
     return this;
   }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/BlobBuilder.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/BlobBuilder.java
@@ -130,12 +130,12 @@ public class BlobBuilder {
     return this;
   }
 
-  public BlobBuilder setIdshort(String idShort) {
+  public BlobBuilder setIdShort(String idShort) {
     this.idShort = idShort;
     return this;
   }
 
-  public BlobBuilder setDisplayname(List<ILangStringNameType> displayName) {
+  public BlobBuilder setDisplayName(List<ILangStringNameType> displayName) {
     this.displayName = displayName;
     return this;
   }
@@ -145,12 +145,12 @@ public class BlobBuilder {
     return this;
   }
 
-  public BlobBuilder setSemanticid(IReference semanticId) {
+  public BlobBuilder setSemanticId(IReference semanticId) {
     this.semanticId = semanticId;
     return this;
   }
 
-  public BlobBuilder setSupplementalsemanticids(List<IReference> supplementalSemanticIds) {
+  public BlobBuilder setSupplementalSemanticIds(List<IReference> supplementalSemanticIds) {
     this.supplementalSemanticIds = supplementalSemanticIds;
     return this;
   }
@@ -160,7 +160,7 @@ public class BlobBuilder {
     return this;
   }
 
-  public BlobBuilder setEmbeddeddataspecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
+  public BlobBuilder setEmbeddedDataSpecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
     this.embeddedDataSpecifications = embeddedDataSpecifications;
     return this;
   }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/CapabilityBuilder.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/CapabilityBuilder.java
@@ -104,12 +104,12 @@ public class CapabilityBuilder {
     return this;
   }
 
-  public CapabilityBuilder setIdshort(String idShort) {
+  public CapabilityBuilder setIdShort(String idShort) {
     this.idShort = idShort;
     return this;
   }
 
-  public CapabilityBuilder setDisplayname(List<ILangStringNameType> displayName) {
+  public CapabilityBuilder setDisplayName(List<ILangStringNameType> displayName) {
     this.displayName = displayName;
     return this;
   }
@@ -119,12 +119,12 @@ public class CapabilityBuilder {
     return this;
   }
 
-  public CapabilityBuilder setSemanticid(IReference semanticId) {
+  public CapabilityBuilder setSemanticId(IReference semanticId) {
     this.semanticId = semanticId;
     return this;
   }
 
-  public CapabilityBuilder setSupplementalsemanticids(List<IReference> supplementalSemanticIds) {
+  public CapabilityBuilder setSupplementalSemanticIds(List<IReference> supplementalSemanticIds) {
     this.supplementalSemanticIds = supplementalSemanticIds;
     return this;
   }
@@ -134,7 +134,7 @@ public class CapabilityBuilder {
     return this;
   }
 
-  public CapabilityBuilder setEmbeddeddataspecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
+  public CapabilityBuilder setEmbeddedDataSpecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
     this.embeddedDataSpecifications = embeddedDataSpecifications;
     return this;
   }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/ConceptDescriptionBuilder.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/ConceptDescriptionBuilder.java
@@ -104,12 +104,12 @@ public class ConceptDescriptionBuilder {
     return this;
   }
 
-  public ConceptDescriptionBuilder setIdshort(String idShort) {
+  public ConceptDescriptionBuilder setIdShort(String idShort) {
     this.idShort = idShort;
     return this;
   }
 
-  public ConceptDescriptionBuilder setDisplayname(List<ILangStringNameType> displayName) {
+  public ConceptDescriptionBuilder setDisplayName(List<ILangStringNameType> displayName) {
     this.displayName = displayName;
     return this;
   }
@@ -124,12 +124,12 @@ public class ConceptDescriptionBuilder {
     return this;
   }
 
-  public ConceptDescriptionBuilder setEmbeddeddataspecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
+  public ConceptDescriptionBuilder setEmbeddedDataSpecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
     this.embeddedDataSpecifications = embeddedDataSpecifications;
     return this;
   }
 
-  public ConceptDescriptionBuilder setIscaseof(List<IReference> isCaseOf) {
+  public ConceptDescriptionBuilder setIsCaseOf(List<IReference> isCaseOf) {
     this.isCaseOf = isCaseOf;
     return this;
   }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/DataSpecificationIec61360Builder.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/DataSpecificationIec61360Builder.java
@@ -93,7 +93,7 @@ public class DataSpecificationIec61360Builder {
       "Argument \"preferredName\" must be non-null.");
   }
 
-  public DataSpecificationIec61360Builder setShortname(List<ILangStringShortNameTypeIec61360> shortName) {
+  public DataSpecificationIec61360Builder setShortName(List<ILangStringShortNameTypeIec61360> shortName) {
     this.shortName = shortName;
     return this;
   }
@@ -103,12 +103,12 @@ public class DataSpecificationIec61360Builder {
     return this;
   }
 
-  public DataSpecificationIec61360Builder setUnitid(IReference unitId) {
+  public DataSpecificationIec61360Builder setUnitId(IReference unitId) {
     this.unitId = unitId;
     return this;
   }
 
-  public DataSpecificationIec61360Builder setSourceofdefinition(String sourceOfDefinition) {
+  public DataSpecificationIec61360Builder setSourceOfDefinition(String sourceOfDefinition) {
     this.sourceOfDefinition = sourceOfDefinition;
     return this;
   }
@@ -118,7 +118,7 @@ public class DataSpecificationIec61360Builder {
     return this;
   }
 
-  public DataSpecificationIec61360Builder setDatatype(DataTypeIec61360 dataType) {
+  public DataSpecificationIec61360Builder setDataType(DataTypeIec61360 dataType) {
     this.dataType = dataType;
     return this;
   }
@@ -128,12 +128,12 @@ public class DataSpecificationIec61360Builder {
     return this;
   }
 
-  public DataSpecificationIec61360Builder setValueformat(String valueFormat) {
+  public DataSpecificationIec61360Builder setValueFormat(String valueFormat) {
     this.valueFormat = valueFormat;
     return this;
   }
 
-  public DataSpecificationIec61360Builder setValuelist(IValueList valueList) {
+  public DataSpecificationIec61360Builder setValueList(IValueList valueList) {
     this.valueList = valueList;
     return this;
   }
@@ -143,7 +143,7 @@ public class DataSpecificationIec61360Builder {
     return this;
   }
 
-  public DataSpecificationIec61360Builder setLeveltype(ILevelType levelType) {
+  public DataSpecificationIec61360Builder setLevelType(ILevelType levelType) {
     this.levelType = levelType;
     return this;
   }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/EmbeddedDataSpecificationBuilder.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/EmbeddedDataSpecificationBuilder.java
@@ -27,7 +27,7 @@ public class EmbeddedDataSpecificationBuilder {
       "Argument \"dataSpecificationContent\" must be non-null.");
   }
 
-  public EmbeddedDataSpecificationBuilder setDataspecification(IReference dataSpecification) {
+  public EmbeddedDataSpecificationBuilder setDataSpecification(IReference dataSpecification) {
     this.dataSpecification = dataSpecification;
     return this;
   }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/EntityBuilder.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/EntityBuilder.java
@@ -134,12 +134,12 @@ public class EntityBuilder {
     return this;
   }
 
-  public EntityBuilder setIdshort(String idShort) {
+  public EntityBuilder setIdShort(String idShort) {
     this.idShort = idShort;
     return this;
   }
 
-  public EntityBuilder setDisplayname(List<ILangStringNameType> displayName) {
+  public EntityBuilder setDisplayName(List<ILangStringNameType> displayName) {
     this.displayName = displayName;
     return this;
   }
@@ -149,12 +149,12 @@ public class EntityBuilder {
     return this;
   }
 
-  public EntityBuilder setSemanticid(IReference semanticId) {
+  public EntityBuilder setSemanticId(IReference semanticId) {
     this.semanticId = semanticId;
     return this;
   }
 
-  public EntityBuilder setSupplementalsemanticids(List<IReference> supplementalSemanticIds) {
+  public EntityBuilder setSupplementalSemanticIds(List<IReference> supplementalSemanticIds) {
     this.supplementalSemanticIds = supplementalSemanticIds;
     return this;
   }
@@ -164,7 +164,7 @@ public class EntityBuilder {
     return this;
   }
 
-  public EntityBuilder setEmbeddeddataspecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
+  public EntityBuilder setEmbeddedDataSpecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
     this.embeddedDataSpecifications = embeddedDataSpecifications;
     return this;
   }
@@ -174,12 +174,12 @@ public class EntityBuilder {
     return this;
   }
 
-  public EntityBuilder setGlobalassetid(String globalAssetId) {
+  public EntityBuilder setGlobalAssetId(String globalAssetId) {
     this.globalAssetId = globalAssetId;
     return this;
   }
 
-  public EntityBuilder setSpecificassetids(List<ISpecificAssetId> specificAssetIds) {
+  public EntityBuilder setSpecificAssetIds(List<ISpecificAssetId> specificAssetIds) {
     this.specificAssetIds = specificAssetIds;
     return this;
   }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/EnvironmentBuilder.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/EnvironmentBuilder.java
@@ -26,7 +26,7 @@ public class EnvironmentBuilder {
    */
   private List<IConceptDescription> conceptDescriptions;
 
-  public EnvironmentBuilder setAssetadministrationshells(List<IAssetAdministrationShell> assetAdministrationShells) {
+  public EnvironmentBuilder setAssetAdministrationShells(List<IAssetAdministrationShell> assetAdministrationShells) {
     this.assetAdministrationShells = assetAdministrationShells;
     return this;
   }
@@ -36,7 +36,7 @@ public class EnvironmentBuilder {
     return this;
   }
 
-  public EnvironmentBuilder setConceptdescriptions(List<IConceptDescription> conceptDescriptions) {
+  public EnvironmentBuilder setConceptDescriptions(List<IConceptDescription> conceptDescriptions) {
     this.conceptDescriptions = conceptDescriptions;
     return this;
   }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/EventPayloadBuilder.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/EventPayloadBuilder.java
@@ -79,12 +79,12 @@ public class EventPayloadBuilder {
       "Argument \"timeStamp\" must be non-null.");
   }
 
-  public EventPayloadBuilder setSourcesemanticid(IReference sourceSemanticId) {
+  public EventPayloadBuilder setSourceSemanticId(IReference sourceSemanticId) {
     this.sourceSemanticId = sourceSemanticId;
     return this;
   }
 
-  public EventPayloadBuilder setObservablesemanticid(IReference observableSemanticId) {
+  public EventPayloadBuilder setObservableSemanticId(IReference observableSemanticId) {
     this.observableSemanticId = observableSemanticId;
     return this;
   }
@@ -94,7 +94,7 @@ public class EventPayloadBuilder {
     return this;
   }
 
-  public EventPayloadBuilder setSubjectid(IReference subjectId) {
+  public EventPayloadBuilder setSubjectId(IReference subjectId) {
     this.subjectId = subjectId;
     return this;
   }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/ExtensionBuilder.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/ExtensionBuilder.java
@@ -63,17 +63,17 @@ public class ExtensionBuilder {
       "Argument \"name\" must be non-null.");
   }
 
-  public ExtensionBuilder setSemanticid(IReference semanticId) {
+  public ExtensionBuilder setSemanticId(IReference semanticId) {
     this.semanticId = semanticId;
     return this;
   }
 
-  public ExtensionBuilder setSupplementalsemanticids(List<IReference> supplementalSemanticIds) {
+  public ExtensionBuilder setSupplementalSemanticIds(List<IReference> supplementalSemanticIds) {
     this.supplementalSemanticIds = supplementalSemanticIds;
     return this;
   }
 
-  public ExtensionBuilder setValuetype(DataTypeDefXsd valueType) {
+  public ExtensionBuilder setValueType(DataTypeDefXsd valueType) {
     this.valueType = valueType;
     return this;
   }
@@ -83,7 +83,7 @@ public class ExtensionBuilder {
     return this;
   }
 
-  public ExtensionBuilder setRefersto(List<IReference> refersTo) {
+  public ExtensionBuilder setRefersTo(List<IReference> refersTo) {
     this.refersTo = refersTo;
     return this;
   }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/FileBuilder.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/FileBuilder.java
@@ -124,12 +124,12 @@ public class FileBuilder {
     return this;
   }
 
-  public FileBuilder setIdshort(String idShort) {
+  public FileBuilder setIdShort(String idShort) {
     this.idShort = idShort;
     return this;
   }
 
-  public FileBuilder setDisplayname(List<ILangStringNameType> displayName) {
+  public FileBuilder setDisplayName(List<ILangStringNameType> displayName) {
     this.displayName = displayName;
     return this;
   }
@@ -139,12 +139,12 @@ public class FileBuilder {
     return this;
   }
 
-  public FileBuilder setSemanticid(IReference semanticId) {
+  public FileBuilder setSemanticId(IReference semanticId) {
     this.semanticId = semanticId;
     return this;
   }
 
-  public FileBuilder setSupplementalsemanticids(List<IReference> supplementalSemanticIds) {
+  public FileBuilder setSupplementalSemanticIds(List<IReference> supplementalSemanticIds) {
     this.supplementalSemanticIds = supplementalSemanticIds;
     return this;
   }
@@ -154,7 +154,7 @@ public class FileBuilder {
     return this;
   }
 
-  public FileBuilder setEmbeddeddataspecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
+  public FileBuilder setEmbeddedDataSpecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
     this.embeddedDataSpecifications = embeddedDataSpecifications;
     return this;
   }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/MultiLanguagePropertyBuilder.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/MultiLanguagePropertyBuilder.java
@@ -116,12 +116,12 @@ public class MultiLanguagePropertyBuilder {
     return this;
   }
 
-  public MultiLanguagePropertyBuilder setIdshort(String idShort) {
+  public MultiLanguagePropertyBuilder setIdShort(String idShort) {
     this.idShort = idShort;
     return this;
   }
 
-  public MultiLanguagePropertyBuilder setDisplayname(List<ILangStringNameType> displayName) {
+  public MultiLanguagePropertyBuilder setDisplayName(List<ILangStringNameType> displayName) {
     this.displayName = displayName;
     return this;
   }
@@ -131,12 +131,12 @@ public class MultiLanguagePropertyBuilder {
     return this;
   }
 
-  public MultiLanguagePropertyBuilder setSemanticid(IReference semanticId) {
+  public MultiLanguagePropertyBuilder setSemanticId(IReference semanticId) {
     this.semanticId = semanticId;
     return this;
   }
 
-  public MultiLanguagePropertyBuilder setSupplementalsemanticids(List<IReference> supplementalSemanticIds) {
+  public MultiLanguagePropertyBuilder setSupplementalSemanticIds(List<IReference> supplementalSemanticIds) {
     this.supplementalSemanticIds = supplementalSemanticIds;
     return this;
   }
@@ -146,7 +146,7 @@ public class MultiLanguagePropertyBuilder {
     return this;
   }
 
-  public MultiLanguagePropertyBuilder setEmbeddeddataspecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
+  public MultiLanguagePropertyBuilder setEmbeddedDataSpecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
     this.embeddedDataSpecifications = embeddedDataSpecifications;
     return this;
   }
@@ -156,7 +156,7 @@ public class MultiLanguagePropertyBuilder {
     return this;
   }
 
-  public MultiLanguagePropertyBuilder setValueid(IReference valueId) {
+  public MultiLanguagePropertyBuilder setValueId(IReference valueId) {
     this.valueId = valueId;
     return this;
   }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/OperationBuilder.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/OperationBuilder.java
@@ -119,12 +119,12 @@ public class OperationBuilder {
     return this;
   }
 
-  public OperationBuilder setIdshort(String idShort) {
+  public OperationBuilder setIdShort(String idShort) {
     this.idShort = idShort;
     return this;
   }
 
-  public OperationBuilder setDisplayname(List<ILangStringNameType> displayName) {
+  public OperationBuilder setDisplayName(List<ILangStringNameType> displayName) {
     this.displayName = displayName;
     return this;
   }
@@ -134,12 +134,12 @@ public class OperationBuilder {
     return this;
   }
 
-  public OperationBuilder setSemanticid(IReference semanticId) {
+  public OperationBuilder setSemanticId(IReference semanticId) {
     this.semanticId = semanticId;
     return this;
   }
 
-  public OperationBuilder setSupplementalsemanticids(List<IReference> supplementalSemanticIds) {
+  public OperationBuilder setSupplementalSemanticIds(List<IReference> supplementalSemanticIds) {
     this.supplementalSemanticIds = supplementalSemanticIds;
     return this;
   }
@@ -149,22 +149,22 @@ public class OperationBuilder {
     return this;
   }
 
-  public OperationBuilder setEmbeddeddataspecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
+  public OperationBuilder setEmbeddedDataSpecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
     this.embeddedDataSpecifications = embeddedDataSpecifications;
     return this;
   }
 
-  public OperationBuilder setInputvariables(List<IOperationVariable> inputVariables) {
+  public OperationBuilder setInputVariables(List<IOperationVariable> inputVariables) {
     this.inputVariables = inputVariables;
     return this;
   }
 
-  public OperationBuilder setOutputvariables(List<IOperationVariable> outputVariables) {
+  public OperationBuilder setOutputVariables(List<IOperationVariable> outputVariables) {
     this.outputVariables = outputVariables;
     return this;
   }
 
-  public OperationBuilder setInoutputvariables(List<IOperationVariable> inoutputVariables) {
+  public OperationBuilder setInoutputVariables(List<IOperationVariable> inoutputVariables) {
     this.inoutputVariables = inoutputVariables;
     return this;
   }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/PropertyBuilder.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/PropertyBuilder.java
@@ -127,12 +127,12 @@ public class PropertyBuilder {
     return this;
   }
 
-  public PropertyBuilder setIdshort(String idShort) {
+  public PropertyBuilder setIdShort(String idShort) {
     this.idShort = idShort;
     return this;
   }
 
-  public PropertyBuilder setDisplayname(List<ILangStringNameType> displayName) {
+  public PropertyBuilder setDisplayName(List<ILangStringNameType> displayName) {
     this.displayName = displayName;
     return this;
   }
@@ -142,12 +142,12 @@ public class PropertyBuilder {
     return this;
   }
 
-  public PropertyBuilder setSemanticid(IReference semanticId) {
+  public PropertyBuilder setSemanticId(IReference semanticId) {
     this.semanticId = semanticId;
     return this;
   }
 
-  public PropertyBuilder setSupplementalsemanticids(List<IReference> supplementalSemanticIds) {
+  public PropertyBuilder setSupplementalSemanticIds(List<IReference> supplementalSemanticIds) {
     this.supplementalSemanticIds = supplementalSemanticIds;
     return this;
   }
@@ -157,7 +157,7 @@ public class PropertyBuilder {
     return this;
   }
 
-  public PropertyBuilder setEmbeddeddataspecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
+  public PropertyBuilder setEmbeddedDataSpecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
     this.embeddedDataSpecifications = embeddedDataSpecifications;
     return this;
   }
@@ -167,7 +167,7 @@ public class PropertyBuilder {
     return this;
   }
 
-  public PropertyBuilder setValueid(IReference valueId) {
+  public PropertyBuilder setValueId(IReference valueId) {
     this.valueId = valueId;
     return this;
   }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/QualifierBuilder.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/QualifierBuilder.java
@@ -69,12 +69,12 @@ public class QualifierBuilder {
       "Argument \"valueType\" must be non-null.");
   }
 
-  public QualifierBuilder setSemanticid(IReference semanticId) {
+  public QualifierBuilder setSemanticId(IReference semanticId) {
     this.semanticId = semanticId;
     return this;
   }
 
-  public QualifierBuilder setSupplementalsemanticids(List<IReference> supplementalSemanticIds) {
+  public QualifierBuilder setSupplementalSemanticIds(List<IReference> supplementalSemanticIds) {
     this.supplementalSemanticIds = supplementalSemanticIds;
     return this;
   }
@@ -89,7 +89,7 @@ public class QualifierBuilder {
     return this;
   }
 
-  public QualifierBuilder setValueid(IReference valueId) {
+  public QualifierBuilder setValueId(IReference valueId) {
     this.valueId = valueId;
     return this;
   }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/RangeBuilder.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/RangeBuilder.java
@@ -129,12 +129,12 @@ public class RangeBuilder {
     return this;
   }
 
-  public RangeBuilder setIdshort(String idShort) {
+  public RangeBuilder setIdShort(String idShort) {
     this.idShort = idShort;
     return this;
   }
 
-  public RangeBuilder setDisplayname(List<ILangStringNameType> displayName) {
+  public RangeBuilder setDisplayName(List<ILangStringNameType> displayName) {
     this.displayName = displayName;
     return this;
   }
@@ -144,12 +144,12 @@ public class RangeBuilder {
     return this;
   }
 
-  public RangeBuilder setSemanticid(IReference semanticId) {
+  public RangeBuilder setSemanticId(IReference semanticId) {
     this.semanticId = semanticId;
     return this;
   }
 
-  public RangeBuilder setSupplementalsemanticids(List<IReference> supplementalSemanticIds) {
+  public RangeBuilder setSupplementalSemanticIds(List<IReference> supplementalSemanticIds) {
     this.supplementalSemanticIds = supplementalSemanticIds;
     return this;
   }
@@ -159,7 +159,7 @@ public class RangeBuilder {
     return this;
   }
 
-  public RangeBuilder setEmbeddeddataspecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
+  public RangeBuilder setEmbeddedDataSpecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
     this.embeddedDataSpecifications = embeddedDataSpecifications;
     return this;
   }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/ReferenceBuilder.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/ReferenceBuilder.java
@@ -44,7 +44,7 @@ public class ReferenceBuilder {
       "Argument \"keys\" must be non-null.");
   }
 
-  public ReferenceBuilder setReferredsemanticid(IReference referredSemanticId) {
+  public ReferenceBuilder setReferredSemanticId(IReference referredSemanticId) {
     this.referredSemanticId = referredSemanticId;
     return this;
   }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/ReferenceElementBuilder.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/ReferenceElementBuilder.java
@@ -111,12 +111,12 @@ public class ReferenceElementBuilder {
     return this;
   }
 
-  public ReferenceElementBuilder setIdshort(String idShort) {
+  public ReferenceElementBuilder setIdShort(String idShort) {
     this.idShort = idShort;
     return this;
   }
 
-  public ReferenceElementBuilder setDisplayname(List<ILangStringNameType> displayName) {
+  public ReferenceElementBuilder setDisplayName(List<ILangStringNameType> displayName) {
     this.displayName = displayName;
     return this;
   }
@@ -126,12 +126,12 @@ public class ReferenceElementBuilder {
     return this;
   }
 
-  public ReferenceElementBuilder setSemanticid(IReference semanticId) {
+  public ReferenceElementBuilder setSemanticId(IReference semanticId) {
     this.semanticId = semanticId;
     return this;
   }
 
-  public ReferenceElementBuilder setSupplementalsemanticids(List<IReference> supplementalSemanticIds) {
+  public ReferenceElementBuilder setSupplementalSemanticIds(List<IReference> supplementalSemanticIds) {
     this.supplementalSemanticIds = supplementalSemanticIds;
     return this;
   }
@@ -141,7 +141,7 @@ public class ReferenceElementBuilder {
     return this;
   }
 
-  public ReferenceElementBuilder setEmbeddeddataspecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
+  public ReferenceElementBuilder setEmbeddedDataSpecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
     this.embeddedDataSpecifications = embeddedDataSpecifications;
     return this;
   }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/RelationshipElementBuilder.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/RelationshipElementBuilder.java
@@ -125,12 +125,12 @@ public class RelationshipElementBuilder {
     return this;
   }
 
-  public RelationshipElementBuilder setIdshort(String idShort) {
+  public RelationshipElementBuilder setIdShort(String idShort) {
     this.idShort = idShort;
     return this;
   }
 
-  public RelationshipElementBuilder setDisplayname(List<ILangStringNameType> displayName) {
+  public RelationshipElementBuilder setDisplayName(List<ILangStringNameType> displayName) {
     this.displayName = displayName;
     return this;
   }
@@ -140,12 +140,12 @@ public class RelationshipElementBuilder {
     return this;
   }
 
-  public RelationshipElementBuilder setSemanticid(IReference semanticId) {
+  public RelationshipElementBuilder setSemanticId(IReference semanticId) {
     this.semanticId = semanticId;
     return this;
   }
 
-  public RelationshipElementBuilder setSupplementalsemanticids(List<IReference> supplementalSemanticIds) {
+  public RelationshipElementBuilder setSupplementalSemanticIds(List<IReference> supplementalSemanticIds) {
     this.supplementalSemanticIds = supplementalSemanticIds;
     return this;
   }
@@ -155,7 +155,7 @@ public class RelationshipElementBuilder {
     return this;
   }
 
-  public RelationshipElementBuilder setEmbeddeddataspecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
+  public RelationshipElementBuilder setEmbeddedDataSpecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
     this.embeddedDataSpecifications = embeddedDataSpecifications;
     return this;
   }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/ResourceBuilder.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/ResourceBuilder.java
@@ -31,7 +31,7 @@ public class ResourceBuilder {
       "Argument \"path\" must be non-null.");
   }
 
-  public ResourceBuilder setContenttype(String contentType) {
+  public ResourceBuilder setContentType(String contentType) {
     this.contentType = contentType;
     return this;
   }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/SpecificAssetIdBuilder.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/SpecificAssetIdBuilder.java
@@ -55,17 +55,17 @@ public class SpecificAssetIdBuilder {
       "Argument \"value\" must be non-null.");
   }
 
-  public SpecificAssetIdBuilder setSemanticid(IReference semanticId) {
+  public SpecificAssetIdBuilder setSemanticId(IReference semanticId) {
     this.semanticId = semanticId;
     return this;
   }
 
-  public SpecificAssetIdBuilder setSupplementalsemanticids(List<IReference> supplementalSemanticIds) {
+  public SpecificAssetIdBuilder setSupplementalSemanticIds(List<IReference> supplementalSemanticIds) {
     this.supplementalSemanticIds = supplementalSemanticIds;
     return this;
   }
 
-  public SpecificAssetIdBuilder setExternalsubjectid(IReference externalSubjectId) {
+  public SpecificAssetIdBuilder setExternalSubjectId(IReference externalSubjectId) {
     this.externalSubjectId = externalSubjectId;
     return this;
   }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/SubmodelBuilder.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/SubmodelBuilder.java
@@ -135,12 +135,12 @@ public class SubmodelBuilder {
     return this;
   }
 
-  public SubmodelBuilder setIdshort(String idShort) {
+  public SubmodelBuilder setIdShort(String idShort) {
     this.idShort = idShort;
     return this;
   }
 
-  public SubmodelBuilder setDisplayname(List<ILangStringNameType> displayName) {
+  public SubmodelBuilder setDisplayName(List<ILangStringNameType> displayName) {
     this.displayName = displayName;
     return this;
   }
@@ -160,12 +160,12 @@ public class SubmodelBuilder {
     return this;
   }
 
-  public SubmodelBuilder setSemanticid(IReference semanticId) {
+  public SubmodelBuilder setSemanticId(IReference semanticId) {
     this.semanticId = semanticId;
     return this;
   }
 
-  public SubmodelBuilder setSupplementalsemanticids(List<IReference> supplementalSemanticIds) {
+  public SubmodelBuilder setSupplementalSemanticIds(List<IReference> supplementalSemanticIds) {
     this.supplementalSemanticIds = supplementalSemanticIds;
     return this;
   }
@@ -175,12 +175,12 @@ public class SubmodelBuilder {
     return this;
   }
 
-  public SubmodelBuilder setEmbeddeddataspecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
+  public SubmodelBuilder setEmbeddedDataSpecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
     this.embeddedDataSpecifications = embeddedDataSpecifications;
     return this;
   }
 
-  public SubmodelBuilder setSubmodelelements(List<ISubmodelElement> submodelElements) {
+  public SubmodelBuilder setSubmodelElements(List<ISubmodelElement> submodelElements) {
     this.submodelElements = submodelElements;
     return this;
   }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/SubmodelElementCollectionBuilder.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/SubmodelElementCollectionBuilder.java
@@ -109,12 +109,12 @@ public class SubmodelElementCollectionBuilder {
     return this;
   }
 
-  public SubmodelElementCollectionBuilder setIdshort(String idShort) {
+  public SubmodelElementCollectionBuilder setIdShort(String idShort) {
     this.idShort = idShort;
     return this;
   }
 
-  public SubmodelElementCollectionBuilder setDisplayname(List<ILangStringNameType> displayName) {
+  public SubmodelElementCollectionBuilder setDisplayName(List<ILangStringNameType> displayName) {
     this.displayName = displayName;
     return this;
   }
@@ -124,12 +124,12 @@ public class SubmodelElementCollectionBuilder {
     return this;
   }
 
-  public SubmodelElementCollectionBuilder setSemanticid(IReference semanticId) {
+  public SubmodelElementCollectionBuilder setSemanticId(IReference semanticId) {
     this.semanticId = semanticId;
     return this;
   }
 
-  public SubmodelElementCollectionBuilder setSupplementalsemanticids(List<IReference> supplementalSemanticIds) {
+  public SubmodelElementCollectionBuilder setSupplementalSemanticIds(List<IReference> supplementalSemanticIds) {
     this.supplementalSemanticIds = supplementalSemanticIds;
     return this;
   }
@@ -139,7 +139,7 @@ public class SubmodelElementCollectionBuilder {
     return this;
   }
 
-  public SubmodelElementCollectionBuilder setEmbeddeddataspecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
+  public SubmodelElementCollectionBuilder setEmbeddedDataSpecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
     this.embeddedDataSpecifications = embeddedDataSpecifications;
     return this;
   }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/SubmodelElementListBuilder.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/generation/SubmodelElementListBuilder.java
@@ -142,12 +142,12 @@ public class SubmodelElementListBuilder {
     return this;
   }
 
-  public SubmodelElementListBuilder setIdshort(String idShort) {
+  public SubmodelElementListBuilder setIdShort(String idShort) {
     this.idShort = idShort;
     return this;
   }
 
-  public SubmodelElementListBuilder setDisplayname(List<ILangStringNameType> displayName) {
+  public SubmodelElementListBuilder setDisplayName(List<ILangStringNameType> displayName) {
     this.displayName = displayName;
     return this;
   }
@@ -157,12 +157,12 @@ public class SubmodelElementListBuilder {
     return this;
   }
 
-  public SubmodelElementListBuilder setSemanticid(IReference semanticId) {
+  public SubmodelElementListBuilder setSemanticId(IReference semanticId) {
     this.semanticId = semanticId;
     return this;
   }
 
-  public SubmodelElementListBuilder setSupplementalsemanticids(List<IReference> supplementalSemanticIds) {
+  public SubmodelElementListBuilder setSupplementalSemanticIds(List<IReference> supplementalSemanticIds) {
     this.supplementalSemanticIds = supplementalSemanticIds;
     return this;
   }
@@ -172,22 +172,22 @@ public class SubmodelElementListBuilder {
     return this;
   }
 
-  public SubmodelElementListBuilder setEmbeddeddataspecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
+  public SubmodelElementListBuilder setEmbeddedDataSpecifications(List<IEmbeddedDataSpecification> embeddedDataSpecifications) {
     this.embeddedDataSpecifications = embeddedDataSpecifications;
     return this;
   }
 
-  public SubmodelElementListBuilder setOrderrelevant(Boolean orderRelevant) {
+  public SubmodelElementListBuilder setOrderRelevant(Boolean orderRelevant) {
     this.orderRelevant = orderRelevant;
     return this;
   }
 
-  public SubmodelElementListBuilder setSemanticidlistelement(IReference semanticIdListElement) {
+  public SubmodelElementListBuilder setSemanticIdListElement(IReference semanticIdListElement) {
     this.semanticIdListElement = semanticIdListElement;
     return this;
   }
 
-  public SubmodelElementListBuilder setValuetypelistelement(DataTypeDefXsd valueTypeListElement) {
+  public SubmodelElementListBuilder setValueTypeListElement(DataTypeDefXsd valueTypeListElement) {
     this.valueTypeListElement = valueTypeListElement;
     return this;
   }


### PR DESCRIPTION
We fix the generated setter names in the Java builder classes so that they match the expected camel case convention. Until now, the setter names are erroneously printed in lower case.