### PR TITLE
Fix update-to-aas-core-meta dev script

### DIFF
--- a/dev_scripts/update_to_aas_core_meta.py
+++ b/dev_scripts/update_to_aas_core_meta.py
@@ -12,7 +12,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from typing import Optional, List, MutableMapping
+from typing import Optional
 
 AAS_CORE_META_DEPENDENCY_RE = re.compile(
     r"aas-core-meta@git\+https://github.com/aas-core-works/aas-core-meta@([a-fA-F0-9]+)#egg=aas-core-meta"
@@ -116,7 +116,7 @@ def _rerecord_everything(repo_dir: pathlib.Path) -> Optional[int]:
                 str(starting_point),
             ],
             env=env,
-            cwd=str(repo_dir)
+            cwd=str(repo_dir),
         )
 
     duration = time.perf_counter() - start

--- a/tests/jsonld_context/test_main.py
+++ b/tests/jsonld_context/test_main.py
@@ -23,11 +23,6 @@ class Test_jsonld_context(unittest.TestCase):
             model_pth = pathlib.Path(module.__file__)
             assert model_pth.exists() and model_pth.is_file(), model_pth
 
-            expected_jsonld_context_path = expected_output_dir / "context.jsonld"
-            expected_jsonld_context = expected_jsonld_context_path.read_text(
-                encoding="utf-8"
-            )
-
             with contextlib.ExitStack() as exit_stack:
                 if tests.common.RERECORD:
                     output_dir = expected_output_dir
@@ -61,19 +56,28 @@ class Test_jsonld_context(unittest.TestCase):
                 self.assertEqual(
                     0, return_code, "Expected 0 return code on valid models"
                 )
-                generated_jsonld_context_path = output_dir / "context.jsonld"
-                generated_jsonld_context = generated_jsonld_context_path.read_text(
-                    encoding="utf-8"
-                )
 
-                self.assertEqual(
-                    generated_jsonld_context,
-                    expected_jsonld_context,
-                    f"The generated and the expected context differ. "
-                    f"The expected JSON-LD context lives "
-                    f"at: {expected_jsonld_context_path}, while the generated one "
-                    f"at: {generated_jsonld_context_path}",
-                )
+                if not tests.common.RERECORD:
+                    generated_jsonld_context_path = output_dir / "context.jsonld"
+                    generated_jsonld_context = generated_jsonld_context_path.read_text(
+                        encoding="utf-8"
+                    )
+
+                    expected_jsonld_context_path = (
+                        expected_output_dir / "context.jsonld"
+                    )
+                    expected_jsonld_context = expected_jsonld_context_path.read_text(
+                        encoding="utf-8"
+                    )
+
+                    self.assertEqual(
+                        generated_jsonld_context,
+                        expected_jsonld_context,
+                        f"The generated and the expected context differ. "
+                        f"The expected JSON-LD context lives "
+                        f"at: {expected_jsonld_context_path}, while the generated one "
+                        f"at: {generated_jsonld_context_path}",
+                    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We perform a series of fixes to the dev script revealed by updating to the latest aas-core-meta.

The errors were caused by the bit rot.