### PR TITLE
Fix type inference for disjunctions with nullness

### DIFF
--- a/aas_core_codegen/cpp/transpilation.py
+++ b/aas_core_codegen/cpp/transpilation.py
@@ -635,6 +635,14 @@ common::{contains_function}(
         for arg_node in node.args:
             arg_type = self.type_map[arg_node]
 
+            # NOTE (mristin):
+            # This is a tough call to make. We decide that a value, for which we
+            # know that it might be null, will not be de-referenced. On the other
+            # hand, if the value is certainly not null, we de-reference it.
+            #
+            # The problem here is that the actual type of the argument in C++ changes
+            # depending on whether we check for its nullness before with an implication.
+
             arg: Optional[Stripped]
             if isinstance(arg_type, intermediate_type_inference.OptionalTypeAnnotation):
                 arg, error = self.transform(arg_node)
@@ -680,6 +688,13 @@ common::{contains_function}(
         for arg_node in node.args:
             arg_type = self.type_map[arg_node]
 
+            # NOTE (mristin):
+            # This is a tough call to make. We decide that a value, for which we
+            # know that it might be null, will not be de-referenced. On the other
+            # hand, if the value is certainly not null, we de-reference it.
+            #
+            # The problem here is that the actual type of the argument in C++ changes
+            # depending on whether we check for its nullness before with an implication.
             arg: Optional[Stripped]
             if isinstance(arg_type, intermediate_type_inference.OptionalTypeAnnotation):
                 arg, error = self.transform(arg_node)

--- a/test_data/cpp/test_main/aas_core_meta.v3/expected_output/verification.cpp
+++ b/test_data/cpp/test_main/aas_core_meta.v3/expected_output/verification.cpp
@@ -11560,7 +11560,7 @@ void OfSubmodelElementList::Execute() {
               (
                 (!(instance_->value().has_value()))
                 || PropertiesOrRangesHaveValueType(
-                  instance_->value(),
+                  (*(instance_->value())),
                   (*(instance_->value_type_list_element()))
                 )
               )

--- a/tests/common.py
+++ b/tests/common.py
@@ -93,6 +93,29 @@ def translate_source_to_intermediate(
     return intermediate.translate(parsed_symbol_table=parsed_symbol_table, atok=atok)
 
 
+def must_translate_source_to_intermediate(
+    source: str,
+) -> intermediate.SymbolTable:
+    atok, parse_exception = parse.source_to_atok(source=source)
+    if parse_exception:
+        raise parse_exception  # pylint: disable=raising-bad-type
+
+    assert atok is not None
+
+    parsed_symbol_table, error = parse_atok(atok=atok)
+    assert error is None, f"{most_underlying_messages(error)}"
+    assert parsed_symbol_table is not None
+
+    symbol_table, error = intermediate.translate(
+        parsed_symbol_table=parsed_symbol_table, atok=atok
+    )
+    assert (
+        error is None
+    ), f"Unexpected error when parsing the source: {most_underlying_messages(error)}"
+    assert symbol_table is not None
+    return symbol_table
+
+
 #: If set, this environment variable indicates that the golden files should be
 #: re-recorded instead of checked against.
 RERECORD = os.environ.get("AAS_CORE_CODEGEN_RERECORD", "").lower() in (

--- a/tests/cpp/test_verification.py
+++ b/tests/cpp/test_verification.py
@@ -1,0 +1,189 @@
+# pylint: disable=missing-docstring
+
+import unittest
+from typing import List
+
+from aas_core_codegen.common import Stripped, Identifier
+from aas_core_codegen.cpp.verification import _generate as cpp_verification_generate
+from aas_core_codegen.intermediate import type_inference as intermediate_type_inference
+from tests import common as tests_common
+
+
+class Test_against_recorded(unittest.TestCase):
+    def test_optional_vector_in_invariant_not_deferenced(self) -> None:
+        # NOTE (mristin):
+        # This is a regression test where we check that an optional list without
+        # implication is not de-referenced in the invariant's transpiled code.
+
+        source = """\
+class Item:
+    value: str
+    
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+@verification
+@implementation_specific
+def check_something(value: Optional[List[Item]]) -> bool:
+    pass
+
+@invariant(
+    lambda self:
+    check_something(self.value),
+    "Some description"
+)
+class Something:
+    value: Optional[List[Item]]
+    
+    def __init__(self, value: Optional[List[Item]] = None) -> None:
+        self.value = value
+        
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
+
+        symbol_table = tests_common.must_translate_source_to_intermediate(source=source)
+
+        base_environment = intermediate_type_inference.populate_base_environment(
+            symbol_table=symbol_table
+        )
+
+        something_cls = symbol_table.must_find_concrete_class(
+            name=Identifier("Something")
+        )
+
+        environment = intermediate_type_inference.MutableEnvironment(
+            parent=base_environment
+        )
+        environment.set(
+            identifier=Identifier("self"),
+            type_annotation=intermediate_type_inference.OurTypeAnnotation(
+                our_type=something_cls
+            ),
+        )
+
+        blocks = []  # type: List[Stripped]
+        for invariant in something_cls.invariants:
+            (
+                condition_expr,
+                error,
+            ) = cpp_verification_generate._transpile_class_invariant(
+                invariant=invariant, symbol_table=symbol_table, environment=environment
+            )
+            assert error is None, (
+                f"Unexpected generation error for an invariant: "
+                f"{tests_common.most_underlying_messages(error)}"
+            )
+            assert condition_expr is not None
+
+            blocks.append(condition_expr)
+
+        assert len(blocks) == 1, (
+            f"Expected only a single block for a single invariant "
+            f"in the class {something_cls.name!r}"
+        )
+
+        # NOTE (mristin):
+        # The implementation of ``CheckSomething`` needs to deal with the optional
+        # values. As soon as something is optional in C++, it will be provided to
+        # the function as-is. This is intentional.
+        self.assertEqual(
+            """\
+CheckSomething(
+  instance_->value()
+)""",
+            blocks[0],
+        )
+
+    def test_optional_in_invariant_dereferenced_if_certainly_not_null(
+        self,
+    ) -> None:
+        # NOTE (mristin):
+        # This is a regression test where we check that an optional value is correctly
+        # de-referenced in the invariant's transpiled code if type inference determines
+        # that it is certainly not null.
+
+        source = """\
+class Item:
+    value: str
+
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+@verification
+@implementation_specific
+def check_something(value: Optional[List[Item]]) -> bool:
+    pass
+
+@invariant(
+    lambda self:
+    (self.value is None) or check_something(self.value),
+    "Some description"
+)
+class Something:
+    value: Optional[List[Item]]
+
+    def __init__(self, value: Optional[List[Item]] = None) -> None:
+        self.value = value
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
+
+        symbol_table = tests_common.must_translate_source_to_intermediate(source=source)
+
+        base_environment = intermediate_type_inference.populate_base_environment(
+            symbol_table=symbol_table
+        )
+
+        something_cls = symbol_table.must_find_concrete_class(
+            name=Identifier("Something")
+        )
+
+        environment = intermediate_type_inference.MutableEnvironment(
+            parent=base_environment
+        )
+        environment.set(
+            identifier=Identifier("self"),
+            type_annotation=intermediate_type_inference.OurTypeAnnotation(
+                our_type=something_cls
+            ),
+        )
+
+        blocks = []  # type: List[Stripped]
+        for invariant in something_cls.invariants:
+            (
+                condition_expr,
+                error,
+            ) = cpp_verification_generate._transpile_class_invariant(
+                invariant=invariant, symbol_table=symbol_table, environment=environment
+            )
+            assert error is None, (
+                f"Unexpected generation error for an invariant: "
+                f"{tests_common.most_underlying_messages(error)}"
+            )
+            assert condition_expr is not None
+
+            blocks.append(condition_expr)
+
+        assert len(blocks) == 1, (
+            f"Expected only a single block for a single invariant "
+            f"in the class {something_cls.name!r}"
+        )
+
+        # NOTE (mristin):
+        # If we know that the value is not optional, we explicitly de-reference it.
+        self.assertEqual(
+            """\
+(
+  (!(instance_->value().has_value()))
+  || CheckSomething(
+    (*(instance_->value()))
+  )
+)""",
+            blocks[0],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/intermediate/test_type_inference.py
+++ b/tests/intermediate/test_type_inference.py
@@ -252,6 +252,28 @@ class Test_with_smoke(unittest.TestCase):
 
         Test_with_smoke.execute(source=source)
 
+    def test_non_nullness_in_disjunction_with_is_none(self) -> None:
+        source = textwrap.dedent(
+            """\
+            @invariant(
+                lambda self:
+                (self.some_property is None) or (self.some_property == "dummy"),
+                "Dummy description"
+            )
+            class Something:
+                some_property: Optional[str]
+
+                def __init__(self, some_property: Optional[str] = None) -> None:
+                    self.some_property = some_property
+
+
+            __version__ = "dummy"
+            __xml_namespace__ = "https://dummy.com"
+            """
+        )
+
+        Test_with_smoke.execute(source=source)
+
     def test_is_none_fails_on_non_optional(self) -> None:
         source = textwrap.dedent(
             """\


### PR DESCRIPTION
We extend the type inference to, correctly, consider the case with disjunctions (``or``) with nullness checks (``is None``).

For example, ``(A is None) or (A == 3)`` means that the first value in the disjunction (``A is None``) implies that ``A`` is non-null in the second value (``A == 3``).