### PR TITLE
Fix issues in SHACL

### DIFF
--- a/aas_core_codegen/rdf_shacl/shacl.py
+++ b/aas_core_codegen/rdf_shacl/shacl.py
@@ -7,6 +7,7 @@ from icontract import ensure, require
 
 from aas_core_codegen import intermediate, specific_implementations, infer_for_schema
 from aas_core_codegen.common import Stripped, Error, assert_never, Identifier
+from aas_core_codegen.infer_for_schema import PatternConstraint
 from aas_core_codegen.jsonschema import main as jsonschema_main
 from aas_core_codegen.rdf_shacl import (
     naming as rdf_shacl_naming,
@@ -23,6 +24,7 @@ def _define_property_shape(
     xml_namespace: Stripped,
     our_type_to_rdfs_range: rdf_shacl_common.OurTypeToRdfsRange,
     constraints_by_property: infer_for_schema.ConstraintsByProperty,
+    pattern_constraint: PatternConstraint
 ) -> Tuple[Optional[Stripped], Optional[Error]]:
     """
     Generate the shape of a property ``prop`` of the intermediate ``cls``.
@@ -31,8 +33,6 @@ def _define_property_shape(
     """
 
     len_constraint = constraints_by_property.len_constraints_by_property.get(prop, None)
-
-    pattern_constraints = constraints_by_property.patterns_by_property.get(prop, [])
 
     # NOTE (mristin, 2023-02-08):
     # This check might come as a bit off. In SHACL, to the best of our understanding —
@@ -43,7 +43,7 @@ def _define_property_shape(
     # further constraints in the descendant classes.
     if (
         len_constraint is None
-        and len(pattern_constraints) == 0
+        and pattern_constraint is None
         and prop.specified_for is not cls
     ):
         return Stripped(""), None
@@ -214,7 +214,7 @@ def _define_property_shape(
 
     # region Define patterns
 
-    for pattern_constraint in pattern_constraints:
+    if pattern_constraint:
         # NOTE (mristin):
         # We need to render the regular expression so that the pattern appears in
         # the canonical form. The original pattern in the specification might be written
@@ -266,20 +266,29 @@ def _define_for_class(
     errors = []  # type: List[Error]
 
     for prop in cls.properties:
-        prop_block, error = _define_property_shape(
-            prop=prop,
-            cls=cls,
-            xml_namespace=xml_namespace,
-            our_type_to_rdfs_range=our_type_to_rdfs_range,
-            constraints_by_property=constraints_by_property,
-        )
+        pattern_constraints = constraints_by_property.patterns_by_property.get(prop, [None,])
+        for pattern_constraint in pattern_constraints:
+            # NOTE (mhrimaz):
+            # In SHACL, a PropertyShape cannot have multiple sh:pattern
+            # this is not valid according to shacl-shacl rules
+            # https://github.com/w3c/data-shapes/blob/gh-pages/shacl/shacl-shacl.ttl
+            # and the behaviour of validator engine is not predictable. So we need to
+            # create multiple sh:property
+            prop_block, error = _define_property_shape(
+                prop=prop,
+                cls=cls,
+                xml_namespace=xml_namespace,
+                our_type_to_rdfs_range=our_type_to_rdfs_range,
+                constraints_by_property=constraints_by_property,
+                pattern_constraint=pattern_constraint
+            )
 
-        if error is not None:
-            errors.append(error)
-        else:
-            assert prop_block is not None
-            if prop_block != "":
-                prop_blocks.append(prop_block)
+            if error is not None:
+                errors.append(error)
+            else:
+                assert prop_block is not None
+                if prop_block != "":
+                    prop_blocks.append(prop_block)
 
     if len(errors) > 0:
         return None, Error(

--- a/aas_core_codegen/rdf_shacl/shacl.py
+++ b/aas_core_codegen/rdf_shacl/shacl.py
@@ -335,7 +335,7 @@ sh:sparql [
 {I}sh:select """
 {II}SELECT ?this ?type
 {II}WHERE {{
-{III}?this rdf:type ?type .
+{III}?this <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
 {III}FILTER (?type = aas:{cls_name})
 {II}}}
 {I}""" ;

--- a/aas_core_codegen/rdf_shacl/shacl.py
+++ b/aas_core_codegen/rdf_shacl/shacl.py
@@ -357,8 +357,6 @@ def generate(
 
 # Metadata
 <{xml_namespace}/> a owl:Ontology ;
-    owl:imports <http://datashapes.org/dash> ;
-    owl:imports sh: ;
     sh:declare [
         a sh:PrefixDeclaration ;
         sh:namespace "{xml_namespace}/"^^xs:anyURI ;

--- a/aas_core_codegen/rdf_shacl/shacl.py
+++ b/aas_core_codegen/rdf_shacl/shacl.py
@@ -301,7 +301,7 @@ aas:{shape_name} a sh:NodeShape ;
             Identifier(f"{inheritance.name}_shape")
         )
 
-        writer.write(f"\n{I}rdfs:subClassOf aas:{subclass_shape_name} ;")
+        writer.write(f"\n{I}sh:node aas:{subclass_shape_name} ;")
 
     if isinstance(cls, intermediate.AbstractClass):
         writer.write("\n")


### PR DESCRIPTION
This pull request fixes some critical issues in the current SHACL #519 and also some of the mentioned issues in https://github.com/admin-shell-io/aas-specs/issues/421

Regarding #519

We had:
```turtle
aas:LangStringDefinitionTypeIec61360Shape a sh:NodeShape ;
    sh:targetClass aas:LangStringDefinitionTypeIec61360 ;
    rdfs:subClassOf aas:AbstractLangStringShape ;
    sh:property [
        a sh:PropertyShape ;
        # *********************************************PROBLEM IS HERE
        sh:path <https://admin-shell.io/aas/3/0/LangStringDefinitionTypeIec61360/text> ;
        sh:datatype xs:string ;
        sh:minCount 1 ;
        sh:maxCount 1 ;
        sh:maxLength 1023 ;
    ] ;
.
```
Now we have:
```turtle
aas:LangStringDefinitionTypeIec61360Shape a sh:NodeShape ;
    sh:targetClass aas:LangStringDefinitionTypeIec61360 ;
    sh:node aas:AbstractLangStringShape ; 
    sh:property [
        a sh:PropertyShape ;
        # **********************************************CHANGE IS HERE
        sh:path <https://admin-shell.io/aas/3/0/AbstractLangString/text> ; 
        sh:datatype xs:string ;
        sh:minCount 1 ;
        sh:maxCount 1 ;
        sh:maxLength 1023 ;
    ] ;
.
```
Which means: previously we had to have  `<https://admin-shell.io/aas/3/0/LangStringDefinitionTypeIec61360/text>` as predicate (DatatypeProperty) for instances of `aas:LangStringDefinitionTypeIec61360`. However, in the generated sample data, and also in the ontology this predicate is missing. So instead of using concrete class in the predicate we should use the abstract class name. IMO, data and ontology are fine and we don't need to change them, SHACL is actually wrong and we can fix it with less side effects (I hope).

---

> - [x] Remove this first pattern wherever possible. It says "only printable Unicode chars" and most of the time is redundant (eg digits are printable chars)

Having multiple pattern in a PropertyShape is not allowed. Two duplicate property path created. Of course this is redundant, and having generic printable regex when other patterns are much more restrictive is unnecessary. People can remove that extra PropertyShape for performance reasons.

We had:
```turtle
aas:ReferableShape a sh:NodeShape ;
    sh:targetClass aas:Referable ;
    rdfs:subClassOf aas:HasExtensionsShape ;
    sh:sparql [
        a sh:SPARQLConstraint ;
        sh:message "(ReferableShape): An aas:Referable is an abstract class. Please use one of the subclasses for the generation of instances."@en ;
        sh:prefixes aas: ;
        sh:select """
            SELECT ?this ?type
            WHERE {
                ?this rdf:type ?type .
                FILTER (?type = aas:Referable)
            }
        """ ;
    ] ;
    sh:property [
        a sh:PropertyShape ;
        sh:path <https://admin-shell.io/aas/3/0/Referable/category> ;
        sh:datatype xs:string ;
        sh:minCount 0 ;
        sh:maxCount 1 ;
        sh:minLength 1 ;
        sh:maxLength 128 ;
        sh:pattern "^[\\x09\\x0A\\x0D\\x20-\\uD7FF\\uE000-\\uFFFD\\U00010000-\\U0010FFFF]*$" ;
    ] ;
    sh:property [
        a sh:PropertyShape ;
        sh:path <https://admin-shell.io/aas/3/0/Referable/idShort> ;
        sh:datatype xs:string ;
        sh:minCount 0 ;
        sh:maxCount 1 ;
        sh:minLength 1 ;
        sh:maxLength 128 ;
        sh:pattern "^[\\x09\\x0A\\x0D\\x20-\\uD7FF\\uE000-\\uFFFD\\U00010000-\\U0010FFFF]*$" ;
        sh:pattern "^[a-zA-Z][a-zA-Z0-9_]*$" ;
        #<<---- **********************************************TWO sh:pattern IS NOT ALLOWED!
    ] ;
    sh:property [
        a sh:PropertyShape ;
        sh:path <https://admin-shell.io/aas/3/0/Referable/displayName> ;
        sh:class aas:LangStringNameType ;
        sh:minCount 0 ;
    ] ;
    sh:property [
        a sh:PropertyShape ;
        sh:path <https://admin-shell.io/aas/3/0/Referable/description> ;
        sh:class aas:LangStringTextType ;
        sh:minCount 0 ;
    ] ;
.
```
Now we have:
```turtle
aas:ReferableShape a sh:NodeShape ;
    sh:targetClass aas:Referable ;
    sh:node aas:HasExtensionsShape ;
    sh:sparql [
        a sh:SPARQLConstraint ;
        sh:message "(ReferableShape): An aas:Referable is an abstract class. Please use one of the subclasses for the generation of instances."@en ;
        sh:prefixes aas: ;
        sh:select """
            SELECT ?this ?type
            WHERE {
                ?this <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type .
                FILTER (?type = aas:Referable)
            }
        """ ;
    ] ;
    sh:property [
        a sh:PropertyShape ;
        sh:path <https://admin-shell.io/aas/3/0/Referable/category> ;
        sh:datatype xs:string ;
        sh:minCount 0 ;
        sh:maxCount 1 ;
        sh:minLength 1 ;
        sh:maxLength 128 ;
        sh:pattern "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$" ;
    ] ; 
    #<<---- **********************************************CHANGE BEGINS HERE
    sh:property [
        a sh:PropertyShape ;
        sh:path <https://admin-shell.io/aas/3/0/Referable/idShort> ;
        sh:datatype xs:string ;
        sh:minCount 0 ;
        sh:maxCount 1 ;
        sh:minLength 1 ;
        sh:maxLength 128 ;
        sh:pattern "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$" ; 
    ] ;
    sh:property [
        a sh:PropertyShape ;
        sh:path <https://admin-shell.io/aas/3/0/Referable/idShort> ; 
        sh:datatype xs:string ;
        sh:minCount 0 ;
        sh:maxCount 1 ;
        sh:minLength 1 ;
        sh:maxLength 128 ;
        sh:pattern "^[a-zA-Z][a-zA-Z0-9_]*$" ; 
    ] ;
    #<<---- **********************************************CHANGE ENDS HERE
    sh:property [
        a sh:PropertyShape ;
        sh:path <https://admin-shell.io/aas/3/0/Referable/displayName> ;
        sh:class aas:LangStringNameType ;
        sh:minCount 0 ;
    ] ;
    sh:property [
        a sh:PropertyShape ;
        sh:path <https://admin-shell.io/aas/3/0/Referable/description> ;
        sh:class aas:LangStringTextType ;
        sh:minCount 0 ;
    ] ;
.
```
Which means: previously it wasn't possible to validate the shacl against the [shacl-shacl](https://github.com/w3c/data-shapes/blob/gh-pages/shacl/shacl-shacl.ttl) (shacl metamodel or shacl-shacl) for example using `pyshacl -m` flag throws an error when you have two `sh:pattern`.

---

> - [x] Declaring a shape subClassOf another shape is questionable at best (a Shape is not a Class, so it cannot be a subClass). What is the purpose of this? (shapes are not inherited this way)

We had:
```turtle
aas:LangStringDefinitionTypeIec61360Shape a sh:NodeShape ;
    sh:targetClass aas:LangStringDefinitionTypeIec61360 ;
    rdfs:subClassOf aas:AbstractLangStringShape ;
    sh:property [
        a sh:PropertyShape ;
        sh:path <https://admin-shell.io/aas/3/0/LangStringDefinitionTypeIec61360/text> ;
        sh:datatype xs:string ;
        sh:minCount 1 ;
        sh:maxCount 1 ;
        sh:maxLength 1023 ;
    ] ;
.
```
Now we have:
```turtle
aas:LangStringDefinitionTypeIec61360Shape a sh:NodeShape ;
    sh:targetClass aas:LangStringDefinitionTypeIec61360 ;
    sh:node aas:AbstractLangStringShape ; #<<---- **********************************************CHANGE IS HERE
    sh:property [
        a sh:PropertyShape ;
        sh:path <https://admin-shell.io/aas/3/0/AbstractLangString/text> ;
        sh:datatype xs:string ;
        sh:minCount 1 ;
        sh:maxCount 1 ;
        sh:maxLength 1023 ;
    ] ;
.
```
Which means: previously `rdfs:subClassOf aas:AbstractLangStringShape ;` had no effect, since we don't have sub classing in SHACL, and rather we should use `sh:node` to state that another NodeShape should hold.

---

> - [x] remove owl:imports <http://datashapes.org/dash> since it doesn't use DASH shape constructs
> - [x] remove owl:imports sh: since it doesn't use shapes from that URL (see https://book.validatingrdf.com/bookHtml011.html#sec126)

They are removed.

---

@mristin I am not aware of all aspects, feel free to modify, change, refactor the code. I haven't added the generated shacl.