### PR TITLE
Check command-line arguments at Python 3.12

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -144,7 +144,7 @@ Call the generator with the appropriate target:
 
     Generate implementations and schemas based on an AAS meta-model.
 
-    optional arguments:
+    options:
       -h, --help            show this help message and exit
       --model_path MODEL_PATH
                             path to the meta-model

--- a/dev/continuous_integration/precommit.py
+++ b/dev/continuous_integration/precommit.py
@@ -345,11 +345,11 @@ def main() -> int:
             "pyproject.toml are consistent."
         )
 
-    # NOTE (mristin, 2022-01-22):
+    # NOTE (mristin):
     # We need to check for the Python version since ``argparse`` output changes
-    # between the versions. Hence, we pin it at the moment to Python 3.8.
+    # between the versions. Hence, we pin it at the moment to Python 3.12.
 
-    if sys.version_info < (3, 9):
+    if (3, 12) <= sys.version_info < (3, 13):
         if (
             Step.CHECK_HELP_IN_README in selects
             and Step.CHECK_HELP_IN_README not in skips
@@ -390,7 +390,7 @@ def main() -> int:
     else:
         print(
             "Skipped checking that --help's and the doc coincide "
-            "since we pin it on Python version 3.8."
+            "since we pin it on Python version 3.12."
         )
 
     return 0


### PR DESCRIPTION
The argparse help output changes between the Python versions, so we always have to pin to a fixed Python version. Previously, that was Python 3.8, but since GitHub removed it from their actions, we pin now to Python 3.12.