### PR TITLE
Fix integer JSON serialization in C++

### DIFF
--- a/aas_core_codegen/cpp/lib/_generate_jsonization.py
+++ b/aas_core_codegen/cpp/lib/_generate_jsonization.py
@@ -2091,7 +2091,7 @@ if (error.has_value()) {{
 }}
 
 result[{json_prop_name_literal}] = std::move(
-{I}{serialized_var}
+{I}{serialized_var}.value()
 );"""
         )
     elif primitive_type is intermediate.PrimitiveType.FLOAT:


### PR DESCRIPTION
The code for JSON serialization of integers is broken in C++, but we have not detected the issue since the official meta-model still does not contain integers as primitives.

The bug was revealed during live tests with a simpler meta-model relying on primitives, which will be merged in shortly.