### PR TITLE
Verify that patterns are anchored

### DIFF
--- a/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/in_union/expected_verification.cs
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/in_union/expected_verification.cs
@@ -22,7 +22,7 @@ namespace dummyNamespace
         [CodeAnalysis.SuppressMessage("ReSharper", "StringLiteralTypo")]
         private static Regex _constructMatchSomething()
         {
-            var pattern = "^\\ud800\\udc00|something$";
+            var pattern = "^(\\ud800\\udc00|something)$";
 
             return new Regex(pattern);
         }

--- a/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/in_union/meta_model.py
+++ b/test_data/csharp/test_verification/pattern_verification/utf32_as_literal/in_union/meta_model.py
@@ -1,6 +1,6 @@
 @verification
 def match_something(text: str) -> bool:
-    pattern = f"^\\U00010000|something$"
+    pattern = "^(\\U00010000|something)$"
     return match(pattern, text) is not None
 
 

--- a/tests/csharp/test_description.py
+++ b/tests/csharp/test_description.py
@@ -471,7 +471,7 @@ class Test_to_render_description_of_signature(unittest.TestCase):
             @verification
             def verify_something(text: str) -> bool:
                 """Verify something."""
-                return match(r'.*', text) is not None
+                return match(r'^.*$', text) is not None
 
             __version__ = "dummy"
             __xml_namespace__ = "https://dummy.com"

--- a/tests/infer_for_schema/test_patterns_on_properties.py
+++ b/tests/infer_for_schema/test_patterns_on_properties.py
@@ -58,7 +58,7 @@ class Test_expected(unittest.TestCase):
             @verification
             def matches_something(text: str) -> bool:
                 prefix = "something"
-                return match(f"{prefix}-[a-zA-Z]+", text) is not None
+                return match(f"^{prefix}-[a-zA-Z]+$", text) is not None
 
 
             @invariant(
@@ -100,7 +100,7 @@ class Test_expected(unittest.TestCase):
                   patterns_by_property={
                     'some_property': [
                       PatternConstraint(
-                        pattern='something-[a-zA-Z]+')]},
+                        pattern='^something-[a-zA-Z]+$')]},
                   set_of_primitives_by_property={},
                   set_of_enumeration_literals_by_property={})"""
             ),
@@ -112,11 +112,11 @@ class Test_expected(unittest.TestCase):
             """\
             @verification
             def matches_something(text: str) -> bool:
-                return match("something-[a-zA-Z]+", text) is not None
+                return match("^something-[a-zA-Z]+$", text) is not None
 
             @verification
             def matches_acme(text: str) -> bool:
-                return match(".*acme.*", text) is not None
+                return match("^.*acme.*$", text) is not None
 
 
             @invariant(
@@ -162,9 +162,9 @@ class Test_expected(unittest.TestCase):
                   patterns_by_property={
                     'some_property': [
                       PatternConstraint(
-                        pattern='something-[a-zA-Z]+'),
+                        pattern='^something-[a-zA-Z]+$'),
                       PatternConstraint(
-                        pattern='.*acme.*')]},
+                        pattern='^.*acme.*$')]},
                   set_of_primitives_by_property={},
                   set_of_enumeration_literals_by_property={})"""
             ),
@@ -176,7 +176,7 @@ class Test_expected(unittest.TestCase):
             """\
             @verification
             def matches_something(text: str) -> bool:
-                return match("something-[a-zA-Z]+", text) is not None
+                return match("^something-[a-zA-Z]+$", text) is not None
 
             @invariant(
                 lambda self:
@@ -224,7 +224,7 @@ class Test_expected(unittest.TestCase):
                   patterns_by_property={
                     'some_property': [
                       PatternConstraint(
-                        pattern='something-[a-zA-Z]+')]},
+                        pattern='^something-[a-zA-Z]+$')]},
                   set_of_primitives_by_property={},
                   set_of_enumeration_literals_by_property={})"""
             ),
@@ -236,11 +236,11 @@ class Test_expected(unittest.TestCase):
             """\
             @verification
             def matches_something(text: str) -> bool:
-                return match("something-[a-zA-Z]+", text) is not None
+                return match("^something-[a-zA-Z]+$", text) is not None
 
             @verification
             def matches_acme(text: str) -> bool:
-                return match(".*acme.*", text) is not None
+                return match("^.*acme.*$", text) is not None
 
             @invariant(
                 lambda self: matches_something(self.some_property),
@@ -298,7 +298,7 @@ class Test_expected(unittest.TestCase):
                   patterns_by_property={
                     'some_property': [
                       PatternConstraint(
-                        pattern='.*acme.*')]},
+                        pattern='^.*acme.*$')]},
                   set_of_primitives_by_property={},
                   set_of_enumeration_literals_by_property={})"""
             ),
@@ -313,7 +313,7 @@ class Test_stacking(unittest.TestCase):
             @verification
             def matches_something(text: str) -> bool:
                 prefix = "something"
-                return match(f"{prefix}-[a-zA-Z]+", text) is not None
+                return match(f"^{prefix}-[a-zA-Z]+$", text) is not None
 
 
             @invariant(
@@ -370,7 +370,7 @@ class Test_stacking(unittest.TestCase):
                   patterns_by_property={
                     'some_property': [
                       PatternConstraint(
-                        pattern='something-[a-zA-Z]+')]},
+                        pattern='^something-[a-zA-Z]+$')]},
                   set_of_primitives_by_property={},
                   set_of_enumeration_literals_by_property={})"""
             ),
@@ -383,7 +383,7 @@ class Test_stacking(unittest.TestCase):
             @verification
             def matches_something(text: str) -> bool:
                 prefix = "something"
-                return match(f"{prefix}-[a-zA-Z]+", text) is not None
+                return match(f"^{prefix}-[a-zA-Z]+$", text) is not None
 
 
             @invariant(
@@ -440,7 +440,7 @@ class Test_stacking(unittest.TestCase):
                   patterns_by_property={
                     'some_property': [
                       PatternConstraint(
-                        pattern='something-[a-zA-Z]+')]},
+                        pattern='^something-[a-zA-Z]+$')]},
                   set_of_primitives_by_property={},
                   set_of_enumeration_literals_by_property={})"""
             ),
@@ -452,11 +452,11 @@ class Test_stacking(unittest.TestCase):
             """\
             @verification
             def matches_something(text: str) -> bool:
-                return match("something-[a-zA-Z]+", text) is not None
+                return match("^something-[a-zA-Z]+$", text) is not None
 
             @verification
             def matches_acme(text: str) -> bool:
-                return match(".*acme.*", text) is not None
+                return match("^.*acme.*$", text) is not None
 
             @invariant(
                 lambda self: matches_something(self.some_property),
@@ -521,9 +521,9 @@ class Test_stacking(unittest.TestCase):
                   patterns_by_property={
                     'some_property': [
                       PatternConstraint(
-                        pattern='.*acme.*'),
+                        pattern='^.*acme.*$'),
                       PatternConstraint(
-                        pattern='something-[a-zA-Z]+')]},
+                        pattern='^something-[a-zA-Z]+$')]},
                   set_of_primitives_by_property={},
                   set_of_enumeration_literals_by_property={})"""
             ),
@@ -535,7 +535,7 @@ class Test_stacking(unittest.TestCase):
             """\
             @verification
             def matches_something(text: str) -> bool:
-                return match("something-[a-zA-Z]+", text) is not None
+                return match("^something-[a-zA-Z]+$", text) is not None
 
             @invariant(
                 lambda self: matches_something(self.some_property),
@@ -599,7 +599,7 @@ class Test_stacking(unittest.TestCase):
                   patterns_by_property={
                     'some_property': [
                       PatternConstraint(
-                        pattern='something-[a-zA-Z]+')]},
+                        pattern='^something-[a-zA-Z]+$')]},
                   set_of_primitives_by_property={},
                   set_of_enumeration_literals_by_property={})"""
             ),
@@ -611,7 +611,7 @@ class Test_stacking(unittest.TestCase):
             """\
             @verification
             def matches_something(text: str) -> bool:
-                return match("something-[a-zA-Z]+", text) is not None
+                return match("^something-[a-zA-Z]+$", text) is not None
 
             @invariant(
                 lambda self: matches_something(self),
@@ -674,7 +674,7 @@ class Test_stacking(unittest.TestCase):
                   patterns_by_property={
                     'some_property': [
                       PatternConstraint(
-                        pattern='something-[a-zA-Z]+')]},
+                        pattern='^something-[a-zA-Z]+$')]},
                   set_of_primitives_by_property={},
                   set_of_enumeration_literals_by_property={})"""
             ),

--- a/tests/infer_for_schema/test_patterns_on_self.py
+++ b/tests/infer_for_schema/test_patterns_on_self.py
@@ -61,7 +61,7 @@ class Test_expected(unittest.TestCase):
             @verification
             def matches_something(text: str) -> bool:
                 prefix = "something"
-                return match(f"{prefix}-[a-zA-Z]+", text) is not None
+                return match(f"^{prefix}-[a-zA-Z]+$", text) is not None
 
 
             @invariant(
@@ -106,7 +106,7 @@ class Test_expected(unittest.TestCase):
                   patterns_by_property={
                     'some_property': [
                       PatternConstraint(
-                        pattern='something-[a-zA-Z]+')]},
+                        pattern='^something-[a-zA-Z]+$')]},
                   set_of_primitives_by_property={},
                   set_of_enumeration_literals_by_property={})"""
             ),
@@ -118,11 +118,11 @@ class Test_expected(unittest.TestCase):
             """\
             @verification
             def matches_something(text: str) -> bool:
-                return match("something-[a-zA-Z]+", text) is not None
+                return match("^something-[a-zA-Z]+$", text) is not None
 
             @verification
             def matches_acme(text: str) -> bool:
-                return match(".*acme.*", text) is not None
+                return match("^.*acme.*$", text) is not None
 
 
             @invariant(
@@ -171,9 +171,9 @@ class Test_expected(unittest.TestCase):
                   patterns_by_property={
                     'some_property': [
                       PatternConstraint(
-                        pattern='something-[a-zA-Z]+'),
+                        pattern='^something-[a-zA-Z]+$'),
                       PatternConstraint(
-                        pattern='.*acme.*')]},
+                        pattern='^.*acme.*$')]},
                   set_of_primitives_by_property={},
                   set_of_enumeration_literals_by_property={})"""
             ),
@@ -185,11 +185,11 @@ class Test_expected(unittest.TestCase):
             """\
             @verification
             def matches_something(text: str) -> bool:
-                return match("something-[a-zA-Z]+", text) is not None
+                return match("^something-[a-zA-Z]+$", text) is not None
 
             @verification
             def matches_acme(text: str) -> bool:
-                return match(".*acme.*", text) is not None
+                return match("^.*acme.*$", text) is not None
 
             @invariant(
                 lambda self: matches_something(self),
@@ -244,9 +244,9 @@ class Test_expected(unittest.TestCase):
                   patterns_by_property={
                     'some_property': [
                       PatternConstraint(
-                        pattern='something-[a-zA-Z]+'),
+                        pattern='^something-[a-zA-Z]+$'),
                       PatternConstraint(
-                        pattern='.*acme.*')]},
+                        pattern='^.*acme.*$')]},
                   set_of_primitives_by_property={},
                   set_of_enumeration_literals_by_property={})"""
             ),


### PR DESCRIPTION
As we transpile to some of the systems which always expect the regular expressions to be anchored at the start and the end (*e.g.*, XSD engines), we verify in the patch that all verification patterns are appropriately anchored. This ensures that the patterns will also be correctly transpiled down the line.