### PR TITLE
Add support for Python 3.11 and 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@master

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,8 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
     license="License :: OSI Approved :: MIT License",
     keywords="asset administration shell code generation industry 4.0 industrie i4.0",
@@ -49,7 +51,7 @@ setup(
             "pyinstaller>=4, <5",
             "twine",
             "jsonschema==3.2.0",
-            "xmlschema==1.10.0",
+            "xmlschema==3.3.1",
             "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@6d5411b#egg=aas-core-meta",
             "ssort==0.12.3",
         ]


### PR DESCRIPTION
We include Python 3.11 and 3.12 in the CI to make sure everything runs on those Python versions as well.

Related issues: #491 and #492