### PR TITLE
Remove AAS-specifics bits from gen. tests in C++

### DIFF
--- a/aas_core_codegen/cpp/tests/_generate_common.py
+++ b/aas_core_codegen/cpp/tests/_generate_common.py
@@ -573,37 +573,6 @@ std::wstring TraceMark(
 {I}const std::wstring model_type = aas::wstringification::to_wstring(
 {II}that.model_type()
 {I});
-
-{I}if ({library_namespace}::types::IsIdentifiable(that)) {{
-{II}const auto& identifiable(
-{III}dynamic_cast<const aas::types::IIdentifiable&>(that)
-{II});
-
-{II}return aas::common::Concat(
-{III}model_type,
-{III}L" with ID ",
-{III}identifiable.id()
-{II});
-{I}}}
-
-{I}if ({library_namespace}::types::IsReferable(that)) {{
-{II}const auto& referable(
-{III}dynamic_cast<const aas::types::IReferable&>(that)
-{II});
-
-{II}if (referable.id_short().has_value()) {{
-{III}return aas::common::Concat(
-{IIII}model_type,
-{IIII}L" with ID-short ",
-{IIII}*(referable.id_short())
-{III});
-{II}}}
-{II}return aas::common::Concat(
-{III}model_type,
-{III}L" with unspecified ID-short"
-{II});
-{I}}}
-
 {I}return model_type;
 }}"""
         ),

--- a/dev/test_data/main/cpp/expected/aas_core_meta.v3/expected_output/test/common.cpp
+++ b/dev/test_data/main/cpp/expected/aas_core_meta.v3/expected_output/test/common.cpp
@@ -287,37 +287,6 @@ std::wstring TraceMark(
   const std::wstring model_type = aas::wstringification::to_wstring(
     that.model_type()
   );
-
-  if (aas_core::aas_3_0::types::IsIdentifiable(that)) {
-    const auto& identifiable(
-      dynamic_cast<const aas::types::IIdentifiable&>(that)
-    );
-
-    return aas::common::Concat(
-      model_type,
-      L" with ID ",
-      identifiable.id()
-    );
-  }
-
-  if (aas_core::aas_3_0::types::IsReferable(that)) {
-    const auto& referable(
-      dynamic_cast<const aas::types::IReferable&>(that)
-    );
-
-    if (referable.id_short().has_value()) {
-      return aas::common::Concat(
-        model_type,
-        L" with ID-short ",
-        *(referable.id_short())
-      );
-    }
-    return aas::common::Concat(
-      model_type,
-      L" with unspecified ID-short"
-    );
-  }
-
   return model_type;
 }
 


### PR DESCRIPTION
We mistakenly included AAS-specific functions in the generated test code in C++. This patch fixes the issue.

The mistake was revelead with live tests on smaller meta-model not related to AAS, which will be merged in shortly.