### PR TITLE
Fix non-recursive verification in C++

### DIFF
--- a/aas_core_codegen/cpp/verification/_generate.py
+++ b/aas_core_codegen/cpp/verification/_generate.py
@@ -656,7 +656,7 @@ bool operator!=(const Iterator& a, const Iterator& b) {{
 
 
 def _generate_non_recursive_verification() -> List[Stripped]:
-    """Generate the ``RecursiveVerification`` class."""
+    """Generate the ``NonRecursiveVerification`` class."""
     return [
         Stripped("// region NonRecursiveVerification"),
         Stripped(
@@ -1725,7 +1725,8 @@ error_ = common::make_unique<Error>(
 );
 // No path is prepended as the error refers to the instance itself.
 ++index_;"""
-                )
+                ),
+                yielding_flow.Yield(),
             ],
         ),
         yielding_flow.command_from_text(

--- a/test_data/cpp/test_main/aas_core_meta.v3/expected_output/verification.cpp
+++ b/test_data/cpp/test_main/aas_core_meta.v3/expected_output/verification.cpp
@@ -24986,7 +24986,7 @@ void RecursiveVerificator::Execute() {
 
       case 1: {
         if (!(!verificator_->Done())) {
-          state_ = 2;
+          state_ = 3;
           continue;
         }
 
@@ -25001,13 +25001,18 @@ void RecursiveVerificator::Execute() {
         // No path is prepended as the error refers to the instance itself.
         ++index_;
 
+        state_ = 2;
+        return;
+      }
+
+      case 2: {
         verificator_->Next();
 
         state_ = 1;
         continue;
       }
 
-      case 2: {
+      case 3: {
         verificator_ = nullptr;
 
         {
@@ -25025,9 +25030,9 @@ void RecursiveVerificator::Execute() {
         }
       }
 
-      case 3: {
+      case 4: {
         if (!(*iterator_ != *iterator_end_)) {
-          state_ = 7;
+          state_ = 8;
           continue;
         }
 
@@ -25037,9 +25042,9 @@ void RecursiveVerificator::Execute() {
         verificator_->Start();
       }
 
-      case 4: {
+      case 5: {
         if (!(!verificator_->Done())) {
-          state_ = 6;
+          state_ = 7;
           continue;
         }
 
@@ -25060,34 +25065,34 @@ void RecursiveVerificator::Execute() {
 
         ++index_;
 
-        state_ = 5;
+        state_ = 6;
         return;
       }
 
-      case 5: {
+      case 6: {
         verificator_->Next();
+
+        state_ = 5;
+        continue;
+      }
+
+      case 7: {
+        verificator_ = nullptr;
+
+        ++(*iterator_);
 
         state_ = 4;
         continue;
       }
 
-      case 6: {
-        verificator_ = nullptr;
-
-        ++(*iterator_);
-
-        state_ = 3;
-        continue;
-      }
-
-      case 7: {
+      case 8: {
         iterator_.reset();
         iterator_end_.reset();
         done_ = true;
         index_ = -1;
 
         // We invalidate the state since we reached the end of the routine.
-        state_ = 8;
+        state_ = 9;
         return;
       }
 


### PR DESCRIPTION
We forgot to put a yield when iterating over the verification errors related to the root instance. We fix the issue in this change.