### PR TITLE
Remove trailing space from test data

### DIFF
--- a/test_data/cpp/test_main/aas_core_meta.v3/expected_output/revm.cpp
+++ b/test_data/cpp/test_main/aas_core_meta.v3/expected_output/revm.cpp
@@ -286,7 +286,7 @@ std::string to_string(const InstructionSplit& instruction) {
 }
 
 InstructionKind InstructionEnd::kind() const {
-  return InstructionKind::End; 
+  return InstructionKind::End;
 }
 
 std::string to_string(const InstructionEnd&) {
@@ -467,7 +467,7 @@ class ThreadList {
 
   /**
    * Pop the thread from the back, returning its program counter.
-   * 
+   *
    * The order of the threads is not guaranteed.
    */
   size_t Pop() {

--- a/test_data/cpp/test_main/aas_core_meta.v3/expected_output/revm.hpp
+++ b/test_data/cpp/test_main/aas_core_meta.v3/expected_output/revm.hpp
@@ -30,7 +30,7 @@ namespace aas_3_0 {
  * https://swtch.com/~rsc/regexp/regexp2.html
  *
  * The ideas for additional instructions were taken from:
- * https://www.codeproject.com/Articles/5256833/Regex-as-a-Tiny-Threaded-Virtual-Machine  
+ * https://www.codeproject.com/Articles/5256833/Regex-as-a-Tiny-Threaded-Virtual-Machine
  * @{
  */
 namespace revm {
@@ -58,7 +58,7 @@ struct Instruction {
 };
 
 /**
- * Match a single character. 
+ * Match a single character.
  *
  * If the character on the String Pointer does not match the `character`, stop this
  * thread as it failed. Otherwise, move the String Pointer to the next character,


### PR DESCRIPTION
We are having trouble with CI on GitHub as it takes a lot of time. The previous run on #504 revealed only much later that we forgot to re-generate the test data. In this patch, we re-generate the test data with the trailing spaces removed.