### PR TITLE
Revert #482 due to a misunderstanding

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,5 @@
 Nico Braunisch (nico.braunisch@tu-dresden.de) for Dresden University of Technology - Institute of Applied Computer Science 
 Tom Gneuss (tom.gneuss@tu-dresden.de) for Dresden University of Technology - Institute of Applied Computer Science 
-Uwe Schmidt (uwe.schmidt1@tu-dresden.de) for Dresden University of Technology - Institute of Applied Computer Science 
-Robert Lehmann (robert.lehmann@tu-dresden.de) for Dresden University of Technology - Institute of Applied Computer Science 
 Elodie Thiéblin (elodie.thieblin@logilab.fr) for Logilab and Siemens AG
 Fabien Amarger (fabien.amarger@logilab.fr) for Logilab and Siemens AG
 Igor Garmaev (i.garmaev@iat.rwth-aachen.de) for RWTH Aachen


### PR DESCRIPTION
The authors added in #482 supplied no commits. While they did contribute to the project with ideas and suggestions, they did not contribute any changes to the code or content of this repository. Since `AUTHORS` concerns the copyright of the content, and not the acknowledgments, we revert the changes in #482.

At this point, we do warmly acknowledge their contributions in ideas and discussions!