### PR TITLE
Allow for `xmlns` attributes in Golang

### DIFF
--- a/aas_core_codegen/golang/xmlization/_generate.py
+++ b/aas_core_codegen/golang/xmlization/_generate.py
@@ -402,19 +402,23 @@ def _generate_check_start_element() -> Stripped:
 func checkStartElement(
 {I}current xml.StartElement,
 ) (err error) {{
-{I}var unexpectedAttr []xml.Attr
+{I}const xmlnsLen = len("xmlns")
+
+{I}unexpectedAttr := 0
 {I}for _, attr := range current.Attr {{
-{II}if attr.Name.Space == "" && attr.Name.Local == "xmlns" {{
+{II}if (attr.Name.Space == "" && attr.Name.Local == "xmlns") ||
+{III}attr.Name.Space == "xmlns" {{
 {III}continue
 {II}}}
-{II}unexpectedAttr = append(unexpectedAttr, attr)
+
+{II}unexpectedAttr++
 {I}}}
-{I}if len(unexpectedAttr) != 0 {{
-{II} err = newDeserializationError(
+{I}if unexpectedAttr != 0 {{
+{II}err = newDeserializationError(
 {III}fmt.Sprintf(
 {IIII}"Expected no attributes except 'xmlns' in the start element, "+
-{IIII}"but got %d in the start element %s",
-{IIII}len(unexpectedAttr), current.Name.Local,
+{IIIII}"but got %d in the start element %s",
+{IIII}unexpectedAttr, current.Name.Local,
 {III}),
 {II})
 {II}return

--- a/test_data/golang/test_main/aas_core_meta.v3/expected_output/xmlization/xmlization.go
+++ b/test_data/golang/test_main/aas_core_meta.v3/expected_output/xmlization/xmlization.go
@@ -344,19 +344,23 @@ const Namespace = "https://admin-shell.io/aas/3/0"
 func checkStartElement(
 	current xml.StartElement,
 ) (err error) {
-	var unexpectedAttr []xml.Attr
+	const xmlnsLen = len("xmlns")
+
+	unexpectedAttr := 0
 	for _, attr := range current.Attr {
-		if attr.Name.Space == "" && attr.Name.Local == "xmlns" {
+		if (attr.Name.Space == "" && attr.Name.Local == "xmlns") ||
+			attr.Name.Space == "xmlns" {
 			continue
 		}
-		unexpectedAttr = append(unexpectedAttr, attr)
+
+		unexpectedAttr++
 	}
-	if len(unexpectedAttr) != 0 {
-		 err = newDeserializationError(
+	if unexpectedAttr != 0 {
+		err = newDeserializationError(
 			fmt.Sprintf(
 				"Expected no attributes except 'xmlns' in the start element, "+
-				"but got %d in the start element %s",
-				len(unexpectedAttr), current.Name.Local,
+					"but got %d in the start element %s",
+				unexpectedAttr, current.Name.Local,
 			),
 		)
 		return


### PR DESCRIPTION
We adapt the Golang SDK generator to ignore both the `xmlns` attribute as well as attributes prefixed with `xmlns:` since they are necessary for correct namespacing even though the AAS specs does not allow any attributes.