### PR TITLE
Remove `docutils.utils.error_reporting`

### DIFF
--- a/aas_core_codegen/parse/_translate.py
+++ b/aas_core_codegen/parse/_translate.py
@@ -25,8 +25,6 @@ import docutils.core
 import docutils.io
 import docutils.nodes
 
-# noinspection PyUnresolvedReferences
-import docutils.utils.error_reporting
 from icontract import ensure, require
 
 from aas_core_codegen.common import (

--- a/continuous_integration/mypy.ini
+++ b/continuous_integration/mypy.ini
@@ -30,9 +30,6 @@ ignore_missing_imports = True
 [mypy-docutils.core]
 ignore_missing_imports = True
 
-[mypy-docutils.utils.error_reporting]
-ignore_missing_imports = True
-
 [mypy-jsonschema]
 ignore_missing_imports = True
 


### PR DESCRIPTION
This module is imported, but has not been used. However, the linting tools missed it.

We detected its import only when running on Python 3.10 which caused many deprecation warnings.