### PR TITLE
Test that list of optionals are unexpected

### DIFF
--- a/dev/test_data/intermediate/unexpected/list_of_optionals/classes/expected_error.txt
+++ b/dev/test_data/intermediate/unexpected/list_of_optionals/classes/expected_error.txt
@@ -1,0 +1,1 @@
+We currently support only a limited set of type annotation patterns. At the moment, we handle only lists non-optionals, but the property 'maybe_items' of the class 'Something' has type: List[Optional[Item]]. Please contact the developers if you need this functionality

--- a/dev/test_data/intermediate/unexpected/list_of_optionals/classes/meta_model.py
+++ b/dev/test_data/intermediate/unexpected/list_of_optionals/classes/meta_model.py
@@ -1,0 +1,18 @@
+from typing import List, Optional
+
+from icontract import invariant
+
+
+class Item:
+    pass
+
+
+class Something:
+    maybe_items: List[Optional[Item]]
+
+    def __init__(self, maybe_items: List[Optional[Item]]) -> None:
+        self.maybe_items = maybe_items
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/dev/test_data/intermediate/unexpected/list_of_optionals/constrained_primitives/expected_error.txt
+++ b/dev/test_data/intermediate/unexpected/list_of_optionals/constrained_primitives/expected_error.txt
@@ -1,0 +1,1 @@
+We currently support only a limited set of type annotation patterns. At the moment, we handle only lists non-optionals, but the property 'maybe_positives' of the class 'Something' has type: List[Optional[Positive]]. Please contact the developers if you need this functionality

--- a/dev/test_data/intermediate/unexpected/list_of_optionals/constrained_primitives/meta_model.py
+++ b/dev/test_data/intermediate/unexpected/list_of_optionals/constrained_primitives/meta_model.py
@@ -1,0 +1,19 @@
+from typing import List, Optional
+
+from icontract import invariant
+
+
+@invariant(lambda self: self > 0, "Larger than zero")
+class Positive(int):
+    pass
+
+
+class Something:
+    maybe_positives: List[Optional[Positive]]
+
+    def __init__(self, maybe_positives: List[Optional[Positive]]) -> None:
+        self.maybe_positives = maybe_positives
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/dev/test_data/intermediate/unexpected/list_of_optionals/enumerations/expected_error.txt
+++ b/dev/test_data/intermediate/unexpected/list_of_optionals/enumerations/expected_error.txt
@@ -1,0 +1,1 @@
+We currently support only a limited set of type annotation patterns. At the moment, we handle only lists non-optionals, but the property 'maybe_answers' of the class 'Something' has type: List[Optional[Answer]]. Please contact the developers if you need this functionality

--- a/dev/test_data/intermediate/unexpected/list_of_optionals/enumerations/meta_model.py
+++ b/dev/test_data/intermediate/unexpected/list_of_optionals/enumerations/meta_model.py
@@ -1,0 +1,20 @@
+from enum import Enum
+from typing import List, Optional
+
+from icontract import invariant
+
+
+class Answer(Enum):
+    Ok = "ok"
+    NotOk = "not-ok"
+
+
+class Something:
+    maybe_answers: List[Optional[Answer]]
+
+    def __init__(self, maybe_answers: List[Optional[Answer]]) -> None:
+        self.maybe_answers = maybe_answers
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/dev/test_data/intermediate/unexpected/list_of_optionals/primitives/expected_error.txt
+++ b/dev/test_data/intermediate/unexpected/list_of_optionals/primitives/expected_error.txt
@@ -1,0 +1,1 @@
+We currently support only a limited set of type annotation patterns. At the moment, we handle only lists non-optionals, but the property 'maybe_ints' of the class 'Something' has type: List[Optional[int]]. Please contact the developers if you need this functionality

--- a/dev/test_data/intermediate/unexpected/list_of_optionals/primitives/meta_model.py
+++ b/dev/test_data/intermediate/unexpected/list_of_optionals/primitives/meta_model.py
@@ -1,0 +1,12 @@
+from typing import List, Optional
+
+
+class Something:
+    maybe_ints: List[Optional[int]]
+
+    def __init__(self, maybe_ints: List[Optional[int]]) -> None:
+        self.maybe_ints = maybe_ints
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"


### PR DESCRIPTION
We write explicit tests for the intermediate layer to assert that the lists of optionals (whatever the optional type) are not supported.