### PR TITLE
Update test data to aas-core-meta bd56058

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
             "twine",
             "jsonschema==3.2.0",
             "xmlschema==3.3.1",
-            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@31d6afd#egg=aas-core-meta",
+            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@bd56058#egg=aas-core-meta",
             "ssort==0.12.3",
         ]
     },

--- a/test_data/cpp/test_main/aas_core_meta.v3/expected_output/verification.cpp
+++ b/test_data/cpp/test_main/aas_core_meta.v3/expected_output/verification.cpp
@@ -11551,7 +11551,7 @@ void OfSubmodelElementList::Execute() {
       case 15: {
         if (
           !((
-            (instance_->value().has_value())
+            (instance_->type_value_list_element().has_value())
             && (
               (
                 instance_->type_value_list_element() == types::AasSubmodelElements::kProperty
@@ -11561,9 +11561,14 @@ void OfSubmodelElementList::Execute() {
           ))
           || ((
             (instance_->value_type_list_element().has_value())
-            && PropertiesOrRangesHaveValueType(
-              (*(instance_->value())),
-              (*(instance_->value_type_list_element()))
+            && (
+              (
+                (!(instance_->value().has_value()))
+                || PropertiesOrRangesHaveValueType(
+                  instance_->value(),
+                  (*(instance_->value_type_list_element()))
+                )
+              )
             )
           ))
         ) {

--- a/test_data/csharp/test_main/aas_core_meta.v3/expected_output/verification.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3/expected_output/verification.cs
@@ -4286,7 +4286,7 @@ namespace AasCore.Aas3_0
 
                 if (!(
                     !(
-                        (that.Value != null)
+                        (that.TypeValueListElement != null)
                         && (
                             that.TypeValueListElement == AasSubmodelElements.Property
                             || that.TypeValueListElement == AasSubmodelElements.Range
@@ -4294,7 +4294,10 @@ namespace AasCore.Aas3_0
                     )
                     || (
                         (that.ValueTypeListElement != null)
-                        && Verification.PropertiesOrRangesHaveValueType(that.Value, that.ValueTypeListElement)
+                        && (
+                            (that.Value == null)
+                            || Verification.PropertiesOrRangesHaveValueType(that.Value, that.ValueTypeListElement)
+                        )
                     )))
                 {
                     yield return new Reporting.Error(

--- a/test_data/golang/test_main/aas_core_meta.v3/expected_output/verification/verification.go
+++ b/test_data/golang/test_main/aas_core_meta.v3/expected_output/verification/verification.go
@@ -5250,14 +5250,15 @@ func VerifySubmodelElementList(
 	}
 
 	if !(
-		!((that.Value() != nil) &&
+		!((that.TypeValueListElement() != nil) &&
 		(that.TypeValueListElement() == aastypes.AASSubmodelElementsProperty ||
 		that.TypeValueListElement() == aastypes.AASSubmodelElementsRange)) ||
 		((that.ValueTypeListElement() != nil) &&
+		((that.Value() == nil) ||
 		PropertiesOrRangesHaveValueType(
 			that.Value(),
 			*that.ValueTypeListElement(),
-		))) {
+		)))) {
 		abort = onError(
 			newVerificationError(
 				"Constraint AASd-109: If type value list element is equal to " +

--- a/test_data/intermediate/real_meta_models/aas_core_meta.v3/expected_symbol_table.txt
+++ b/test_data/intermediate/real_meta_models/aas_core_meta.v3/expected_symbol_table.txt
@@ -9841,7 +9841,7 @@ SymbolTable(
                       instance=Name(
                         identifier='self',
                         original_node=...),
-                      name='value',
+                      name='type_value_list_element',
                       original_node=...),
                     original_node=...),
                   Or(
@@ -9888,20 +9888,31 @@ SymbolTable(
                       name='value_type_list_element',
                       original_node=...),
                     original_node=...),
-                  FunctionCall(
-                    name='properties_or_ranges_have_value_type',
-                    args=[
-                      Member(
-                        instance=Name(
-                          identifier='self',
+                  Or(
+                    values=[
+                      IsNone(
+                        value=Member(
+                          instance=Name(
+                            identifier='self',
+                            original_node=...),
+                          name='value',
                           original_node=...),
-                        name='value',
                         original_node=...),
-                      Member(
-                        instance=Name(
-                          identifier='self',
-                          original_node=...),
-                        name='value_type_list_element',
+                      FunctionCall(
+                        name='properties_or_ranges_have_value_type',
+                        args=[
+                          Member(
+                            instance=Name(
+                              identifier='self',
+                              original_node=...),
+                            name='value',
+                            original_node=...),
+                          Member(
+                            instance=Name(
+                              identifier='self',
+                              original_node=...),
+                            name='value_type_list_element',
+                            original_node=...)],
                         original_node=...)],
                     original_node=...)],
                 original_node=...),

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/verification/Verification.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/verification/Verification.java
@@ -3795,7 +3795,7 @@ public class Verification {
 
       if (!(
         !(
-            (that.getValue().isPresent())
+            (that.getTypeValueListElement() != null)
             && (
                 that.getTypeValueListElement() == AasSubmodelElements.PROPERTY
                 || that.getTypeValueListElement() == AasSubmodelElements.RANGE
@@ -3803,9 +3803,12 @@ public class Verification {
         )
         || (
             (that.getValueTypeListElement().isPresent())
-            && propertiesOrRangesHaveValueType(
-                that.getValue().orElse(null),
-                that.getValueTypeListElement().orElse(null))
+            && (
+                (!that.getValue().isPresent())
+                || propertiesOrRangesHaveValueType(
+                    that.getValue().orElse(null),
+                    that.getValueTypeListElement().orElse(null))
+            )
         ))) {
         errorStream = Stream.<Reporting.Error>concat(errorStream,
           Stream.of(new Reporting.Error(

--- a/test_data/parse/real_meta_models/aas_core_meta.v3/expected_symbol_table.txt
+++ b/test_data/parse/real_meta_models/aas_core_meta.v3/expected_symbol_table.txt
@@ -4470,7 +4470,7 @@ UnverifiedSymbolTable(
                       instance=Name(
                         identifier='self',
                         original_node=...),
-                      name='value',
+                      name='type_value_list_element',
                       original_node=...),
                     original_node=...),
                   Or(
@@ -4517,20 +4517,31 @@ UnverifiedSymbolTable(
                       name='value_type_list_element',
                       original_node=...),
                     original_node=...),
-                  FunctionCall(
-                    name='properties_or_ranges_have_value_type',
-                    args=[
-                      Member(
-                        instance=Name(
-                          identifier='self',
+                  Or(
+                    values=[
+                      IsNone(
+                        value=Member(
+                          instance=Name(
+                            identifier='self',
+                            original_node=...),
+                          name='value',
                           original_node=...),
-                        name='value',
                         original_node=...),
-                      Member(
-                        instance=Name(
-                          identifier='self',
-                          original_node=...),
-                        name='value_type_list_element',
+                      FunctionCall(
+                        name='properties_or_ranges_have_value_type',
+                        args=[
+                          Member(
+                            instance=Name(
+                              identifier='self',
+                              original_node=...),
+                            name='value',
+                            original_node=...),
+                          Member(
+                            instance=Name(
+                              identifier='self',
+                              original_node=...),
+                            name='value_type_list_element',
+                            original_node=...)],
                         original_node=...)],
                     original_node=...)],
                 original_node=...),

--- a/test_data/python/test_main/aas_core_meta.v3/expected_output/verification.py
+++ b/test_data/python/test_main/aas_core_meta.v3/expected_output/verification.py
@@ -3426,7 +3426,7 @@ class _Transformer(
         if not (
             not (
                 (
-                    (that.value is not None)
+                    (that.type_value_list_element is not None)
                     and (
                         (
                             that.type_value_list_element == aas_types.AASSubmodelElements.PROPERTY
@@ -3438,9 +3438,14 @@ class _Transformer(
             or (
                 (
                     (that.value_type_list_element is not None)
-                    and properties_or_ranges_have_value_type(
-                        that.value,
-                        that.value_type_list_element
+                    and (
+                        (
+                            (that.value is None)
+                            or properties_or_ranges_have_value_type(
+                                that.value,
+                                that.value_type_list_element
+                            )
+                        )
                     )
                 )
             )

--- a/test_data/typescript/test_main/aas_core_meta.v3/expected_output/verification.ts
+++ b/test_data/typescript/test_main/aas_core_meta.v3/expected_output/verification.ts
@@ -3988,7 +3988,7 @@ class Verifier
     if (!(
       !(
         (
-          (that.value !== null)
+          (that.typeValueListElement !== null)
           && (
             (
               that.typeValueListElement == AasTypes.AasSubmodelElements.Property
@@ -4000,9 +4000,14 @@ class Verifier
       || (
         (
           (that.valueTypeListElement !== null)
-          && propertiesOrRangesHaveValueType(
-            that.value,
-            that.valueTypeListElement
+          && (
+            (
+              (that.value === null)
+              || propertiesOrRangesHaveValueType(
+                that.value,
+                that.valueTypeListElement
+              )
+            )
           )
         )
       )


### PR DESCRIPTION
We update the development requirements to and re-record the test data for [aas-core-meta bd56058].

Notably, we propagate the fix for AASd-109 in V3.0 where we change the invariant such that it checks for consistency among properties even when a ``value`` property is missing. This affects only the re-recording of the test data corresponding to V3.0 meta-model.

[aas-core-meta bd56058]: https://github.com/aas-core-works/aas-core-meta/commit/bd56058