### PR TITLE
Enforce None default for optional constructor args

### DIFF
--- a/test_data/intermediate/unexpected/optional_constructor_arguments_wo_default/default_non_none/expected_error.txt
+++ b/test_data/intermediate/unexpected/optional_constructor_arguments_wo_default/default_non_none/expected_error.txt
@@ -1,0 +1,1 @@
+Expected the optional constructor argument 'property_b' of class 'SomethingAbstract' to default to ``None``, but it was set to a non-None default.

--- a/test_data/intermediate/unexpected/optional_constructor_arguments_wo_default/default_non_none/meta_model.py
+++ b/test_data/intermediate/unexpected/optional_constructor_arguments_wo_default/default_non_none/meta_model.py
@@ -1,0 +1,16 @@
+class SomethingAbstract:
+    property_a: str
+    property_b: Optional[str]
+
+    def __init__(
+        self,
+        property_a: str,
+        # The default to None is missing here.
+        property_b: Optional[str] = "abc",
+    ) -> None:
+        self.property_a = property_a
+        self.property_b = property_b
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/intermediate/unexpected/optional_constructor_arguments_wo_default/no_default/expected_error.txt
+++ b/test_data/intermediate/unexpected/optional_constructor_arguments_wo_default/no_default/expected_error.txt
@@ -1,0 +1,1 @@
+Expected the optional constructor argument 'property_b' of class 'SomethingAbstract' to default to ``None``, but no default has been set.

--- a/test_data/intermediate/unexpected/optional_constructor_arguments_wo_default/no_default/meta_model.py
+++ b/test_data/intermediate/unexpected/optional_constructor_arguments_wo_default/no_default/meta_model.py
@@ -1,0 +1,16 @@
+class SomethingAbstract:
+    property_a: str
+    property_b: Optional[str]
+
+    def __init__(
+        self,
+        property_a: str,
+        # The default to None is missing here.
+        property_b: Optional[str],
+    ) -> None:
+        self.property_a = property_a
+        self.property_b = property_b
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/test_data/opcua/test_main/concrete_class_with_enum/meta_model.py
+++ b/test_data/opcua/test_main/concrete_class_with_enum/meta_model.py
@@ -10,7 +10,7 @@ class Something:
     def __init__(
         self,
         modelling_kind: Modelling_kind,
-        optional_modelling_kind: Optional[Modelling_kind],
+        optional_modelling_kind: Optional[Modelling_kind] = None,
     ) -> None:
         self.modelling_kind = modelling_kind
         self.optional_modelling_kind = optional_modelling_kind

--- a/test_data/opcua/test_main/concrete_class_with_list_of_instances/meta_model.py
+++ b/test_data/opcua/test_main/concrete_class_with_list_of_instances/meta_model.py
@@ -9,7 +9,9 @@ class Something:
     items: List[Item]
     optional_items: Optional[List[Item]]
 
-    def __init__(self, items: List[Item], optional_items: Optional[List[Item]]) -> None:
+    def __init__(
+        self, items: List[Item], optional_items: Optional[List[Item]] = None
+    ) -> None:
         self.items = items
         self.optional_items = optional_items
 

--- a/test_data/opcua/test_main/concrete_class_with_primitive_attributes/meta_model.py
+++ b/test_data/opcua/test_main/concrete_class_with_primitive_attributes/meta_model.py
@@ -18,11 +18,11 @@ class Something:
         some_float: float,
         some_str: str,
         some_byte_array: bytearray,
-        some_optional_bool: Optional[bool],
-        some_optional_int: Optional[int],
-        some_optional_float: Optional[float],
-        some_optional_str: Optional[str],
-        some_optional_byte_array: Optional[bytearray],
+        some_optional_bool: Optional[bool] = None,
+        some_optional_int: Optional[int] = None,
+        some_optional_float: Optional[float] = None,
+        some_optional_str: Optional[str] = None,
+        some_optional_byte_array: Optional[bytearray] = None,
     ) -> None:
         self.some_bool = some_bool
         self.some_int = some_int

--- a/test_data/proto/test_main/expected/concrete_class_with_enum/meta_model.py
+++ b/test_data/proto/test_main/expected/concrete_class_with_enum/meta_model.py
@@ -10,7 +10,7 @@ class Something:
     def __init__(
         self,
         modelling_kind: Modelling_kind,
-        optional_modelling_kind: Optional[Modelling_kind],
+        optional_modelling_kind: Optional[Modelling_kind] = None,
     ) -> None:
         self.modelling_kind = modelling_kind
         self.optional_modelling_kind = optional_modelling_kind

--- a/test_data/proto/test_main/expected/concrete_class_with_list_of_instances/meta_model.py
+++ b/test_data/proto/test_main/expected/concrete_class_with_list_of_instances/meta_model.py
@@ -9,7 +9,9 @@ class Something:
     items: List[Item]
     optional_items: Optional[List[Item]]
 
-    def __init__(self, items: List[Item], optional_items: Optional[List[Item]]) -> None:
+    def __init__(
+        self, items: List[Item], optional_items: Optional[List[Item]] = None
+    ) -> None:
         self.items = items
         self.optional_items = optional_items
 

--- a/test_data/proto/test_main/expected/concrete_class_with_primitive_attributes/meta_model.py
+++ b/test_data/proto/test_main/expected/concrete_class_with_primitive_attributes/meta_model.py
@@ -18,11 +18,11 @@ class Something:
         some_float: float,
         some_str: str,
         some_byte_array: bytearray,
-        some_optional_bool: Optional[bool],
-        some_optional_int: Optional[int],
-        some_optional_float: Optional[float],
-        some_optional_str: Optional[str],
-        some_optional_byte_array: Optional[bytearray],
+        some_optional_bool: Optional[bool] = None,
+        some_optional_int: Optional[int] = None,
+        some_optional_float: Optional[float] = None,
+        some_optional_str: Optional[str] = None,
+        some_optional_byte_array: Optional[bytearray] = None,
     ) -> None:
         self.some_bool = some_bool
         self.some_int = some_int

--- a/test_data/python_protobuf/test_main/concrete_class_with_enum/meta_model.py
+++ b/test_data/python_protobuf/test_main/concrete_class_with_enum/meta_model.py
@@ -10,7 +10,7 @@ class Something:
     def __init__(
         self,
         modelling_kind: Modelling_kind,
-        optional_modelling_kind: Optional[Modelling_kind],
+        optional_modelling_kind: Optional[Modelling_kind] = None
     ) -> None:
         self.modelling_kind = modelling_kind
         self.optional_modelling_kind = optional_modelling_kind

--- a/test_data/python_protobuf/test_main/concrete_class_with_list_of_instances/meta_model.py
+++ b/test_data/python_protobuf/test_main/concrete_class_with_list_of_instances/meta_model.py
@@ -9,7 +9,11 @@ class Something:
     items: List[Item]
     optional_items: Optional[List[Item]]
 
-    def __init__(self, items: List[Item], optional_items: Optional[List[Item]]) -> None:
+    def __init__(
+            self,
+            items: List[Item],
+            optional_items: Optional[List[Item]] = None
+    ) -> None:
         self.items = items
         self.optional_items = optional_items
 

--- a/test_data/python_protobuf/test_main/concrete_class_with_primitive_attributes/meta_model.py
+++ b/test_data/python_protobuf/test_main/concrete_class_with_primitive_attributes/meta_model.py
@@ -18,11 +18,11 @@ class Something:
         some_float: float,
         some_str: str,
         some_byte_array: bytearray,
-        some_optional_bool: Optional[bool],
-        some_optional_int: Optional[int],
-        some_optional_float: Optional[float],
-        some_optional_str: Optional[str],
-        some_optional_byte_array: Optional[bytearray],
+        some_optional_bool: Optional[bool] = None,
+        some_optional_int: Optional[int] = None,
+        some_optional_float: Optional[float] = None,
+        some_optional_str: Optional[str] = None,
+        some_optional_byte_array: Optional[bytearray] = None
     ) -> None:
         self.some_bool = some_bool
         self.some_int = some_int

--- a/test_data/rdf_shacl/test_main/unexpected/regression_len_constraint_on_class_property/expected_output/stderr.txt
+++ b/test_data/rdf_shacl/test_main/unexpected/regression_len_constraint_on_class_property/expected_output/stderr.txt
@@ -1,3 +1,3 @@
-Failed to generate the SHACL schema based on <meta_model.py>:
-* Failed to generate the shape definition for Something
-    At line 54 and column 6: (mristin, 2023-02-08): A length constraint has been inferred for the property 'value' in the class 'Something' whose type is a class, namely Optional[Value]. We do not know how to impose the length constraints on a property of type *class* in SHACL at this moment. If this is not a bug in your meta-model, please contact the developers to see how to implement this feature.
+Failed to translate the parsed symbol table to intermediate symbol table:
+* At line 1 and column 1: Failed to translate the parsed symbol table to an intermediate symbol table
+    At line 56 and column 25: Expected the optional constructor argument 'value' of class 'Something' to default to ``None``, but no default has been set.

--- a/tests/proto/test_main.py
+++ b/tests/proto/test_main.py
@@ -66,7 +66,8 @@ class Test_against_recorded(unittest.TestCase):
 
                 if stderr.getvalue() != "":
                     raise AssertionError(
-                        f"Expected no stderr on valid models, but got:\n"
+                        f"Expected no stderr on valid models, but got "
+                        f"for {test_case.model_path}:\n"
                         f"{stderr.getvalue()}"
                     )
 


### PR DESCRIPTION
We enforce that all optional constructor arguments must be given a ``None`` default value for consistency. We struggled in downstream projects where optional arguments *without* a default caused a lot of confusion.

Therefore, to make the life of the downstream users simpler (*e.g.*, people using the generated SDKs), we impose that all constructor arguments must be initialized with a ``None`` default, which is in line with expectations of most of the programmers.