### PR TITLE
Update test data to aas-core-meta f2fd738

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
             "twine",
             "jsonschema==3.2.0",
             "xmlschema==3.3.1",
-            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@5d409d6#egg=aas-core-meta",
+            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@f2fd738#egg=aas-core-meta",
             "ssort==0.12.3",
         ]
     },

--- a/test_data/cpp/test_main/aas_core_meta.v3/expected_output/verification.hpp
+++ b/test_data/cpp/test_main/aas_core_meta.v3/expected_output/verification.hpp
@@ -812,6 +812,18 @@ bool IsBcp47ForEnglish(
  * \param that value to be verified
  * \return Iterable over constraint violations
  */
+std::unique_ptr<IVerification> VerifyXmlSerializableString(
+  const std::wstring& that
+);
+
+/**
+ * \brief Verify that the invariants hold for \p that value.
+ *
+ * The \p that value should outlive the verification.
+ *
+ * \param that value to be verified
+ * \return Iterable over constraint violations
+ */
 std::unique_ptr<IVerification> VerifyNonEmptyXmlSerializableString(
   const std::wstring& that
 );

--- a/test_data/csharp/test_main/aas_core_meta.v3/expected_output/verification.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3/expected_output/verification.cs
@@ -9557,6 +9557,22 @@ namespace AasCore.Aas3_0
         /// <summary>
         /// Verify the constraints of <paramref name="that" />.
         /// </summary>
+        public static IEnumerable<Reporting.Error> VerifyXmlSerializableString (
+            string that)
+        {
+            if (!Verification.MatchesXmlSerializableString(that))
+            {
+                yield return new Reporting.Error(
+                    "Invariant violated:\n" +
+                    "Constraint AASd-130: An attribute with data type 'string' " +
+                    "shall consist of these characters only: " +
+                    "^[\\x09\\x0A\\x0D\\x20-\\uD7FF\\uE000-\\uFFFD\\U00010000-\\U0010FFFF]*$.");
+            }
+        }
+
+        /// <summary>
+        /// Verify the constraints of <paramref name="that" />.
+        /// </summary>
         public static IEnumerable<Reporting.Error> VerifyNonEmptyXmlSerializableString (
             string that)
         {
@@ -9976,13 +9992,6 @@ namespace AasCore.Aas3_0
                     "Constraint AASd-130: An attribute with data type 'string' " +
                     "shall consist of these characters only: " +
                     "^[\\x09\\x0A\\x0D\\x20-\\uD7FF\\uE000-\\uFFFD\\U00010000-\\U0010FFFF]*$.");
-            }
-
-            if (!(that.Length >= 1))
-            {
-                yield return new Reporting.Error(
-                    "Invariant violated:\n" +
-                    "The value must not be empty.");
             }
         }
 

--- a/test_data/golang/test_main/aas_core_meta.v3/expected_output/verification/verification.go
+++ b/test_data/golang/test_main/aas_core_meta.v3/expected_output/verification/verification.go
@@ -13065,6 +13065,34 @@ func VerifyDataSpecificationIEC61360(
 // If `onError` returns abort `true`, this function will abort
 // further verification as well, and return abort `true`. Otherwise,
 // abort `false` is returned.
+func VerifyXMLSerializableString(
+	that string,
+	onError func(*VerificationError) bool,
+) (abort bool) {
+	abort = false
+
+	if !MatchesXMLSerializableString(that) {
+		abort = onError(
+			newVerificationError(
+				"Constraint AASd-130: An attribute with data type 'string' " +
+				"shall consist of these characters only: " +
+				"^[\\x09\\x0A\\x0D\\x20-\\uD7FF\\uE000-\\uFFFD\\U00010000-\\U0010FFFF]*$.",
+			),
+		)
+		if abort {
+			return
+		}
+	}
+
+	return
+}
+
+// Verify the constraints of `that` value.
+//
+// You have to supply the callback `onError` to iterate over the errors.
+// If `onError` returns abort `true`, this function will abort
+// further verification as well, and return abort `true`. Otherwise,
+// abort `false` is returned.
 func VerifyNonEmptyXMLSerializableString(
 	that string,
 	onError func(*VerificationError) bool,
@@ -13740,16 +13768,6 @@ func VerifyValueDataType(
 				"shall consist of these characters only: " +
 				"^[\\x09\\x0A\\x0D\\x20-\\uD7FF\\uE000-\\uFFFD\\U00010000-\\U0010FFFF]*$.",
 			),
-		)
-		if abort {
-			return
-		}
-	}
-
-	if !(len(that) >= 1) {
-		abort = onError(
-			newVerificationError(
-				"The value must not be empty.",),
 		)
 		if abort {
 			return

--- a/test_data/intermediate/real_meta_models/aas_core_meta.v3/expected_symbol_table.txt
+++ b/test_data/intermediate/real_meta_models/aas_core_meta.v3/expected_symbol_table.txt
@@ -1,7 +1,7 @@
 SymbolTable(
   our_types=[
     ConstrainedPrimitive(
-      name='Non_empty_XML_serializable_string',
+      name='XML_serializable_string',
       inheritances=[],
       inheritance_id_set=...,
       ancestors=[],
@@ -20,7 +20,43 @@ SymbolTable(
                   identifier='self',
                   original_node=...)],
               original_node=...)"""),
-          specified_for='Reference to ConstrainedPrimitive Non_empty_XML_serializable_string',
+          specified_for='Reference to ConstrainedPrimitive XML_serializable_string',
+          parsed=...)],
+      invariant_id_set=...,
+      description=DescriptionOfOurType(
+        summary='<paragraph>Represent a string which must be serializable to XML.</paragraph>',
+        remarks=[],
+        constraints_by_identifier=[
+          [
+            'AASd-130',
+            textwrap.dedent("""\
+              <field_body><paragraph>An attribute with data type "string" shall consist of these characters only:
+              <literal>^[\\x09\\x0A\\x0D\\x20-\\uD7FF\\uE000-\\uFFFD\\u00010000-\\u0010FFFF]*$</literal>.</paragraph></field_body>""")]],
+        parsed=...),
+      parsed=...),
+    ConstrainedPrimitive(
+      name='Non_empty_XML_serializable_string',
+      inheritances=[
+        'Reference to ConstrainedPrimitive XML_serializable_string'],
+      inheritance_id_set=...,
+      ancestors=[
+        'Reference to ConstrainedPrimitive XML_serializable_string'],
+      ancestor_id_set=...,
+      descendant_id_set=...,
+      constrainee='STR',
+      is_implementation_specific=False,
+      invariants=[
+        Invariant(
+          description="Constraint AASd-130: An attribute with data type 'string' shall consist of these characters only: ^[\\x09\\x0A\\x0D\\x20-\\uD7FF\\uE000-\\uFFFD\\U00010000-\\U0010FFFF]*$.",
+          body=textwrap.dedent("""\
+            FunctionCall(
+              name='matches_XML_serializable_string',
+              args=[
+                Name(
+                  identifier='self',
+                  original_node=...)],
+              original_node=...)"""),
+          specified_for='Reference to ConstrainedPrimitive XML_serializable_string',
           parsed=...),
         Invariant(
           description='The value must not be empty.',
@@ -42,17 +78,9 @@ SymbolTable(
           parsed=...)],
       invariant_id_set=...,
       description=DescriptionOfOurType(
-        summary='<paragraph>Represent a string with at least one character.</paragraph>',
-        remarks=[
-          textwrap.dedent("""\
-            <paragraph>The string should also be serializable to XML, which is the background for
-            the following constraint.</paragraph>""")],
-        constraints_by_identifier=[
-          [
-            'AASd-130',
-            textwrap.dedent("""\
-              <field_body><paragraph>An attribute with data type "string" shall consist of these characters only:
-              <literal>^[\\x09\\x0A\\x0D\\x20-\\uD7FF\\uE000-\\uFFFD\\u00010000-\\u0010FFFF]*$</literal>.</paragraph></field_body>""")]],
+        summary='<paragraph>Represent an XML-serializable string with at least one character.</paragraph>',
+        remarks=[],
+        constraints_by_identifier=[],
         parsed=...),
       parsed=...),
     ConstrainedPrimitive(
@@ -148,6 +176,7 @@ SymbolTable(
         'Reference to ConstrainedPrimitive Non_empty_XML_serializable_string'],
       inheritance_id_set=...,
       ancestors=[
+        'Reference to ConstrainedPrimitive XML_serializable_string',
         'Reference to ConstrainedPrimitive Non_empty_XML_serializable_string'],
       ancestor_id_set=...,
       descendant_id_set=...,
@@ -164,7 +193,7 @@ SymbolTable(
                   identifier='self',
                   original_node=...)],
               original_node=...)"""),
-          specified_for='Reference to ConstrainedPrimitive Non_empty_XML_serializable_string',
+          specified_for='Reference to ConstrainedPrimitive XML_serializable_string',
           parsed=...),
         Invariant(
           description='The value must not be empty.',
@@ -215,6 +244,7 @@ SymbolTable(
         'Reference to ConstrainedPrimitive Non_empty_XML_serializable_string'],
       inheritance_id_set=...,
       ancestors=[
+        'Reference to ConstrainedPrimitive XML_serializable_string',
         'Reference to ConstrainedPrimitive Non_empty_XML_serializable_string'],
       ancestor_id_set=...,
       descendant_id_set=...,
@@ -231,7 +261,7 @@ SymbolTable(
                   identifier='self',
                   original_node=...)],
               original_node=...)"""),
-          specified_for='Reference to ConstrainedPrimitive Non_empty_XML_serializable_string',
+          specified_for='Reference to ConstrainedPrimitive XML_serializable_string',
           parsed=...),
         Invariant(
           description='The value must not be empty.',
@@ -282,6 +312,7 @@ SymbolTable(
         'Reference to ConstrainedPrimitive Non_empty_XML_serializable_string'],
       inheritance_id_set=...,
       ancestors=[
+        'Reference to ConstrainedPrimitive XML_serializable_string',
         'Reference to ConstrainedPrimitive Non_empty_XML_serializable_string'],
       ancestor_id_set=...,
       descendant_id_set=...,
@@ -298,7 +329,7 @@ SymbolTable(
                   identifier='self',
                   original_node=...)],
               original_node=...)"""),
-          specified_for='Reference to ConstrainedPrimitive Non_empty_XML_serializable_string',
+          specified_for='Reference to ConstrainedPrimitive XML_serializable_string',
           parsed=...),
         Invariant(
           description='The value must not be empty.',
@@ -349,6 +380,7 @@ SymbolTable(
         'Reference to ConstrainedPrimitive Non_empty_XML_serializable_string'],
       inheritance_id_set=...,
       ancestors=[
+        'Reference to ConstrainedPrimitive XML_serializable_string',
         'Reference to ConstrainedPrimitive Non_empty_XML_serializable_string'],
       ancestor_id_set=...,
       descendant_id_set=...,
@@ -365,7 +397,7 @@ SymbolTable(
                   identifier='self',
                   original_node=...)],
               original_node=...)"""),
-          specified_for='Reference to ConstrainedPrimitive Non_empty_XML_serializable_string',
+          specified_for='Reference to ConstrainedPrimitive XML_serializable_string',
           parsed=...),
         Invariant(
           description='The value must not be empty.',
@@ -428,6 +460,7 @@ SymbolTable(
         'Reference to ConstrainedPrimitive Non_empty_XML_serializable_string'],
       inheritance_id_set=...,
       ancestors=[
+        'Reference to ConstrainedPrimitive XML_serializable_string',
         'Reference to ConstrainedPrimitive Non_empty_XML_serializable_string'],
       ancestor_id_set=...,
       descendant_id_set=...,
@@ -444,7 +477,7 @@ SymbolTable(
                   identifier='self',
                   original_node=...)],
               original_node=...)"""),
-          specified_for='Reference to ConstrainedPrimitive Non_empty_XML_serializable_string',
+          specified_for='Reference to ConstrainedPrimitive XML_serializable_string',
           parsed=...),
         Invariant(
           description='The value must not be empty.',
@@ -507,6 +540,7 @@ SymbolTable(
         'Reference to ConstrainedPrimitive Non_empty_XML_serializable_string'],
       inheritance_id_set=...,
       ancestors=[
+        'Reference to ConstrainedPrimitive XML_serializable_string',
         'Reference to ConstrainedPrimitive Non_empty_XML_serializable_string'],
       ancestor_id_set=...,
       descendant_id_set=...,
@@ -523,7 +557,7 @@ SymbolTable(
                   identifier='self',
                   original_node=...)],
               original_node=...)"""),
-          specified_for='Reference to ConstrainedPrimitive Non_empty_XML_serializable_string',
+          specified_for='Reference to ConstrainedPrimitive XML_serializable_string',
           parsed=...),
         Invariant(
           description='The value must not be empty.',
@@ -574,6 +608,7 @@ SymbolTable(
         'Reference to ConstrainedPrimitive Non_empty_XML_serializable_string'],
       inheritance_id_set=...,
       ancestors=[
+        'Reference to ConstrainedPrimitive XML_serializable_string',
         'Reference to ConstrainedPrimitive Non_empty_XML_serializable_string'],
       ancestor_id_set=...,
       descendant_id_set=...,
@@ -590,7 +625,7 @@ SymbolTable(
                   identifier='self',
                   original_node=...)],
               original_node=...)"""),
-          specified_for='Reference to ConstrainedPrimitive Non_empty_XML_serializable_string',
+          specified_for='Reference to ConstrainedPrimitive XML_serializable_string',
           parsed=...),
         Invariant(
           description='The value must not be empty.',
@@ -671,6 +706,7 @@ SymbolTable(
         'Reference to ConstrainedPrimitive Non_empty_XML_serializable_string'],
       inheritance_id_set=...,
       ancestors=[
+        'Reference to ConstrainedPrimitive XML_serializable_string',
         'Reference to ConstrainedPrimitive Non_empty_XML_serializable_string'],
       ancestor_id_set=...,
       descendant_id_set=...,
@@ -687,7 +723,7 @@ SymbolTable(
                   identifier='self',
                   original_node=...)],
               original_node=...)"""),
-          specified_for='Reference to ConstrainedPrimitive Non_empty_XML_serializable_string',
+          specified_for='Reference to ConstrainedPrimitive XML_serializable_string',
           parsed=...),
         Invariant(
           description='The value must not be empty.',
@@ -760,6 +796,7 @@ SymbolTable(
         'Reference to ConstrainedPrimitive Identifier'],
       inheritance_id_set=...,
       ancestors=[
+        'Reference to ConstrainedPrimitive XML_serializable_string',
         'Reference to ConstrainedPrimitive Non_empty_XML_serializable_string',
         'Reference to ConstrainedPrimitive Identifier'],
       ancestor_id_set=...,
@@ -777,7 +814,7 @@ SymbolTable(
                   identifier='self',
                   original_node=...)],
               original_node=...)"""),
-          specified_for='Reference to ConstrainedPrimitive Non_empty_XML_serializable_string',
+          specified_for='Reference to ConstrainedPrimitive XML_serializable_string',
           parsed=...),
         Invariant(
           description='The value must not be empty.',
@@ -831,6 +868,7 @@ SymbolTable(
         'Reference to ConstrainedPrimitive Name_type'],
       inheritance_id_set=...,
       ancestors=[
+        'Reference to ConstrainedPrimitive XML_serializable_string',
         'Reference to ConstrainedPrimitive Non_empty_XML_serializable_string',
         'Reference to ConstrainedPrimitive Name_type'],
       ancestor_id_set=...,
@@ -848,7 +886,7 @@ SymbolTable(
                   identifier='self',
                   original_node=...)],
               original_node=...)"""),
-          specified_for='Reference to ConstrainedPrimitive Non_empty_XML_serializable_string',
+          specified_for='Reference to ConstrainedPrimitive XML_serializable_string',
           parsed=...),
         Invariant(
           description='The value must not be empty.',
@@ -896,10 +934,10 @@ SymbolTable(
     ConstrainedPrimitive(
       name='Value_data_type',
       inheritances=[
-        'Reference to ConstrainedPrimitive Non_empty_XML_serializable_string'],
+        'Reference to ConstrainedPrimitive XML_serializable_string'],
       inheritance_id_set=...,
       ancestors=[
-        'Reference to ConstrainedPrimitive Non_empty_XML_serializable_string'],
+        'Reference to ConstrainedPrimitive XML_serializable_string'],
       ancestor_id_set=...,
       descendant_id_set=...,
       constrainee='STR',
@@ -915,25 +953,7 @@ SymbolTable(
                   identifier='self',
                   original_node=...)],
               original_node=...)"""),
-          specified_for='Reference to ConstrainedPrimitive Non_empty_XML_serializable_string',
-          parsed=...),
-        Invariant(
-          description='The value must not be empty.',
-          body=textwrap.dedent("""\
-            Comparison(
-              left=FunctionCall(
-                name='len',
-                args=[
-                  Name(
-                    identifier='self',
-                    original_node=...)],
-                original_node=...),
-              op='GE',
-              right=Constant(
-                value=1,
-                original_node=...),
-              original_node=...)"""),
-          specified_for='Reference to ConstrainedPrimitive Non_empty_XML_serializable_string',
+          specified_for='Reference to ConstrainedPrimitive XML_serializable_string',
           parsed=...)],
       invariant_id_set=...,
       description=DescriptionOfOurType(
@@ -948,6 +968,7 @@ SymbolTable(
         'Reference to ConstrainedPrimitive Name_type'],
       inheritance_id_set=...,
       ancestors=[
+        'Reference to ConstrainedPrimitive XML_serializable_string',
         'Reference to ConstrainedPrimitive Non_empty_XML_serializable_string',
         'Reference to ConstrainedPrimitive Name_type'],
       ancestor_id_set=...,
@@ -965,7 +986,7 @@ SymbolTable(
                   identifier='self',
                   original_node=...)],
               original_node=...)"""),
-          specified_for='Reference to ConstrainedPrimitive Non_empty_XML_serializable_string',
+          specified_for='Reference to ConstrainedPrimitive XML_serializable_string',
           parsed=...),
         Invariant(
           description='The value must not be empty.',
@@ -27456,6 +27477,7 @@ SymbolTable(
     'Reference to our type Blob_type',
     'Reference to our type Capability',
     'Reference to our type Concept_description',
+    'Reference to our type XML_serializable_string',
     'Reference to our type Non_empty_XML_serializable_string',
     'Reference to our type Content_type',
     'Reference to our type Data_specification_content',
@@ -27515,6 +27537,7 @@ SymbolTable(
     'Reference to our type Data_type_def_XSD',
     'Reference to our type Data_type_IEC_61360'],
   constrained_primitives=[
+    'Reference to our type XML_serializable_string',
     'Reference to our type Non_empty_XML_serializable_string',
     'Reference to our type Date_time_UTC',
     'Reference to our type Duration',

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/verification/Verification.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/verification/Verification.java
@@ -9366,6 +9366,25 @@ public class Verification {
   /**
    * Verify the constraints of {@code that}.
    */
+  public static Stream<Reporting.Error> verifyXmlSerializableString (
+    String that) {
+    Stream<Reporting.Error> errorStream = Stream.empty();
+
+    if (!matchesXmlSerializableString(that)) {
+      errorStream = Stream.<Reporting.Error>concat(errorStream,
+        Stream.of(new Reporting.Error(
+          "Invariant violated:\n" +
+          "Constraint AASd-130: An attribute with data type \'string\' " +
+          "shall consist of these characters only: " +
+          "^[\\x09\\x0A\\x0D\\x20-\\uD7FF\\uE000-\\uFFFD\\U00010000-\\U0010FFFF]*$.")));
+    }
+
+    return errorStream;
+  }
+
+  /**
+   * Verify the constraints of {@code that}.
+   */
   public static Stream<Reporting.Error> verifyNonEmptyXmlSerializableString (
     String that) {
     Stream<Reporting.Error> errorStream = Stream.empty();
@@ -9830,13 +9849,6 @@ public class Verification {
           "Constraint AASd-130: An attribute with data type \'string\' " +
           "shall consist of these characters only: " +
           "^[\\x09\\x0A\\x0D\\x20-\\uD7FF\\uE000-\\uFFFD\\U00010000-\\U0010FFFF]*$.")));
-    }
-
-    if (!(that.length() >= 1)) {
-      errorStream = Stream.<Reporting.Error>concat(errorStream,
-        Stream.of(new Reporting.Error(
-          "Invariant violated:\n" +
-          "The value must not be empty.")));
     }
 
     return errorStream;

--- a/test_data/jsonld_context/aas_core_meta.v3/output/context.jsonld
+++ b/test_data/jsonld_context/aas_core_meta.v3/output/context.jsonld
@@ -679,11 +679,6 @@
       "@type": "@id",
       "@context": {}
     },
-    "dataSpecificationContent": {
-      "@id": "aas:EmbeddedDataSpecification/dataSpecificationContent",
-      "@type": "@id",
-      "@context": {}
-    },
     "dataSpecification": {
       "@id": "aas:EmbeddedDataSpecification/dataSpecification",
       "@type": "@id",
@@ -696,6 +691,11 @@
           "@type": "@vocab"
         }
       }
+    },
+    "dataSpecificationContent": {
+      "@id": "aas:EmbeddedDataSpecification/dataSpecificationContent",
+      "@type": "@id",
+      "@context": {}
     },
     "nom": {
       "@id": "aas:LevelType/nom"

--- a/test_data/jsonschema/test_main/aas_core_meta.v3/expected_output/schema.json
+++ b/test_data/jsonschema/test_main/aas_core_meta.v3/expected_output/schema.json
@@ -650,7 +650,6 @@
             },
             "value": {
               "type": "string",
-              "minLength": 1,
               "pattern": "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$"
             },
             "refersTo": {
@@ -1027,7 +1026,6 @@
             },
             "value": {
               "type": "string",
-              "minLength": 1,
               "pattern": "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$"
             },
             "valueId": {
@@ -1082,7 +1080,6 @@
             },
             "value": {
               "type": "string",
-              "minLength": 1,
               "pattern": "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$"
             },
             "valueId": {
@@ -1116,12 +1113,10 @@
             },
             "min": {
               "type": "string",
-              "minLength": 1,
               "pattern": "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$"
             },
             "max": {
               "type": "string",
-              "minLength": 1,
               "pattern": "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$"
             },
             "modelType": {

--- a/test_data/opcua/test_main/aas_core_meta.v3/expected_output/nodeset.xml
+++ b/test_data/opcua/test_main/aas_core_meta.v3/expected_output/nodeset.xml
@@ -5324,7 +5324,7 @@
     </Value>
   </UAVariable>
   <UAObject
-    NodeId="ns=1;i=1391739223"
+    NodeId="ns=1;i=2000147256"
     BrowseName="1:ConstraintAasd130"
     ParentNodeId="i=85"
   >
@@ -5341,16 +5341,16 @@
   </UAObject>
   <UAVariable
     DataType="String"
-    NodeId="ns=1;i=870408013"
+    NodeId="ns=1;i=1253151859"
     BrowseName="1:text"
-    ParentNodeId="ns=1;i=1391739223"
+    ParentNodeId="ns=1;i=2000147256"
   >
     <DisplayName>text</DisplayName>
     <References>
       <Reference
         ReferenceType="HasProperty"
         IsForward="false"
-      >ns=1;i=1391739223</Reference>
+      >ns=1;i=2000147256</Reference>
       <Reference
         ReferenceType="HasTypeDefinition"
       >i=63</Reference>
@@ -5361,16 +5361,16 @@
   </UAVariable>
   <UAVariable
     DataType="String"
-    NodeId="ns=1;i=992901875"
+    NodeId="ns=1;i=64838112"
     BrowseName="1:identifier"
-    ParentNodeId="ns=1;i=1391739223"
+    ParentNodeId="ns=1;i=2000147256"
   >
     <DisplayName>identifier</DisplayName>
     <References>
       <Reference
         ReferenceType="HasProperty"
         IsForward="false"
-      >ns=1;i=1391739223</Reference>
+      >ns=1;i=2000147256</Reference>
       <Reference
         ReferenceType="HasTypeDefinition"
       >i=63</Reference>
@@ -5994,6 +5994,21 @@
   <!-- Constraints end here. -->
   <!-- Constrained primitives start here. -->
   <UADataType
+    NodeId="ns=1;i=1219980333"
+    BrowseName="1:AASXmlSerializableStringDataType"
+  >
+    <DisplayName>AASXmlSerializableStringDataType</DisplayName>
+    <References>
+      <Reference
+        ReferenceType="HasSubtype"
+        IsForward="false"
+      >String</Reference>
+      <Reference
+        ReferenceType="ns=1;i=2053660172"
+      >ns=1;i=2000147256</Reference>
+    </References>
+  </UADataType>
+  <UADataType
     NodeId="ns=1;i=880155738"
     BrowseName="1:AASNonEmptyXmlSerializableStringDataType"
   >
@@ -6005,7 +6020,7 @@
       >String</Reference>
       <Reference
         ReferenceType="ns=1;i=2053660172"
-      >ns=1;i=1391739223</Reference>
+      >ns=1;i=2000147256</Reference>
       <Reference
         ReferenceType="ns=1;i=2053660172"
       >ns=1;i=1586258210</Reference>
@@ -6068,7 +6083,7 @@
       >String</Reference>
       <Reference
         ReferenceType="ns=1;i=2053660172"
-      >ns=1;i=1391739223</Reference>
+      >ns=1;i=2000147256</Reference>
       <Reference
         ReferenceType="ns=1;i=2053660172"
       >ns=1;i=1586258210</Reference>
@@ -6089,7 +6104,7 @@
       >String</Reference>
       <Reference
         ReferenceType="ns=1;i=2053660172"
-      >ns=1;i=1391739223</Reference>
+      >ns=1;i=2000147256</Reference>
       <Reference
         ReferenceType="ns=1;i=2053660172"
       >ns=1;i=1586258210</Reference>
@@ -6110,7 +6125,7 @@
       >String</Reference>
       <Reference
         ReferenceType="ns=1;i=2053660172"
-      >ns=1;i=1391739223</Reference>
+      >ns=1;i=2000147256</Reference>
       <Reference
         ReferenceType="ns=1;i=2053660172"
       >ns=1;i=1586258210</Reference>
@@ -6131,7 +6146,7 @@
       >String</Reference>
       <Reference
         ReferenceType="ns=1;i=2053660172"
-      >ns=1;i=1391739223</Reference>
+      >ns=1;i=2000147256</Reference>
       <Reference
         ReferenceType="ns=1;i=2053660172"
       >ns=1;i=1586258210</Reference>
@@ -6155,7 +6170,7 @@
       >String</Reference>
       <Reference
         ReferenceType="ns=1;i=2053660172"
-      >ns=1;i=1391739223</Reference>
+      >ns=1;i=2000147256</Reference>
       <Reference
         ReferenceType="ns=1;i=2053660172"
       >ns=1;i=1586258210</Reference>
@@ -6179,7 +6194,7 @@
       >String</Reference>
       <Reference
         ReferenceType="ns=1;i=2053660172"
-      >ns=1;i=1391739223</Reference>
+      >ns=1;i=2000147256</Reference>
       <Reference
         ReferenceType="ns=1;i=2053660172"
       >ns=1;i=1586258210</Reference>
@@ -6200,7 +6215,7 @@
       >String</Reference>
       <Reference
         ReferenceType="ns=1;i=2053660172"
-      >ns=1;i=1391739223</Reference>
+      >ns=1;i=2000147256</Reference>
       <Reference
         ReferenceType="ns=1;i=2053660172"
       >ns=1;i=1586258210</Reference>
@@ -6236,7 +6251,7 @@
       >String</Reference>
       <Reference
         ReferenceType="ns=1;i=2053660172"
-      >ns=1;i=1391739223</Reference>
+      >ns=1;i=2000147256</Reference>
       <Reference
         ReferenceType="ns=1;i=2053660172"
       >ns=1;i=1586258210</Reference>
@@ -6260,7 +6275,7 @@
       >String</Reference>
       <Reference
         ReferenceType="ns=1;i=2053660172"
-      >ns=1;i=1391739223</Reference>
+      >ns=1;i=2000147256</Reference>
       <Reference
         ReferenceType="ns=1;i=2053660172"
       >ns=1;i=1586258210</Reference>
@@ -6281,7 +6296,7 @@
       >String</Reference>
       <Reference
         ReferenceType="ns=1;i=2053660172"
-      >ns=1;i=1391739223</Reference>
+      >ns=1;i=2000147256</Reference>
       <Reference
         ReferenceType="ns=1;i=2053660172"
       >ns=1;i=1586258210</Reference>
@@ -6302,10 +6317,7 @@
       >String</Reference>
       <Reference
         ReferenceType="ns=1;i=2053660172"
-      >ns=1;i=1391739223</Reference>
-      <Reference
-        ReferenceType="ns=1;i=2053660172"
-      >ns=1;i=1586258210</Reference>
+      >ns=1;i=2000147256</Reference>
     </References>
   </UADataType>
   <UADataType
@@ -6320,7 +6332,7 @@
       >String</Reference>
       <Reference
         ReferenceType="ns=1;i=2053660172"
-      >ns=1;i=1391739223</Reference>
+      >ns=1;i=2000147256</Reference>
       <Reference
         ReferenceType="ns=1;i=2053660172"
       >ns=1;i=1586258210</Reference>

--- a/test_data/parse/real_meta_models/aas_core_meta.v3/expected_symbol_table.txt
+++ b/test_data/parse/real_meta_models/aas_core_meta.v3/expected_symbol_table.txt
@@ -1,7 +1,7 @@
 UnverifiedSymbolTable(
   our_types=[
     ConcreteClass(
-      name='Non_empty_XML_serializable_string',
+      name='XML_serializable_string',
       is_implementation_specific=False,
       inheritances=[
         'str'],
@@ -18,7 +18,22 @@ UnverifiedSymbolTable(
                   identifier='self',
                   original_node=...)],
               original_node=...)"""),
-          node=...),
+          node=...)],
+      serialization=None,
+      description=Description(
+        document=...,
+        node=...),
+      node=...,
+      properties_by_name=...,
+      methods_by_name=...),
+    ConcreteClass(
+      name='Non_empty_XML_serializable_string',
+      is_implementation_specific=False,
+      inheritances=[
+        'XML_serializable_string'],
+      properties=[],
+      methods=[],
+      invariants=[
         Invariant(
           description='The value must not be empty.',
           body=textwrap.dedent("""\
@@ -470,7 +485,7 @@ UnverifiedSymbolTable(
       name='Value_data_type',
       is_implementation_specific=False,
       inheritances=[
-        'Non_empty_XML_serializable_string'],
+        'XML_serializable_string'],
       properties=[],
       methods=[],
       invariants=[],

--- a/test_data/python/test_main/aas_core_meta.v3/expected_output/verification.py
+++ b/test_data/python/test_main/aas_core_meta.v3/expected_output/verification.py
@@ -8301,6 +8301,18 @@ def verify(
     yield from _TRANSFORMER.transform(that)
 
 
+def verify_xml_serializable_string(
+        that: str
+) -> Iterator[Error]:
+    """Verify the constraints of :paramref:`that`."""
+    if not matches_xml_serializable_string(that):
+        yield Error(
+            "Constraint AASd-130: An attribute with data type 'string' " +
+            'shall consist of these characters only: ' +
+            '^[\\x09\\x0A\\x0D\\x20-\\uD7FF\\uE000-\\uFFFD\\U00010000-\\U0010FFFF]*$.'
+        )
+
+
 def verify_non_empty_xml_serializable_string(
         that: str
 ) -> Iterator[Error]:
@@ -8617,11 +8629,6 @@ def verify_value_data_type(
             "Constraint AASd-130: An attribute with data type 'string' " +
             'shall consist of these characters only: ' +
             '^[\\x09\\x0A\\x0D\\x20-\\uD7FF\\uE000-\\uFFFD\\U00010000-\\U0010FFFF]*$.'
-        )
-
-    if not (len(that) >= 1):
-        yield Error(
-            'The value must not be empty.'
         )
 
 

--- a/test_data/rdf_shacl/test_main/expected/aas_core_meta.v3/expected_output/shacl-schema.ttl
+++ b/test_data/rdf_shacl/test_main/expected/aas_core_meta.v3/expected_output/shacl-schema.ttl
@@ -592,7 +592,6 @@ aas:ExtensionShape a sh:NodeShape ;
         sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
-        sh:minLength 1 ;
         sh:pattern "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$" ;
     ] ;
     sh:property [
@@ -945,7 +944,6 @@ aas:PropertyShape a sh:NodeShape ;
         sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
-        sh:minLength 1 ;
         sh:pattern "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$" ;
     ] ;
     sh:property [
@@ -1012,7 +1010,6 @@ aas:QualifierShape a sh:NodeShape ;
         sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
-        sh:minLength 1 ;
         sh:pattern "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$" ;
     ] ;
     sh:property [
@@ -1040,7 +1037,6 @@ aas:RangeShape a sh:NodeShape ;
         sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
-        sh:minLength 1 ;
         sh:pattern "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$" ;
     ] ;
     sh:property [
@@ -1049,7 +1045,6 @@ aas:RangeShape a sh:NodeShape ;
         sh:datatype xs:string ;
         sh:minCount 0 ;
         sh:maxCount 1 ;
-        sh:minLength 1 ;
         sh:pattern "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$" ;
     ] ;
 .

--- a/test_data/typescript/test_main/aas_core_meta.v3/expected_output/verification.ts
+++ b/test_data/typescript/test_main/aas_core_meta.v3/expected_output/verification.ts
@@ -9764,6 +9764,24 @@ export function *verify(
  * @param that - to be verified
  * @returns errors, if any
  */
+export function *verifyXmlSerializableString(
+  that: string
+): IterableIterator<VerificationError> {
+  if (!matchesXmlSerializableString(that)) {
+    yield new VerificationError(
+      "Constraint AASd-130: An attribute with data type 'string' " +
+      "shall consist of these characters only: " +
+      "^[\\x09\\x0A\\x0D\\x20-\\uD7FF\\uE000-\\uFFFD\\U00010000-\\U0010FFFF]*$."
+    )
+  }
+}
+
+/**
+ * Verify the constraints of `that` value.
+ *
+ * @param that - to be verified
+ * @returns errors, if any
+ */
 export function *verifyNonEmptyXmlSerializableString(
   that: string
 ): IterableIterator<VerificationError> {
@@ -10187,12 +10205,6 @@ export function *verifyValueDataType(
       "Constraint AASd-130: An attribute with data type 'string' " +
       "shall consist of these characters only: " +
       "^[\\x09\\x0A\\x0D\\x20-\\uD7FF\\uE000-\\uFFFD\\U00010000-\\U0010FFFF]*$."
-    )
-  }
-
-  if (!(that.length >= 1)) {
-    yield new VerificationError(
-      "The value must not be empty."
     )
   }
 }


### PR DESCRIPTION
We update the development requirements to and re-record the test data for [aas-core-meta f2fd738].

Notably, we propagate the latest fixes for V3.0.2 from aas-core-meta.

[aas-core-meta f2fd738]: https://github.com/aas-core-works/aas-core-meta/commit/f2fd738