### PR TITLE
Fix error message in Go de-jsonization of strings

### DIFF
--- a/aas_core_codegen/golang/jsonization/_generate.py
+++ b/aas_core_codegen/golang/jsonization/_generate.py
@@ -180,7 +180,7 @@ func stringFromJsonable(
 {II}return
 {I}}} else {{
 {II}err = newDeserializationError(
-{III}fmt.Sprintf("Expected a boolean, but got %T", jsonable),
+{III}fmt.Sprintf("Expected a string, but got %T", jsonable),
 {II})
 {II}return
 {I}}}
@@ -1416,7 +1416,7 @@ switch that.{model_type_getter}() {{
 
     return Stripped(
         f"""\
-// Serialize ``that`` instance to a JSON-able representation.
+// Serialize “that“ instance to a JSON-able representation.
 //
 // Return a structure which can be readily converted to JSON,
 // or an error if some value could not be converted.

--- a/test_data/golang/test_main/aas_core_meta.v3/expected_output/jsonization/jsonization.go
+++ b/test_data/golang/test_main/aas_core_meta.v3/expected_output/jsonization/jsonization.go
@@ -178,7 +178,7 @@ func stringFromJsonable(
 		return
 	} else {
 		err = newDeserializationError(
-			fmt.Sprintf("Expected a boolean, but got %T", jsonable),
+			fmt.Sprintf("Expected a string, but got %T", jsonable),
 		)
 		return
 	}
@@ -20859,7 +20859,7 @@ func dataSpecificationIEC61360ToMap(
 	return
 }
 
-// Serialize ``that`` instance to a JSON-able representation.
+// Serialize “that“ instance to a JSON-able representation.
 //
 // Return a structure which can be readily converted to JSON,
 // or an error if some value could not be converted.


### PR DESCRIPTION
We erroneously copy-pasted the error message from the function for de-serialization of booleans to the function for de-serialization of strings, misleading the user of the generated code.

This patch fixes the issue.