### PR TITLE
Test list of primitives for JSON schema

### DIFF
--- a/dev/test_data/main/jsonschema/expected/list_of_primitives/examples/expected/empty/model.json
+++ b/dev/test_data/main/jsonschema/expected/list_of_primitives/examples/expected/empty/model.json
@@ -1,0 +1,7 @@
+{
+  "someBools": [],
+  "someInts": [],
+  "someFloats": [],
+  "someStrings": [],
+  "someBytes": []
+}

--- a/dev/test_data/main/jsonschema/expected/list_of_primitives/examples/expected/non_empty/model.json
+++ b/dev/test_data/main/jsonschema/expected/list_of_primitives/examples/expected/non_empty/model.json
@@ -1,0 +1,7 @@
+{
+  "someBools": [true, false, true],
+  "someInts": [1, 0, -42, 100],
+  "someFloats": [3.14, -0.5, 2.718],
+  "someStrings": ["hello", "world", "example"],
+  "someBytes": ["SGVsbG8=", "V29ybGQ=", "AQID"]
+}

--- a/dev/test_data/main/jsonschema/expected/list_of_primitives/expected_output/schema.json
+++ b/dev/test_data/main/jsonschema/expected/list_of_primitives/expected_output/schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "DummyForTest",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/Something"
+    }
+  ],
+  "$id": "https://dummy.com",
+  "definitions": {
+    "ModelType": {
+      "type": "string",
+      "enum": []
+    },
+    "Something": {
+      "type": "object",
+      "properties": {
+        "someBools": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        "someInts": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        },
+        "someFloats": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "someStrings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "someBytes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "contentEncoding": "base64"
+          }
+        }
+      },
+      "required": [
+        "someBools",
+        "someInts",
+        "someFloats",
+        "someStrings",
+        "someBytes"
+      ]
+    }
+  }
+}

--- a/dev/test_data/main/jsonschema/expected/list_of_primitives/expected_output/stdout.txt
+++ b/dev/test_data/main/jsonschema/expected/list_of_primitives/expected_output/stdout.txt
@@ -1,0 +1,1 @@
+Code generated to: <output dir>

--- a/dev/test_data/main/jsonschema/expected/list_of_primitives/input/snippets/schema_base.json
+++ b/dev/test_data/main/jsonschema/expected/list_of_primitives/input/snippets/schema_base.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "DummyForTest",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/Something"
+    }
+  ]
+}

--- a/dev/test_data/main/jsonschema/expected/list_of_primitives/meta_model.py
+++ b/dev/test_data/main/jsonschema/expected/list_of_primitives/meta_model.py
@@ -1,0 +1,29 @@
+from typing import List
+
+from icontract import DBC
+
+
+class Something(DBC):
+    some_bools: List[bool]
+    some_ints: List[int]
+    some_floats: List[float]
+    some_strings: List[str]
+    some_bytes: List[bytearray]
+
+    def __init__(
+            self,
+            some_bools: List[bool],
+            some_ints: List[int],
+            some_floats: List[float],
+            some_strings: List[str],
+            some_bytes: List[bytearray]
+    ) -> None:
+        self.some_bools = some_bools
+        self.some_ints = some_ints
+        self.some_floats = some_floats
+        self.some_strings = some_strings
+        self.some_bytes = some_bytes
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/dev/test_data/main/jsonschema/expected/list_of_primitives_with_invariants/examples/expected/minimal/model.json
+++ b/dev/test_data/main/jsonschema/expected/list_of_primitives_with_invariants/examples/expected/minimal/model.json
@@ -1,0 +1,7 @@
+{
+  "someBools": [true],
+  "someInts": [1],
+  "someFloats": [1.0],
+  "someStrings": ["ok"],
+  "someBytes": ["AA=="]
+}

--- a/dev/test_data/main/jsonschema/expected/list_of_primitives_with_invariants/expected_output/schema.json
+++ b/dev/test_data/main/jsonschema/expected/list_of_primitives_with_invariants/expected_output/schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "DummyForTest",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/Something"
+    }
+  ],
+  "$id": "https://dummy.com",
+  "definitions": {
+    "ModelType": {
+      "type": "string",
+      "enum": []
+    },
+    "Something": {
+      "type": "object",
+      "properties": {
+        "someBools": {
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          },
+          "minItems": 1
+        },
+        "someInts": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          },
+          "minItems": 1
+        },
+        "someFloats": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 1
+        },
+        "someStrings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
+        "someBytes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "contentEncoding": "base64"
+          },
+          "minItems": 1
+        }
+      },
+      "required": [
+        "someBools",
+        "someInts",
+        "someFloats",
+        "someStrings",
+        "someBytes"
+      ]
+    }
+  }
+}

--- a/dev/test_data/main/jsonschema/expected/list_of_primitives_with_invariants/expected_output/stdout.txt
+++ b/dev/test_data/main/jsonschema/expected/list_of_primitives_with_invariants/expected_output/stdout.txt
@@ -1,0 +1,1 @@
+Code generated to: <output dir>

--- a/dev/test_data/main/jsonschema/expected/list_of_primitives_with_invariants/input/snippets/schema_base.json
+++ b/dev/test_data/main/jsonschema/expected/list_of_primitives_with_invariants/input/snippets/schema_base.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "DummyForTest",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/Something"
+    }
+  ]
+}

--- a/dev/test_data/main/jsonschema/expected/list_of_primitives_with_invariants/meta_model.py
+++ b/dev/test_data/main/jsonschema/expected/list_of_primitives_with_invariants/meta_model.py
@@ -1,0 +1,46 @@
+from typing import List
+
+from icontract import DBC, invariant
+
+
+# NOTE (mristin):
+# These invariants are probably not translatable to JSON schema due to limitations
+# of infer_for_schema, but they should still be silently ignored, without raising
+# an error.
+@invariant(lambda self: len(self.some_bytes[0]) > 0, "Invariant 9")
+@invariant(lambda self: self.some_strings[0] == "ok", "Invariant 8")
+@invariant(lambda self: self.some_floats[0] == 1.0, "Invariant 7")
+@invariant(lambda self: self.some_ints[0] == 1, "Invariant 6")
+@invariant(lambda self: self.some_bools[0] == True, "Invariant 5")
+# NOTE (mristin):
+# The following invariants should be handled by infer_for_schema, and thus reflected
+# in the JSON schema.
+@invariant(lambda self: len(self.some_bools) > 0, "Invariant 4")
+@invariant(lambda self: len(self.some_ints) > 0, "Invariant 3")
+@invariant(lambda self: len(self.some_floats) > 0, "Invariant 2")
+@invariant(lambda self: len(self.some_strings) > 0, "Invariant 1")
+@invariant(lambda self: len(self.some_bytes) > 0, "Invariant 0")
+class Something(DBC):
+    some_bools: List[bool]
+    some_ints: List[int]
+    some_floats: List[float]
+    some_strings: List[str]
+    some_bytes: List[bytearray]
+
+    def __init__(
+            self,
+            some_bools: List[bool],
+            some_ints: List[int],
+            some_floats: List[float],
+            some_strings: List[str],
+            some_bytes: List[bytearray]
+    ) -> None:
+        self.some_bools = some_bools
+        self.some_ints = some_ints
+        self.some_floats = some_floats
+        self.some_strings = some_strings
+        self.some_bytes = some_bytes
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/dev/tests/common.py
+++ b/dev/tests/common.py
@@ -116,9 +116,11 @@ def must_translate_source_to_intermediate(
     return symbol_table
 
 
+RERECORD_ENVIRONMENT_VARIABLE_NAME = "AAS_CORE_CODEGEN_TESTS_RERECORD"
+
 #: If set, this environment variable indicates that the golden files should be
 #: re-recorded instead of checked against.
-RERECORD = os.environ.get("AAS_CORE_CODEGEN_TESTS_RERECORD", "").lower() in (
+RERECORD = os.environ.get(RERECORD_ENVIRONMENT_VARIABLE_NAME, "").lower() in (
     "1",
     "true",
     "on",

--- a/dev/tests/test_main.py
+++ b/dev/tests/test_main.py
@@ -69,9 +69,14 @@ class _TestCase(unittest.TestCase):
 
                 expected_output_dir.mkdir(exist_ok=True, parents=True)
             else:
-                assert (
-                    expected_output_dir.exists() and expected_output_dir.is_dir()
-                ), expected_output_dir
+                assert expected_output_dir.exists() and expected_output_dir.is_dir(), (
+                    f"The environment variable "
+                    f"{tests.common.RERECORD_ENVIRONMENT_VARIABLE_NAME} has not been "
+                    f"set, so no output will be re-recorded and has to be tested "
+                    f"against the golden previously recorded output, but the directory "
+                    f"to the expected output either does not exist or "
+                    f"is not a directory: {expected_output_dir}"
+                )
 
                 # pylint: disable=consider-using-with
                 tmp_dir = tempfile.TemporaryDirectory()
@@ -278,6 +283,18 @@ class Test_jsonschema(_TestCase):
     def test_expected_aas_core_meta_v3(self) -> None:
         self._run_expected_test(
             target=aas_core_codegen.main.Target.JSONSCHEMA, case_name="aas_core_meta.v3"
+        )
+
+    def test_expected_list_of_primitives(self) -> None:
+        self._run_expected_test(
+            target=aas_core_codegen.main.Target.JSONSCHEMA,
+            case_name="list_of_primitives",
+        )
+
+    def test_expected_list_of_primitives_with_invariants(self) -> None:
+        self._run_expected_test(
+            target=aas_core_codegen.main.Target.JSONSCHEMA,
+            case_name="list_of_primitives_with_invariants",
         )
 
     def test_expected_regression_when_len_constraints_on_inherited_property(


### PR DESCRIPTION
We add a couple of tests to establish the current state of list-of-primitives support in JSON schema generator.