### PR TITLE
Update test data to aas-core-meta 77d3442

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
             "twine",
             "jsonschema==3.2.0",
             "xmlschema==3.3.1",
-            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@35aa2cc#egg=aas-core-meta",
+            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@77d3442#egg=aas-core-meta",
             "ssort==0.12.3",
         ]
     },

--- a/test_data/cpp/test_main/aas_core_meta.v3/expected_output/enhancing.hpp
+++ b/test_data/cpp/test_main/aas_core_meta.v3/expected_output/enhancing.hpp
@@ -7104,20 +7104,6 @@ class EnhancedEmbeddedDataSpecification
     return types::ModelType::kEmbeddedDataSpecification;
   }
 
-  const std::shared_ptr<types::IDataSpecificationContent>& data_specification_content() const override {
-    return instance_->data_specification_content();
-  }
-
-  std::shared_ptr<types::IDataSpecificationContent>& mutable_data_specification_content() override {
-    return instance_->mutable_data_specification_content();
-  }
-
-  void set_data_specification_content(
-    std::shared_ptr<types::IDataSpecificationContent> value
-  ) override {
-    instance_->set_data_specification_content(value);
-  }
-
   const std::shared_ptr<types::IReference>& data_specification() const override {
     return instance_->data_specification();
   }
@@ -7130,6 +7116,20 @@ class EnhancedEmbeddedDataSpecification
     std::shared_ptr<types::IReference> value
   ) override {
     instance_->set_data_specification(value);
+  }
+
+  const std::shared_ptr<types::IDataSpecificationContent>& data_specification_content() const override {
+    return instance_->data_specification_content();
+  }
+
+  std::shared_ptr<types::IDataSpecificationContent>& mutable_data_specification_content() override {
+    return instance_->mutable_data_specification_content();
+  }
+
+  void set_data_specification_content(
+    std::shared_ptr<types::IDataSpecificationContent> value
+  ) override {
+    instance_->set_data_specification_content(value);
   }
 
   const std::shared_ptr<E>& enhancement() const {
@@ -13524,16 +13524,16 @@ std::shared_ptr<types::IEmbeddedDataSpecification> WrapEmbeddedDataSpecification
   // We assume that we already checked whether `that` has been enhanced
   // in the caller.
 
-  that->set_data_specification_content(
+  that->set_data_specification(
     Wrap<E>(
-      that->data_specification_content(),
+      that->data_specification(),
       factory
     )
   );
 
-  that->set_data_specification(
+  that->set_data_specification_content(
     Wrap<E>(
-      that->data_specification(),
+      that->data_specification_content(),
       factory
     )
   );

--- a/test_data/cpp/test_main/aas_core_meta.v3/expected_output/iteration.cpp
+++ b/test_data/cpp/test_main/aas_core_meta.v3/expected_output/iteration.cpp
@@ -11300,10 +11300,10 @@ void IteratorOverEmbeddedDataSpecification::Execute() {
         index_ = -1;
         done_ = false;
 
-        property_ = Property::kDataSpecificationContent;
+        property_ = Property::kDataSpecification;
         item_ = std::move(
           std::static_pointer_cast<types::IClass>(
-            casted_->data_specification_content()
+            casted_->data_specification()
           )
         );
         ++index_;
@@ -11313,10 +11313,10 @@ void IteratorOverEmbeddedDataSpecification::Execute() {
       }
 
       case 1: {
-        property_ = Property::kDataSpecification;
+        property_ = Property::kDataSpecificationContent;
         item_ = std::move(
           std::static_pointer_cast<types::IClass>(
-            casted_->data_specification()
+            casted_->data_specification_content()
           )
         );
         ++index_;

--- a/test_data/cpp/test_main/aas_core_meta.v3/expected_output/jsonization.cpp
+++ b/test_data/cpp/test_main/aas_core_meta.v3/expected_output/jsonization.cpp
@@ -23529,8 +23529,8 @@ std::pair<
 }
 
 std::set<std::string> kPropertiesInEmbeddedDataSpecification = {
-  "dataSpecificationContent",
-  "dataSpecification"
+  "dataSpecification",
+  "dataSpecificationContent"
 };
 
 std::pair<
@@ -23585,18 +23585,6 @@ std::pair<
 
   // region Check required properties
 
-  if (!json.contains("dataSpecificationContent")) {
-    return std::make_pair<
-      common::optional<std::shared_ptr<types::IEmbeddedDataSpecification> >,
-      common::optional<DeserializationError>
-    >(
-      common::nullopt,
-      common::make_optional<DeserializationError>(
-        L"The required property dataSpecificationContent is missing"
-      )
-    );
-  }
-
   if (!json.contains("dataSpecification")) {
     return std::make_pair<
       common::optional<std::shared_ptr<types::IEmbeddedDataSpecification> >,
@@ -23609,45 +23597,29 @@ std::pair<
     );
   }
 
+  if (!json.contains("dataSpecificationContent")) {
+    return std::make_pair<
+      common::optional<std::shared_ptr<types::IEmbeddedDataSpecification> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      common::make_optional<DeserializationError>(
+        L"The required property dataSpecificationContent is missing"
+      )
+    );
+  }
+
   // endregion Check required properties
 
   // region Initialization
 
   common::optional<DeserializationError> error;
 
-  common::optional<std::shared_ptr<types::IDataSpecificationContent> > the_data_specification_content;
-
   common::optional<std::shared_ptr<types::IReference> > the_data_specification;
 
+  common::optional<std::shared_ptr<types::IDataSpecificationContent> > the_data_specification_content;
+
   // endregion Initialization
-
-  // region De-serialize dataSpecificationContent
-
-  std::tie(
-    the_data_specification_content,
-    error
-  ) = DeserializeDataSpecificationContent(
-    json["dataSpecificationContent"],
-    additional_properties
-  );
-
-  if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<PropertySegment>(
-        L"dataSpecificationContent"
-      )
-    );
-
-    return std::make_pair<
-      common::optional<std::shared_ptr<types::IEmbeddedDataSpecification> >,
-      common::optional<DeserializationError>
-    >(
-      common::nullopt,
-      std::move(error)
-    );
-  }
-
-  // endregion De-serialize dataSpecificationContent
 
   // region De-serialize dataSpecification
 
@@ -23677,6 +23649,34 @@ std::pair<
 
   // endregion De-serialize dataSpecification
 
+  // region De-serialize dataSpecificationContent
+
+  std::tie(
+    the_data_specification_content,
+    error
+  ) = DeserializeDataSpecificationContent(
+    json["dataSpecificationContent"],
+    additional_properties
+  );
+
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<PropertySegment>(
+        L"dataSpecificationContent"
+      )
+    );
+
+    return std::make_pair<
+      common::optional<std::shared_ptr<types::IEmbeddedDataSpecification> >,
+      common::optional<DeserializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  // endregion De-serialize dataSpecificationContent
+
   return std::make_pair(
     common::make_optional<
       std::shared_ptr<types::IEmbeddedDataSpecification>
@@ -23685,8 +23685,8 @@ std::pair<
       // We deliberately do not use std::make_shared here to avoid an unnecessary
       // upcast.
       new types::EmbeddedDataSpecification(
-        std::move(*the_data_specification_content),
-        std::move(*the_data_specification)
+        std::move(*the_data_specification),
+        std::move(*the_data_specification_content)
       )
     ),
     common::nullopt
@@ -36920,33 +36920,6 @@ std::pair<
 
   common::optional<SerializationError> error;
 
-  common::optional<nlohmann::json> json_data_specification_content;
-  std::tie(
-    json_data_specification_content,
-    error
-  ) = SerializeIClass(
-    *that.data_specification_content()
-  );
-  if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kDataSpecificationContent
-      )
-    );
-
-    return std::make_pair<
-      common::optional<nlohmann::json>,
-      common::optional<SerializationError>
-    >(
-      common::nullopt,
-      std::move(error)
-    );
-  }
-
-  result["dataSpecificationContent"] = std::move(
-    *json_data_specification_content
-  );
-
   common::optional<nlohmann::json> json_data_specification;
   std::tie(
     json_data_specification,
@@ -36972,6 +36945,33 @@ std::pair<
 
   result["dataSpecification"] = std::move(
     *json_data_specification
+  );
+
+  common::optional<nlohmann::json> json_data_specification_content;
+  std::tie(
+    json_data_specification_content,
+    error
+  ) = SerializeIClass(
+    *that.data_specification_content()
+  );
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<iteration::PropertySegment>(
+        iteration::Property::kDataSpecificationContent
+      )
+    );
+
+    return std::make_pair<
+      common::optional<nlohmann::json>,
+      common::optional<SerializationError>
+    >(
+      common::nullopt,
+      std::move(error)
+    );
+  }
+
+  result["dataSpecificationContent"] = std::move(
+    *json_data_specification_content
   );
 
   return std::make_pair<

--- a/test_data/cpp/test_main/aas_core_meta.v3/expected_output/types.cpp
+++ b/test_data/cpp/test_main/aas_core_meta.v3/expected_output/types.cpp
@@ -6911,30 +6911,16 @@ void Environment::set_concept_descriptions(
 // region EmbeddedDataSpecification
 
 EmbeddedDataSpecification::EmbeddedDataSpecification(
-  std::shared_ptr<IDataSpecificationContent> data_specification_content,
-  std::shared_ptr<IReference> data_specification
+  std::shared_ptr<IReference> data_specification,
+  std::shared_ptr<IDataSpecificationContent> data_specification_content
 ) {
-  data_specification_content_ = std::move(data_specification_content);
-
   data_specification_ = std::move(data_specification);
+
+  data_specification_content_ = std::move(data_specification_content);
 }
 
 ModelType EmbeddedDataSpecification::model_type() const {
   return ModelType::kEmbeddedDataSpecification;
-}
-
-const std::shared_ptr<IDataSpecificationContent>& EmbeddedDataSpecification::data_specification_content() const {
-  return data_specification_content_;
-}
-
-std::shared_ptr<IDataSpecificationContent>& EmbeddedDataSpecification::mutable_data_specification_content() {
-  return data_specification_content_;
-}
-
-void EmbeddedDataSpecification::set_data_specification_content(
-  std::shared_ptr<IDataSpecificationContent> value
-) {
-  data_specification_content_ = value;
 }
 
 const std::shared_ptr<IReference>& EmbeddedDataSpecification::data_specification() const {
@@ -6949,6 +6935,20 @@ void EmbeddedDataSpecification::set_data_specification(
   std::shared_ptr<IReference> value
 ) {
   data_specification_ = value;
+}
+
+const std::shared_ptr<IDataSpecificationContent>& EmbeddedDataSpecification::data_specification_content() const {
+  return data_specification_content_;
+}
+
+std::shared_ptr<IDataSpecificationContent>& EmbeddedDataSpecification::mutable_data_specification_content() {
+  return data_specification_content_;
+}
+
+void EmbeddedDataSpecification::set_data_specification_content(
+  std::shared_ptr<IDataSpecificationContent> value
+) {
+  data_specification_content_ = value;
 }
 
 // endregion EmbeddedDataSpecification

--- a/test_data/cpp/test_main/aas_core_meta.v3/expected_output/types.hpp
+++ b/test_data/cpp/test_main/aas_core_meta.v3/expected_output/types.hpp
@@ -2927,19 +2927,6 @@ class IEmbeddedDataSpecification
     : virtual public IClass {
  public:
   ///@{
-  /// \brief Actual content of the data specification
-
-  virtual const std::shared_ptr<IDataSpecificationContent>& data_specification_content() const = 0;
-
-  virtual std::shared_ptr<IDataSpecificationContent>& mutable_data_specification_content() = 0;
-
-  virtual void set_data_specification_content(
-    std::shared_ptr<IDataSpecificationContent> value
-  ) = 0;
-
-  ///@}
-
-  ///@{
   /// \brief Reference to the data specification
 
   virtual const std::shared_ptr<IReference>& data_specification() const = 0;
@@ -2948,6 +2935,19 @@ class IEmbeddedDataSpecification
 
   virtual void set_data_specification(
     std::shared_ptr<IReference> value
+  ) = 0;
+
+  ///@}
+
+  ///@{
+  /// \brief Actual content of the data specification
+
+  virtual const std::shared_ptr<IDataSpecificationContent>& data_specification_content() const = 0;
+
+  virtual std::shared_ptr<IDataSpecificationContent>& mutable_data_specification_content() = 0;
+
+  virtual void set_data_specification_content(
+    std::shared_ptr<IDataSpecificationContent> value
   ) = 0;
 
   ///@}
@@ -10270,23 +10270,11 @@ class EmbeddedDataSpecification
     : public IEmbeddedDataSpecification {
  public:
   EmbeddedDataSpecification(
-    std::shared_ptr<IDataSpecificationContent> data_specification_content,
-    std::shared_ptr<IReference> data_specification
+    std::shared_ptr<IReference> data_specification,
+    std::shared_ptr<IDataSpecificationContent> data_specification_content
   );
 
   ModelType model_type() const override;
-
-  // region Get and set data_specification_content_
-
-  const std::shared_ptr<IDataSpecificationContent>& data_specification_content() const override;
-
-  std::shared_ptr<IDataSpecificationContent>& mutable_data_specification_content() override;
-
-  void set_data_specification_content(
-    std::shared_ptr<IDataSpecificationContent> value
-  ) override;
-
-  // endregion
 
   // region Get and set data_specification_
 
@@ -10300,12 +10288,24 @@ class EmbeddedDataSpecification
 
   // endregion
 
+  // region Get and set data_specification_content_
+
+  const std::shared_ptr<IDataSpecificationContent>& data_specification_content() const override;
+
+  std::shared_ptr<IDataSpecificationContent>& mutable_data_specification_content() override;
+
+  void set_data_specification_content(
+    std::shared_ptr<IDataSpecificationContent> value
+  ) override;
+
+  // endregion
+
   ~EmbeddedDataSpecification() override = default;
 
  private:
-  std::shared_ptr<IDataSpecificationContent> data_specification_content_;
-
   std::shared_ptr<IReference> data_specification_;
+
+  std::shared_ptr<IDataSpecificationContent> data_specification_content_;
 };
 
 class LevelType

--- a/test_data/cpp/test_main/aas_core_meta.v3/expected_output/visitation.cpp
+++ b/test_data/cpp/test_main/aas_core_meta.v3/expected_output/visitation.cpp
@@ -3090,14 +3090,14 @@ void PassThroughVisitor::VisitEnvironment(
 void PassThroughVisitor::VisitEmbeddedDataSpecification(
   const std::shared_ptr<types::IEmbeddedDataSpecification>& that
 ) {
-  // mutable_data_specification_content
-  Visit(
-    that->mutable_data_specification_content()
-  );
-
   // mutable_data_specification
   Visit(
     that->mutable_data_specification()
+  );
+
+  // mutable_data_specification_content
+  Visit(
+    that->mutable_data_specification_content()
   );
 }
 

--- a/test_data/cpp/test_main/aas_core_meta.v3/expected_output/xmlization.cpp
+++ b/test_data/cpp/test_main/aas_core_meta.v3/expected_output/xmlization.cpp
@@ -14216,8 +14216,8 @@ enum class OfEnvironment : std::uint32_t {
 };  // enum class OfEnvironment
 
 enum class OfEmbeddedDataSpecification : std::uint32_t {
-  kDataSpecificationContent = 0,
-  kDataSpecification = 1
+  kDataSpecification = 0,
+  kDataSpecificationContent = 1
 };  // enum class OfEmbeddedDataSpecification
 
 enum class OfLevelType : std::uint32_t {
@@ -15447,12 +15447,12 @@ const std::unordered_map<
   OfEmbeddedDataSpecification
 > kMapOfEmbeddedDataSpecification = {
   {
-    "dataSpecificationContent",
-    OfEmbeddedDataSpecification::kDataSpecificationContent
-  },
-  {
     "dataSpecification",
     OfEmbeddedDataSpecification::kDataSpecification
+  },
+  {
+    "dataSpecificationContent",
+    OfEmbeddedDataSpecification::kDataSpecificationContent
   }
 };
 
@@ -31505,9 +31505,9 @@ std::pair<
 
   // region Initialization
 
-  common::optional<std::shared_ptr<types::IDataSpecificationContent> > the_data_specification_content;
-
   common::optional<std::shared_ptr<types::IReference> > the_data_specification;
+
+  common::optional<std::shared_ptr<types::IDataSpecificationContent> > the_data_specification_content;
 
   // endregion Initialization
 
@@ -31586,12 +31586,6 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfEmbeddedDataSpecification::kDataSpecificationContent:
-        std::tie(
-          the_data_specification_content,
-          error
-        ) = DataSpecificationContentFromElement(reader);
-        break;
       case properties::OfEmbeddedDataSpecification::kDataSpecification:
         std::tie(
           the_data_specification,
@@ -31599,6 +31593,12 @@ std::pair<
         ) = ReferenceFromSequence<
           types::IReference
         >(reader);
+        break;
+      case properties::OfEmbeddedDataSpecification::kDataSpecificationContent:
+        std::tie(
+          the_data_specification_content,
+          error
+        ) = DataSpecificationContentFromElement(reader);
         break;
       default:
         throw std::logic_error(
@@ -31684,19 +31684,19 @@ std::pair<
 
   // region Check required properties
 
-  if (!the_data_specification_content.has_value()) {
-    return NoInstanceAndDeserializationErrorWithCause<
-      std::shared_ptr<T>
-    >(
-      L"The required property dataSpecificationContent is missing"
-    );
-  }
-
   if (!the_data_specification.has_value()) {
     return NoInstanceAndDeserializationErrorWithCause<
       std::shared_ptr<T>
     >(
       L"The required property dataSpecification is missing"
+    );
+  }
+
+  if (!the_data_specification_content.has_value()) {
+    return NoInstanceAndDeserializationErrorWithCause<
+      std::shared_ptr<T>
+    >(
+      L"The required property dataSpecificationContent is missing"
     );
   }
 
@@ -31710,8 +31710,8 @@ std::pair<
       // We deliberately do not use std::make_shared here to avoid an unnecessary
       // upcast.
       new types::EmbeddedDataSpecification(
-        std::move(*the_data_specification_content),
-        std::move(*the_data_specification)
+        std::move(*the_data_specification),
+        std::move(*the_data_specification_content)
       )
     ),
     common::nullopt
@@ -53744,43 +53744,6 @@ common::optional<SerializationError> SerializeEmbeddedDataSpecificationAsSequenc
 ) {
   common::optional<SerializationError> error;
 
-  const std::shared_ptr<types::IDataSpecificationContent>& the_data_specification_content(
-    that.data_specification_content()
-  );
-  writer.StartElement(
-    "dataSpecificationContent"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeDataSpecificationContentAsElement(
-    *the_data_specification_content,
-    writer
-  );
-  if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kDataSpecificationContent
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "dataSpecificationContent"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kDataSpecificationContent
-      )
-    );
-
-    return error;
-  }
-
   const std::shared_ptr<types::IReference>& the_data_specification(
     that.data_specification()
   );
@@ -53812,6 +53775,43 @@ common::optional<SerializationError> SerializeEmbeddedDataSpecificationAsSequenc
     error->path.segments.emplace_front(
       common::make_unique<iteration::PropertySegment>(
         iteration::Property::kDataSpecification
+      )
+    );
+
+    return error;
+  }
+
+  const std::shared_ptr<types::IDataSpecificationContent>& the_data_specification_content(
+    that.data_specification_content()
+  );
+  writer.StartElement(
+    "dataSpecificationContent"
+  );
+  if (writer.error().has_value()) {
+    return writer.move_error();
+  }
+  error = SerializeDataSpecificationContentAsElement(
+    *the_data_specification_content,
+    writer
+  );
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<iteration::PropertySegment>(
+        iteration::Property::kDataSpecificationContent
+      )
+    );
+
+    return error;
+  }
+  writer.StopElement(
+    "dataSpecificationContent"
+  );
+  if (writer.error().has_value()) {
+    error = writer.move_error();
+
+    error->path.segments.emplace_front(
+      common::make_unique<iteration::PropertySegment>(
+        iteration::Property::kDataSpecificationContent
       )
     );
 

--- a/test_data/csharp/test_main/aas_core_meta.v3/expected_output/copying.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3/expected_output/copying.cs
@@ -502,8 +502,8 @@ namespace AasCore.Aas3_0
             )
             {
                 return new Aas.EmbeddedDataSpecification(
-                    that.DataSpecificationContent,
-                    that.DataSpecification);
+                    that.DataSpecification,
+                    that.DataSpecificationContent);
             }
 
             public override Aas.IClass TransformLevelType(
@@ -2456,8 +2456,8 @@ namespace AasCore.Aas3_0
             )
             {
                 return new Aas.EmbeddedDataSpecification(
-                    Deep(that.DataSpecificationContent),
-                    Deep(that.DataSpecification)
+                    Deep(that.DataSpecification),
+                    Deep(that.DataSpecificationContent)
                 );
             }
 

--- a/test_data/csharp/test_main/aas_core_meta.v3/expected_output/enhancing.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3/expected_output/enhancing.cs
@@ -3713,16 +3713,16 @@ namespace AasCore.Aas3_0
                 _instance = instance;
             }
 
-            public IDataSpecificationContent DataSpecificationContent
-            {
-                get => _instance.DataSpecificationContent;
-                set => _instance.DataSpecificationContent = value;
-            }
-
             public IReference DataSpecification
             {
                 get => _instance.DataSpecification;
                 set => _instance.DataSpecification = value;
+            }
+
+            public IDataSpecificationContent DataSpecificationContent
+            {
+                get => _instance.DataSpecificationContent;
+                set => _instance.DataSpecificationContent = value;
             }
 
             public IEnumerable<Aas.IClass> DescendOnce()
@@ -7649,17 +7649,6 @@ namespace AasCore.Aas3_0
                     );
                 }
 
-                var transformedDataSpecificationContent = Transform(
-                    that.DataSpecificationContent
-                );
-                var castedDataSpecificationContent = (
-                    transformedDataSpecificationContent as Aas.IDataSpecificationContent
-                ) ?? throw new System.InvalidOperationException(
-                    "Expected the transformed value to be a IDataSpecificationContent, " +
-                    $"but got: {transformedDataSpecificationContent}"
-                );
-                that.DataSpecificationContent = castedDataSpecificationContent;
-
                 var transformedDataSpecification = Transform(
                     that.DataSpecification
                 );
@@ -7670,6 +7659,17 @@ namespace AasCore.Aas3_0
                     $"but got: {transformedDataSpecification}"
                 );
                 that.DataSpecification = castedDataSpecification;
+
+                var transformedDataSpecificationContent = Transform(
+                    that.DataSpecificationContent
+                );
+                var castedDataSpecificationContent = (
+                    transformedDataSpecificationContent as Aas.IDataSpecificationContent
+                ) ?? throw new System.InvalidOperationException(
+                    "Expected the transformed value to be a IDataSpecificationContent, " +
+                    $"but got: {transformedDataSpecificationContent}"
+                );
+                that.DataSpecificationContent = castedDataSpecificationContent;
 
                 var enhancement = _enhancementFactory(that);
                 return (enhancement == null)

--- a/test_data/csharp/test_main/aas_core_meta.v3/expected_output/jsonization.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3/expected_output/jsonization.cs
@@ -15264,42 +15264,13 @@ namespace AasCore.Aas3_0
                     return null;
                 }
 
-                IDataSpecificationContent? theDataSpecificationContent = null;
                 IReference? theDataSpecification = null;
+                IDataSpecificationContent? theDataSpecificationContent = null;
 
                 foreach (var keyValue in obj)
                 {
                     switch (keyValue.Key)
                     {
-                        case "dataSpecificationContent":
-                        {
-                            if (keyValue.Value == null)
-                            {
-                                error = new Reporting.Error(
-                                    "Unexpected null for a required property");
-                                error.PrependSegment(
-                                    new Reporting.NameSegment(
-                                        "dataSpecificationContent"));
-                                return null;
-                            }
-
-                            theDataSpecificationContent = DeserializeImplementation.IDataSpecificationContentFrom(
-                                keyValue.Value,
-                                out error);
-                            if (error != null)
-                            {
-                                error.PrependSegment(
-                                    new Reporting.NameSegment(
-                                        "dataSpecificationContent"));
-                                return null;
-                            }
-                            if (theDataSpecificationContent == null)
-                            {
-                                throw new System.InvalidOperationException(
-                                    "Unexpected theDataSpecificationContent null when error is also null");
-                            }
-                            break;
-                        }
                         case "dataSpecification":
                         {
                             if (keyValue.Value == null)
@@ -15329,18 +15300,40 @@ namespace AasCore.Aas3_0
                             }
                             break;
                         }
+                        case "dataSpecificationContent":
+                        {
+                            if (keyValue.Value == null)
+                            {
+                                error = new Reporting.Error(
+                                    "Unexpected null for a required property");
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "dataSpecificationContent"));
+                                return null;
+                            }
+
+                            theDataSpecificationContent = DeserializeImplementation.IDataSpecificationContentFrom(
+                                keyValue.Value,
+                                out error);
+                            if (error != null)
+                            {
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "dataSpecificationContent"));
+                                return null;
+                            }
+                            if (theDataSpecificationContent == null)
+                            {
+                                throw new System.InvalidOperationException(
+                                    "Unexpected theDataSpecificationContent null when error is also null");
+                            }
+                            break;
+                        }
                         default:
                             error = new Reporting.Error(
                                 $"Unexpected property: {keyValue.Key}");
                             return null;
                     }
-                }
-
-                if (theDataSpecificationContent == null)
-                {
-                    error = new Reporting.Error(
-                        "Required property \"dataSpecificationContent\" is missing");
-                    return null;
                 }
 
                 if (theDataSpecification == null)
@@ -15350,11 +15343,18 @@ namespace AasCore.Aas3_0
                     return null;
                 }
 
+                if (theDataSpecificationContent == null)
+                {
+                    error = new Reporting.Error(
+                        "Required property \"dataSpecificationContent\" is missing");
+                    return null;
+                }
+
                 return new Aas.EmbeddedDataSpecification(
-                    theDataSpecificationContent
+                    theDataSpecification
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"),
-                    theDataSpecification
+                    theDataSpecificationContent
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"));
             }  // internal static EmbeddedDataSpecificationFrom
@@ -20750,11 +20750,11 @@ namespace AasCore.Aas3_0
             {
                 var result = new Nodes.JsonObject();
 
-                result["dataSpecificationContent"] = Transform(
-                    that.DataSpecificationContent);
-
                 result["dataSpecification"] = Transform(
                     that.DataSpecification);
+
+                result["dataSpecificationContent"] = Transform(
+                    that.DataSpecificationContent);
 
                 return result;
             }

--- a/test_data/csharp/test_main/aas_core_meta.v3/expected_output/types.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3/expected_output/types.cs
@@ -11887,14 +11887,14 @@ namespace AasCore.Aas3_0
     public interface IEmbeddedDataSpecification : IClass
     {
         /// <summary>
-        /// Actual content of the data specification
-        /// </summary>
-        public IDataSpecificationContent DataSpecificationContent { get; set; }
-
-        /// <summary>
         /// Reference to the data specification
         /// </summary>
         public IReference DataSpecification { get; set; }
+
+        /// <summary>
+        /// Actual content of the data specification
+        /// </summary>
+        public IDataSpecificationContent DataSpecificationContent { get; set; }
     }
 
     /// <summary>
@@ -11903,14 +11903,14 @@ namespace AasCore.Aas3_0
     public class EmbeddedDataSpecification : IEmbeddedDataSpecification
     {
         /// <summary>
-        /// Actual content of the data specification
-        /// </summary>
-        public IDataSpecificationContent DataSpecificationContent { get; set; }
-
-        /// <summary>
         /// Reference to the data specification
         /// </summary>
         public IReference DataSpecification { get; set; }
+
+        /// <summary>
+        /// Actual content of the data specification
+        /// </summary>
+        public IDataSpecificationContent DataSpecificationContent { get; set; }
 
         /// <summary>
         /// Iterate over all the class instances referenced from this instance
@@ -11918,9 +11918,9 @@ namespace AasCore.Aas3_0
         /// </summary>
         public IEnumerable<IClass> DescendOnce()
         {
-            yield return DataSpecificationContent;
-
             yield return DataSpecification;
+
+            yield return DataSpecificationContent;
         }
 
         /// <summary>
@@ -11928,18 +11928,18 @@ namespace AasCore.Aas3_0
         /// </summary>
         public IEnumerable<IClass> Descend()
         {
-            yield return DataSpecificationContent;
-
-            // Recurse
-            foreach (var anItem in DataSpecificationContent.Descend())
-            {
-                yield return anItem;
-            }
-
             yield return DataSpecification;
 
             // Recurse
             foreach (var anItem in DataSpecification.Descend())
+            {
+                yield return anItem;
+            }
+
+            yield return DataSpecificationContent;
+
+            // Recurse
+            foreach (var anItem in DataSpecificationContent.Descend())
             {
                 yield return anItem;
             }
@@ -11986,11 +11986,11 @@ namespace AasCore.Aas3_0
         }
 
         public EmbeddedDataSpecification(
-            IDataSpecificationContent dataSpecificationContent,
-            IReference dataSpecification)
+            IReference dataSpecification,
+            IDataSpecificationContent dataSpecificationContent)
         {
-            DataSpecificationContent = dataSpecificationContent;
             DataSpecification = dataSpecification;
+            DataSpecificationContent = dataSpecificationContent;
         }
     }
 

--- a/test_data/csharp/test_main/aas_core_meta.v3/expected_output/verification.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3/expected_output/verification.cs
@@ -9111,19 +9111,19 @@ namespace AasCore.Aas3_0
                 Aas.IEmbeddedDataSpecification that
             )
             {
-                foreach (var error in Verification.Verify(that.DataSpecificationContent))
-                {
-                    error.PrependSegment(
-                        new Reporting.NameSegment(
-                            "dataSpecificationContent"));
-                    yield return error;
-                }
-
                 foreach (var error in Verification.Verify(that.DataSpecification))
                 {
                     error.PrependSegment(
                         new Reporting.NameSegment(
                             "dataSpecification"));
+                    yield return error;
+                }
+
+                foreach (var error in Verification.Verify(that.DataSpecificationContent))
+                {
+                    error.PrependSegment(
+                        new Reporting.NameSegment(
+                            "dataSpecificationContent"));
                     yield return error;
                 }
             }

--- a/test_data/csharp/test_main/aas_core_meta.v3/expected_output/xmlization.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3/expected_output/xmlization.cs
@@ -16958,8 +16958,8 @@ namespace AasCore.Aas3_0
             {
                 error = null;
 
-                IDataSpecificationContent? theDataSpecificationContent = null;
                 IReference? theDataSpecification = null;
+                IDataSpecificationContent? theDataSpecificationContent = null;
 
                 if (!isEmptySequence)
                 {
@@ -17005,6 +17005,20 @@ namespace AasCore.Aas3_0
 
                         switch (elementName)
                         {
+                            case "dataSpecification":
+                            {
+                                theDataSpecification = ReferenceFromSequence(
+                                    reader, isEmptyProperty, out error);
+
+                                if (error != null)
+                                {
+                                    error.PrependSegment(
+                                        new Reporting.NameSegment(
+                                            "dataSpecification"));
+                                    return null;
+                                }
+                                break;
+                            }
                             case "dataSpecificationContent":
                             {
                                 if (isEmptyProperty)
@@ -17054,20 +17068,6 @@ namespace AasCore.Aas3_0
                                     error.PrependSegment(
                                         new Reporting.NameSegment(
                                             "dataSpecificationContent"));
-                                    return null;
-                                }
-                                break;
-                            }
-                            case "dataSpecification":
-                            {
-                                theDataSpecification = ReferenceFromSequence(
-                                    reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "dataSpecification"));
                                     return null;
                                 }
                                 break;
@@ -17125,14 +17125,6 @@ namespace AasCore.Aas3_0
                     }
                 }
 
-                if (theDataSpecificationContent == null)
-                {
-                    error = new Reporting.Error(
-                        "The required property DataSpecificationContent has not been given " +
-                        "in the XML representation of an instance of class EmbeddedDataSpecification");
-                    return null;
-                }
-
                 if (theDataSpecification == null)
                 {
                     error = new Reporting.Error(
@@ -17141,11 +17133,19 @@ namespace AasCore.Aas3_0
                     return null;
                 }
 
+                if (theDataSpecificationContent == null)
+                {
+                    error = new Reporting.Error(
+                        "The required property DataSpecificationContent has not been given " +
+                        "in the XML representation of an instance of class EmbeddedDataSpecification");
+                    return null;
+                }
+
                 return new Aas.EmbeddedDataSpecification(
-                    theDataSpecificationContent
+                    theDataSpecification
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"),
-                    theDataSpecification
+                    theDataSpecificationContent
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"));
             }  // internal static Aas.EmbeddedDataSpecification? EmbeddedDataSpecificationFromSequence
@@ -25823,21 +25823,21 @@ namespace AasCore.Aas3_0
                 Xml.XmlWriter writer)
             {
                 writer.WriteStartElement(
-                    "dataSpecificationContent",
-                    NS);
-
-                this.Visit(
-                    that.DataSpecificationContent,
-                    writer);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
                     "dataSpecification",
                     NS);
 
                 this.ReferenceToSequence(
                     that.DataSpecification,
+                    writer);
+
+                writer.WriteEndElement();
+
+                writer.WriteStartElement(
+                    "dataSpecificationContent",
+                    NS);
+
+                this.Visit(
+                    that.DataSpecificationContent,
                     writer);
 
                 writer.WriteEndElement();

--- a/test_data/golang/test_main/aas_core_meta.v3/expected_output/enhancing/enhancing.go
+++ b/test_data/golang/test_main/aas_core_meta.v3/expected_output/enhancing/enhancing.go
@@ -6148,17 +6148,6 @@ func (eeds *enhancedEmbeddedDataSpecification[E]) Descend(
 	return eeds.instance.Descend(action)
 }
 
-func (eeds *enhancedEmbeddedDataSpecification[E]) DataSpecificationContent(
-) aastypes.IDataSpecificationContent {
-	return eeds.instance.DataSpecificationContent()
-}
-
-func (eeds *enhancedEmbeddedDataSpecification[E]) SetDataSpecificationContent(
-	value aastypes.IDataSpecificationContent,
-) {
-	eeds.instance.SetDataSpecificationContent(value)
-}
-
 func (eeds *enhancedEmbeddedDataSpecification[E]) DataSpecification(
 ) aastypes.IReference {
 	return eeds.instance.DataSpecification()
@@ -6168,6 +6157,17 @@ func (eeds *enhancedEmbeddedDataSpecification[E]) SetDataSpecification(
 	value aastypes.IReference,
 ) {
 	eeds.instance.SetDataSpecification(value)
+}
+
+func (eeds *enhancedEmbeddedDataSpecification[E]) DataSpecificationContent(
+) aastypes.IDataSpecificationContent {
+	return eeds.instance.DataSpecificationContent()
+}
+
+func (eeds *enhancedEmbeddedDataSpecification[E]) SetDataSpecificationContent(
+	value aastypes.IDataSpecificationContent,
+) {
+	eeds.instance.SetDataSpecificationContent(value)
 }
 
 func (eeds *enhancedEmbeddedDataSpecification[E]) getEnhancement(
@@ -6198,20 +6198,20 @@ func wrapEmbeddedDataSpecification[E any](
 		result = that
 	}
 
-	theDataSpecificationContent := that.DataSpecificationContent()
-	that.SetDataSpecificationContent(
-		Wrap[E](
-			theDataSpecificationContent,
-			factory,
-		).(aastypes.IDataSpecificationContent),
-	)
-
 	theDataSpecification := that.DataSpecification()
 	that.SetDataSpecification(
 		Wrap[E](
 			theDataSpecification,
 			factory,
 		).(aastypes.IReference),
+	)
+
+	theDataSpecificationContent := that.DataSpecificationContent()
+	that.SetDataSpecificationContent(
+		Wrap[E](
+			theDataSpecificationContent,
+			factory,
+		).(aastypes.IDataSpecificationContent),
 	)
 
 	return

--- a/test_data/golang/test_main/aas_core_meta.v3/expected_output/jsonization/jsonization.go
+++ b/test_data/golang/test_main/aas_core_meta.v3/expected_output/jsonization/jsonization.go
@@ -13127,30 +13127,14 @@ func embeddedDataSpecificationFromMapWithoutDispatch(
 	result aastypes.IEmbeddedDataSpecification,
 	err error,
 ) {
-	var theDataSpecificationContent aastypes.IDataSpecificationContent
 	var theDataSpecification aastypes.IReference
+	var theDataSpecificationContent aastypes.IDataSpecificationContent
 
-	foundDataSpecificationContent := false
 	foundDataSpecification := false
+	foundDataSpecificationContent := false
 
 	for k, v := range m {
 		switch k {
-		case "dataSpecificationContent":
-			theDataSpecificationContent, err = DataSpecificationContentFromJsonable(
-				v,
-			)
-			if err != nil {
-				if deseriaErr, ok := err.(*DeserializationError); ok {
-					deseriaErr.Path.PrependName(
-						&aasreporting.NameSegment{
-							Name: "dataSpecificationContent",
-						},
-					)
-				}
-				return
-			}
-			foundDataSpecificationContent = true
-
 		case "dataSpecification":
 			theDataSpecification, err = ReferenceFromJsonable(
 				v,
@@ -13167,6 +13151,22 @@ func embeddedDataSpecificationFromMapWithoutDispatch(
 			}
 			foundDataSpecification = true
 
+		case "dataSpecificationContent":
+			theDataSpecificationContent, err = DataSpecificationContentFromJsonable(
+				v,
+			)
+			if err != nil {
+				if deseriaErr, ok := err.(*DeserializationError); ok {
+					deseriaErr.Path.PrependName(
+						&aasreporting.NameSegment{
+							Name: "dataSpecificationContent",
+						},
+					)
+				}
+				return
+			}
+			foundDataSpecificationContent = true
+
 		default:
 			err = newDeserializationError(
 				fmt.Sprintf(
@@ -13178,13 +13178,6 @@ func embeddedDataSpecificationFromMapWithoutDispatch(
 		}
 	}
 
-	if !foundDataSpecificationContent {
-		err = newDeserializationError(
-			"The required property 'dataSpecificationContent' is missing",
-		)
-		return
-	}
-
 	if !foundDataSpecification {
 		err = newDeserializationError(
 			"The required property 'dataSpecification' is missing",
@@ -13192,9 +13185,16 @@ func embeddedDataSpecificationFromMapWithoutDispatch(
 		return
 	}
 
+	if !foundDataSpecificationContent {
+		err = newDeserializationError(
+			"The required property 'dataSpecificationContent' is missing",
+		)
+		return
+	}
+
 	result = aastypes.NewEmbeddedDataSpecification(
-		theDataSpecificationContent,
 		theDataSpecification,
+		theDataSpecificationContent,
 	)
 
 	return
@@ -21206,23 +21206,6 @@ func embeddedDataSpecificationToMap(
 ) (result map[string]interface{}, err error) {
 	result = make(map[string]interface{})
 
-	var jsonableDataSpecificationContent interface{}
-	jsonableDataSpecificationContent, err = ToJsonable(
-		that.DataSpecificationContent(),
-	)
-	if err != nil {
-		if seriaErr, ok := err.(*SerializationError); ok {
-			seriaErr.Path.PrependName(
-				&aasreporting.NameSegment{
-					Name: "DataSpecificationContent()",
-				},
-			)
-		}
-
-		return
-	}
-	result["dataSpecificationContent"] = jsonableDataSpecificationContent
-
 	var jsonableDataSpecification interface{}
 	jsonableDataSpecification, err = ToJsonable(
 		that.DataSpecification(),
@@ -21239,6 +21222,23 @@ func embeddedDataSpecificationToMap(
 		return
 	}
 	result["dataSpecification"] = jsonableDataSpecification
+
+	var jsonableDataSpecificationContent interface{}
+	jsonableDataSpecificationContent, err = ToJsonable(
+		that.DataSpecificationContent(),
+	)
+	if err != nil {
+		if seriaErr, ok := err.(*SerializationError); ok {
+			seriaErr.Path.PrependName(
+				&aasreporting.NameSegment{
+					Name: "DataSpecificationContent()",
+				},
+			)
+		}
+
+		return
+	}
+	result["dataSpecificationContent"] = jsonableDataSpecificationContent
 
 	return
 }

--- a/test_data/golang/test_main/aas_core_meta.v3/expected_output/types/types.go
+++ b/test_data/golang/test_main/aas_core_meta.v3/expected_output/types/types.go
@@ -11426,18 +11426,18 @@ func IsDataSpecificationContent(
 type IEmbeddedDataSpecification interface {
 	IClass
 
-	// Actual content of the data specification
-	DataSpecificationContent() IDataSpecificationContent;
-
-	SetDataSpecificationContent(
-		value IDataSpecificationContent,
-	);
-
 	// Reference to the data specification
 	DataSpecification() IReference;
 
 	SetDataSpecification(
 		value IReference,
+	);
+
+	// Actual content of the data specification
+	DataSpecificationContent() IDataSpecificationContent;
+
+	SetDataSpecificationContent(
+		value IDataSpecificationContent,
 	);
 }
 
@@ -11455,19 +11455,8 @@ func IsEmbeddedDataSpecification(
 
 // Implements IEmbeddedDataSpecification.
 type EmbeddedDataSpecification struct {
-	dataSpecificationContent IDataSpecificationContent
 	dataSpecification IReference
-}
-
-func (eds *EmbeddedDataSpecification) DataSpecificationContent(
-) IDataSpecificationContent {
-	return eds.dataSpecificationContent
-}
-
-func (eds *EmbeddedDataSpecification) SetDataSpecificationContent(
-	value IDataSpecificationContent,
-) {
-	eds.dataSpecificationContent = value
+	dataSpecificationContent IDataSpecificationContent
 }
 
 func (eds *EmbeddedDataSpecification) DataSpecification(
@@ -11479,6 +11468,17 @@ func (eds *EmbeddedDataSpecification) SetDataSpecification(
 	value IReference,
 ) {
 	eds.dataSpecification = value
+}
+
+func (eds *EmbeddedDataSpecification) DataSpecificationContent(
+) IDataSpecificationContent {
+	return eds.dataSpecificationContent
+}
+
+func (eds *EmbeddedDataSpecification) SetDataSpecificationContent(
+	value IDataSpecificationContent,
+) {
+	eds.dataSpecificationContent = value
 }
 
 func (eds *EmbeddedDataSpecification) ModelType(
@@ -11498,14 +11498,14 @@ func (eds *EmbeddedDataSpecification) DescendOnce(
 	action func(IClass) bool,
 ) (abort bool) {
 	abort = action(
-		eds.dataSpecificationContent,
+		eds.dataSpecification,
 	)
 	if abort {
 		return
 	}
 
 	abort = action(
-		eds.dataSpecification,
+		eds.dataSpecificationContent,
 	)
 	if abort {
 		return
@@ -11524,19 +11524,6 @@ func (eds *EmbeddedDataSpecification) Descend(
 	action func(IClass) bool,
 ) (abort bool) {
 	abort = action(
-		eds.dataSpecificationContent,
-	)
-	if abort {
-		return
-	}
-	abort = eds.dataSpecificationContent.Descend(
-		action,
-	)
-	if abort {
-		return
-	}
-
-	abort = action(
 		eds.dataSpecification,
 	)
 	if abort {
@@ -11549,18 +11536,31 @@ func (eds *EmbeddedDataSpecification) Descend(
 		return
 	}
 
+	abort = action(
+		eds.dataSpecificationContent,
+	)
+	if abort {
+		return
+	}
+	abort = eds.dataSpecificationContent.Descend(
+		action,
+	)
+	if abort {
+		return
+	}
+
 	return
 }
 
 // Create a new instance of EmbeddedDataSpecification with
 // the given properties.
 func NewEmbeddedDataSpecification(
-	dataSpecificationContent IDataSpecificationContent,
 	dataSpecification IReference,
+	dataSpecificationContent IDataSpecificationContent,
 ) *EmbeddedDataSpecification {
 	return &EmbeddedDataSpecification{
-		dataSpecificationContent: dataSpecificationContent,
 		dataSpecification: dataSpecification,
+		dataSpecificationContent: dataSpecificationContent,
 	}
 }
 

--- a/test_data/golang/test_main/aas_core_meta.v3/expected_output/verification/verification.go
+++ b/test_data/golang/test_main/aas_core_meta.v3/expected_output/verification/verification.go
@@ -12325,32 +12325,6 @@ func VerifyEmbeddedDataSpecification(
 ) (abort bool) {
 	abort = false
 
-	if that.DataSpecificationContent() == nil {
-		abort = onError(
-			newVerificationError(
-				"Required property not set: DataSpecificationContent",
-			),
-		)
-		if abort {
-			return
-		}
-	} else {
-		abort = Verify(
-			that.DataSpecificationContent(),
-			func(err *VerificationError) bool {
-				err.Path.PrependName(
-					&aasreporting.NameSegment{
-						Name: "DataSpecificationContent",
-					},
-				)
-				return onError(err)
-			},
-		)
-		if abort {
-			return
-		}
-	}
-
 	if that.DataSpecification() == nil {
 		abort = onError(
 			newVerificationError(
@@ -12367,6 +12341,32 @@ func VerifyEmbeddedDataSpecification(
 				err.Path.PrependName(
 					&aasreporting.NameSegment{
 						Name: "DataSpecification",
+					},
+				)
+				return onError(err)
+			},
+		)
+		if abort {
+			return
+		}
+	}
+
+	if that.DataSpecificationContent() == nil {
+		abort = onError(
+			newVerificationError(
+				"Required property not set: DataSpecificationContent",
+			),
+		)
+		if abort {
+			return
+		}
+	} else {
+		abort = Verify(
+			that.DataSpecificationContent(),
+			func(err *VerificationError) bool {
+				err.Path.PrependName(
+					&aasreporting.NameSegment{
+						Name: "DataSpecificationContent",
 					},
 				)
 				return onError(err)

--- a/test_data/golang/test_main/aas_core_meta.v3/expected_output/xmlization/xmlization.go
+++ b/test_data/golang/test_main/aas_core_meta.v3/expected_output/xmlization/xmlization.go
@@ -9710,11 +9710,11 @@ func readEmbeddedDataSpecificationAsSequence(
 	next xml.Token,
 	err error,
 ) {
-	var theDataSpecificationContent aastypes.IDataSpecificationContent
 	var theDataSpecification aastypes.IReference
+	var theDataSpecificationContent aastypes.IDataSpecificationContent
 
-	foundDataSpecificationContent := false
 	foundDataSpecification := false
+	foundDataSpecificationContent := false
 
 	for {
 		current, err = skipEmptyTextWhitespaceAndComments(decoder, current)
@@ -9756,6 +9756,13 @@ func readEmbeddedDataSpecificationAsSequence(
 
 		var valueErr error
 		switch local {
+		case "dataSpecification":
+			theDataSpecification, current, valueErr =  readReferenceAsSequence(
+				decoder,
+				current,
+			)
+			foundDataSpecification = true
+
 		case "dataSpecificationContent":
 			theDataSpecificationContent, valueErr =  readDataSpecificationContentWithLookahead(
 				decoder,
@@ -9767,13 +9774,6 @@ func readEmbeddedDataSpecificationAsSequence(
 				current, valueErr = readNext(decoder, current)
 			}
 			foundDataSpecificationContent = true
-
-		case "dataSpecification":
-			theDataSpecification, current, valueErr =  readReferenceAsSequence(
-				decoder,
-				current,
-			)
-			foundDataSpecification = true
 
 		default:
 			valueErr = newDeserializationError(
@@ -9819,13 +9819,6 @@ func readEmbeddedDataSpecificationAsSequence(
 
 	next = current
 
-	if !foundDataSpecificationContent {
-		err = newDeserializationError(
-			"The required property 'dataSpecificationContent' is missing",
-		)
-		return
-	}
-
 	if !foundDataSpecification {
 		err = newDeserializationError(
 			"The required property 'dataSpecification' is missing",
@@ -9833,9 +9826,16 @@ func readEmbeddedDataSpecificationAsSequence(
 		return
 	}
 
+	if !foundDataSpecificationContent {
+		err = newDeserializationError(
+			"The required property 'dataSpecificationContent' is missing",
+		)
+		return
+	}
+
 	instance = aastypes.NewEmbeddedDataSpecification(
-		theDataSpecificationContent,
 		theDataSpecification,
+		theDataSpecificationContent,
 	)
 	return
 }
@@ -21711,6 +21711,46 @@ func writeEmbeddedDataSpecificationAsSequence(
 	encoder *xml.Encoder,
 	that aastypes.IEmbeddedDataSpecification,
 ) (err error) {
+	// region DataSpecification
+
+	err = writeStartElement(
+		encoder,
+		"dataSpecification",
+		false,
+	)
+	if err != nil {
+		return
+	}
+	err = writeReferenceAsSequence(
+		encoder,
+		that.DataSpecification(),
+	)
+	if err != nil {
+		if seriaErr, ok := err.(*SerializationError); ok {
+			seriaErr.Path.PrependName(
+				&aasreporting.NameSegment{
+					Name: "DataSpecification()",
+				},
+			)
+		}
+		return
+	}
+	err = writeEndElement(
+		encoder,
+		"dataSpecification",
+		false,
+	)
+	if err != nil {
+		return
+	}
+
+	err = encoder.Flush()
+	if err != nil {
+		return err
+	}
+
+	// endregion
+
 	// region DataSpecificationContent
 
 	err = writeStartElement(
@@ -21740,46 +21780,6 @@ func writeEmbeddedDataSpecificationAsSequence(
 		encoder,
 		"dataSpecificationContent",
 	false,
-	)
-	if err != nil {
-		return
-	}
-
-	err = encoder.Flush()
-	if err != nil {
-		return err
-	}
-
-	// endregion
-
-	// region DataSpecification
-
-	err = writeStartElement(
-		encoder,
-		"dataSpecification",
-		false,
-	)
-	if err != nil {
-		return
-	}
-	err = writeReferenceAsSequence(
-		encoder,
-		that.DataSpecification(),
-	)
-	if err != nil {
-		if seriaErr, ok := err.(*SerializationError); ok {
-			seriaErr.Path.PrependName(
-				&aasreporting.NameSegment{
-					Name: "DataSpecification()",
-				},
-			)
-		}
-		return
-	}
-	err = writeEndElement(
-		encoder,
-		"dataSpecification",
-		false,
 	)
 	if err != nil {
 		return

--- a/test_data/intermediate/real_meta_models/aas_core_meta.v3/expected_symbol_table.txt
+++ b/test_data/intermediate/real_meta_models/aas_core_meta.v3/expected_symbol_table.txt
@@ -25613,18 +25613,6 @@ SymbolTable(
       concrete_descendants=[],
       properties=[
         Property(
-          name='data_specification_content',
-          type_annotation=OurTypeAnnotation(
-            our_type='Reference to our type Data_specification_content',
-            parsed=...),
-          description=DescriptionOfProperty(
-            summary='<paragraph>Actual content of the data specification</paragraph>',
-            remarks=[],
-            constraints_by_identifier=[],
-            parsed=...),
-          specified_for='Reference to ConcreteClass Embedded_data_specification',
-          parsed=...),
-        Property(
           name='data_specification',
           type_annotation=OurTypeAnnotation(
             our_type='Reference to our type Reference',
@@ -25635,22 +25623,34 @@ SymbolTable(
             constraints_by_identifier=[],
             parsed=...),
           specified_for='Reference to ConcreteClass Embedded_data_specification',
+          parsed=...),
+        Property(
+          name='data_specification_content',
+          type_annotation=OurTypeAnnotation(
+            our_type='Reference to our type Data_specification_content',
+            parsed=...),
+          description=DescriptionOfProperty(
+            summary='<paragraph>Actual content of the data specification</paragraph>',
+            remarks=[],
+            constraints_by_identifier=[],
+            parsed=...),
+          specified_for='Reference to ConcreteClass Embedded_data_specification',
           parsed=...)],
       methods=[],
       constructor=Constructor(
         name='__init__',
         arguments=[
           Argument(
-            name='data_specification_content',
+            name='data_specification',
             type_annotation=OurTypeAnnotation(
-              our_type='Reference to our type Data_specification_content',
+              our_type='Reference to our type Reference',
               parsed=...),
             default=None,
             parsed=...),
           Argument(
-            name='data_specification',
+            name='data_specification_content',
             type_annotation=OurTypeAnnotation(
-              our_type='Reference to our type Reference',
+              our_type='Reference to our type Data_specification_content',
               parsed=...),
             default=None,
             parsed=...)],
@@ -25666,24 +25666,24 @@ SymbolTable(
         statements=[
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specification_content',
-              argument='data_specification_content',
+              name='data_specification',
+              argument='data_specification',
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specification',
-              argument='data_specification',
+              name='data_specification_content',
+              argument='data_specification_content',
               default=None)""")],
         inlined_statements=[
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specification_content',
-              argument='data_specification_content',
+              name='data_specification',
+              argument='data_specification',
               default=None)"""),
           textwrap.dedent("""\
             AssignArgument(
-              name='data_specification',
-              argument='data_specification',
+              name='data_specification_content',
+              argument='data_specification_content',
               default=None)""")]),
       invariants=[],
       serialization=Serialization(

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/copying/Copying.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/copying/Copying.java
@@ -506,8 +506,8 @@ public class Copying
             IEmbeddedDataSpecification that
         ) {
             return new EmbeddedDataSpecification(
-                that.getDataSpecificationContent(),
-                that.getDataSpecification());
+                that.getDataSpecification(),
+                that.getDataSpecificationContent());
         }
 
         @Override
@@ -2512,8 +2512,8 @@ public class Copying
             IEmbeddedDataSpecification that
         ) {
             return new EmbeddedDataSpecification(
-                deep(that.getDataSpecificationContent()),
-                deep(that.getDataSpecification())
+                deep(that.getDataSpecification()),
+                deep(that.getDataSpecificationContent())
             );
         }
 

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/enhancing/EnhancedEmbeddedDataSpecification.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/enhancing/EnhancedEmbeddedDataSpecification.java
@@ -30,16 +30,6 @@ public class EnhancedEmbeddedDataSpecification<EnhancementT>
   }
 
   @Override
-  public IDataSpecificationContent getDataSpecificationContent() {
-    return instance.getDataSpecificationContent();
-  }
-
-  @Override
-  public void setDataSpecificationContent(IDataSpecificationContent dataSpecificationContent) {
-    instance.setDataSpecificationContent(dataSpecificationContent);
-  }
-
-  @Override
   public IReference getDataSpecification() {
     return instance.getDataSpecification();
   }
@@ -47,6 +37,16 @@ public class EnhancedEmbeddedDataSpecification<EnhancementT>
   @Override
   public void setDataSpecification(IReference dataSpecification) {
     instance.setDataSpecification(dataSpecification);
+  }
+
+  @Override
+  public IDataSpecificationContent getDataSpecificationContent() {
+    return instance.getDataSpecificationContent();
+  }
+
+  @Override
+  public void setDataSpecificationContent(IDataSpecificationContent dataSpecificationContent) {
+    instance.setDataSpecificationContent(dataSpecificationContent);
   }
 
   public Iterable<IClass> descendOnce() {

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/enhancing/Wrapper.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/enhancing/Wrapper.java
@@ -3105,17 +3105,6 @@ class Wrapper<EnhancementT> extends AbstractTransformer<IClass> {
       );
     }
 
-    IDataSpecificationContent dataSpecificationContent = that.getDataSpecificationContent();
-    IClass transformedDataSpecificationContent = transform(dataSpecificationContent);
-    if (!(transformedDataSpecificationContent instanceof IDataSpecificationContent)) {
-      throw new UnsupportedOperationException(
-        "Expected the transformed value to be a IDataSpecificationContent " +
-        ", but got: " + transformedDataSpecificationContent
-      );
-    }
-    IDataSpecificationContent castedDataSpecificationContent = (IDataSpecificationContent) transformedDataSpecificationContent;
-    that.setDataSpecificationContent(castedDataSpecificationContent);
-
     IReference dataSpecification = that.getDataSpecification();
     IClass transformedDataSpecification = transform(dataSpecification);
     if (!(transformedDataSpecification instanceof IReference)) {
@@ -3126,6 +3115,17 @@ class Wrapper<EnhancementT> extends AbstractTransformer<IClass> {
     }
     IReference castedDataSpecification = (IReference) transformedDataSpecification;
     that.setDataSpecification(castedDataSpecification);
+
+    IDataSpecificationContent dataSpecificationContent = that.getDataSpecificationContent();
+    IClass transformedDataSpecificationContent = transform(dataSpecificationContent);
+    if (!(transformedDataSpecificationContent instanceof IDataSpecificationContent)) {
+      throw new UnsupportedOperationException(
+        "Expected the transformed value to be a IDataSpecificationContent " +
+        ", but got: " + transformedDataSpecificationContent
+      );
+    }
+    IDataSpecificationContent castedDataSpecificationContent = (IDataSpecificationContent) transformedDataSpecificationContent;
+    that.setDataSpecificationContent(castedDataSpecificationContent);
 
     Optional<EnhancementT> enhancement = enhancementFactory.apply(that);
     return !enhancement.isPresent()

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/jsonization/Jsonization.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/jsonization/Jsonization.java
@@ -10929,27 +10929,13 @@ public class Jsonization {
           return Result.failure(error);
         }
 
-        IDataSpecificationContent theDataSpecificationContent = null;
         IReference theDataSpecification = null;
+        IDataSpecificationContent theDataSpecificationContent = null;
 
         for (Iterator<Map.Entry<String, JsonNode>> iterator = node.fields(); iterator.hasNext(); ) {
           Map.Entry<String, JsonNode> currentNode = iterator.next();
 
           switch (currentNode.getKey()) {
-            case "dataSpecificationContent": {
-              if (currentNode.getValue() == null) {
-                continue;
-              }
-
-              final Result<? extends IDataSpecificationContent> theDataSpecificationContentResult = tryIDataSpecificationContentFrom(currentNode.getValue());
-              if (theDataSpecificationContentResult.isError()) {
-                theDataSpecificationContentResult.getError()
-                  .prependSegment(new Reporting.NameSegment("dataSpecificationContent"));
-                return theDataSpecificationContentResult.castTo(EmbeddedDataSpecification.class);
-              }
-              theDataSpecificationContent = theDataSpecificationContentResult.getResult();
-              break;
-            }
             case "dataSpecification": {
               if (currentNode.getValue() == null) {
                 continue;
@@ -10964,6 +10950,20 @@ public class Jsonization {
               theDataSpecification = theDataSpecificationResult.getResult();
               break;
             }
+            case "dataSpecificationContent": {
+              if (currentNode.getValue() == null) {
+                continue;
+              }
+
+              final Result<? extends IDataSpecificationContent> theDataSpecificationContentResult = tryIDataSpecificationContentFrom(currentNode.getValue());
+              if (theDataSpecificationContentResult.isError()) {
+                theDataSpecificationContentResult.getError()
+                  .prependSegment(new Reporting.NameSegment("dataSpecificationContent"));
+                return theDataSpecificationContentResult.castTo(EmbeddedDataSpecification.class);
+              }
+              theDataSpecificationContent = theDataSpecificationContentResult.getResult();
+              break;
+            }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
@@ -10972,21 +10972,21 @@ public class Jsonization {
           }
         }
 
-        if (theDataSpecificationContent == null) {
-          final Reporting.Error error = new Reporting.Error(
-            "Required property \"dataSpecificationContent\" is missing");
-          return Result.failure(error);
-        }
-
         if (theDataSpecification == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"dataSpecification\" is missing");
           return Result.failure(error);
         }
 
+        if (theDataSpecificationContent == null) {
+          final Reporting.Error error = new Reporting.Error(
+            "Required property \"dataSpecificationContent\" is missing");
+          return Result.failure(error);
+        }
+
         return Result.success(new EmbeddedDataSpecification(
-          theDataSpecificationContent,
-          theDataSpecification));
+          theDataSpecification,
+          theDataSpecificationContent));
       }
 
       /**
@@ -15121,11 +15121,11 @@ public class Jsonization {
       ) {
         final ObjectNode result = JsonNodeFactory.instance.objectNode();
 
-        result.set("dataSpecificationContent", transform(
-          that.getDataSpecificationContent()));
-
         result.set("dataSpecification", transform(
           that.getDataSpecification()));
+
+        result.set("dataSpecificationContent", transform(
+          that.getDataSpecificationContent()));
 
         return result;
       }

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/types/impl/EmbeddedDataSpecification.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/types/impl/EmbeddedDataSpecification.java
@@ -31,33 +31,21 @@ import java.util.Objects;
  */
 public class EmbeddedDataSpecification implements IEmbeddedDataSpecification {
   /**
-   * Actual content of the data specification
-   */
-  private IDataSpecificationContent dataSpecificationContent;
-
-  /**
    * Reference to the data specification
    */
   private IReference dataSpecification;
 
+  /**
+   * Actual content of the data specification
+   */
+  private IDataSpecificationContent dataSpecificationContent;
+
   public EmbeddedDataSpecification(
-    IDataSpecificationContent dataSpecificationContent,
-    IReference dataSpecification) {
-    this.dataSpecificationContent = Objects.requireNonNull(
-      dataSpecificationContent,
-      "Argument \"dataSpecificationContent\" must be non-null.");
+    IReference dataSpecification,
+    IDataSpecificationContent dataSpecificationContent) {
     this.dataSpecification = Objects.requireNonNull(
       dataSpecification,
       "Argument \"dataSpecification\" must be non-null.");
-  }
-
-  @Override
-  public IDataSpecificationContent getDataSpecificationContent() {
-    return dataSpecificationContent;
-  }
-
-  @Override
-  public void setDataSpecificationContent(IDataSpecificationContent dataSpecificationContent) {
     this.dataSpecificationContent = Objects.requireNonNull(
       dataSpecificationContent,
       "Argument \"dataSpecificationContent\" must be non-null.");
@@ -73,6 +61,18 @@ public class EmbeddedDataSpecification implements IEmbeddedDataSpecification {
     this.dataSpecification = Objects.requireNonNull(
       dataSpecification,
       "Argument \"dataSpecification\" must be non-null.");
+  }
+
+  @Override
+  public IDataSpecificationContent getDataSpecificationContent() {
+    return dataSpecificationContent;
+  }
+
+  @Override
+  public void setDataSpecificationContent(IDataSpecificationContent dataSpecificationContent) {
+    this.dataSpecificationContent = Objects.requireNonNull(
+      dataSpecificationContent,
+      "Argument \"dataSpecificationContent\" must be non-null.");
   }
 
   /**
@@ -152,14 +152,14 @@ public class EmbeddedDataSpecification implements IEmbeddedDataSpecification {
     private Stream<IClass> stream() {
       Stream<IClass> memberStream = Stream.empty();
 
-      if (dataSpecificationContent != null) {
-        memberStream = Stream.concat(memberStream,
-          Stream.<IClass>of(EmbeddedDataSpecification.this.dataSpecificationContent));
-      }
-
       if (dataSpecification != null) {
         memberStream = Stream.concat(memberStream,
           Stream.<IClass>of(EmbeddedDataSpecification.this.dataSpecification));
+      }
+
+      if (dataSpecificationContent != null) {
+        memberStream = Stream.concat(memberStream,
+          Stream.<IClass>of(EmbeddedDataSpecification.this.dataSpecificationContent));
       }
 
       return memberStream;
@@ -191,16 +191,16 @@ public class EmbeddedDataSpecification implements IEmbeddedDataSpecification {
     private Stream<IClass> stream() {
       Stream<IClass> memberStream = Stream.empty();
 
-      if (dataSpecificationContent != null) {
-        memberStream = Stream.concat(memberStream,
-          Stream.concat(Stream.<IClass>of(EmbeddedDataSpecification.this.dataSpecificationContent),
-            StreamSupport.stream(EmbeddedDataSpecification.this.dataSpecificationContent.descend().spliterator(), false)));
-      }
-
       if (dataSpecification != null) {
         memberStream = Stream.concat(memberStream,
           Stream.concat(Stream.<IClass>of(EmbeddedDataSpecification.this.dataSpecification),
             StreamSupport.stream(EmbeddedDataSpecification.this.dataSpecification.descend().spliterator(), false)));
+      }
+
+      if (dataSpecificationContent != null) {
+        memberStream = Stream.concat(memberStream,
+          Stream.concat(Stream.<IClass>of(EmbeddedDataSpecification.this.dataSpecificationContent),
+            StreamSupport.stream(EmbeddedDataSpecification.this.dataSpecificationContent.descend().spliterator(), false)));
       }
 
       return memberStream;

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/types/model/IEmbeddedDataSpecification.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/types/model/IEmbeddedDataSpecification.java
@@ -17,18 +17,18 @@ import java.util.Optional;
  */
 public interface IEmbeddedDataSpecification extends IClass {
   /**
-   * Actual content of the data specification
-   */
-  IDataSpecificationContent getDataSpecificationContent();
-
-  void setDataSpecificationContent(IDataSpecificationContent dataSpecificationContent);
-
-  /**
    * Reference to the data specification
    */
   IReference getDataSpecification();
 
   void setDataSpecification(IReference dataSpecification);
+
+  /**
+   * Actual content of the data specification
+   */
+  IDataSpecificationContent getDataSpecificationContent();
+
+  void setDataSpecificationContent(IDataSpecificationContent dataSpecificationContent);
 }
 
 /*

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/verification/Verification.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/verification/Verification.java
@@ -8871,20 +8871,20 @@ public class Verification {
       Stream<Reporting.Error> errorStream = Stream.empty();
 
       errorStream = Stream.<Reporting.Error>concat(errorStream,
-        Stream.of(that.getDataSpecificationContent())
-          .flatMap(Verification::verifyToErrorStream)
-            .map(error -> {
-              error.prependSegment(
-                new Reporting.NameSegment("dataSpecificationContent"));
-              return error;
-            }));
-
-      errorStream = Stream.<Reporting.Error>concat(errorStream,
         Stream.of(that.getDataSpecification())
           .flatMap(Verification::verifyToErrorStream)
             .map(error -> {
               error.prependSegment(
                 new Reporting.NameSegment("dataSpecification"));
+              return error;
+            }));
+
+      errorStream = Stream.<Reporting.Error>concat(errorStream,
+        Stream.of(that.getDataSpecificationContent())
+          .flatMap(Verification::verifyToErrorStream)
+            .map(error -> {
+              error.prependSegment(
+                new Reporting.NameSegment("dataSpecificationContent"));
               return error;
             }));
 

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/xmlization/Xmlization.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/xmlization/Xmlization.java
@@ -13199,8 +13199,8 @@ public class Xmlization {
     private static Result<EmbeddedDataSpecification> tryEmbeddedDataSpecificationFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
-      IDataSpecificationContent theDataSpecificationContent = null;
       IReference theDataSpecification = null;
+      IDataSpecificationContent theDataSpecificationContent = null;
 
       if (!isEmptySequence) {
         skipWhitespaceAndComments(reader);
@@ -13236,6 +13236,22 @@ public class Xmlization {
           final String elementName = tryElementName.getResult();
 
           switch (tryElementName.getResult()) {
+            case "dataSpecification":
+            {
+              Result<Reference> tryDataSpecification = tryReferenceFromSequence(
+                reader, isEmptyProperty);
+
+              if (tryDataSpecification.isError()) {
+                tryDataSpecification.getError()
+                  .prependSegment(
+                    new Reporting.NameSegment(
+                      "dataSpecification"));
+                return tryDataSpecification.castTo(EmbeddedDataSpecification.class);
+              }
+
+              theDataSpecification = tryDataSpecification.getResult();
+              break;
+            }
             case "dataSpecificationContent":
             {
               if (isEmptyProperty) {
@@ -13289,22 +13305,6 @@ public class Xmlization {
               theDataSpecificationContent = tryDataSpecificationContent.getResult();
               break;
             }
-            case "dataSpecification":
-            {
-              Result<Reference> tryDataSpecification = tryReferenceFromSequence(
-                reader, isEmptyProperty);
-
-              if (tryDataSpecification.isError()) {
-                tryDataSpecification.getError()
-                  .prependSegment(
-                    new Reporting.NameSegment(
-                      "dataSpecification"));
-                return tryDataSpecification.castTo(EmbeddedDataSpecification.class);
-              }
-
-              theDataSpecification = tryDataSpecification.getResult();
-              break;
-            }
             default:
               final Reporting.Error error = new Reporting.Error(
                 "We expected properties of the class EmbeddedDataSpecification, " +
@@ -13325,13 +13325,6 @@ public class Xmlization {
         }
       }
 
-      if (theDataSpecificationContent == null) {
-        final Reporting.Error error = new Reporting.Error(
-          "The required property dataSpecificationContent has not been given " +
-          "in the XML representation of an instance of class EmbeddedDataSpecification");
-        return Result.failure(error);
-      }
-
       if (theDataSpecification == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property dataSpecification has not been given " +
@@ -13339,9 +13332,16 @@ public class Xmlization {
         return Result.failure(error);
       }
 
+      if (theDataSpecificationContent == null) {
+        final Reporting.Error error = new Reporting.Error(
+          "The required property dataSpecificationContent has not been given " +
+          "in the XML representation of an instance of class EmbeddedDataSpecification");
+        return Result.failure(error);
+      }
+
       return Result.success(new EmbeddedDataSpecification(
-        theDataSpecificationContent,
-        theDataSpecification));
+        theDataSpecification,
+        theDataSpecificationContent));
     }
 
     /**
@@ -21716,14 +21716,14 @@ public class Xmlization {
       XMLStreamWriter writer) {
       try {
         writer.writeStartElement(
-          "dataSpecificationContent");
+          "dataSpecification");
         if (topLevel) {
           writer.writeNamespace("xmlns", AAS_NAME_SPACE);
           topLevel = false;
         }
 
-        this.visit(
-          that.getDataSpecificationContent(),
+        this.referenceToSequence(
+          that.getDataSpecification(),
           writer);
 
         writer.writeEndElement();
@@ -21733,14 +21733,14 @@ public class Xmlization {
 
       try {
         writer.writeStartElement(
-          "dataSpecification");
+          "dataSpecificationContent");
         if (topLevel) {
           writer.writeNamespace("xmlns", AAS_NAME_SPACE);
           topLevel = false;
         }
 
-        this.referenceToSequence(
-          that.getDataSpecification(),
+        this.visit(
+          that.getDataSpecificationContent(),
           writer);
 
         writer.writeEndElement();

--- a/test_data/jsonschema/test_main/aas_core_meta.v3/expected_output/schema.json
+++ b/test_data/jsonschema/test_main/aas_core_meta.v3/expected_output/schema.json
@@ -505,16 +505,16 @@
     "EmbeddedDataSpecification": {
       "type": "object",
       "properties": {
-        "dataSpecificationContent": {
-          "$ref": "#/definitions/DataSpecificationContent_choice"
-        },
         "dataSpecification": {
           "$ref": "#/definitions/Reference"
+        },
+        "dataSpecificationContent": {
+          "$ref": "#/definitions/DataSpecificationContent_choice"
         }
       },
       "required": [
-        "dataSpecificationContent",
-        "dataSpecification"
+        "dataSpecification",
+        "dataSpecificationContent"
       ]
     },
     "Entity": {

--- a/test_data/parse/real_meta_models/aas_core_meta.v3/expected_symbol_table.txt
+++ b/test_data/parse/real_meta_models/aas_core_meta.v3/expected_symbol_table.txt
@@ -10822,18 +10822,18 @@ UnverifiedSymbolTable(
       inheritances=[],
       properties=[
         Property(
-          name='data_specification_content',
+          name='data_specification',
           type_annotation=AtomicTypeAnnotation(
-            identifier='Data_specification_content',
+            identifier='Reference',
             node=...),
           description=Description(
             document=...,
             node=...),
           node=...),
         Property(
-          name='data_specification',
+          name='data_specification_content',
           type_annotation=AtomicTypeAnnotation(
-            identifier='Reference',
+            identifier='Data_specification_content',
             node=...),
           description=Description(
             document=...,
@@ -10850,16 +10850,16 @@ UnverifiedSymbolTable(
               default=None,
               node=...),
             Argument(
-              name='data_specification_content',
+              name='data_specification',
               type_annotation=AtomicTypeAnnotation(
-                identifier='Data_specification_content',
+                identifier='Reference',
                 node=...),
               default=None,
               node=...),
             Argument(
-              name='data_specification',
+              name='data_specification_content',
               type_annotation=AtomicTypeAnnotation(
-                identifier='Reference',
+                identifier='Data_specification_content',
                 node=...),
               default=None,
               node=...)],

--- a/test_data/proto/test_main/expected/aas_core_meta.v3/expected_output/types.proto
+++ b/test_data/proto/test_main/expected/aas_core_meta.v3/expected_output/types.proto
@@ -3282,14 +3282,14 @@ message Environment {
 /// </summary>
 message EmbeddedDataSpecification {
   /// <summary>
-  /// Actual content of the data specification
-  /// </summary>
-  DataSpecificationContent_choice data_specification_content = 1;
-
-  /// <summary>
   /// Reference to the data specification
   /// </summary>
-  Reference data_specification = 2;
+  Reference data_specification = 1;
+
+  /// <summary>
+  /// Actual content of the data specification
+  /// </summary>
+  DataSpecificationContent_choice data_specification_content = 2;
 }
 
 enum DataTypeIec61360 {

--- a/test_data/python/test_main/aas_core_meta.v3/expected_output/jsonization.py
+++ b/test_data/python/test_main/aas_core_meta.v3/expected_output/jsonization.py
@@ -9502,25 +9502,12 @@ class _SetterForEmbeddedDataSpecification:
 
     def __init__(self) -> None:
         """Initialize with all the properties unset."""
-        self.data_specification_content: Optional[aas_types.DataSpecificationContent] = None
         self.data_specification: Optional[aas_types.Reference] = None
+        self.data_specification_content: Optional[aas_types.DataSpecificationContent] = None
 
     def ignore(self, jsonable: Jsonable) -> None:
         """Ignore :paramref:`jsonable` and do not set anything."""
         pass
-
-    def set_data_specification_content_from_jsonable(
-            self,
-            jsonable: Jsonable
-    ) -> None:
-        """
-        Parse :paramref:`jsonable` as the value of :py:attr:`~data_specification_content`.
-
-        :param jsonable: input to be parsed
-        """
-        self.data_specification_content = data_specification_content_from_jsonable(
-            jsonable
-        )
 
     def set_data_specification_from_jsonable(
             self,
@@ -9532,6 +9519,19 @@ class _SetterForEmbeddedDataSpecification:
         :param jsonable: input to be parsed
         """
         self.data_specification = reference_from_jsonable(
+            jsonable
+        )
+
+    def set_data_specification_content_from_jsonable(
+            self,
+            jsonable: Jsonable
+    ) -> None:
+        """
+        Parse :paramref:`jsonable` as the value of :py:attr:`~data_specification_content`.
+
+        :param jsonable: input to be parsed
+        """
+        self.data_specification_content = data_specification_content_from_jsonable(
             jsonable
         )
 
@@ -9574,19 +9574,19 @@ def embedded_data_specification_from_jsonable(
             )
             raise exception
 
-    if setter.data_specification_content is None:
-        raise DeserializationException(
-            "The required property 'dataSpecificationContent' is missing"
-        )
-
     if setter.data_specification is None:
         raise DeserializationException(
             "The required property 'dataSpecification' is missing"
         )
 
+    if setter.data_specification_content is None:
+        raise DeserializationException(
+            "The required property 'dataSpecificationContent' is missing"
+        )
+
     return aas_types.EmbeddedDataSpecification(
-        setter.data_specification_content,
-        setter.data_specification
+        setter.data_specification,
+        setter.data_specification_content
     )
 
 
@@ -11610,10 +11610,10 @@ _SETTER_MAP_FOR_EMBEDDED_DATA_SPECIFICATION: Mapping[
         None
     ]
 ] = {
-    'dataSpecificationContent':
-        _SetterForEmbeddedDataSpecification.set_data_specification_content_from_jsonable,
     'dataSpecification':
         _SetterForEmbeddedDataSpecification.set_data_specification_from_jsonable,
+    'dataSpecificationContent':
+        _SetterForEmbeddedDataSpecification.set_data_specification_content_from_jsonable,
     'modelType':
         _SetterForEmbeddedDataSpecification.ignore
 }
@@ -13174,12 +13174,12 @@ class _Serializer(
         """Serialize :paramref:`that` to a JSON-able representation."""
         jsonable: MutableMapping[str, MutableJsonable] = dict()
 
-        jsonable['dataSpecificationContent'] = (
-            self.transform(that.data_specification_content)
-        )
-
         jsonable['dataSpecification'] = (
             self.transform(that.data_specification)
+        )
+
+        jsonable['dataSpecificationContent'] = (
+            self.transform(that.data_specification_content)
         )
 
         return jsonable

--- a/test_data/python/test_main/aas_core_meta.v3/expected_output/types.py
+++ b/test_data/python/test_main/aas_core_meta.v3/expected_output/types.py
@@ -5554,11 +5554,11 @@ class DataSpecificationContent(Class):
 class EmbeddedDataSpecification(Class):
     """Embed the content of a data specification."""
 
-    #: Actual content of the data specification
-    data_specification_content: 'DataSpecificationContent'
-
     #: Reference to the data specification
     data_specification: 'Reference'
+
+    #: Actual content of the data specification
+    data_specification_content: 'DataSpecificationContent'
 
     def descend_once(self) -> Iterator[Class]:
         """
@@ -5568,9 +5568,9 @@ class EmbeddedDataSpecification(Class):
 
         :yield: instances directly referenced from this instance
         """
-        yield self.data_specification_content
-
         yield self.data_specification
+
+        yield self.data_specification_content
 
     def descend(self) -> Iterator[Class]:
         """
@@ -5578,13 +5578,13 @@ class EmbeddedDataSpecification(Class):
 
         :yield: instances recursively referenced from this instance
         """
-        yield self.data_specification_content
-
-        yield from self.data_specification_content.descend()
-
         yield self.data_specification
 
         yield from self.data_specification.descend()
+
+        yield self.data_specification_content
+
+        yield from self.data_specification_content.descend()
 
     def accept(self, visitor: "AbstractVisitor") -> None:
         """Dispatch the :paramref:`visitor` on this instance."""
@@ -5618,12 +5618,12 @@ class EmbeddedDataSpecification(Class):
 
     def __init__(
             self,
-            data_specification_content: 'DataSpecificationContent',
-            data_specification: 'Reference'
+            data_specification: 'Reference',
+            data_specification_content: 'DataSpecificationContent'
     ) -> None:
         """Initialize with the given values."""
-        self.data_specification_content = data_specification_content
         self.data_specification = data_specification
+        self.data_specification_content = data_specification_content
 
 
 class DataTypeIEC61360(enum.Enum):

--- a/test_data/python/test_main/aas_core_meta.v3/expected_output/verification.py
+++ b/test_data/python/test_main/aas_core_meta.v3/expected_output/verification.py
@@ -7895,20 +7895,20 @@ class _Transformer(
             self,
             that: aas_types.EmbeddedDataSpecification
     ) -> Iterator[Error]:
-        for error in self.transform(that.data_specification_content):
-            error.path._prepend(
-                PropertySegment(
-                    that,
-                    'data_specification_content'
-                )
-            )
-            yield error
-
         for error in self.transform(that.data_specification):
             error.path._prepend(
                 PropertySegment(
                     that,
                     'data_specification'
+                )
+            )
+            yield error
+
+        for error in self.transform(that.data_specification_content):
+            error.path._prepend(
+                PropertySegment(
+                    that,
+                    'data_specification_content'
                 )
             )
             yield error

--- a/test_data/python/test_main/aas_core_meta.v3/expected_output/xmlization.py
+++ b/test_data/python/test_main/aas_core_meta.v3/expected_output/xmlization.py
@@ -24234,8 +24234,22 @@ class _ReaderAndSetterForEmbeddedDataSpecification:
 
     def __init__(self) -> None:
         """Initialize with all the properties unset."""
-        self.data_specification_content: Optional[aas_types.DataSpecificationContent] = None
         self.data_specification: Optional[aas_types.Reference] = None
+        self.data_specification_content: Optional[aas_types.DataSpecificationContent] = None
+
+    def read_and_set_data_specification(
+        self,
+        element: Element,
+        iterator: Iterator[Tuple[str, Element]]
+    ) -> None:
+        """
+        Read :paramref:`element` as the property
+        :py:attr:`.types.EmbeddedDataSpecification.data_specification` and set it.
+        """
+        self.data_specification = _read_reference_as_sequence(
+            element,
+            iterator
+        )
 
     def read_and_set_data_specification_content(
         self,
@@ -24273,20 +24287,6 @@ class _ReaderAndSetterForEmbeddedDataSpecification:
         _read_end_element(element, iterator)
 
         self.data_specification_content = result
-
-    def read_and_set_data_specification(
-        self,
-        element: Element,
-        iterator: Iterator[Tuple[str, Element]]
-    ) -> None:
-        """
-        Read :paramref:`element` as the property
-        :py:attr:`.types.EmbeddedDataSpecification.data_specification` and set it.
-        """
-        self.data_specification = _read_reference_as_sequence(
-            element,
-            iterator
-        )
 
 
 def _read_embedded_data_specification_as_sequence(
@@ -24367,19 +24367,19 @@ def _read_embedded_data_specification_as_sequence(
             exception.path._prepend(ElementSegment(next_element))
             raise
 
-    if reader_and_setter.data_specification_content is None:
-        raise DeserializationException(
-            "The required property 'dataSpecificationContent' is missing"
-        )
-
     if reader_and_setter.data_specification is None:
         raise DeserializationException(
             "The required property 'dataSpecification' is missing"
         )
 
+    if reader_and_setter.data_specification_content is None:
+        raise DeserializationException(
+            "The required property 'dataSpecificationContent' is missing"
+        )
+
     return aas_types.EmbeddedDataSpecification(
-        reader_and_setter.data_specification_content,
-        reader_and_setter.data_specification
+        reader_and_setter.data_specification,
+        reader_and_setter.data_specification_content
     )
 
 
@@ -27295,10 +27295,10 @@ _READ_AND_SET_DISPATCH_FOR_EMBEDDED_DATA_SPECIFICATION: Mapping[
         None
     ]
 ] = {
-    'dataSpecificationContent':
-        _ReaderAndSetterForEmbeddedDataSpecification.read_and_set_data_specification_content,
     'dataSpecification':
         _ReaderAndSetterForEmbeddedDataSpecification.read_and_set_data_specification,
+    'dataSpecificationContent':
+        _ReaderAndSetterForEmbeddedDataSpecification.read_and_set_data_specification_content,
 }
 
 
@@ -30751,15 +30751,15 @@ class _Serializer(aas_types.AbstractVisitor):
 
         :param that: instance to be serialized
         """
-        self._write_start_element('dataSpecificationContent')
-        self.visit(that.data_specification_content)
-        self._write_end_element('dataSpecificationContent')
-
         self._write_start_element('dataSpecification')
         self._write_reference_as_sequence(
             that.data_specification
         )
         self._write_end_element('dataSpecification')
+
+        self._write_start_element('dataSpecificationContent')
+        self.visit(that.data_specification_content)
+        self._write_end_element('dataSpecificationContent')
 
     def visit_embedded_data_specification(
         self,

--- a/test_data/python_protobuf/test_main/aas_core_meta.v3/expected_output/pbization.py
+++ b/test_data/python_protobuf/test_main/aas_core_meta.v3/expected_output/pbization.py
@@ -3901,11 +3901,11 @@ def embedded_data_specification_from_pb(
 
     """
     return types.EmbeddedDataSpecification(
-        data_specification_content=data_specification_content_from_pb_choice(
-            that.data_specification_content
-        ),
         data_specification=reference_from_pb(
             that.data_specification
+        ),
+        data_specification_content=data_specification_content_from_pb_choice(
+            that.data_specification_content
         )
     )
 
@@ -9846,17 +9846,17 @@ def embedded_data_specification_to_pb(
         # Do something with some_bytes. For example, transfer them
         # over the wire.
     """
-    data_specification_content_to_pb_choice(
-        that.data_specification_content,
-        target.data_specification_content
-    )
-
     # We clear so that the field is set even if all the properties are None.
     target.data_specification.Clear()
 
     reference_to_pb(
         that.data_specification,
         target.data_specification
+    )
+
+    data_specification_content_to_pb_choice(
+        that.data_specification_content,
+        target.data_specification_content
     )
 
 

--- a/test_data/rdf_shacl/test_main/expected/aas_core_meta.v3/expected_output/shacl-schema.ttl
+++ b/test_data/rdf_shacl/test_main/expected/aas_core_meta.v3/expected_output/shacl-schema.ttl
@@ -415,15 +415,15 @@ aas:EmbeddedDataSpecificationShape a sh:NodeShape ;
     sh:targetClass aas:EmbeddedDataSpecification ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/EmbeddedDataSpecification/dataSpecificationContent> ;
-        sh:class aas:DataSpecificationContent ;
+        sh:path <https://admin-shell.io/aas/3/0/EmbeddedDataSpecification/dataSpecification> ;
+        sh:class aas:Reference ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
     ] ;
     sh:property [
         a sh:PropertyShape ;
-        sh:path <https://admin-shell.io/aas/3/0/EmbeddedDataSpecification/dataSpecification> ;
-        sh:class aas:Reference ;
+        sh:path <https://admin-shell.io/aas/3/0/EmbeddedDataSpecification/dataSpecificationContent> ;
+        sh:class aas:DataSpecificationContent ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
     ] ;

--- a/test_data/typescript/test_main/aas_core_meta.v3/expected_output/jsonization.ts
+++ b/test_data/typescript/test_main/aas_core_meta.v3/expected_output/jsonization.ts
@@ -14452,29 +14452,9 @@ export function dataSpecificationContentFromJsonable(
  * of {@link types!EmbeddedDataSpecification}.
  */
 class SetterForEmbeddedDataSpecification {
-  dataSpecificationContent: AasTypes.IDataSpecificationContent | null = null;
-
   dataSpecification: AasTypes.Reference | null = null;
 
-  /**
-   * Parse `jsonable` as the value of {@link dataSpecificationContent}.
-   *
-   * @param jsonable - to be parsed
-   * @returns error, if any
-   */
-  setDataSpecificationContentFromJsonable(
-    jsonable: JsonValue
-  ): DeserializationError | null {
-    const parsedOrError = dataSpecificationContentFromJsonable(
-      jsonable
-    );
-    if (parsedOrError.error !== null) {
-      return parsedOrError.error;
-    } else {
-      this.dataSpecificationContent = parsedOrError.mustValue();
-      return null;
-    }
-  }
+  dataSpecificationContent: AasTypes.IDataSpecificationContent | null = null;
 
   /**
    * Parse `jsonable` as the value of {@link dataSpecification}.
@@ -14492,6 +14472,26 @@ class SetterForEmbeddedDataSpecification {
       return parsedOrError.error;
     } else {
       this.dataSpecification = parsedOrError.mustValue();
+      return null;
+    }
+  }
+
+  /**
+   * Parse `jsonable` as the value of {@link dataSpecificationContent}.
+   *
+   * @param jsonable - to be parsed
+   * @returns error, if any
+   */
+  setDataSpecificationContentFromJsonable(
+    jsonable: JsonValue
+  ): DeserializationError | null {
+    const parsedOrError = dataSpecificationContentFromJsonable(
+      jsonable
+    );
+    if (parsedOrError.error !== null) {
+      return parsedOrError.error;
+    } else {
+      this.dataSpecificationContent = parsedOrError.mustValue();
       return null;
     }
   }
@@ -14557,14 +14557,6 @@ export function embeddedDataSpecificationFromJsonable(
     }
   }
 
-  if (setter.dataSpecificationContent === null) {
-    return newDeserializationError<
-      AasTypes.EmbeddedDataSpecification
-    >(
-      "The required property 'dataSpecificationContent' is missing"
-    );
-  }
-
   if (setter.dataSpecification === null) {
     return newDeserializationError<
       AasTypes.EmbeddedDataSpecification
@@ -14573,13 +14565,21 @@ export function embeddedDataSpecificationFromJsonable(
     );
   }
 
+  if (setter.dataSpecificationContent === null) {
+    return newDeserializationError<
+      AasTypes.EmbeddedDataSpecification
+    >(
+      "The required property 'dataSpecificationContent' is missing"
+    );
+  }
+
   return new AasCommon.Either<
     AasTypes.EmbeddedDataSpecification,
     DeserializationError
   >(
     new AasTypes.EmbeddedDataSpecification(
-      setter.dataSpecificationContent,
-      setter.dataSpecification
+      setter.dataSpecification,
+      setter.dataSpecificationContent
     ),
     null
   );
@@ -18062,12 +18062,12 @@ const SETTER_MAP_FOR_EMBEDDED_DATA_SPECIFICATION =
   >(
     [
       [
-        "dataSpecificationContent",
-        SetterForEmbeddedDataSpecification.prototype.setDataSpecificationContentFromJsonable
-      ],
-      [
         "dataSpecification",
         SetterForEmbeddedDataSpecification.prototype.setDataSpecificationFromJsonable
+      ],
+      [
+        "dataSpecificationContent",
+        SetterForEmbeddedDataSpecification.prototype.setDataSpecificationContentFromJsonable
       ],
     ]
   );
@@ -20530,11 +20530,11 @@ class Serializer extends AasTypes.AbstractTransformer<JsonObject> {
   ): JsonObject {
     const jsonable: JsonObject = {};
 
-    jsonable["dataSpecificationContent"] =
-      this.transform(that.dataSpecificationContent);
-
     jsonable["dataSpecification"] =
       this.transform(that.dataSpecification);
+
+    jsonable["dataSpecificationContent"] =
+      this.transform(that.dataSpecificationContent);
 
     return jsonable;
   }

--- a/test_data/typescript/test_main/aas_core_meta.v3/expected_output/types.ts
+++ b/test_data/typescript/test_main/aas_core_meta.v3/expected_output/types.ts
@@ -9934,14 +9934,14 @@ export class EmbeddedDataSpecification extends Class {
   }
 
   /**
-   * Actual content of the data specification
-   */
-  dataSpecificationContent: IDataSpecificationContent;
-
-  /**
    * Reference to the data specification
    */
   dataSpecification: Reference;
+
+  /**
+   * Actual content of the data specification
+   */
+  dataSpecificationContent: IDataSpecificationContent;
 
   /**
    * Iterate over the instances referenced from this instance.
@@ -9951,9 +9951,9 @@ export class EmbeddedDataSpecification extends Class {
    * @returns Iterator over the referenced instances
    */
   *descendOnce(): IterableIterator<Class> {
-    yield this.dataSpecificationContent;
-
     yield this.dataSpecification;
+
+    yield this.dataSpecificationContent;
   }
 
   /**
@@ -9962,13 +9962,13 @@ export class EmbeddedDataSpecification extends Class {
    * @returns Iterator over the referenced instances
    */
   *descend(): IterableIterator<Class> {
-    yield this.dataSpecificationContent;
-
-    yield * this.dataSpecificationContent.descend();
-
     yield this.dataSpecification;
 
     yield * this.dataSpecification.descend();
+
+    yield this.dataSpecificationContent;
+
+    yield * this.dataSpecificationContent.descend();
   }
 
   /**
@@ -10024,12 +10024,12 @@ export class EmbeddedDataSpecification extends Class {
   }
 
   constructor(
-    dataSpecificationContent: IDataSpecificationContent,
-    dataSpecification: Reference
+    dataSpecification: Reference,
+    dataSpecificationContent: IDataSpecificationContent
   ) {
     super();
-    this.dataSpecificationContent = dataSpecificationContent;
     this.dataSpecification = dataSpecification;
+    this.dataSpecificationContent = dataSpecificationContent;
   }
 }
 

--- a/test_data/typescript/test_main/aas_core_meta.v3/expected_output/verification.ts
+++ b/test_data/typescript/test_main/aas_core_meta.v3/expected_output/verification.ts
@@ -9280,24 +9280,24 @@ class Verifier
   ): IterableIterator<VerificationError> {
     if (context === true) {
       for (const error of this.transformWithContext(
-          that.dataSpecificationContent, context)
-      ) {
-        error.path.prepend(
-          new PropertySegment(
-            that,
-            "dataSpecificationContent"
-          )
-        );
-        yield error;
-      }
-
-      for (const error of this.transformWithContext(
           that.dataSpecification, context)
       ) {
         error.path.prepend(
           new PropertySegment(
             that,
             "dataSpecification"
+          )
+        );
+        yield error;
+      }
+
+      for (const error of this.transformWithContext(
+          that.dataSpecificationContent, context)
+      ) {
+        error.path.prepend(
+          new PropertySegment(
+            that,
+            "dataSpecificationContent"
           )
         );
         yield error;

--- a/test_data/xsd/test_main/aas_core_meta.v3/expected_output/schema.xsd
+++ b/test_data/xsd/test_main/aas_core_meta.v3/expected_output/schema.xsd
@@ -277,6 +277,7 @@
   </xs:group>
   <xs:group name="embeddedDataSpecification">
     <xs:sequence>
+      <xs:element name="dataSpecification" type="reference_t"/>
       <xs:element name="dataSpecificationContent">
         <xs:complexType>
           <xs:sequence>
@@ -284,7 +285,6 @@
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="dataSpecification" type="reference_t"/>
     </xs:sequence>
   </xs:group>
   <xs:group name="entity">


### PR DESCRIPTION
We update the development requirements to and re-record the test data for [aas-core-meta 77d3442].

Notably, we propagate the fix for V3.0 in the meta-model which reverted the order of ``data_specification`` and ``data_specification_content``. This was necessary so that the XML schemas for V3.0 remain backwards compatible.

[aas-core-meta 77d3442]: https://github.com/aas-core-works/aas-core-meta/commit/77d3442