### PR TITLE
Namespaces / Packages in generated *.proto

### DIFF
--- a/aas_core_codegen/protobuf/main.py
+++ b/aas_core_codegen/protobuf/main.py
@@ -66,16 +66,16 @@ def execute(context: run.Context, stdout: TextIO, stderr: TextIO) -> int:
         )
         return 1
 
-    namespace_key = specific_implementations.ImplementationKey("namespace.txt")
+    namespace_key = specific_implementations.ImplementationKey("package.txt")
     namespace_text = context.spec_impls.get(namespace_key, None)
     if namespace_text is None:
-        stderr.write(f"The namespace snippet is missing: {namespace_key}\n")
+        stderr.write(f"The package snippet is missing: {namespace_key}\n")
         return 1
 
     if not proto_common.NAMESPACE_IDENTIFIER_RE.fullmatch(namespace_text):
         stderr.write(
             f"The text from the snippet {namespace_key} "
-            f"is not a valid namespace identifier: {namespace_text!r}\n"
+            f"is not a valid package identifier: {namespace_text!r}\n"
         )
         return 1
 

--- a/aas_core_codegen/protobuf/structure/_generate.py
+++ b/aas_core_codegen/protobuf/structure/_generate.py
@@ -484,7 +484,9 @@ syntax = "proto3";
 
 package {namespace};
 
-option csharp_namespace = "{namespace}.Proto";
+option csharp_namespace = "AasCore.Aas3_0.Proto";
+option java_package = "aas_core.aas3_0.types.proto";
+option go_package = "github.com/aas-core-works/aas-core3.0-golang/types/proto";
 
 
 {code_blocks_joined}"""

--- a/aas_core_codegen/protobuf/structure/_generate.py
+++ b/aas_core_codegen/protobuf/structure/_generate.py
@@ -484,6 +484,8 @@ syntax = "proto3";
 
 package {namespace};
 
+option csharp_namespace = "{namespace}.Proto";
+
 
 {code_blocks_joined}"""
         ),

--- a/test_data/proto/test_main/expected/aas_core_meta.v3/expected_output/types.proto
+++ b/test_data/proto/test_main/expected/aas_core_meta.v3/expected_output/types.proto
@@ -5,7 +5,11 @@
 
 syntax = "proto3";
 
-package aas_core3;
+package aas_core.aas3_0;
+
+option csharp_namespace = "AasCore.Aas3_0.Proto";
+option java_package = "aas_core.aas3_0.types.proto";
+option go_package = "github.com/aas-core-works/aas-core3.0-golang/types/proto";
 
 
 /// <summary>
@@ -3282,14 +3286,14 @@ message Environment {
 /// </summary>
 message EmbeddedDataSpecification {
   /// <summary>
-  /// Reference to the data specification
-  /// </summary>
-  Reference data_specification = 1;
-
-  /// <summary>
   /// Actual content of the data specification
   /// </summary>
-  DataSpecificationContent_choice data_specification_content = 2;
+  DataSpecificationContent_choice data_specification_content = 1;
+
+  /// <summary>
+  /// Reference to the data specification
+  /// </summary>
+  Reference data_specification = 2;
 }
 
 enum DataTypeIec61360 {

--- a/test_data/proto/test_main/expected/aas_core_meta.v3/input/snippets/namespace.txt
+++ b/test_data/proto/test_main/expected/aas_core_meta.v3/input/snippets/namespace.txt
@@ -1,1 +1,0 @@
-aas_core3

--- a/test_data/proto/test_main/expected/aas_core_meta.v3/input/snippets/package.txt
+++ b/test_data/proto/test_main/expected/aas_core_meta.v3/input/snippets/package.txt
@@ -1,0 +1,1 @@
+aas_core.aas3_0


### PR DESCRIPTION
Previously, the *.proto files did not contain any hints about the namespace/package names in the target language. Thus, the protoc compiler just generated default namespaces.

Using the options as specified in this PR, the namespaces in the target languages of protoc are known beforehand.