### PR TITLE
Fix `AUTHORS` for conplement AG

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,4 +3,5 @@ Fabien Amarger (contact@logilab.fr, fabien.amarger@logilab.fr) for Logilab and S
 Igor Garmaev (i.garmaev@iat.rwth-aachen.de) for RWTH Aachen
 Marko Ristin (marko@ristin.ch, marko.ristin@gmail.com, rist@zhaw.ch) for Zurich University of Applied Sciences (ZHAW)
 Sebastian Heppner (s.heppner@iat.rwth-aachen.de) for RWTH Aachen
+Markus Böhm (Markus.Boehm@conplement.de) for Conplement AG
 Tobias Langer (Tobias.Langer@conplement.de) for Conplement AG

--- a/AUTHORS
+++ b/AUTHORS
@@ -3,5 +3,5 @@ Fabien Amarger (contact@logilab.fr, fabien.amarger@logilab.fr) for Logilab and S
 Igor Garmaev (i.garmaev@iat.rwth-aachen.de) for RWTH Aachen
 Marko Ristin (marko@ristin.ch, marko.ristin@gmail.com, rist@zhaw.ch) for Zurich University of Applied Sciences (ZHAW)
 Sebastian Heppner (s.heppner@iat.rwth-aachen.de) for RWTH Aachen
-Markus Böhm (Markus.Boehm@conplement.de) for Conplement AG
-Tobias Langer (Tobias.Langer@conplement.de) for Conplement AG
+Markus Böhm (Markus.Boehm@conplement.de) for conplement AG
+Tobias Langer (Tobias.Langer@conplement.de) for conplement AG


### PR DESCRIPTION
We add Markus Böhm as contributor for conplement AG and correct the spelling of conplement AG.