### PR TITLE
Update test data to aas-core-meta 35aa2cc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
             "twine",
             "jsonschema==3.2.0",
             "xmlschema==3.3.1",
-            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@bd56058#egg=aas-core-meta",
+            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@35aa2cc#egg=aas-core-meta",
             "ssort==0.12.3",
         ]
     },

--- a/test_data/cpp/test_main/aas_core_meta.v3/expected_output/verification.cpp
+++ b/test_data/cpp/test_main/aas_core_meta.v3/expected_output/verification.cpp
@@ -11551,13 +11551,8 @@ void OfSubmodelElementList::Execute() {
       case 15: {
         if (
           !((
-            (instance_->type_value_list_element().has_value())
-            && (
-              (
-                instance_->type_value_list_element() == types::AasSubmodelElements::kProperty
-                || instance_->type_value_list_element() == types::AasSubmodelElements::kRange
-              )
-            )
+            instance_->type_value_list_element() == types::AasSubmodelElements::kProperty
+            || instance_->type_value_list_element() == types::AasSubmodelElements::kRange
           ))
           || ((
             (instance_->value_type_list_element().has_value())

--- a/test_data/csharp/test_main/aas_core_meta.v3/expected_output/verification.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3/expected_output/verification.cs
@@ -4286,11 +4286,8 @@ namespace AasCore.Aas3_0
 
                 if (!(
                     !(
-                        (that.TypeValueListElement != null)
-                        && (
-                            that.TypeValueListElement == AasSubmodelElements.Property
-                            || that.TypeValueListElement == AasSubmodelElements.Range
-                        )
+                        that.TypeValueListElement == AasSubmodelElements.Property
+                        || that.TypeValueListElement == AasSubmodelElements.Range
                     )
                     || (
                         (that.ValueTypeListElement != null)

--- a/test_data/golang/test_main/aas_core_meta.v3/expected_output/verification/verification.go
+++ b/test_data/golang/test_main/aas_core_meta.v3/expected_output/verification/verification.go
@@ -5250,9 +5250,8 @@ func VerifySubmodelElementList(
 	}
 
 	if !(
-		!((that.TypeValueListElement() != nil) &&
-		(that.TypeValueListElement() == aastypes.AASSubmodelElementsProperty ||
-		that.TypeValueListElement() == aastypes.AASSubmodelElementsRange)) ||
+		!(that.TypeValueListElement() == aastypes.AASSubmodelElementsProperty ||
+		that.TypeValueListElement() == aastypes.AASSubmodelElementsRange) ||
 		((that.ValueTypeListElement() != nil) &&
 		((that.Value() == nil) ||
 		PropertiesOrRangesHaveValueType(

--- a/test_data/intermediate/real_meta_models/aas_core_meta.v3/expected_symbol_table.txt
+++ b/test_data/intermediate/real_meta_models/aas_core_meta.v3/expected_symbol_table.txt
@@ -9834,48 +9834,37 @@ SymbolTable(
           description='Constraint AASd-109: If type value list element is equal to Property or Range value type list element shall be set and all first level child elements shall have the value type as specified in value type list element.',
           body=textwrap.dedent("""\
             Implication(
-              antecedent=And(
+              antecedent=Or(
                 values=[
-                  IsNotNone(
-                    value=Member(
+                  Comparison(
+                    left=Member(
                       instance=Name(
                         identifier='self',
                         original_node=...),
                       name='type_value_list_element',
                       original_node=...),
-                    original_node=...),
-                  Or(
-                    values=[
-                      Comparison(
-                        left=Member(
-                          instance=Name(
-                            identifier='self',
-                            original_node=...),
-                          name='type_value_list_element',
-                          original_node=...),
-                        op='EQ',
-                        right=Member(
-                          instance=Name(
-                            identifier='AAS_submodel_elements',
-                            original_node=...),
-                          name='Property',
-                          original_node=...),
+                    op='EQ',
+                    right=Member(
+                      instance=Name(
+                        identifier='AAS_submodel_elements',
                         original_node=...),
-                      Comparison(
-                        left=Member(
-                          instance=Name(
-                            identifier='self',
-                            original_node=...),
-                          name='type_value_list_element',
-                          original_node=...),
-                        op='EQ',
-                        right=Member(
-                          instance=Name(
-                            identifier='AAS_submodel_elements',
-                            original_node=...),
-                          name='Range',
-                          original_node=...),
-                        original_node=...)],
+                      name='Property',
+                      original_node=...),
+                    original_node=...),
+                  Comparison(
+                    left=Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='type_value_list_element',
+                      original_node=...),
+                    op='EQ',
+                    right=Member(
+                      instance=Name(
+                        identifier='AAS_submodel_elements',
+                        original_node=...),
+                      name='Range',
+                      original_node=...),
                     original_node=...)],
                 original_node=...),
               consequent=And(

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/verification/Verification.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/verification/Verification.java
@@ -3795,11 +3795,8 @@ public class Verification {
 
       if (!(
         !(
-            (that.getTypeValueListElement() != null)
-            && (
-                that.getTypeValueListElement() == AasSubmodelElements.PROPERTY
-                || that.getTypeValueListElement() == AasSubmodelElements.RANGE
-            )
+            that.getTypeValueListElement() == AasSubmodelElements.PROPERTY
+            || that.getTypeValueListElement() == AasSubmodelElements.RANGE
         )
         || (
             (that.getValueTypeListElement().isPresent())

--- a/test_data/parse/real_meta_models/aas_core_meta.v3/expected_symbol_table.txt
+++ b/test_data/parse/real_meta_models/aas_core_meta.v3/expected_symbol_table.txt
@@ -4463,48 +4463,37 @@ UnverifiedSymbolTable(
           description='Constraint AASd-109: If type value list element is equal to Property or Range value type list element shall be set and all first level child elements shall have the value type as specified in value type list element.',
           body=textwrap.dedent("""\
             Implication(
-              antecedent=And(
+              antecedent=Or(
                 values=[
-                  IsNotNone(
-                    value=Member(
+                  Comparison(
+                    left=Member(
                       instance=Name(
                         identifier='self',
                         original_node=...),
                       name='type_value_list_element',
                       original_node=...),
-                    original_node=...),
-                  Or(
-                    values=[
-                      Comparison(
-                        left=Member(
-                          instance=Name(
-                            identifier='self',
-                            original_node=...),
-                          name='type_value_list_element',
-                          original_node=...),
-                        op='EQ',
-                        right=Member(
-                          instance=Name(
-                            identifier='AAS_submodel_elements',
-                            original_node=...),
-                          name='Property',
-                          original_node=...),
+                    op='EQ',
+                    right=Member(
+                      instance=Name(
+                        identifier='AAS_submodel_elements',
                         original_node=...),
-                      Comparison(
-                        left=Member(
-                          instance=Name(
-                            identifier='self',
-                            original_node=...),
-                          name='type_value_list_element',
-                          original_node=...),
-                        op='EQ',
-                        right=Member(
-                          instance=Name(
-                            identifier='AAS_submodel_elements',
-                            original_node=...),
-                          name='Range',
-                          original_node=...),
-                        original_node=...)],
+                      name='Property',
+                      original_node=...),
+                    original_node=...),
+                  Comparison(
+                    left=Member(
+                      instance=Name(
+                        identifier='self',
+                        original_node=...),
+                      name='type_value_list_element',
+                      original_node=...),
+                    op='EQ',
+                    right=Member(
+                      instance=Name(
+                        identifier='AAS_submodel_elements',
+                        original_node=...),
+                      name='Range',
+                      original_node=...),
                     original_node=...)],
                 original_node=...),
               consequent=And(

--- a/test_data/python/test_main/aas_core_meta.v3/expected_output/verification.py
+++ b/test_data/python/test_main/aas_core_meta.v3/expected_output/verification.py
@@ -3426,13 +3426,8 @@ class _Transformer(
         if not (
             not (
                 (
-                    (that.type_value_list_element is not None)
-                    and (
-                        (
-                            that.type_value_list_element == aas_types.AASSubmodelElements.PROPERTY
-                            or that.type_value_list_element == aas_types.AASSubmodelElements.RANGE
-                        )
-                    )
+                    that.type_value_list_element == aas_types.AASSubmodelElements.PROPERTY
+                    or that.type_value_list_element == aas_types.AASSubmodelElements.RANGE
                 )
             )
             or (

--- a/test_data/typescript/test_main/aas_core_meta.v3/expected_output/verification.ts
+++ b/test_data/typescript/test_main/aas_core_meta.v3/expected_output/verification.ts
@@ -3988,13 +3988,8 @@ class Verifier
     if (!(
       !(
         (
-          (that.typeValueListElement !== null)
-          && (
-            (
-              that.typeValueListElement == AasTypes.AasSubmodelElements.Property
-              || that.typeValueListElement == AasTypes.AasSubmodelElements.Range
-            )
-          )
+          that.typeValueListElement == AasTypes.AasSubmodelElements.Property
+          || that.typeValueListElement == AasTypes.AasSubmodelElements.Range
         )
       )
       || (


### PR DESCRIPTION
We update the development requirements to and re-record the test data for [aas-core-meta 35aa2cc].

Notably, we propagate the fix for V3.0 in the meta-model of Constraint AASd-109 for type inference as we erroneously included a non-nullness check for a non-optional attribute (``type_value_list_element``).

[aas-core-meta 35aa2cc]: https://github.com/aas-core-works/aas-core-meta/commit/35aa2cc