### PR TITLE
Rename `parse.retree.BaseVisitor` to pass-through

### DIFF
--- a/aas_core_codegen/parse/retree/__init__.py
+++ b/aas_core_codegen/parse/retree/__init__.py
@@ -35,7 +35,7 @@ TermValueUnion = _types.TermValueUnion
 Visitor = _types.Visitor
 Transformer = _types.Transformer
 
-BaseVisitor = _visitor.BaseVisitor
+PassThroughVisitor = _visitor.PassThroughVisitor
 
 dump = _stringify.dump
 

--- a/aas_core_codegen/parse/retree/_fix.py
+++ b/aas_core_codegen/parse/retree/_fix.py
@@ -9,7 +9,7 @@ from aas_core_codegen.parse.retree import (
 )
 
 
-class _FixForUTF16Regex(retree_visitor.BaseVisitor):
+class _FixForUTF16Regex(retree_visitor.PassThroughVisitor):
     """
     Modify the pattern in-place so that UTF-32 can be dealt by UTF-16-only regex engine.
 

--- a/aas_core_codegen/parse/retree/_visitor.py
+++ b/aas_core_codegen/parse/retree/_visitor.py
@@ -15,7 +15,7 @@ from aas_core_codegen.parse.retree._types import (
 from aas_core_codegen.parse.tree import FormattedValue
 
 
-class BaseVisitor(Visitor):
+class PassThroughVisitor(Visitor):
     """Visit all the nodes recursively without any action."""
 
     def visit_regex(self, node: Regex) -> None:

--- a/aas_core_codegen/xsd/main.py
+++ b/aas_core_codegen/xsd/main.py
@@ -124,7 +124,7 @@ def _undo_escaping_backslash_x_u_and_U_in_pattern(pattern: str) -> str:
     return "".join(parts)
 
 
-class _AnchorRemover(parse_retree.BaseVisitor):
+class _AnchorRemover(parse_retree.PassThroughVisitor):
     """
     Remove anchors from a regex in-place.
 


### PR DESCRIPTION
We rename `parse.retree.BaseVisitor` to `PassThroughVisitor` in alignment with the naming used for the generated SDKs. The name "base visitor" is also a bit of a misnomer as it insinuates some kind of an abstract class, while the pass-through visitor is explicitly a concrete class.