### PR TITLE
Exclude Eiffel's keyword ``result``

### DIFF
--- a/aas_core_codegen/parse/_translate.py
+++ b/aas_core_codegen/parse/_translate.py
@@ -2750,7 +2750,11 @@ def _verify_symbol_table(
                 "rename",
                 "require",
                 "rescue",
-                "result",
+                # NOTE (mristin, 2024-06-19):
+                # We exclude the keyword ``result`` from the checks as the AAS server
+                # API at version 3.0 already uses it for one of the object properties.
+                # We have to work around it in the code generator for Eiffel SDK.
+                # "result",
                 "retry",
                 "select",
                 "separate",


### PR DESCRIPTION
We exclude the keyword ``result`` from the list of the check for reserved keywords in the translation phase. The keyword is already a part of the AAS Server specification, so we can not roll back on this one, unfortunately.