### PR TITLE
Check matching between properties and constructors

### DIFF
--- a/test_data/csharp/test_verification/builtin_functions/len/on_list/meta_model.py
+++ b/test_data/csharp/test_verification/builtin_functions/len/on_list/meta_model.py
@@ -12,7 +12,7 @@ class Item:
 class Something:
     some_property: List[Item]
 
-    def __init__(self, some_property: Item) -> None:
+    def __init__(self, some_property: List[Item]) -> None:
         self.some_property = some_property
 
 

--- a/test_data/intermediate/unexpected/invariant/unexpected_argument_count_to_len/meta_model.py
+++ b/test_data/intermediate/unexpected/invariant/unexpected_argument_count_to_len/meta_model.py
@@ -12,7 +12,7 @@ class Item:
 class Something:
     some_property: List[Item]
 
-    def __init__(self, some_property: Item) -> None:
+    def __init__(self, some_property: List[Item]) -> None:
         self.some_property = some_property
 
 


### PR DESCRIPTION
So far, we only checked in the translation phase that the names and the order of the properties and the constructor arguments match. In this change, we also check that they match in type annotations, which is the assumption we make in many code generators.