### PR TITLE
Update test data to aas-core-meta 899add1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
             "twine",
             "jsonschema==3.2.0",
             "xmlschema==3.3.1",
-            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@f2fd738#egg=aas-core-meta",
+            "aas-core-meta@git+https://github.com/aas-core-works/aas-core-meta@899add1#egg=aas-core-meta",
             "ssort==0.12.3",
         ]
     },

--- a/test_data/cpp/test_main/aas_core_meta.v3/expected_output/verification.cpp
+++ b/test_data/cpp/test_main/aas_core_meta.v3/expected_output/verification.cpp
@@ -21540,7 +21540,7 @@ void OfReference::Execute() {
           || common::AllRange(
             [&](size_t i) -> bool {
               return !(instance_->keys().at(i)->type() == types::KeyTypes::kSubmodelElementList)
-              || MatchesXsPositiveInteger(
+              || MatchesXsNonNegativeInteger(
                 instance_->keys().at(i + (1))->value()
               );
             },

--- a/test_data/csharp/test_main/aas_core_meta.v3/expected_output/verification.cs
+++ b/test_data/csharp/test_main/aas_core_meta.v3/expected_output/verification.cs
@@ -8883,7 +8883,7 @@ namespace AasCore.Aas3_0
                             that.Keys.Count - 1
                         ).All(
                             i => !(that.Keys[i].Type == KeyTypes.SubmodelElementList)
-                                || Verification.MatchesXsPositiveInteger(that.Keys[i + 1].Value))
+                                || Verification.MatchesXsNonNegativeInteger(that.Keys[i + 1].Value))
                     )))
                 {
                     yield return new Reporting.Error(

--- a/test_data/golang/test_main/aas_core_meta.v3/expected_output/verification/verification.go
+++ b/test_data/golang/test_main/aas_core_meta.v3/expected_output/verification/verification.go
@@ -11927,7 +11927,9 @@ func VerifyReference(
 		aascommon.AllRange(
 			func(i int) bool {
 				return !(that.Keys()[i].Type() == aastypes.KeyTypesSubmodelElementList) ||
-					MatchesXsPositiveInteger(that.Keys()[i + 1].Value())
+					MatchesXsNonNegativeInteger(
+						that.Keys()[i + 1].Value(),
+					)
 			},
 			0,
 			len(that.Keys()) - 1,

--- a/test_data/intermediate/real_meta_models/aas_core_meta.v3/expected_symbol_table.txt
+++ b/test_data/intermediate/real_meta_models/aas_core_meta.v3/expected_symbol_table.txt
@@ -24367,7 +24367,7 @@ SymbolTable(
                       original_node=...),
                     original_node=...),
                   consequent=FunctionCall(
-                    name='matches_xs_positive_integer',
+                    name='matches_xs_non_negative_integer',
                     args=[
                       Member(
                         instance=Index(

--- a/test_data/java/test_main/aas_core_meta.v3/expected_output/verification/Verification.java
+++ b/test_data/java/test_main/aas_core_meta.v3/expected_output/verification/Verification.java
@@ -8620,7 +8620,7 @@ public class Verification {
                 that.getKeys().size() - 1
             ).allMatch(
                 i -> !(that.getKeys().get(i).getType() == KeyTypes.SUBMODEL_ELEMENT_LIST)
-                    || matchesXsPositiveInteger(that.getKeys().get(i + 1).getValue()))
+                    || matchesXsNonNegativeInteger(that.getKeys().get(i + 1).getValue()))
         ))) {
         errorStream = Stream.<Reporting.Error>concat(errorStream,
           Stream.of(new Reporting.Error(

--- a/test_data/parse/real_meta_models/aas_core_meta.v3/expected_symbol_table.txt
+++ b/test_data/parse/real_meta_models/aas_core_meta.v3/expected_symbol_table.txt
@@ -9987,7 +9987,7 @@ UnverifiedSymbolTable(
                       original_node=...),
                     original_node=...),
                   consequent=FunctionCall(
-                    name='matches_xs_positive_integer',
+                    name='matches_xs_non_negative_integer',
                     args=[
                       Member(
                         instance=Index(

--- a/test_data/python/test_main/aas_core_meta.v3/expected_output/verification.py
+++ b/test_data/python/test_main/aas_core_meta.v3/expected_output/verification.py
@@ -7697,7 +7697,9 @@ class _Transformer(
             or (
                 all(
                     not (that.keys[i].type == aas_types.KeyTypes.SUBMODEL_ELEMENT_LIST)
-                    or matches_xs_positive_integer(that.keys[i + 1].value)
+                    or matches_xs_non_negative_integer(
+                        that.keys[i + 1].value
+                    )
                     for i in range(
                         0,
                         len(that.keys) - 1

--- a/test_data/typescript/test_main/aas_core_meta.v3/expected_output/verification.ts
+++ b/test_data/typescript/test_main/aas_core_meta.v3/expected_output/verification.ts
@@ -9040,7 +9040,7 @@ class Verifier
             ),
             i =>
               !(AasCommon.at(that.keys, i).type == AasTypes.KeyTypes.SubmodelElementList)
-              || matchesXsPositiveInteger(
+              || matchesXsNonNegativeInteger(
                 AasCommon.at(that.keys, i + 1).value
               )
           )


### PR DESCRIPTION
We update the development requirements to and re-record the test data for [aas-core-meta 899add1].

Notably, this includes [the fix #370 on aas-core-meta] related to constraints on list indices in references.

[aas-core-meta 899add1]: https://github.com/aas-core-works/aas-core-meta/commit/899add1
[the fix #370 on aas-core-meta]: https://github.com/aas-core-works/aas-core-meta/pull/370