### PR TITLE
Infer schema constraints for values

### DIFF
--- a/aas_core_codegen/infer_for_schema/__init__.py
+++ b/aas_core_codegen/infer_for_schema/__init__.py
@@ -11,11 +11,16 @@ from aas_core_codegen.infer_for_schema import (
 
 LenConstraint = _types.LenConstraint
 PatternConstraint = _types.PatternConstraint
-ConstraintsByProperty = _types.ConstraintsByProperty
 SetOfPrimitivesConstraint = _types.SetOfPrimitivesConstraint
 SetOfEnumerationLiteralsConstraint = _types.SetOfEnumerationLiteralsConstraint
 
+Constraints = _types.Constraints
+ConstraintsByValue = _types.ConstraintsByValue
+
 infer_constraints_by_class = _inline.infer_constraints_by_class
-merge_constraints_with_ancestors = _inline.merge_constraints_with_ancestors
+
+tightening_steps_from_other_to_that_constraints = (
+    _inline.tightening_steps_from_other_to_that_constraints
+)
 
 dump = _stringify.dump

--- a/aas_core_codegen/infer_for_schema/_inline.py
+++ b/aas_core_codegen/infer_for_schema/_inline.py
@@ -1,46 +1,283 @@
 """Merge constrained primitives as property constraints."""
 import collections
-from typing import Tuple, Optional, List, Mapping, MutableMapping, Sequence
+import itertools
+from typing import (
+    Tuple,
+    Optional,
+    List,
+    Mapping,
+    MutableMapping,
+    Sequence,
+    Set,
+    Union,
+    Iterator,
+)
 
 from icontract import ensure
 
 from aas_core_codegen import intermediate
-from aas_core_codegen.common import Error
+from aas_core_codegen.common import Error, assert_never
 from aas_core_codegen.infer_for_schema import (
     _len as infer_for_schema_len,
     _pattern as infer_for_schema_pattern,
     _set as infer_for_schema_set,
 )
 from aas_core_codegen.infer_for_schema._types import (
-    ConstraintsByProperty,
+    Constraints,
     LenConstraint,
     PatternConstraint,
     SetOfPrimitivesConstraint,
     SetOfEnumerationLiteralsConstraint,
+    ConstraintsByValue,
+    MutableConstraintsByValue,
 )
 
 
-@ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
-def _infer_len_constraints_by_constrained_primitive(
-    symbol_table: intermediate.SymbolTable,
-) -> Tuple[
-    Optional[MutableMapping[intermediate.ConstrainedPrimitive, LenConstraint]],
-    Optional[List[Error]],
-]:
-    """Infer the constraints on ``len(.)`` of the constrained primitives."""
+def _min_or_none(that: Optional[int], other: Optional[int]) -> Optional[int]:
+    """Compute the minimum or return None if both values are None."""
+    if that is not None and other is not None:
+        return min(that, other)
 
-    # NOTE (mristin, 2022-02-11):
-    # We do this inference in two passes. In the first pass, we only infer
-    # the constraints defined for the constrained primitive and ignore the ancestors.
-    # In the second pass, we stack the constraints of the ancestors as well.
+    elif that is None and other is not None:
+        return other
 
+    elif that is not None and other is None:
+        return that
+
+    elif that is None and other is None:
+        return None
+
+    else:
+        raise AssertionError("Unhandled execution path")
+
+
+def _max_or_none(that: Optional[int], other: Optional[int]) -> Optional[int]:
+    """Compute the maximum or return None if both values are None."""
+    if that is not None and other is not None:
+        return max(that, other)
+
+    elif that is None and other is not None:
+        return other
+
+    elif that is not None and other is None:
+        return that
+
+    elif that is None and other is None:
+        return None
+
+    else:
+        raise AssertionError("Unhandled execution path")
+
+
+def _merge_len_constraints(
+    that: Optional[LenConstraint], other: Optional[LenConstraint]
+) -> Optional[LenConstraint]:
+    if that is not None and other is not None:
+        return LenConstraint(
+            min_value=_max_or_none(that.min_value, other.min_value),
+            max_value=_min_or_none(that.max_value, other.max_value),
+        )
+
+    elif that is not None and other is None:
+        return that
+
+    elif that is None and other is not None:
+        return other
+
+    elif that is None and other is None:
+        return None
+
+    else:
+        raise AssertionError("Unhandled execution path")
+
+
+def _merge_pattern_constraints(
+    that: Optional[Sequence[PatternConstraint]],
+    other: Optional[Sequence[PatternConstraint]],
+) -> Optional[Sequence[PatternConstraint]]:
+    if that is not None and other is not None:
+        observed_pattern_set: Set[str] = set()
+
+        result: List[PatternConstraint] = []
+
+        for pattern_constraint in itertools.chain(that, other):
+            if pattern_constraint.pattern not in observed_pattern_set:
+                result.append(pattern_constraint)
+                observed_pattern_set.add(pattern_constraint.pattern)
+
+        return result
+
+    elif that is not None and other is None:
+        return that
+
+    elif that is None and other is not None:
+        return other
+
+    elif that is None and other is None:
+        return None
+
+    else:
+        raise AssertionError("Unhandled execution path")
+
+
+def _merge_set_of_primitives_constraints(
+    that: Optional[SetOfPrimitivesConstraint],
+    other: Optional[SetOfPrimitivesConstraint],
+) -> Optional[SetOfPrimitivesConstraint]:
+    if that is not None and other is not None:
+        if that.a_type != other.a_type:
+            raise ValueError(
+                "Constraints on sets of primitives of different primitive types "
+                f"can not be merged together; that primitive type is {that.a_type}, "
+                f"other primitive type is {other.a_type}."
+            )
+
+        value_histo: MutableMapping[
+            Union[bool, int, float, str, bytearray], int
+        ] = collections.OrderedDict()
+
+        literal_by_value: MutableMapping[
+            Union[bool, int, float, str, bytearray], intermediate.PrimitiveSetLiteral
+        ] = {}
+
+        for literal in itertools.chain(that.literals, other.literals):
+            if literal.value not in value_histo:
+                value_histo[literal.value] = 1
+            else:
+                value_histo[literal.value] += 1
+
+            literal_by_value[literal.value] = literal
+
+        return SetOfPrimitivesConstraint(
+            # NOTE (mristin):
+            # We simply pick one of the types as we assert before that that.a_type
+            # and other.a_type must be the same.
+            a_type=that.a_type,
+            # NOTE (mristin):
+            # We need to compute the intersection, so we only pick the literals which we
+            # observed twice, once in each list of literals.
+            literals=[
+                literal_by_value[value]
+                for value, count in value_histo.items()
+                if count == 2
+            ],
+        )
+
+    elif that is not None and other is None:
+        return that
+
+    elif that is None and other is not None:
+        return other
+
+    elif that is None and other is None:
+        return None
+
+    else:
+        raise AssertionError("Unhandled execution path")
+
+
+def _merge_set_of_enumeration_literals_constraints(
+    that: Optional[SetOfEnumerationLiteralsConstraint],
+    other: Optional[SetOfEnumerationLiteralsConstraint],
+) -> Optional[SetOfEnumerationLiteralsConstraint]:
+    if that is not None and other is not None:
+        if that.enumeration is not other.enumeration:
+            raise ValueError(
+                "Constraints on sets of enumeration literals of different enumerations "
+                f"can not be merged together; that enumeration is {that.enumeration}, "
+                f"other enumeration is {other.enumeration}."
+            )
+
+        literal_by_id: MutableMapping[int, intermediate.EnumerationLiteral] = dict()
+
+        literal_id_histo: MutableMapping[int, int] = collections.OrderedDict()
+
+        for literal in itertools.chain(that.literals, other.literals):
+            literal_id = id(literal)
+
+            if literal_id not in literal_id_histo:
+                literal_id_histo[literal_id] = 1
+            else:
+                literal_id_histo[literal_id] += 1
+
+            literal_by_id[literal_id] = literal
+
+        return SetOfEnumerationLiteralsConstraint(
+            # NOTE (mristin):
+            # We simply pick one of the enumerations as we assert before that
+            # enumeration and other enumeration are one and the same.
+            enumeration=that.enumeration,
+            # NOTE (mristin):
+            # We need to compute the intersection, so we only pick the literals which we
+            # observed twice, once in each list of literals.
+            literals=[
+                literal_by_id[literal_id]
+                for literal_id, count in literal_id_histo.items()
+                if count == 2
+            ],
+        )
+
+    elif that is not None and other is None:
+        return that
+
+    elif that is None and other is not None:
+        return other
+
+    elif that is None and other is None:
+        return None
+
+    else:
+        raise AssertionError("Unhandled execution path")
+
+
+def _merge_constraints(
+    that: Optional[Constraints], other: Optional[Constraints]
+) -> Optional[Constraints]:
+    """Combine the constraints on tighter bounds."""
+    if that is not None and other is not None:
+        return Constraints(
+            len_constraint=_merge_len_constraints(
+                that.len_constraint, other.len_constraint
+            ),
+            patterns=_merge_pattern_constraints(that.patterns, other.patterns),
+            set_of_primitives=_merge_set_of_primitives_constraints(
+                that.set_of_primitives, other.set_of_primitives
+            ),
+            set_of_enumeration_literals=_merge_set_of_enumeration_literals_constraints(
+                that.set_of_enumeration_literals, other.set_of_enumeration_literals
+            ),
+        )
+
+    elif that is not None and other is None:
+        return that
+
+    elif that is None and other is not None:
+        return other
+
+    elif that is None and other is None:
+        return None
+
+    else:
+        raise AssertionError("Unhandled execution path")
+
+
+def _infer_constraints_of_constrained_primitive_without_inheritance(
+    constrained_primitive: intermediate.ConstrainedPrimitive,
+    pattern_verifications_by_name: infer_for_schema_pattern.PatternVerificationsByName,
+) -> Tuple[Optional[Constraints], Optional[List[Error]]]:
+    """
+    Infer the constraints from the invariants on self of the constrained primitive.
+
+    We do not go up (or down) the inheritance tree -- the constraints from the parents
+    are not inherited at this step.
+
+    If there are no constraints inferred from the constrained primitive, we return None.
+    """
     errors = []  # type: List[Error]
 
-    first_pass: MutableMapping[
-        intermediate.ConstrainedPrimitive, LenConstraint
-    ] = collections.OrderedDict()
+    len_constraint: Optional[LenConstraint] = None
 
-    for constrained_primitive in symbol_table.constrained_primitives:
+    if constrained_primitive.constrainee in infer_for_schema_len.LENGTHABLE_PRIMITIVES:
         (
             len_constraint,
             len_constraint_errors,
@@ -53,116 +290,300 @@ def _infer_len_constraints_by_constrained_primitive(
         else:
             assert len_constraint is not None
 
-            first_pass[constrained_primitive] = len_constraint
+            # NOTE (mristin):
+            # We do not want to keep dummy constraints.
+            if len_constraint.min_value is None and len_constraint.max_value is None:
+                len_constraint = None
+
+    pattern_constraints: Optional[Sequence[PatternConstraint]] = None
+
+    if constrained_primitive.constrainee is intermediate.PrimitiveType.STR:
+        pattern_constraints = infer_for_schema_pattern.infer_patterns_on_self(
+            constrained_primitive=constrained_primitive,
+            pattern_verifications_by_name=pattern_verifications_by_name,
+        )
+
+        if len(pattern_constraints) == 0:
+            # NOTE (mristin):
+            # We do not want to keep dummy constraints.
+            pattern_constraints = None
 
     if len(errors) > 0:
         return None, errors
 
-    second_pass: MutableMapping[
-        intermediate.ConstrainedPrimitive, LenConstraint
-    ] = collections.OrderedDict()
+    if len_constraint is None and pattern_constraints is None:
+        return None, None
 
-    for our_type in symbol_table.our_types_topologically_sorted:
-        if isinstance(our_type, intermediate.ConstrainedPrimitive):
-            # NOTE (mristin, 2022-02-11):
-            # We make the copy in order to avoid bugs when we start processing
-            # the inheritances.
-            len_constraint = first_pass[our_type].copy()
-
-            for inheritance in our_type.inheritances:
-                inherited_len_constraint = second_pass.get(inheritance, None)
-                assert (
-                    inherited_len_constraint is not None
-                ), "Expected topological order"
-
-                if inherited_len_constraint.min_value is not None:
-                    len_constraint.min_value = (
-                        max(
-                            len_constraint.min_value, inherited_len_constraint.min_value
-                        )
-                        if len_constraint.min_value is not None
-                        else inherited_len_constraint.min_value
-                    )
-
-                if inherited_len_constraint.max_value is not None:
-                    len_constraint.max_value = (
-                        min(
-                            len_constraint.max_value, inherited_len_constraint.max_value
-                        )
-                        if len_constraint.max_value is not None
-                        else inherited_len_constraint.max_value
-                    )
-
-            second_pass[our_type] = len_constraint
-
-    assert len(errors) == 0
-    return second_pass, None
+    return (
+        Constraints(
+            len_constraint=len_constraint,
+            patterns=pattern_constraints,
+            # NOTE (mristin):
+            # We do not match the set of primitives on the constrained primitives at the
+            # moment, but this could be easily implemented.
+            set_of_primitives=None,
+            set_of_enumeration_literals=None,
+        ),
+        None,
+    )
 
 
-def _infer_pattern_constraints_by_constrained_primitive(
+@ensure(lambda result: not (result[1] is not None) or len(result[1]) > 0)
+@ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
+def _infer_constraints_by_constrained_primitive(
     symbol_table: intermediate.SymbolTable,
     pattern_verifications_by_name: infer_for_schema_pattern.PatternVerificationsByName,
-) -> MutableMapping[intermediate.ConstrainedPrimitive, List[PatternConstraint]]:
-    """Infer the pattern constraints of the constrained strings."""
+) -> Tuple[
+    Optional[MutableMapping[intermediate.ConstrainedPrimitive, Constraints]],
+    Optional[List[Error]],
+]:
+    """
+    Infer the constraints from the constrained primitives considering the inheritance.
 
-    # NOTE (mristin, 2022-02-11):
-    # We do this inference in two passes. In the first pass, we only infer
-    # the constraints defined for the constrained primitive and ignore the ancestors.
-    # In the second pass, we stack the constraints of the ancestors as well.
+    If there are no constraints for the given constrained primitive, it is not present
+    in the mapping.
+    """
+    errors: List[Error] = []
 
-    first_pass: MutableMapping[
-        intermediate.ConstrainedPrimitive,
-        List[PatternConstraint],
-    ] = collections.OrderedDict()
+    mapping: MutableMapping[intermediate.ConstrainedPrimitive, Constraints] = dict()
 
-    for our_type in symbol_table.our_types:
-        if (
-            isinstance(our_type, intermediate.ConstrainedPrimitive)
-            and our_type.constrainee is intermediate.PrimitiveType.STR
-        ):
-            pattern_constraints = infer_for_schema_pattern.infer_patterns_on_self(
-                constrained_primitive=our_type,
-                pattern_verifications_by_name=pattern_verifications_by_name,
+    # NOTE (mristin):
+    # We perform the first pass where we disregard inheritance and return if there are
+    # any errors. We can then be certain that there will be no errors when we stack
+    # the constraints considering the inheritance tree.
+
+    for constrained_primitive in symbol_table.constrained_primitives:
+        (
+            constraints,
+            errors_constrained_primitive,
+        ) = _infer_constraints_of_constrained_primitive_without_inheritance(
+            constrained_primitive=constrained_primitive,
+            pattern_verifications_by_name=pattern_verifications_by_name,
+        )
+
+        if errors_constrained_primitive is not None:
+            errors.append(
+                Error(
+                    constrained_primitive.parsed.node,
+                    f"Failed to infer the schema constraints "
+                    f"from constrained primitive {constrained_primitive.name!r}",
+                    errors_constrained_primitive,
+                )
             )
 
-            first_pass[our_type] = pattern_constraints
+        if constraints is not None:
+            mapping[constrained_primitive] = constraints
 
-    second_pass: MutableMapping[
-        intermediate.ConstrainedPrimitive,
-        List[PatternConstraint],
-    ] = collections.OrderedDict()
+    if len(errors) > 0:
+        return None, errors
 
-    for our_type in first_pass:
-        # NOTE (mristin, 2022-02-11):
-        # We make the copy in order to avoid bugs when we start processing
-        # the inheritances.
-        pattern_constraints = first_pass[our_type][:]
+    for our_type in symbol_table.our_types_topologically_sorted:
+        if not isinstance(our_type, intermediate.ConstrainedPrimitive):
+            continue
 
-        for inheritance in our_type.inheritances:
-            assert inheritance in first_pass, (
-                f"We are processing the constrained primitive {our_type.name!r}. "
-                f"However, its parent, {inheritance.name!r}, has not been processed in "
-                f"the first pass. Something probably went wrong in the first pass."
+        # NOTE (mristin):
+        # We rename for clarity when the reader reads the previous code.
+        constrained_primitive = our_type
+
+        constraints = mapping.get(constrained_primitive, None)
+
+        # NOTE (mristin):
+        # The topological order ensures that we have processed the parents already.
+        for parent in constrained_primitive.inheritances:
+            # NOTE (mristin):
+            # The constrained primitive inherits all the constraints from the parent,
+            # and then it might tighten them some more.
+            constraints = _merge_constraints(mapping.get(parent, None), constraints)
+
+        if constraints is not None:
+            mapping[constrained_primitive] = constraints
+
+    return mapping, None
+
+
+def _over_non_optional_type_annotations(
+    type_annotation: intermediate.TypeAnnotationUnion,
+) -> Iterator[intermediate.TypeAnnotationExceptOptional]:
+    """
+    Iterate recursively over the type annotation and all its nested type annotations.
+
+    The optional type annotations are recursed into, but will not be yielded.
+    """
+    if not isinstance(type_annotation, intermediate.OptionalTypeAnnotation):
+        yield type_annotation
+
+    if isinstance(type_annotation, intermediate.OptionalTypeAnnotation):
+        yield from _over_non_optional_type_annotations(type_annotation.value)
+
+    elif isinstance(type_annotation, intermediate.ListTypeAnnotation):
+        yield from _over_non_optional_type_annotations(type_annotation.items)
+
+    elif isinstance(
+        type_annotation,
+        (intermediate.PrimitiveTypeAnnotation, intermediate.OurTypeAnnotation),
+    ):
+        pass
+
+    else:
+        # noinspection PyTypeChecker
+        assert_never(type_annotation)
+
+
+@ensure(
+    lambda result: not (result[0] is not None)
+    or (all(not constraints.is_empty() for constraints in result[0].values()))
+)
+@ensure(lambda result: not (result[1] is not None) or len(result[1]) >= 1)
+@ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
+def _infer_constraints_of_class_values_without_inheritance(
+    cls: intermediate.ClassUnion,
+    constraints_by_constrained_primitive: Mapping[
+        intermediate.ConstrainedPrimitive, Constraints
+    ],
+    pattern_verifications_by_name: infer_for_schema_pattern.PatternVerificationsByName,
+    symbol_table: intermediate.SymbolTable,
+) -> Tuple[Optional[MutableConstraintsByValue], Optional[List[Error]],]:
+    """
+    Infer the constraints on all the possible values of the class.
+
+    The class hierarchy is not taken into account; we consider only the invariants
+    defined for this class.
+    """
+    errors: List[Error] = []
+
+    mapping: MutableConstraintsByValue = dict()
+
+    # region Constraints on length
+    (
+        len_constraints_from_invariants,
+        some_errors,
+    ) = infer_for_schema_len.len_constraints_from_invariants(cls=cls)
+
+    if some_errors is not None:
+        errors.extend(some_errors)
+    else:
+        assert len_constraints_from_invariants is not None
+
+        for prop, len_constraint in len_constraints_from_invariants.items():
+            if len_constraint.min_value is None and len_constraint.max_value is None:
+                continue
+
+            type_anno = intermediate.beneath_optional(prop.type_annotation)
+
+            merged_constraints = _merge_constraints(
+                mapping.get(type_anno, None), Constraints(len_constraint=len_constraint)
             )
 
-            inherited_pattern_constraints = second_pass.get(inheritance, None)
-            assert inherited_pattern_constraints is not None, (
-                f"Expected topological order. However, our type {our_type.name!r} "
-                f"is being processed before one of its parents, {inheritance.name!r}."
+            if merged_constraints is not None:
+                mapping[type_anno] = merged_constraints
+
+    # endregion
+
+    # region Pattern constraints
+
+    patterns_from_invariants_by_property = (
+        infer_for_schema_pattern.patterns_from_invariants(
+            cls=cls,
+            pattern_verifications_by_name=pattern_verifications_by_name,
+        )
+    )
+
+    for prop, pattern_constraints in patterns_from_invariants_by_property.items():
+        if len(pattern_constraints) == 0:
+            continue
+
+        type_anno = intermediate.beneath_optional(prop.type_annotation)
+
+        merged_constraints = _merge_constraints(
+            mapping.get(type_anno, None), Constraints(patterns=pattern_constraints)
+        )
+
+        if merged_constraints is not None:
+            mapping[type_anno] = merged_constraints
+
+    # endregion
+
+    # region Constraints from constant sets
+
+    # fmt: off
+    set_constraints, some_errors = (
+        infer_for_schema_set.infer_set_constraints_by_property_from_invariants(
+            cls=cls,
+            symbol_table=symbol_table
+        )
+    )
+    # fmt: on
+
+    if some_errors is not None:
+        errors.extend(some_errors)
+    else:
+        assert set_constraints is not None
+
+        for (
+            prop,
+            set_of_primitives_constraint,
+        ) in set_constraints.set_of_primitives_by_property.items():
+            type_anno = intermediate.beneath_optional(prop.type_annotation)
+
+            merged_constraints = _merge_constraints(
+                mapping.get(type_anno, None),
+                Constraints(set_of_primitives=set_of_primitives_constraint),
             )
 
-            pattern_constraints = inherited_pattern_constraints + pattern_constraints
+            if merged_constraints is not None:
+                mapping[type_anno] = merged_constraints
 
-        second_pass[our_type] = pattern_constraints
+        for (
+            prop,
+            set_of_enumeration_literals_constraint,
+        ) in set_constraints.set_of_enumeration_literals_by_property.items():
+            type_anno = intermediate.beneath_optional(prop.type_annotation)
 
-    return second_pass
+            merged_constraints = _merge_constraints(
+                mapping.get(type_anno, None),
+                Constraints(
+                    set_of_enumeration_literals=set_of_enumeration_literals_constraint
+                ),
+            )
+
+            if merged_constraints is not None:
+                mapping[type_anno] = merged_constraints
+
+    # endregion
+
+    if len(errors) > 0:
+        return None, errors
+
+    # region Patterns from constrained primitives
+
+    for prop in cls.properties:
+        for type_anno in _over_non_optional_type_annotations(prop.type_annotation):
+            if not isinstance(type_anno, intermediate.OurTypeAnnotation):
+                continue
+
+            if not isinstance(type_anno.our_type, intermediate.ConstrainedPrimitive):
+                continue
+
+            constraints = _merge_constraints(
+                mapping.get(type_anno, None),
+                constraints_by_constrained_primitive.get(type_anno.our_type, None),
+            )
+
+            if constraints is not None and not constraints.is_empty():
+                mapping[type_anno] = constraints
+
+    # endregion
+
+    assert len(errors) == 0
+    return mapping, None
 
 
+@ensure(lambda result: not (result[1] is not None) or len(result[1]) > 0)
 @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
 def infer_constraints_by_class(
     symbol_table: intermediate.SymbolTable,
 ) -> Tuple[
-    Optional[MutableMapping[intermediate.ClassUnion, ConstraintsByProperty]],
+    Optional[Mapping[intermediate.ClassUnion, ConstraintsByValue]],
     Optional[List[Error]],
 ]:
     """Infer the constraints from the invariants and constrained primitives."""
@@ -175,519 +596,240 @@ def infer_constraints_by_class(
     )
 
     (
-        len_constraints_by_constrained_primitive,
+        constraints_by_constrained_primitive,
         some_errors,
-    ) = _infer_len_constraints_by_constrained_primitive(symbol_table=symbol_table)
+    ) = _infer_constraints_by_constrained_primitive(
+        symbol_table=symbol_table,
+        pattern_verifications_by_name=pattern_verifications_by_name,
+    )
+
     if some_errors is not None:
         errors.extend(some_errors)
 
     if len(errors) > 0:
         return None, errors
 
-    assert len_constraints_by_constrained_primitive is not None
+    assert constraints_by_constrained_primitive is not None
 
-    patterns_by_constrained_primitive = (
-        _infer_pattern_constraints_by_constrained_primitive(
-            symbol_table=symbol_table,
-            pattern_verifications_by_name=pattern_verifications_by_name,
-        )
-    )
-
-    result: MutableMapping[
-        intermediate.ClassUnion, ConstraintsByProperty
-    ] = collections.OrderedDict()
+    mapping: MutableMapping[intermediate.ClassUnion, MutableConstraintsByValue] = dict()
 
     for cls in symbol_table.classes:
-        # region Infer constraints on ``len(.)``
-
-        len_constraints_by_property: MutableMapping[
-            intermediate.Property, LenConstraint
-        ] = collections.OrderedDict()
-
         (
-            len_constraints_from_invariants,
-            len_constraints_errors,
-        ) = infer_for_schema_len.len_constraints_from_invariants(cls=cls)
-
-        if len_constraints_errors is not None:
-            errors.extend(len_constraints_errors)
-            continue
-
-        assert len_constraints_from_invariants is not None
-
-        patterns_by_property: MutableMapping[
-            intermediate.Property, List[PatternConstraint]
-        ] = collections.OrderedDict()
-
-        patterns_from_invariants_by_property = (
-            infer_for_schema_pattern.patterns_from_invariants(
-                cls=cls,
-                pattern_verifications_by_name=pattern_verifications_by_name,
-            )
+            constraints_by_value,
+            some_errors,
+        ) = _infer_constraints_of_class_values_without_inheritance(
+            cls=cls,
+            constraints_by_constrained_primitive=constraints_by_constrained_primitive,
+            pattern_verifications_by_name=pattern_verifications_by_name,
+            symbol_table=symbol_table,
         )
-
-        # region Merge the length constraints
-
-        for prop in cls.properties:
-            # NOTE (mristin, 2022-03-03):
-            # We need to go beneath ``Optional`` as the constraints are applied even
-            # if a property is optional. In cases where cardinality is affected by
-            # ``Optional``, the client code needs to cover them separately.
-            type_anno = intermediate.beneath_optional(prop.type_annotation)
-
-            len_constraint_from_type: Optional[LenConstraint] = None
-
-            len_constraint_from_invariants = len_constraints_from_invariants.get(
-                prop, None
-            )
-
-            if (
-                isinstance(type_anno, intermediate.OurTypeAnnotation)
-                and isinstance(type_anno.our_type, intermediate.ConstrainedPrimitive)
-                # NOTE (mristin, 2023-02-06):
-                # We infer constraints for constrained primitives only for
-                # the class that defines the property, and skip these constraints
-                # in the descendant classes. This is necessary to avoid
-                # unnecessary repetitions of constraints in the schemas.
-                #
-                # In case your schema engine *does not* support inheritance or other
-                # forms of stacking constraints over classes, see the method
-                # ``merge_constraints_with_ancestors``.
-                and prop.specified_for is cls
-            ):
-                len_constraint_from_type = len_constraints_by_constrained_primitive.get(
-                    type_anno.our_type, None
-                )
-
-            # Merge the constraint from the type and from the invariants
-
-            if (
-                len_constraint_from_type is None
-                and len_constraint_from_invariants is None
-            ):
-                pass
-
-            elif (
-                len_constraint_from_type is not None
-                and len_constraint_from_invariants is None
-            ):
-                if (
-                    len_constraint_from_type.min_value is not None
-                    or len_constraint_from_type.max_value is not None
-                ):
-                    len_constraints_by_property[prop] = len_constraint_from_type
-
-            elif (
-                len_constraint_from_type is None
-                and len_constraint_from_invariants is not None
-            ):
-                if (
-                    len_constraint_from_invariants.min_value is not None
-                    or len_constraint_from_invariants.max_value is not None
-                ):
-                    len_constraints_by_property[prop] = len_constraint_from_invariants
-
-            elif (
-                len_constraint_from_type is not None
-                and len_constraint_from_invariants is not None
-            ):
-                # NOTE (mristin, 2022-03-02):
-                # We have to make the bounds *stricter* since both
-                # the type constraints and the invariant(s) need to be satisfied.
-
-                min_value = infer_for_schema_len.max_with_none(
-                    len_constraint_from_type.min_value,
-                    len_constraint_from_invariants.min_value,
-                )
-
-                max_value = infer_for_schema_len.min_with_none(
-                    len_constraint_from_type.max_value,
-                    len_constraint_from_invariants.max_value,
-                )
-
-                if (
-                    min_value is not None
-                    and max_value is not None
-                    and min_value > max_value
-                ):
-                    errors.append(
-                        Error(
-                            cls.parsed.node,
-                            f"The inferred minimum and maximum value on len(.) "
-                            f"is contradictory: "
-                            f"minimum = {min_value}, maximum = {max_value}; "
-                            f"please check the invariants and "
-                            f"any involved constrained primitives",
-                        )
-                    )
-                    continue
-
-                if min_value is not None or max_value is not None:
-                    len_constraints_by_property[prop] = LenConstraint(
-                        min_value=min_value, max_value=max_value
-                    )
-
-            else:
-                raise AssertionError(
-                    f"Unhandled case: "
-                    f"{len_constraint_from_type=}, {len_constraint_from_invariants}"
-                )
-
-        # endregion
-
-        # region Infer constraints on string patterns
-
-        for prop in cls.properties:
-            # NOTE (mristin, 2022-03-03):
-            # We need to go beneath ``Optional`` as the constraints are applied even
-            # if a property is optional. In cases where cardinality is affected by
-            # ``Optional``, the client code needs to cover them separately.
-            type_anno = intermediate.beneath_optional(prop.type_annotation)
-
-            patterns_from_type: List[PatternConstraint] = []
-            patterns_from_invariants = patterns_from_invariants_by_property.get(
-                prop, []
-            )
-
-            if (
-                isinstance(type_anno, intermediate.OurTypeAnnotation)
-                and isinstance(type_anno.our_type, intermediate.ConstrainedPrimitive)
-                # NOTE (mristin, 2023-02-06):
-                # We infer constraints for constrained primitives only for
-                # the class that defines the property, and skip these constraints
-                # in the descendant classes. This is necessary to avoid
-                # unnecessary repetitions of constraints in the schemas.
-                #
-                # In case your schema engine *does not* support inheritance or other
-                # forms of stacking constraints over classes, see the method
-                # ``merge_constraints_with_ancestors``.
-                and prop.specified_for is cls
-            ):
-                patterns_from_type = patterns_by_constrained_primitive.get(
-                    type_anno.our_type, []
-                )
-
-            merged = patterns_from_type + patterns_from_invariants
-
-            if len(merged) > 0:
-                patterns_by_property[prop] = merged
-
-        # endregion
-
-        # region Infer constraints on constant sets
-
-        # fmt: off
-        set_constraints, some_errors = (
-            infer_for_schema_set.infer_set_constraints_by_property_from_invariants(
-                cls=cls,
-                symbol_table=symbol_table
-            )
-        )
-        # fmt: on
 
         if some_errors is not None:
             errors.extend(some_errors)
             continue
 
-        assert set_constraints is not None
+        assert constraints_by_value is not None
 
-        # endregion
-
-        # fmt: off
-        result[cls] = ConstraintsByProperty(
-            len_constraints_by_property=len_constraints_by_property,
-            patterns_by_property=patterns_by_property,
-            set_of_primitives_by_property=set_constraints.set_of_primitives_by_property,
-            set_of_enumeration_literals_by_property=(
-                set_constraints.set_of_enumeration_literals_by_property
-            )
-        )
-        # fmt: on
+        mapping[cls] = constraints_by_value
 
     if len(errors) > 0:
         return None, errors
 
-    return result, None
-
-
-@ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
-def merge_constraints_with_ancestors(
-    symbol_table: intermediate.SymbolTable,
-    constraints_by_class: Mapping[intermediate.ClassUnion, ConstraintsByProperty],
-) -> Tuple[
-    Optional[MutableMapping[intermediate.ClassUnion, ConstraintsByProperty]],
-    Optional[Error],
-]:
-    """
-    Merge the constraints over all the classes with their ancestors.
-
-    Usually, when you generate a schema, you do *not* want to inherit the constraints
-    over the properties. Most schema engines will do that for you, and you want to be
-    as explicit as possible in the schema for readability (whereas merged constraints
-    might not be as readable, since you do not explicitly see their origin).
-
-    However, for some applications we indeed want to stack the constraints and merge
-    them. For example, this is the case when we (semi-)automatically generate test
-    data. In those cases, you should use this function.
-
-    The length constraints are merged by picking the smaller interval that fits.
-    Patterns are simply stacked together.
-    """
-    new_constraints_by_class: MutableMapping[
-        intermediate.ClassUnion, ConstraintsByProperty
-    ] = collections.OrderedDict()
-
+    # NOTE (mristin):
+    # We stack now the constraints considering the class hierarchy. The topological
+    # order guarantees that the parents have been processed before the children.
     for our_type in symbol_table.our_types_topologically_sorted:
         if not isinstance(
             our_type, (intermediate.AbstractClass, intermediate.ConcreteClass)
         ):
             continue
 
-        this_constraints_by_props = constraints_by_class[our_type]
+        # NOTE (mristin):
+        # We introduce the alias for better readability with the previous section.
+        cls = our_type
 
-        new_len_constraints_by_property: MutableMapping[
-            intermediate.Property, LenConstraint
-        ] = collections.OrderedDict()
+        that_constraints_by_value = mapping[cls]
 
-        new_patterns_by_property: MutableMapping[
-            intermediate.Property, Sequence[PatternConstraint]
-        ] = collections.OrderedDict()
+        for parent in cls.inheritances:
+            parent_constraints_by_value = mapping[parent]
 
-        new_set_of_primitives_by_property: MutableMapping[
-            intermediate.Property, SetOfPrimitivesConstraint
-        ] = collections.OrderedDict()
-
-        new_set_of_enum_literals_by_property: MutableMapping[
-            intermediate.Property, SetOfEnumerationLiteralsConstraint
-        ] = collections.OrderedDict()
-
-        for prop in our_type.properties:
-            # region Merge len constraints
-
-            len_constraints = []
-
-            this_len_constraint = (
-                this_constraints_by_props.len_constraints_by_property.get(prop, None)
-            )
-            if this_len_constraint is not None:
-                len_constraints.append(this_len_constraint)
-
-            for parent in our_type.inheritances:
-                # NOTE (mristin, 2022-05-15):
-                # Assume here that all the ancestors already inherited their constraints
-                # due to the topological order in the iteration.
-                that_constraints_by_props = new_constraints_by_class[parent]
-
-                that_len_constraint = (
-                    that_constraints_by_props.len_constraints_by_property.get(
-                        prop, None
-                    )
-                )
-                if that_len_constraint is not None:
-                    len_constraints.append(that_len_constraint)
-
-            min_value = None
-            max_value = None
-
-            for len_constraint in len_constraints:
-                if min_value is None:
-                    min_value = len_constraint.min_value
-                else:
-                    if len_constraint.min_value is not None:
-                        min_value = max(len_constraint.min_value, min_value)
-
-                if max_value is None:
-                    max_value = len_constraint.max_value
-                else:
-                    if len_constraint.max_value is not None:
-                        max_value = min(len_constraint.max_value, max_value)
-
-            if (
-                min_value is not None
-                and max_value is not None
-                and min_value > max_value
-            ):
-                return None, Error(
-                    our_type.parsed.node,
-                    f"We could not stack the length constraints "
-                    f"on the property {prop.name} as they are contradicting: "
-                    f"min_value == {min_value} and max_value == {max_value}. "
-                    f"Please check the invariants and the invariants of all "
-                    f"the ancestors.",
+            # NOTE (mristin):
+            # The class inherits all the constraints from the parent, and then it might
+            # tighten them some more.
+            for type_anno, parent_constraints in parent_constraints_by_value.items():
+                merged_constraints = _merge_constraints(
+                    parent_constraints,
+                    that_constraints_by_value.get(type_anno, None),
                 )
 
-            if min_value is not None or max_value is not None:
-                new_len_constraints_by_property[prop] = LenConstraint(
-                    min_value=min_value, max_value=max_value
-                )
+                if merged_constraints is not None:
+                    that_constraints_by_value[type_anno] = merged_constraints
 
-            # endregion
+    return mapping, None
 
-            # region Merge patterns
 
-            # NOTE (mristin, 2022-05-15):
-            # The following logic has quadratic time complexity, but it seems that
-            # the runtime is currently no problem in practice.
+def tightening_steps_from_other_to_that_constraints(
+    that: Constraints, other: Optional[Constraints]
+) -> Optional[Constraints]:
+    """
+    Identify constraints to be updated to go from ``other`` to ``that``.
 
-            patterns = []  # type: List[PatternConstraint]
+    This function is used to spot tightening of the constraints in the children
+    classes which override the parents' constraints.
 
-            this_patterns = this_constraints_by_props.patterns_by_property.get(
-                prop, None
-            )
-            if this_patterns is not None:
-                patterns.extend(this_patterns)
+    We assume that the in-lining and merging of the constraints has been already
+    performed before. Any constraints in the ``other`` which differs from ``that``
+    constraint is assumed to be "overridden" (*i.e.*, tightened) by ``that`` constraint.
 
-            set_of_this_patterns = (
-                set()
-                if this_patterns is None
-                else set(this_pattern.pattern for this_pattern in this_patterns)
-            )
+    You can think of the resulting constraint list as all the constraints that a child
+    class (corresponding to ``that``) imposes in addition to constraints that are already
+    imposed by the parent class (corresponding to ``other``).
+    """
+    if other is None:
+        return that
 
-            for parent in our_type.inheritances:
-                # NOTE (mristin, 2022-05-15):
-                # Assume here that all the ancestors already inherited their constraints
-                # due to the topological order in the iteration.
-                that_constraints_by_props = new_constraints_by_class[parent]
+    len_constraint: Optional[LenConstraint] = None
 
-                that_patterns = that_constraints_by_props.patterns_by_property.get(
-                    prop, None
-                )
-
-                if that_patterns is not None:
-                    for that_pattern in that_patterns:
-                        # NOTE (mristin, 2022-06-15):
-                        # We have to make sure that we do not inherit the same pattern
-                        # from the parent.
-                        #
-                        # This is particularly important if the inherited property is a
-                        # constrained primitive. In that case, if we didn't check for
-                        # the duplicates, we would inherit the same pattern multiple
-                        # times as we can not distinguish whether the pattern
-                        # comes from an invariant of the parent or an invariant of
-                        # the constrained primitive.
-                        if that_pattern.pattern not in set_of_this_patterns:
-                            patterns.append(that_pattern)
-
-            if len(patterns) > 0:
-                new_patterns_by_property[prop] = patterns
-
-            # endregion
-
-            # region Merge sets of primitives
-
-            sets_of_primitives = []  # type: List[SetOfPrimitivesConstraint]
-
-            # fmt: off
-            this_set_of_primitives = (
-                this_constraints_by_props.set_of_primitives_by_property.get(prop, None)
-            )
-            # fmt: on
-
-            if this_set_of_primitives is not None:
-                sets_of_primitives.append(this_set_of_primitives)
-
-            for parent in our_type.inheritances:
-                # NOTE (mristin, 2022-07-08):
-                # Assume here that all the ancestors already inherited their constraints
-                # due to the topological order in the iteration.
-
-                that_constraints_by_props = new_constraints_by_class[parent]
-
-                # fmt: off
-                that_set_of_primitives = (
-                    that_constraints_by_props.set_of_primitives_by_property.get(
-                        prop, None)
-                )
-                # fmt: on
-
-                if that_set_of_primitives is not None:
-                    sets_of_primitives.append(that_set_of_primitives)
-
-            if len(sets_of_primitives) > 0:
-                # fmt: off
-                new_set_of_primitives_by_property[prop] = (
-                    infer_for_schema_set.intersect_set_of_primitives_constraints(
-                        constraints=sets_of_primitives)
-                )
-                # fmt: on
-
-            # endregion
-
-            # region Merge sets of enumeration literals
-
-            sets_of_enum_literals = []  # type: List[SetOfEnumerationLiteralsConstraint]
-
-            # fmt: off
-            this_set_of_enum_literals = (
-                this_constraints_by_props.set_of_enumeration_literals_by_property.get(
-                    prop, None
-                )
-            )
-            # fmt: on
-
-            if this_set_of_enum_literals is not None:
-                sets_of_enum_literals.append(this_set_of_enum_literals)
-
-            for parent in our_type.inheritances:
-                # NOTE (mristin, 2022-07-08):
-                # Assume here that all the ancestors already inherited their constraints
-                # due to the topological order in the iteration.
-
-                that_constraints_by_props = new_constraints_by_class[parent]
-
-                # fmt: off
-                that_set_of_enum_literals = (
-                    that_constraints_by_props
-                    .set_of_enumeration_literals_by_property
-                    .get(
-                        prop, None
-                    )
-                )
-                # fmt: on
-
-                if that_set_of_enum_literals is not None:
-                    sets_of_enum_literals.append(that_set_of_enum_literals)
-
-            if len(sets_of_enum_literals) > 0:
-                # fmt: off
-                new_set_of_enum_literals_by_property[prop] = (
-                    infer_for_schema_set
-                    .intersect_set_of_enumeration_literals_constraints(
-                        constraints=sets_of_enum_literals
-                    )
-                )
-                # fmt: on
-
-            # endregion
-
-        new_constraints_by_class[our_type] = ConstraintsByProperty(
-            len_constraints_by_property=new_len_constraints_by_property,
-            patterns_by_property=new_patterns_by_property,
-            set_of_primitives_by_property=new_set_of_primitives_by_property,
-            set_of_enumeration_literals_by_property=new_set_of_enum_literals_by_property,
+    if other.len_constraint is not None:
+        assert that.len_constraint is not None, (
+            "The ``other``, corresponding to a parent class, defines a length constraint, "
+            "but the child class, corresponding to ``that``, relaxes the constraint and "
+            "defines no length constraints. This breaks the behavioral subtyping. "
+            "Have the constraints been properly merged and inlined?\n"
+            f"{other.len_constraint=}"
         )
 
-    for our_type, constraints_by_property in new_constraints_by_class.items():
-        for (
-            prop,
-            set_of_primitives,
-        ) in constraints_by_property.set_of_primitives_by_property.items():
-            if len(set_of_primitives.literals) == 0:
-                return None, Error(
-                    prop.parsed.node,
-                    f"The property {prop.name!r} of our type {our_type.name!r} "
-                    f"is constrained to an empty set of primitive literals",
-                )
+        len_constraint = (
+            that.len_constraint
+            if not that.len_constraint.equals(other.len_constraint)
+            else None
+        )
+    else:
+        len_constraint = that.len_constraint
 
-        for (
-            prop,
-            set_of_enum_literals,
-        ) in constraints_by_property.set_of_enumeration_literals_by_property.items():
-            if len(set_of_enum_literals.literals) == 0:
-                return None, Error(
-                    prop.parsed.node,
-                    f"The property {prop.name!r} of our type {our_type.name!r} "
-                    f"is constrained to an empty set of enumeration literals",
-                )
+    patterns: Optional[Sequence[PatternConstraint]] = None
 
-    return new_constraints_by_class, None
+    if other.patterns is not None:
+        assert that.patterns is not None, (
+            "The ``other``, corresponding to a parent class, defines patterns, "
+            "but the child class, corresponding to ``that``, relaxes the constraint and "
+            "defines no patterns. This breaks the behavioral subtyping. "
+            "Have the constraints been properly merged and inlined?\n"
+            f"{other.patterns=}, {that.patterns=}"
+        )
+
+        other_pattern_set = set(
+            pattern_constraint.pattern for pattern_constraint in other.patterns
+        )
+
+        that_pattern_set = set(
+            pattern_constraint.pattern for pattern_constraint in that.patterns
+        )
+
+        assert other_pattern_set.intersection(that_pattern_set) == other_pattern_set, (
+            "The ``other``, corresponding to a parent class, defines more patterns "
+            "than the child class, corresponding to ``that`` -- this amounts to relaxing "
+            "constraints. This breaks the behavioral subtyping. "
+            "Have the constraints been properly merged and inlined?\n"
+            f"{other.patterns=}, {that.patterns=}"
+        )
+
+        # NOTE (mristin):
+        # We select only patterns which are not already defined in ``other``, as
+        # the ``other`` corresponds to the parent class.
+        patterns = [
+            pattern_constraint
+            for pattern_constraint in that.patterns
+            if pattern_constraint.pattern not in other_pattern_set
+        ]
+
+        if len(patterns) == 0:
+            patterns = None
+    else:
+        patterns = that.patterns
+
+    set_of_primitives: Optional[SetOfPrimitivesConstraint] = None
+
+    if other.set_of_primitives is not None:
+        assert that.set_of_primitives is not None, (
+            "The ``other``, corresponding to a parent class, defines set of primitives, "
+            "but the child class, corresponding to ``that``, relaxes the constraint and "
+            "defines no set of primitives. This breaks the behavioral subtyping. "
+            "Have the constraints been properly merged and inlined?\n"
+            f"{other.set_of_primitives=}"
+        )
+
+        other_set_of_primitives = set(
+            literal.value for literal in other.set_of_primitives.literals
+        )
+
+        that_set_of_primitives = set(
+            literal.value for literal in that.set_of_primitives.literals
+        )
+
+        assert (
+            that_set_of_primitives.intersection(other_set_of_primitives)
+            == that_set_of_primitives
+        ), (
+            "The ``that``, corresponding to a child class, can only tighten the set of "
+            "allowed primitives from ``other``, which corresponds to the parent class. "
+            "However, ``that`` defines more literals -- this breaks the behavioral "
+            "subtyping. Have the constraints been properly merged and inlined?\n"
+            f"{other.set_of_primitives=}, {that.set_of_primitives=}"
+        )
+
+        if not that.set_of_primitives.equals(other.set_of_primitives):
+            set_of_primitives = that.set_of_primitives
+
+    else:
+        set_of_primitives = that.set_of_primitives
+
+    set_of_enumeration_literals: Optional[SetOfEnumerationLiteralsConstraint] = None
+
+    if other.set_of_enumeration_literals is not None:
+        assert that.set_of_enumeration_literals is not None, (
+            "The ``other``, corresponding to a parent class, defines set of "
+            "enumeration literals, but the child class, corresponding to ``that``, "
+            "relaxes the constraint and defines no set of enumeration literals. This "
+            "breaks the behavioral subtyping. Have the constraints been properly merged "
+            "and inlined?\n"
+            f"{other.set_of_enumeration_literals=}"
+        )
+
+        other_set_of_enumeration_literals = set(
+            literal.value for literal in other.set_of_enumeration_literals.literals
+        )
+
+        that_set_of_enumeration_literals = set(
+            literal.value for literal in that.set_of_enumeration_literals.literals
+        )
+
+        assert (
+            that_set_of_enumeration_literals.intersection(
+                other_set_of_enumeration_literals
+            )
+            == that_set_of_enumeration_literals
+        ), (
+            "The ``that``, corresponding to a child class, can only tighten the set of "
+            "allowed enumeration literals from ``other``, which corresponds to "
+            "the parent class. However, ``that`` defines more literals -- this breaks "
+            "the behavioral subtyping. Have the constraints been properly merged and "
+            "inlined?\n"
+            f"{other.set_of_enumeration_literals=}, {that.set_of_enumeration_literals=}"
+        )
+
+        if not that.set_of_enumeration_literals.equals(
+            other.set_of_enumeration_literals
+        ):
+            set_of_enumeration_literals = that.set_of_enumeration_literals
+    else:
+        set_of_enumeration_literals = that.set_of_enumeration_literals
+
+    tightening = Constraints(
+        len_constraint=len_constraint,
+        patterns=patterns,
+        set_of_primitives=set_of_primitives,
+        set_of_enumeration_literals=set_of_enumeration_literals,
+    )
+
+    return tightening

--- a/aas_core_codegen/infer_for_schema/_stringify.py
+++ b/aas_core_codegen/infer_for_schema/_stringify.py
@@ -1,14 +1,13 @@
 """Represent inferred constraints as strings."""
-import collections
 from typing import Union, Optional
 
 from aas_core_codegen import stringify, intermediate
 from aas_core_codegen.infer_for_schema._types import (
     LenConstraint,
     PatternConstraint,
-    ConstraintsByProperty,
     SetOfPrimitivesConstraint,
     SetOfEnumerationLiteralsConstraint,
+    Constraints,
 )
 
 
@@ -79,71 +78,35 @@ def _stringify_set_of_enumeration_literals_constraint(
     return result
 
 
-def _stringify_constraints_by_property(that: ConstraintsByProperty) -> stringify.Entity:
+def _stringify_constraints(that: Constraints) -> stringify.Entity:
     result = stringify.Entity(
         name=that.__class__.__name__,
         properties=[
             stringify.Property(
-                "len_constraints_by_property",
-                # fmt: off
-                collections.OrderedDict(
-                    [
-                        # NOTE (mristin, 2022-05-18):
-                        # Mypy could not infer that an identifier is also a string.
-                        # Hence, we need to explicitly convert to a str here.
-                        (str(prop.name), _stringify_len_constraint(len_constraint))
-                        for prop, len_constraint in
-                        that.len_constraints_by_property.items()
-                    ]
-                ),
-                # fmt: on
+                "len_constraint",
+                _stringify_len_constraint(that.len_constraint)
+                if that.len_constraint is not None
+                else None,
             ),
             stringify.Property(
-                "patterns_by_property",
-                # fmt: off
-                collections.OrderedDict(
-                    [
-                        (
-                            # NOTE (mristin, 2022-05-18):
-                            # Mypy could not infer that an identifier is also a string.
-                            # Hence, we need to explicitly convert to a str here.
-                            str(prop.name),
-                            [_stringify(pattern) for pattern in patterns],
-                        )
-                        for prop, patterns in that.patterns_by_property.items()
-                    ]
-                ),
-                # fmt: on
+                "patterns",
+                [_stringify_pattern_constraint(pattern) for pattern in that.patterns]
+                if that.patterns is not None
+                else None,
             ),
             stringify.Property(
-                "set_of_primitives_by_property",
-                # fmt: off
-                collections.OrderedDict(
-                    [
-                        # NOTE (mristin, 2022-07-08):
-                        # Mypy could not infer that an identifier is also a string.
-                        # Hence, we need to explicitly convert to a str here.
-                        (str(prop.name), _stringify(set_of_primitives))
-                        for prop, set_of_primitives in
-                        that.set_of_primitives_by_property.items()
-                    ]
-                ),
-                # fmt: on
+                "set_of_primitives",
+                _stringify_set_of_primitives_constraint(that.set_of_primitives)
+                if that.set_of_primitives is not None
+                else None,
             ),
             stringify.Property(
-                "set_of_enumeration_literals_by_property",
-                # fmt: off
-                collections.OrderedDict(
-                    [
-                        # NOTE (mristin, 2022-07-08):
-                        # Mypy could not infer that an identifier is also a string.
-                        # Hence, we need to explicitly convert to a str here.
-                        (str(prop.name), _stringify(set_of_enum_literals))
-                        for prop, set_of_enum_literals in
-                        that.set_of_enumeration_literals_by_property.items()
-                    ]
-                ),
-                # fmt: on
+                "set_of_enumeration_literals",
+                _stringify_set_of_enumeration_literals_constraint(
+                    that.set_of_enumeration_literals
+                )
+                if that.set_of_enumeration_literals is not None
+                else None,
             ),
         ],
     )
@@ -156,7 +119,7 @@ Dumpable = Union[
     PatternConstraint,
     SetOfPrimitivesConstraint,
     SetOfEnumerationLiteralsConstraint,
-    ConstraintsByProperty,
+    Constraints,
 ]
 
 _DISPATCH = {
@@ -168,7 +131,7 @@ _DISPATCH = {
         _stringify_set_of_enumeration_literals_constraint
     ),
     # fmt: on
-    ConstraintsByProperty: _stringify_constraints_by_property,
+    Constraints: _stringify_constraints,
 }
 
 stringify.assert_dispatch_exhaustive(dispatch=_DISPATCH, dumpable=Dumpable)

--- a/aas_core_codegen/infer_for_schema/_types.py
+++ b/aas_core_codegen/infer_for_schema/_types.py
@@ -1,9 +1,15 @@
 """Provide data structures for the constraint inferences."""
-from typing import Mapping, Sequence, Optional
+import sys
+from typing import Mapping, Sequence, Optional, Final, MutableMapping
 
-from icontract import require
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
 
-from aas_core_codegen import intermediate
+from icontract import require  # pylint: disable=wrong-import-position
+
+from aas_core_codegen import intermediate  # pylint: disable=wrong-import-position
 
 
 class LenConstraint:
@@ -12,6 +18,9 @@ class LenConstraint:
 
     Both bounds are inclusive: ``min_value ≤ len ≤ max_value``.
     """
+
+    min_value: Final[Optional[int]]
+    max_value: Final[Optional[int]]
 
     # fmt: off
     @require(
@@ -25,9 +34,12 @@ class LenConstraint:
         self.min_value = min_value
         self.max_value = max_value
 
-    def copy(self) -> "LenConstraint":
-        """Create a copy of the self."""
-        return LenConstraint(min_value=self.min_value, max_value=self.max_value)
+    def equals(self, other: Optional["LenConstraint"]) -> bool:
+        """Return true if the other constraint equals semantically ours."""
+        if other is None:
+            return False
+
+        return self.min_value == other.min_value and self.max_value == other.max_value
 
     def __str__(self) -> str:
         return (
@@ -39,9 +51,18 @@ class LenConstraint:
 class PatternConstraint:
     """Constrain a string to comply to a regular expression."""
 
+    pattern: Final[str]
+
     def __init__(self, pattern: str) -> None:
         """Initialize with the given values."""
         self.pattern = pattern
+
+    def equals(self, other: Optional["PatternConstraint"]) -> bool:
+        """Return true if the other constraint equals semantically ours."""
+        if other is None:
+            return False
+
+        return self.pattern == other.pattern
 
     def __repr__(self) -> str:
         """Represent the constraint with the pattern."""
@@ -53,6 +74,9 @@ class PatternConstraint:
 
 class SetOfPrimitivesConstraint:
     """Constrain a primitive value to be a member of a pre-defined set of values."""
+
+    a_type: Final[intermediate.PrimitiveType]
+    literals: Final[Sequence[intermediate.PrimitiveSetLiteral]]
 
     # fmt: off
     @require(
@@ -72,6 +96,20 @@ class SetOfPrimitivesConstraint:
         self.a_type = a_type
         self.literals = literals
 
+    def equals(self, other: Optional["SetOfPrimitivesConstraint"]) -> bool:
+        """Return true if the other constraint equals semantically ours."""
+        if other is None:
+            return False
+
+        return (
+            self.a_type == other.a_type
+            and len(self.literals) == len(other.literals)
+            and all(
+                id(that_literal) == id(other_literal)
+                for that_literal, other_literal in zip(self.literals, other.literals)
+            )
+        )
+
     def __repr__(self) -> str:
         """Represent the constraint with the pattern."""
         return f"<{self.__class__.__name__} at 0x{id(self):x}>"
@@ -79,6 +117,9 @@ class SetOfPrimitivesConstraint:
 
 class SetOfEnumerationLiteralsConstraint:
     """Constrain a value to be a member of a pre-defined set of values."""
+
+    enumeration: Final[intermediate.Enumeration]
+    literals: Final[Sequence[intermediate.EnumerationLiteral]]
 
     # fmt: off
     @require(
@@ -98,38 +139,73 @@ class SetOfEnumerationLiteralsConstraint:
         self.enumeration = enumeration
         self.literals = literals
 
+    @require(
+        lambda self, other: not (other is not None)
+        or (other.enumeration is self.enumeration),
+        "Both self and other must refer to the same enumeration for "
+        "an equality comparison to make sense.",
+    )
+    def equals(self, other: Optional["SetOfEnumerationLiteralsConstraint"]) -> bool:
+        """Return true if the other constraint equals semantically ours."""
+        if other is None:
+            return False
+
+        return len(self.literals) == len(other.literals) and all(
+            id(that_literal) == id(other_literal)
+            for that_literal, other_literal in zip(self.literals, other.literals)
+        )
+
     def __repr__(self) -> str:
         """Represent the constraint with the pattern."""
         return f"<{self.__class__.__name__} at 0x{id(self):x}>"
 
 
-class ConstraintsByProperty:
+class Constraints:
     """
-    Represent all the inferred property constraints of one of our types.
+    Represent all the inferred constraints for a value.
 
     The constraints coming from the constrained primitives are in-lined and hence also
     included in this representation.
     """
 
+    len_constraint: Final[Optional[LenConstraint]]
+    patterns: Final[Optional[Sequence[PatternConstraint]]]
+    set_of_primitives: Final[Optional[SetOfPrimitivesConstraint]]
+    set_of_enumeration_literals: Final[Optional[SetOfEnumerationLiteralsConstraint]]
+
+    @require(lambda patterns: not (patterns is not None) or len(patterns) > 0)
     def __init__(
         self,
-        len_constraints_by_property: Mapping[intermediate.Property, LenConstraint],
-        patterns_by_property: Mapping[
-            intermediate.Property, Sequence[PatternConstraint]
-        ],
-        set_of_primitives_by_property: Mapping[
-            intermediate.Property, SetOfPrimitivesConstraint
-        ],
-        set_of_enumeration_literals_by_property: Mapping[
-            intermediate.Property, SetOfEnumerationLiteralsConstraint
-        ],
+        len_constraint: Optional[LenConstraint] = None,
+        patterns: Optional[Sequence[PatternConstraint]] = None,
+        set_of_primitives: Optional[SetOfPrimitivesConstraint] = None,
+        set_of_enumeration_literals: Optional[
+            SetOfEnumerationLiteralsConstraint
+        ] = None,
     ) -> None:
         """Initialize with the given values."""
-        self.len_constraints_by_property = len_constraints_by_property
-        self.patterns_by_property = patterns_by_property
-        self.set_of_primitives_by_property = set_of_primitives_by_property
+        self.len_constraint = len_constraint
+        self.patterns = patterns
+        self.set_of_primitives = set_of_primitives
         # fmt: off
-        self.set_of_enumeration_literals_by_property = (
-            set_of_enumeration_literals_by_property
+        self.set_of_enumeration_literals = (
+            set_of_enumeration_literals
         )
         # fmt: on
+
+    def is_empty(self) -> bool:
+        """Return True if no constraints are set."""
+        return (
+            self.len_constraint is None
+            and self.patterns is None
+            and self.set_of_primitives is None
+            and self.set_of_enumeration_literals is None
+        )
+
+
+#: Represent the constraints inferred for the given value in a class.
+ConstraintsByValue: TypeAlias = Mapping[intermediate.TypeAnnotationUnion, Constraints]
+
+MutableConstraintsByValue: TypeAlias = MutableMapping[
+    intermediate.TypeAnnotationUnion, Constraints
+]

--- a/aas_core_codegen/jsonschema/main.py
+++ b/aas_core_codegen/jsonschema/main.py
@@ -1,5 +1,6 @@
 """Generate JSON schema corresponding to the meta-model."""
 import collections
+import itertools
 import json
 from typing import (
     TextIO,
@@ -11,6 +12,9 @@ from typing import (
     Sequence,
     Mapping,
     Callable,
+    Iterator,
+    Final,
+    cast,
 )
 
 from icontract import ensure, require
@@ -56,88 +60,230 @@ _PRIMITIVE_MAP = {
 assert all(literal in _PRIMITIVE_MAP for literal in intermediate.PrimitiveType)
 
 
-def _define_primitive_type(
-    primitive_type: intermediate.PrimitiveType,
-) -> MutableMapping[str, Any]:
-    """Generate the definition for the given ``primitive_type``."""
-    definition = collections.OrderedDict([("type", _PRIMITIVE_MAP[primitive_type])])
+class _AllOf:
+    """Represent a sequence of JSON schema declarations."""
 
-    if primitive_type is intermediate.PrimitiveType.BYTEARRAY:
-        definition["contentEncoding"] = "base64"
+    subschemas: Final[Sequence[Mapping[str, Any]]]
 
-    return definition
+    @require(lambda subschemas: len(subschemas) > 0)
+    def __init__(self, subschemas: Sequence[Mapping[str, Any]]) -> None:
+        self.subschemas = subschemas
+
+
+def _translate_constraints(
+    type_annotation: intermediate.TypeAnnotationExceptOptional,
+    constraints: Optional[infer_for_schema.Constraints],
+    fix_pattern: Callable[[str], str],
+) -> Optional[_AllOf]:
+    """
+    Translate the constraints for a value into JSON schema.
+
+    If none of the constraints could be translated, return None.
+    """
+    if constraints is None:
+        return None
+
+    primitive_type = intermediate.try_primitive_type(type_annotation)
+
+    base_subschema: MutableMapping[str, Any] = collections.OrderedDict()
+
+    additional_subschemas: List[MutableMapping[str, Any]] = []
+
+    if primitive_type is not None:
+        if (
+            primitive_type
+            in (intermediate.PrimitiveType.STR, intermediate.PrimitiveType.BYTEARRAY)
+            and constraints.len_constraint is not None
+        ):
+            if constraints.len_constraint.min_value is not None:
+                base_subschema["minLength"] = constraints.len_constraint.min_value
+
+            if constraints.len_constraint.max_value is not None:
+                base_subschema["maxLength"] = constraints.len_constraint.max_value
+
+        if (
+            primitive_type == intermediate.PrimitiveType.STR
+            and constraints.patterns is not None
+            and len(constraints.patterns) > 0
+        ):
+            if len(constraints.patterns) == 1:
+                base_subschema["pattern"] = fix_pattern(constraints.patterns[0].pattern)
+            else:
+                iterator = iter(constraints.patterns)
+
+                first_pattern = next(iterator)
+
+                base_subschema["pattern"] = fix_pattern(first_pattern.pattern)
+
+                for pattern_constraint in iterator:
+                    additional_subschema: MutableMapping[
+                        str, Any
+                    ] = collections.OrderedDict()
+
+                    additional_subschema["pattern"] = fix_pattern(
+                        pattern_constraint.pattern
+                    )
+
+                    additional_subschemas.append(additional_subschema)
+
+    if isinstance(type_annotation, intermediate.ListTypeAnnotation):
+        if constraints.len_constraint is not None:
+            if constraints.len_constraint.min_value is not None:
+                base_subschema["minItems"] = constraints.len_constraint.min_value
+
+            if constraints.len_constraint.max_value is not None:
+                base_subschema["maxItems"] = constraints.len_constraint.max_value
+
+    assert (
+        not (len(base_subschema) == 0) or len(additional_subschemas) == 0
+    ), "If base subschema is empty, no additional subschemas are expected."
+
+    if len(base_subschema) == 0:
+        return None
+
+    return _AllOf([base_subschema] + additional_subschemas)
+
+
+def _all_of_as_jsonable_mapping(all_of: _AllOf) -> MutableMapping[str, Any]:
+    """
+    Render the instance of AllOf JSON schema construct to a JSON-able mapping.
+
+    If it consists of just one subschema, that schema is simply returned.
+    """
+    if len(all_of.subschemas) == 1:
+        return cast(MutableMapping[str, Any], all_of.subschemas[0])
+
+    # NOTE (mristin):
+    # We want to make it easier for code generators to see the base schema *before*
+    # ``allOf``, so that they can ignore ``allOf`` in case that they can not process
+    # it, but still get enough relevant information from the first base subschema.
+    mapping: MutableMapping[str, Any] = collections.OrderedDict(all_of.subschemas[0])
+
+    mapping["allOf"] = all_of.subschemas[1:]
+
+    return mapping
 
 
 @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
 def _define_type(
     type_annotation: intermediate.TypeAnnotationExceptOptional,
+    constraints_by_value: infer_for_schema.ConstraintsByValue,
+    fix_pattern: Callable[[str], str],
 ) -> Tuple[Optional[MutableMapping[str, Any]], Optional[Error]]:
-    """Generate the type definition for ``type_annotation``."""
-    if isinstance(type_annotation, intermediate.PrimitiveTypeAnnotation):
-        return _define_primitive_type(type_annotation.a_type), None
+    """
+    Generate the type definition for ``type_annotation``.
 
-    elif isinstance(type_annotation, intermediate.OurTypeAnnotation):
-        model_type = naming.json_model_type(type_annotation.our_type.name)
+    The constraints-by-value define all the constraints of the class nesting a property
+    of this type.
 
-        if isinstance(type_annotation.our_type, intermediate.Enumeration):
-            return (
-                collections.OrderedDict([("$ref", f"#/definitions/{model_type}")]),
-                None,
+    The ``fix_pattern`` determines how the pattern should be translated for
+    the regex engine. For example, some JSON schema verification engines expect only
+    characters below Basic Multilingual Plane (BMP), and use surrogate pairs to
+    represent characters above BMP.
+    """
+    definition: MutableMapping[str, Any] = collections.OrderedDict()
+
+    constraints = constraints_by_value.get(type_annotation, None)
+
+    primitive_type = intermediate.try_primitive_type(type_annotation)
+
+    if primitive_type is not None:
+        definition["type"] = _PRIMITIVE_MAP[primitive_type]
+
+        if primitive_type is intermediate.PrimitiveType.BYTEARRAY:
+            definition["contentEncoding"] = "base64"
+
+    else:
+        if isinstance(type_annotation, intermediate.PrimitiveTypeAnnotation):
+            raise AssertionError(
+                f"Expected to handle this path before with try_primitive_type: "
+                f"{type_annotation=}, {primitive_type}"
             )
 
-        elif isinstance(type_annotation.our_type, intermediate.ConstrainedPrimitive):
-            return _define_primitive_type(type_annotation.our_type.constrainee), None
+        elif isinstance(type_annotation, intermediate.OurTypeAnnotation):
+            model_type = naming.json_model_type(type_annotation.our_type.name)
 
-        elif isinstance(type_annotation.our_type, intermediate.Class):
-            if len(type_annotation.our_type.concrete_descendants) > 0:
-                return (
-                    collections.OrderedDict(
-                        [("$ref", f"#/definitions/{model_type}_choice")]
-                    ),
-                    None,
-                )
-            else:
+            if isinstance(type_annotation.our_type, intermediate.Enumeration):
                 return (
                     collections.OrderedDict([("$ref", f"#/definitions/{model_type}")]),
                     None,
                 )
 
+            elif isinstance(
+                type_annotation.our_type, intermediate.ConstrainedPrimitive
+            ):
+                raise AssertionError(
+                    "Expected to handle this path before with try_primitive_type"
+                )
+
+            elif isinstance(type_annotation.our_type, intermediate.Class):
+                if len(type_annotation.our_type.concrete_descendants) > 0:
+                    return (
+                        collections.OrderedDict(
+                            [("$ref", f"#/definitions/{model_type}_choice")]
+                        ),
+                        None,
+                    )
+                else:
+                    return (
+                        collections.OrderedDict(
+                            [("$ref", f"#/definitions/{model_type}")]
+                        ),
+                        None,
+                    )
+
+            else:
+                assert_never(type_annotation.our_type)
+
+        elif isinstance(type_annotation, intermediate.ListTypeAnnotation):
+            assert not isinstance(
+                type_annotation.items, intermediate.OptionalTypeAnnotation
+            ), (
+                "NOTE (mristin): Lists of optional values were not expected "
+                "at the time when we implemented this. Please contact the developers "
+                "if you need this functionality."
+            )
+
+            items_type_definition, items_error = _define_type(
+                type_annotation=type_annotation.items,
+                constraints_by_value=constraints_by_value,
+                fix_pattern=fix_pattern,
+            )
+
+            if items_error is not None:
+                return None, items_error
+
+            assert items_type_definition is not None
+
+            definition["type"] = "array"
+            definition["items"] = items_type_definition
+
         else:
-            assert_never(type_annotation.our_type)
+            assert_never(type_annotation)
 
-    elif isinstance(type_annotation, intermediate.ListTypeAnnotation):
-        assert not isinstance(
-            type_annotation.items, intermediate.OptionalTypeAnnotation
-        ), (
-            "NOTE (mristin, 2023-02-06): Lists of optional values were not expected "
-            "at the time when we implemented this. Please contact the developers "
-            "if you need this functionality."
+    if constraints is None:
+        return definition, None
+    else:
+        all_of = _translate_constraints(
+            type_annotation=type_annotation,
+            constraints=constraints,
+            fix_pattern=fix_pattern,
         )
 
-        items_type_definition, items_error = _define_type(
-            type_annotation=type_annotation.items
-        )
+        if all_of is None:
+            return definition, None
 
-        if items_error is not None:
-            return None, items_error
+        base_subschema = all_of.subschemas[0]
 
-        assert items_type_definition is not None
+        # NOTE (mristin):
+        # We put the type definitions first for readability.
+        definition.update(base_subschema)
 
         return (
-            collections.OrderedDict(
-                [("type", "array"), ("items", items_type_definition)]
+            _all_of_as_jsonable_mapping(
+                _AllOf([definition, *itertools.islice(all_of.subschemas, 1, None)])
             ),
             None,
-        )
-
-    else:
-        raise NotImplementedError(
-            f"(mristin, 2021-11-10):\n"
-            f"We implemented only a subset of possible type annotations "
-            f"to be represented in a JSON schema since we lacked more information "
-            f"about the context.\n\n"
-            f"This feature needs yet to be implemented.\n\n"
-            f"{type_annotation=}"
         )
 
 
@@ -170,173 +316,40 @@ def fix_pattern_for_utf16(pattern: str) -> str:
     return "".join(parts_str)
 
 
-def _define_constraints_for_primitive_type(
-    primitive_type: intermediate.PrimitiveType,
-    len_constraint: Optional[infer_for_schema.LenConstraint],
-    pattern_constraints: Optional[Sequence[infer_for_schema.PatternConstraint]],
-    fix_pattern: Callable[[str], str],
-) -> MutableMapping[str, Any]:
+def _over_non_optional_type_annotations(
+    type_annotation: intermediate.TypeAnnotationUnion,
+) -> Iterator[intermediate.TypeAnnotationUnion]:
     """
-    Generate the constraints, if any, for the ``primitive_type``.
+    Iterate recursively over the type annotation and all its nested type annotations.
 
-    If there are no constraints, an empty mapping is returned.
-
-    The ``fix_pattern`` determines how the pattern should be translated for
-    the regex engine. For example, some JSON schema verification engines expect only
-    characters below Basic Multilingual Plane (BMP), and use surrogate pairs to
-    represent characters above BMP.
+    The optional type annotations are recursed into, but will not be yielded.
     """
-    definition = collections.OrderedDict()  # type: MutableMapping[str, Any]
+    if not isinstance(type_annotation, intermediate.OptionalTypeAnnotation):
+        yield type_annotation
 
-    if (
-        primitive_type
-        in (intermediate.PrimitiveType.STR, intermediate.PrimitiveType.BYTEARRAY)
-        and len_constraint is not None
-    ):
-        if len_constraint.min_value is not None:
-            definition["minLength"] = len_constraint.min_value
-
-        if len_constraint.max_value is not None:
-            definition["maxLength"] = len_constraint.max_value
-
-    if (
-        primitive_type == intermediate.PrimitiveType.STR
-        and pattern_constraints is not None
-        and len(pattern_constraints) > 0
-    ):
-        if len(pattern_constraints) == 1:
-            definition["pattern"] = fix_pattern(pattern_constraints[0].pattern)
-        else:
-            all_of = [definition]  # type: List[MutableMapping[str, Any]]
-
-            for pattern_constraint in pattern_constraints:
-                all_of.append(
-                    collections.OrderedDict(
-                        [
-                            (
-                                "pattern",
-                                fix_pattern(pattern_constraint.pattern),
-                            )
-                        ]
-                    )
-                )
-
-            definition = collections.OrderedDict([("allOf", all_of)])
-
-    return definition
-
-
-@ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
-def _define_constraints(
-    type_annotation: intermediate.TypeAnnotation,
-    len_constraint: Optional[infer_for_schema.LenConstraint],
-    pattern_constraints: Optional[Sequence[infer_for_schema.PatternConstraint]],
-    fix_pattern: Callable[[str], str],
-) -> Tuple[Optional[MutableMapping[str, Any]], Optional[Error]]:
-    """
-    Generate only the constraints for the given ``type_annotation``.
-
-    The type is generated in a separated function, `_generate_type`.
-
-    The ``fix_pattern`` determines how the pattern should be translated for
-    the regex engine. For example, some JSON schema verification engines expect only
-    characters below Basic Multilingual Plane (BMP), and use surrogate pairs to
-    represent characters above BMP.
-
-    If there are no constraints, an empty mapping is returned.
-    """
-    if isinstance(type_annotation, intermediate.PrimitiveTypeAnnotation):
-        return (
-            _define_constraints_for_primitive_type(
-                primitive_type=type_annotation.a_type,
-                len_constraint=len_constraint,
-                pattern_constraints=pattern_constraints,
-                fix_pattern=fix_pattern,
-            ),
-            None,
-        )
-
-    elif isinstance(type_annotation, intermediate.OurTypeAnnotation):
-        if isinstance(type_annotation.our_type, intermediate.Enumeration):
-            return collections.OrderedDict(), None
-
-        elif isinstance(type_annotation.our_type, intermediate.ConstrainedPrimitive):
-            # NOTE (mristin, 2022-02-11):
-            # We in-line the constraints from the constrained primitives directly
-            # in the properties. We do not want to introduce separate definitions
-            # for them as that would make it more difficult for downstream code
-            # generators to generate meaningful code (*e.g.*, code generators for
-            # OpenAPI3).
-            return (
-                _define_constraints_for_primitive_type(
-                    primitive_type=type_annotation.our_type.constrainee,
-                    len_constraint=len_constraint,
-                    pattern_constraints=pattern_constraints,
-                    fix_pattern=fix_pattern,
-                ),
-                None,
-            )
-
-        elif isinstance(type_annotation.our_type, intermediate.Class):
-            # NOTE (mristin, 2023-02-06):
-            # There are no constraints for class itself in JSON schema. We define
-            # constraints only per properties at the moment.
-            return collections.OrderedDict(), None
-
-        else:
-            assert_never(type_annotation.our_type)
+    if isinstance(type_annotation, intermediate.OptionalTypeAnnotation):
+        yield from _over_non_optional_type_annotations(type_annotation.value)
 
     elif isinstance(type_annotation, intermediate.ListTypeAnnotation):
-        # NOTE (mristin, 2021-12-02):
-        # We do not propagate the inference of constraints to sub-lists
-        # so in this case we set all the constraint on the ``items`` to none.
-        # This behavior might change in the future when we encounter such
-        # constraints and have more context available.
+        yield from _over_non_optional_type_annotations(type_annotation.items)
 
-        definition = collections.OrderedDict()
-
-        if len_constraint is not None:
-            if len_constraint.min_value is not None:
-                assert (
-                    "minItems" not in definition
-                ), "Unexpected property 'minItems' in the JSON type definition"
-
-                definition["minItems"] = len_constraint.min_value
-
-            if len_constraint.max_value is not None:
-                assert (
-                    "maxItems" not in definition
-                ), "Unexpected property 'maxItems' in the JSON type definition"
-
-                definition["maxItems"] = len_constraint.max_value
-
-        return definition, None
-
-    elif isinstance(type_annotation, intermediate.OptionalTypeAnnotation):
-        raise NotImplementedError(
-            f"(mristin, 2021-11-10):\n"
-            f"Nested optional values are unexpected in the JSON schema. "
-            f"We did not implement them at the moment since we need more information "
-            f"about the context.\n\n"
-            f"This feature needs yet to be implemented.\n\n"
-            f"{type_annotation=}"
-        )
+    elif isinstance(
+        type_annotation,
+        (intermediate.PrimitiveTypeAnnotation, intermediate.OurTypeAnnotation),
+    ):
+        pass
 
     else:
-        raise NotImplementedError(
-            f"(mristin, 2021-11-10):\n"
-            f"We implemented only a subset of possible type annotations "
-            f"to be represented in a JSON schema since we lacked more information "
-            f"about the context.\n\n"
-            f"This feature needs yet to be implemented.\n\n"
-            f"{type_annotation=}"
-        )
+        # noinspection PyTypeChecker
+        assert_never(type_annotation)
 
 
 @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
 def _define_properties(
     cls: intermediate.ClassUnion,
-    constraints_by_property: infer_for_schema.ConstraintsByProperty,
+    constraints_by_class: Mapping[
+        intermediate.ClassUnion, infer_for_schema.ConstraintsByValue
+    ],
     fix_pattern: Callable[[str], str],
 ) -> Tuple[Optional[MutableMapping[str, Any]], Optional[List[Error]]]:
     """
@@ -355,52 +368,78 @@ def _define_properties(
 
     properties = collections.OrderedDict()  # type: MutableMapping[str, Any]
 
+    constraints_by_value = constraints_by_class[cls]
+
     for prop in cls.properties:
         prop_name = naming.json_property(prop.name)
 
-        len_constraint = constraints_by_property.len_constraints_by_property.get(
-            prop, None
-        )
-
-        pattern_constraints = constraints_by_property.patterns_by_property.get(
-            prop, None
-        )
-
         type_anno = intermediate.beneath_optional(prop.type_annotation)
 
-        definition = collections.OrderedDict()  # type: MutableMapping[str, Any]
+        definition: Optional[MutableMapping[str, Any]] = None
 
-        # NOTE (mristin, 2023-02-06):
-        # The properties are inherited through ``allOf``. We can not change the type
-        # of property in the children as this would result in a conflict and
-        # unsatisfiable schema. Therefore, we define the type for a property only
-        # at the parent class, where the property is defined for the first time.
         if prop.specified_for is cls:
-            property_definition, error = _define_type(type_annotation=type_anno)
+            maybe_definition, error = _define_type(
+                type_annotation=type_anno,
+                constraints_by_value=constraints_by_value,
+                fix_pattern=fix_pattern,
+            )
 
             if error is not None:
                 errors.append(error)
             else:
-                assert property_definition is not None
-                definition.update(property_definition)
-
-        constraints_definition, error = _define_constraints(
-            type_annotation=type_anno,
-            len_constraint=len_constraint,
-            pattern_constraints=pattern_constraints,
-            fix_pattern=fix_pattern,
-        )
-        if error is not None:
-            errors.append(error)
+                assert maybe_definition is not None
+                definition = maybe_definition
         else:
-            assert constraints_definition is not None
-            definition.update(constraints_definition)
+            # NOTE (mristin):
+            # The properties are inherited through ``allOf``. We can not change the type
+            # of property in the children as this would result in a conflict and
+            # unsatisfiable schema. Therefore, we define the type for a property only
+            # at the parent class, where the property is defined for the first time.
+            #
+            # However, children classes can tighten constraints, so we have to reflect
+            # that here. While we could theoretically check for all the constraints
+            # deep into the nested type annotations, we currently limit ourselves to
+            # check only if the constraints differ at the property level due to
+            # the lack of time.
 
-        # NOTE (mristin, 2023-02-06):
-        # We do not want to pollute the schema with empty definitions. An empty
-        # definition results if there are no constraints and the property is inherited
-        # from an ancestor class through ``allOf``.
-        if len(definition) > 0:
+            constraints = constraints_by_value.get(type_anno, None)
+            if constraints is None:
+                continue
+
+            for parent in cls.inheritances:
+                parent_constraints = constraints_by_class[parent].get(type_anno, None)
+
+                # NOTE (mristin):
+                # We leverage here the fact that we do not make additional copies
+                # when merging the constraints in case where one of the constraints is
+                # none (see ``infer_for_schema._inline._merge_*`` functions).
+                if parent_constraints is not None:
+                    assert (
+                        constraints is not None
+                    ), "We can only tighten the constraints, but not relax them."
+
+                    # fmt: off
+                    constraints = (
+                        infer_for_schema
+                        .tightening_steps_from_other_to_that_constraints(
+                            that=constraints,
+                            other=parent_constraints,
+                        )
+                    )
+                    # fmt: on
+
+            all_of = _translate_constraints(
+                type_annotation=type_anno,
+                constraints=constraints,
+                fix_pattern=fix_pattern,
+            )
+
+            if all_of is not None:
+                definition = _all_of_as_jsonable_mapping(all_of)
+
+        # NOTE (mristin):
+        # We do not want to pollute the schema with empty definitions.
+        if definition is not None and len(definition) > 0:
             properties[prop_name] = definition
 
     if len(errors) > 0:
@@ -473,7 +512,9 @@ def _define_all_of_for_inheritance(
 @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
 def _generate_inheritable_definition(
     cls: intermediate.ClassUnion,
-    constraints_by_property: infer_for_schema.ConstraintsByProperty,
+    constraints_by_class: Mapping[
+        intermediate.ClassUnion, infer_for_schema.ConstraintsByValue
+    ],
     fix_pattern: Callable[[str], str],
 ) -> Tuple[Optional[MutableMapping[str, Any]], Optional[List[Error]]]:
     """
@@ -490,7 +531,7 @@ def _generate_inheritable_definition(
 
     properties, properties_error = _define_properties(
         cls=cls,
-        constraints_by_property=constraints_by_property,
+        constraints_by_class=constraints_by_class,
         fix_pattern=fix_pattern,
     )
     if properties_error is not None:
@@ -571,7 +612,9 @@ def _generate_choice_definition(
 @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
 def _generate_concrete_definition(
     cls: intermediate.ClassUnion,
-    constraints_by_property: infer_for_schema.ConstraintsByProperty,
+    constraints_by_class: Mapping[
+        intermediate.ClassUnion, infer_for_schema.ConstraintsByValue
+    ],
     fix_pattern: Callable[[str], str],
 ) -> Tuple[Optional[MutableMapping[str, Any]], Optional[List[Error]]]:
     """
@@ -580,7 +623,7 @@ def _generate_concrete_definition(
     The ``fix_pattern`` determines how the pattern should be translated for
     the respective JSON schema engine.
     """
-    # NOTE (mristin, 2023-03-13):
+    # NOTE (mristin):
     # We distinguish between two definitions corresponding to the same concrete
     # class:
     #
@@ -616,7 +659,7 @@ def _generate_concrete_definition(
 
     properties, properties_error = _define_properties(
         cls=cls,
-        constraints_by_property=constraints_by_property,
+        constraints_by_class=constraints_by_class,
         fix_pattern=fix_pattern,
     )
     if properties_error is not None:
@@ -850,7 +893,7 @@ def generate(
                     errors.append(update_error)
 
             elif isinstance(our_type, intermediate.ConstrainedPrimitive):
-                # NOTE (mristin, 2022-02-11):
+                # NOTE (mristin):
                 # We in-line the constraints from the constrained primitives directly
                 # in the properties. We do not want to introduce separate definitions
                 # for them as that would make it more difficult for downstream code
@@ -865,7 +908,7 @@ def generate(
                     # region Inheritable
                     inheritable, definition_errors = _generate_inheritable_definition(
                         cls=our_type,
-                        constraints_by_property=constraints_by_class[our_type],
+                        constraints_by_class=constraints_by_class,
                         fix_pattern=fix_pattern,
                     )
 
@@ -897,7 +940,7 @@ def generate(
                 if isinstance(our_type, intermediate.ConcreteClass):
                     definition, definition_errors = _generate_concrete_definition(
                         cls=our_type,
-                        constraints_by_property=constraints_by_class[our_type],
+                        constraints_by_class=constraints_by_class,
                         fix_pattern=fix_pattern,
                     )
                     if definition_errors is not None:

--- a/aas_core_codegen/smoke/main.py
+++ b/aas_core_codegen/smoke/main.py
@@ -157,19 +157,6 @@ def execute(model_path: pathlib.Path, stderr: TextIO) -> int:
 
     assert constraints_by_class is not None
 
-    _, error = infer_for_schema.merge_constraints_with_ancestors(
-        symbol_table=ir_symbol_table, constraints_by_class=constraints_by_class
-    )
-    if errors is not None:
-        run.write_error_report(
-            message=f"Failed to merge the constraints with ancestors for the schemas "
-            f"based on {model_path}",
-            errors=[lineno_columner.error_message(error)],
-            stderr=stderr,
-        )
-
-        return 1
-
     errors = _smoke_transpile_to_csharp(symbol_table=ir_symbol_table)
 
     if len(errors) > 0:

--- a/aas_core_codegen/xsd/main.py
+++ b/aas_core_codegen/xsd/main.py
@@ -5,7 +5,7 @@ import re
 # noinspection PyUnresolvedReferences
 import xml.dom.minidom
 import xml.etree.ElementTree as ET
-from typing import TextIO, MutableMapping, Optional, Tuple, List, Sequence, Any
+from typing import TextIO, MutableMapping, Optional, Tuple, List, Any, Mapping
 
 import greenery
 from icontract import ensure, require
@@ -179,8 +179,7 @@ def _translate_pattern(pattern: str) -> Tuple[Optional[str], Optional[str]]:
 
 def _generate_xs_restriction(
     base_type: intermediate.PrimitiveType,
-    len_constraint: Optional[infer_for_schema.LenConstraint],
-    pattern_constraints: Optional[Sequence[infer_for_schema.PatternConstraint]],
+    constraints: Optional[infer_for_schema.Constraints],
 ) -> Tuple[Optional[ET.Element], Optional[str]]:
     """
     Generate the ``xs:restriction`` for the given primitive.
@@ -188,14 +187,17 @@ def _generate_xs_restriction(
     Return the restriction element (if any length or pattern constraints), or
     an error.
     """
-    if len_constraint is None and (
-        pattern_constraints is None or (len(pattern_constraints) == 0)
+    if constraints is None:
+        return None, None
+
+    if constraints.len_constraint is None and (
+        constraints.patterns is None or (len(constraints.patterns) == 0)
     ):
         return None, None
 
     restriction = ET.Element("xs:restriction", {"base": _PRIMITIVE_MAP[base_type]})
 
-    # NOTE (mristin, 2023-02-27):
+    # NOTE (mristin):
     # We skip the general XML character pattern. It makes greenery
     # unbearably slow since it instantiates *each* character in
     # the character range. Since XML engines can not deal with the special
@@ -203,10 +205,10 @@ def _generate_xs_restriction(
     # the XSD pattern restrictions.
     patterns_relevant_for_xsd: Optional[List[infer_for_schema.PatternConstraint]] = None
 
-    if pattern_constraints is not None:
+    if constraints.patterns is not None:
         patterns_relevant_for_xsd = [
             pattern_constraint
-            for pattern_constraint in pattern_constraints
+            for pattern_constraint in constraints.patterns
             if pattern_constraint.pattern
             != (
                 "^[\\x09\\x0A\\x0D\\x20-\\uD7FF\\uE000-\\uFFFD"
@@ -229,7 +231,7 @@ def _generate_xs_restriction(
             merger = None  # type: Optional[Any]
             for pattern_constraint in patterns_relevant_for_xsd:
                 # NOTE (mristin, 2023-02-27):
-                # Greenery expects the characters to be in unicode and not escaped.
+                # Greenery expects the characters to be in Unicode and not escaped.
                 translated_for_greenery = _undo_escaping_backslash_x_u_and_U_in_pattern(
                     pattern_constraint.pattern
                 )
@@ -270,16 +272,16 @@ def _generate_xs_restriction(
 
         restriction.append(pattern)
 
-    if len_constraint is not None:
-        if len_constraint.min_value is not None:
+    if constraints.len_constraint is not None:
+        if constraints.len_constraint.min_value is not None:
             min_length = ET.Element(
-                "xs:minLength", {"value": str(len_constraint.min_value)}
+                "xs:minLength", {"value": str(constraints.len_constraint.min_value)}
             )
             restriction.append(min_length)
 
-        if len_constraint.max_value is not None:
+        if constraints.len_constraint.max_value is not None:
             max_length = ET.Element(
-                "xs:maxLength", {"value": str(len_constraint.max_value)}
+                "xs:maxLength", {"value": str(constraints.len_constraint.max_value)}
             )
             restriction.append(max_length)
 
@@ -288,9 +290,7 @@ def _generate_xs_restriction(
 
 @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
 def _generate_xs_element_for_a_primitive_property(
-    prop: intermediate.Property,
-    len_constraint: Optional[infer_for_schema.LenConstraint],
-    pattern_constraints: Optional[Sequence[infer_for_schema.PatternConstraint]],
+    prop: intermediate.Property, constraints: Optional[infer_for_schema.Constraints]
 ) -> Tuple[Optional[ET.Element], Optional[Error]]:
     """
     Generate the ``xs:element`` for a primitive property.
@@ -323,7 +323,7 @@ def _generate_xs_element_for_a_primitive_property(
             None,
         )
 
-    # NOTE (mristin, 2022-03-30):
+    # NOTE (mristin):
     # Specify the type of the ``type_anno`` here with assert instead of specifying it
     # in the pre-condition to help mypy a bit.
 
@@ -334,9 +334,7 @@ def _generate_xs_element_for_a_primitive_property(
     ), f"Expected a primitive or a constrained primitive, but got: {type_anno}"
 
     xs_restriction, error = _generate_xs_restriction(
-        base_type=base_type,
-        len_constraint=len_constraint,
-        pattern_constraints=pattern_constraints,
+        base_type=base_type, constraints=constraints
     )
     if error is not None:
         return None, Error(
@@ -368,8 +366,7 @@ def _generate_xs_element_for_a_primitive_property(
 
 @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
 def _generate_xs_element_for_a_list_property(
-    prop: intermediate.Property,
-    len_constraint: Optional[infer_for_schema.LenConstraint],
+    prop: intermediate.Property, constraints: Optional[infer_for_schema.Constraints]
 ) -> Tuple[Optional[ET.Element], Optional[Error]]:
     """Generate the ``xs:element`` for a list property."""
     type_anno = intermediate.beneath_optional(prop.type_annotation)
@@ -381,12 +378,13 @@ def _generate_xs_element_for_a_list_property(
 
     min_occurs = "0"
     max_occurs = "unbounded"
-    if len_constraint is not None:
-        if len_constraint.min_value is not None:
-            min_occurs = str(len_constraint.min_value)
+    if constraints is not None:
+        if constraints.len_constraint is not None:
+            if constraints.len_constraint.min_value is not None:
+                min_occurs = str(constraints.len_constraint.min_value)
 
-        if len_constraint.max_value is not None:
-            max_occurs = str(len_constraint.max_value)
+            if constraints.len_constraint.max_value is not None:
+                max_occurs = str(constraints.len_constraint.max_value)
 
     xs_element: ET.Element
 
@@ -508,9 +506,7 @@ def _generate_xs_element_for_a_list_property(
 
 @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
 def _generate_xs_element_for_a_property(
-    prop: intermediate.Property,
-    len_constraint: Optional[infer_for_schema.LenConstraint],
-    pattern_constraints: Optional[Sequence[infer_for_schema.PatternConstraint]],
+    prop: intermediate.Property, constraints: Optional[infer_for_schema.Constraints]
 ) -> Tuple[Optional[ET.Element], Optional[Error]]:
     """Generate the definition of an ``xs:element`` for a property."""
     type_anno = intermediate.beneath_optional(prop.type_annotation)
@@ -519,9 +515,7 @@ def _generate_xs_element_for_a_property(
 
     if isinstance(type_anno, intermediate.PrimitiveTypeAnnotation):
         xs_element, error = _generate_xs_element_for_a_primitive_property(
-            prop=prop,
-            len_constraint=len_constraint,
-            pattern_constraints=pattern_constraints,
+            prop=prop, constraints=constraints
         )
         if error is not None:
             return None, error
@@ -541,9 +535,7 @@ def _generate_xs_element_for_a_property(
 
         elif isinstance(our_type, intermediate.ConstrainedPrimitive):
             xs_element, error = _generate_xs_element_for_a_primitive_property(
-                prop=prop,
-                len_constraint=len_constraint,
-                pattern_constraints=pattern_constraints,
+                prop=prop, constraints=constraints
             )
             if error is not None:
                 return None, error
@@ -588,7 +580,7 @@ def _generate_xs_element_for_a_property(
 
     elif isinstance(type_anno, intermediate.ListTypeAnnotation):
         xs_element, error = _generate_xs_element_for_a_list_property(
-            prop=prop, len_constraint=len_constraint
+            prop=prop, constraints=constraints
         )
         if error is not None:
             return None, error
@@ -609,28 +601,41 @@ def _generate_xs_element_for_a_property(
 @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
 def _define_properties(
     cls: intermediate.ClassUnion,
-    constraints_by_property: infer_for_schema.ConstraintsByProperty,
+    constraints_by_class: Mapping[
+        intermediate.ClassUnion, infer_for_schema.ConstraintsByValue
+    ],
 ) -> Tuple[Optional[List[ET.Element]], Optional[List[Error]]]:
     """Define the properties of the ``cls`` as a sequence of tags."""
     sequence = []  # type: List[ET.Element]
     errors = []  # type: List[Error]
 
+    constraints_by_value = constraints_by_class[cls]
+
     for prop in cls.properties:
+        # NOTE (mristin):
+        # While we allow our classes to tighten the constraints from the parents, XSD
+        # does not allow us to *easily* tighten the constraints in a group.
+        #
+        # Instead of making it really complicated, we simply ignore the tightening
+        # of the constraints in the children classes.
+        #
+        # If we ever want to implement this feature, we have to define three intermediate
+        # structures:
+        # 1) Abstract parent class,
+        # 2) Restricted class, only tightening the elements with
+        #    ``<xs:restriction base="...">``, and
+        # 3) Extended class which includes properties specified only for the class with
+        #    ``<xs:extension base="...">``.
+
         if prop.specified_for is not cls:
             continue
 
-        len_constraint = constraints_by_property.len_constraints_by_property.get(
-            prop, None
-        )
+        type_anno = intermediate.beneath_optional(prop.type_annotation)
 
-        pattern_constraints = constraints_by_property.patterns_by_property.get(
-            prop, None
-        )
+        constraints = constraints_by_value.get(type_anno, None)
 
         xs_element, error = _generate_xs_element_for_a_property(
-            prop=prop,
-            len_constraint=len_constraint,
-            pattern_constraints=pattern_constraints,
+            prop=prop, constraints=constraints
         )
         if error is not None:
             errors.append(error)
@@ -646,11 +651,13 @@ def _define_properties(
 
 def _generate_xs_group_for_class(
     cls: intermediate.ClassUnion,
-    constraints_by_property: infer_for_schema.ConstraintsByProperty,
+    constraints_by_class: Mapping[
+        intermediate.ClassUnion, infer_for_schema.ConstraintsByValue
+    ],
 ) -> Tuple[Optional[ET.Element], Optional[Error]]:
     """Generate the ``xs:group`` representation of the class properties."""
     properties, properties_errors = _define_properties(
-        cls=cls, constraints_by_property=constraints_by_property
+        cls=cls, constraints_by_class=constraints_by_class
     )
 
     if properties_errors is not None:
@@ -680,7 +687,9 @@ def _generate_xs_group_for_class(
 @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
 def _define_for_class(
     cls: intermediate.ClassUnion,
-    constraints_by_property: infer_for_schema.ConstraintsByProperty,
+    constraints_by_class: Mapping[
+        intermediate.ClassUnion, infer_for_schema.ConstraintsByValue
+    ],
 ) -> Tuple[Optional[List[ET.Element]], Optional[Error]]:
     """
     Generate the definitions for the class ``cls``.
@@ -693,7 +702,7 @@ def _define_for_class(
     # See: https://stackoverflow.com/questions/1198755/xml-schemas-with-multiple-inheritance
 
     xs_group, xs_group_error = _generate_xs_group_for_class(
-        cls=cls, constraints_by_property=constraints_by_property
+        cls=cls, constraints_by_class=constraints_by_class
     )
     if xs_group_error is not None:
         return None, xs_group_error
@@ -1100,7 +1109,7 @@ def _generate(
                 our_type, (intermediate.AbstractClass, intermediate.ConcreteClass)
             ):
                 elements, definition_error = _define_for_class(
-                    cls=our_type, constraints_by_property=constraints_by_class[our_type]
+                    cls=our_type, constraints_by_class=constraints_by_class
                 )
 
                 if definition_error is not None:

--- a/dev/test_data/main/jsonschema/expected/aas_core_meta.v3/expected_output/schema.json
+++ b/dev/test_data/main/jsonschema/expected/aas_core_meta.v3/expected_output/schema.json
@@ -58,14 +58,10 @@
           "properties": {
             "version": {
               "type": "string",
+              "minLength": 1,
+              "maxLength": 4,
+              "pattern": "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$",
               "allOf": [
-                {
-                  "minLength": 1,
-                  "maxLength": 4
-                },
-                {
-                  "pattern": "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$"
-                },
                 {
                   "pattern": "^(0|[1-9][0-9]*)$"
                 }
@@ -73,14 +69,10 @@
             },
             "revision": {
               "type": "string",
+              "minLength": 1,
+              "maxLength": 4,
+              "pattern": "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$",
               "allOf": [
-                {
-                  "minLength": 1,
-                  "maxLength": 4
-                },
-                {
-                  "pattern": "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$"
-                },
                 {
                   "pattern": "^(0|[1-9][0-9]*)$"
                 }
@@ -256,14 +248,10 @@
             },
             "contentType": {
               "type": "string",
+              "minLength": 1,
+              "maxLength": 100,
+              "pattern": "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$",
               "allOf": [
-                {
-                  "minLength": 1,
-                  "maxLength": 100
-                },
-                {
-                  "pattern": "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$"
-                },
                 {
                   "pattern": "^([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+/([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+([ \\t]*;[ \\t]*([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+=(([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+|\"(([\\t !#-\\[\\]-~]|[\\x80-\\xff])|\\\\([\\t !-~]|[\\x80-\\xff]))*\"))*$"
                 }
@@ -681,14 +669,10 @@
             },
             "contentType": {
               "type": "string",
+              "minLength": 1,
+              "maxLength": 100,
+              "pattern": "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$",
               "allOf": [
-                {
-                  "minLength": 1,
-                  "maxLength": 100
-                },
-                {
-                  "pattern": "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$"
-                },
                 {
                   "pattern": "^([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+/([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+([ \\t]*;[ \\t]*([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+=(([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+|\"(([\\t !#-\\[\\]-~]|[\\x80-\\xff])|\\\\([\\t !-~]|[\\x80-\\xff]))*\"))*$"
                 }
@@ -829,6 +813,7 @@
         {
           "properties": {
             "text": {
+              "minLength": 1,
               "maxLength": 1023
             }
           }
@@ -843,6 +828,7 @@
         {
           "properties": {
             "text": {
+              "minLength": 1,
               "maxLength": 128
             }
           }
@@ -857,6 +843,7 @@
         {
           "properties": {
             "text": {
+              "minLength": 1,
               "maxLength": 255
             }
           }
@@ -871,6 +858,7 @@
         {
           "properties": {
             "text": {
+              "minLength": 1,
               "maxLength": 18
             }
           }
@@ -885,6 +873,7 @@
         {
           "properties": {
             "text": {
+              "minLength": 1,
               "maxLength": 1023
             }
           }
@@ -1144,14 +1133,10 @@
             },
             "idShort": {
               "type": "string",
+              "minLength": 1,
+              "maxLength": 128,
+              "pattern": "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$",
               "allOf": [
-                {
-                  "minLength": 1,
-                  "maxLength": 128
-                },
-                {
-                  "pattern": "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$"
-                },
                 {
                   "pattern": "^[a-zA-Z][a-zA-Z0-9_]*$"
                 }
@@ -1283,14 +1268,10 @@
         },
         "contentType": {
           "type": "string",
+          "minLength": 1,
+          "maxLength": 100,
+          "pattern": "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$",
           "allOf": [
-            {
-              "minLength": 1,
-              "maxLength": 100
-            },
-            {
-              "pattern": "^([\\x09\\x0a\\x0d\\x20-\\ud7ff\\ue000-\\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$"
-            },
             {
               "pattern": "^([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+/([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+([ \\t]*;[ \\t]*([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+=(([!#$%&'*+\\-.^_`|~0-9a-zA-Z])+|\"(([\\t !#-\\[\\]-~]|[\\x80-\\xff])|\\\\([\\t !-~]|[\\x80-\\xff]))*\"))*$"
             }

--- a/dev/test_data/main/jsonschema/expected/regression_when_len_constraints_on_inherited_property/examples/expected/lang_string_name_type/simple.json
+++ b/dev/test_data/main/jsonschema/expected/regression_when_len_constraints_on_inherited_property/examples/expected/lang_string_name_type/simple.json
@@ -1,0 +1,3 @@
+{
+  "text": "Example name"
+}

--- a/dev/test_data/main/xsd/expected/regression_when_len_constraints_on_inherited_property/examples/expected/lang_string_name_type/simple.xml
+++ b/dev/test_data/main/xsd/expected/regression_when_len_constraints_on_inherited_property/examples/expected/lang_string_name_type/simple.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<langStringNameType xmlns="https://dummy.com">
+  <text>Example name</text>
+</langStringNameType>

--- a/dev/test_data/main/xsd/expected/regression_when_len_constraints_on_inherited_property/expected_output/schema.xsd
+++ b/dev/test_data/main/xsd/expected/regression_when_len_constraints_on_inherited_property/expected_output/schema.xsd
@@ -1,0 +1,39 @@
+<?xml version="1.0" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="https://dummy.com" elementFormDefault="qualified" targetNamespace="https://dummy.com">
+  <xs:group name="abstractLangString">
+    <xs:sequence>
+      <xs:element name="text">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:minLength value="10"/>
+            <xs:maxLength value="1024"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="abstractLangString_choice">
+    <xs:choice>
+      <xs:element name="langStringNameType" type="langStringNameType_t"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="langStringNameType">
+    <xs:sequence>
+      <xs:group ref="abstractLangString"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="valueDataType">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+  <xs:complexType name="abstractLangString_t">
+    <xs:sequence>
+      <xs:group ref="abstractLangString"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="langStringNameType_t">
+    <xs:sequence>
+      <xs:group ref="langStringNameType"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="langStringNameType" type="langStringNameType_t"/>
+</xs:schema>

--- a/dev/test_data/main/xsd/expected/regression_when_len_constraints_on_inherited_property/expected_output/stdout.txt
+++ b/dev/test_data/main/xsd/expected/regression_when_len_constraints_on_inherited_property/expected_output/stdout.txt
@@ -1,0 +1,1 @@
+Code generated to: <output dir>

--- a/dev/test_data/main/xsd/expected/regression_when_len_constraints_on_inherited_property/input/snippets/root_element.xml
+++ b/dev/test_data/main/xsd/expected/regression_when_len_constraints_on_inherited_property/input/snippets/root_element.xml
@@ -1,0 +1,8 @@
+<xs:schema
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns="https://dummy.com"
+        elementFormDefault="qualified"
+        targetNamespace="https://dummy.com"
+>
+    <xs:element name="langStringNameType" type="langStringNameType_t" />
+</xs:schema>

--- a/dev/test_data/main/xsd/expected/regression_when_len_constraints_on_inherited_property/meta_model.py
+++ b/dev/test_data/main/xsd/expected/regression_when_len_constraints_on_inherited_property/meta_model.py
@@ -1,0 +1,51 @@
+"""
+We encountered a bug when designing V3.0. The schema constraints on
+the descendant classes where not inferred if an invariant  involved properties
+inherited from the parent class.
+
+This unit test illustrates the setting, and prevents regressions.
+"""
+
+# NOTE (mristin):
+# The XSD generator expects the constrained primitive Value data type to be defined
+# since we had to hard-wire it. If we remove that hard-wiring, we can also remove
+# this definition as well.
+
+class Value_data_type(str, DBC):
+    pass
+
+
+
+@abstract
+@invariant(
+    lambda self: len(self.text) >= 10,
+    "String shall have a minimum length of 10 characters.",
+)
+@invariant(
+    lambda self: len(self.text) <= 1024,
+    "String shall have a maximum length of 1024 characters.",
+)
+class Abstract_lang_string(DBC):
+    text: str
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+# NOTE (mristin):
+# The XSD is too complicated when it comes to tightening of constraints in children
+# classes (there needs to be introduced two types: one for restricting the inherited
+# properties and another one for extending them). At the moment (2026-04-29), we do not
+# want to dive into that kind of complexity which would substantially change
+# the resulting XSD schemas. Instead, we document the behavior in this test case.
+@invariant(
+    lambda self: len(self.text) <= 128,
+    "String shall have a maximum length of 128 characters.",
+)
+class Lang_string_name_type(Abstract_lang_string, DBC):
+    def __init__(self, text: str) -> None:
+        Abstract_lang_string.__init__(self, text=text)
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/dev/tests/infer_for_schema/common.py
+++ b/dev/tests/infer_for_schema/common.py
@@ -1,6 +1,7 @@
 """Provide functions shared among the tests."""
-from typing import Tuple, MutableMapping
+from typing import Tuple, Optional, Mapping
 
+import aas_core_codegen.common
 import tests.common
 from aas_core_codegen import intermediate, infer_for_schema
 from aas_core_codegen.common import Identifier
@@ -28,7 +29,7 @@ def parse_to_symbol_table_and_something_cls_and_constraints_by_class(
 ) -> Tuple[
     intermediate.SymbolTable,
     intermediate.ClassUnion,
-    MutableMapping[intermediate.ClassUnion, infer_for_schema.ConstraintsByProperty],
+    Mapping[intermediate.ClassUnion, infer_for_schema.ConstraintsByValue],
 ]:
     """
     Parse the ``source``.
@@ -45,3 +46,32 @@ def parse_to_symbol_table_and_something_cls_and_constraints_by_class(
     assert constraints_by_class is not None
 
     return symbol_table, something_cls, constraints_by_class
+
+
+def select_constraints_of_property(
+    cls: intermediate.ClassUnion,
+    property_name: str,
+    constraints_by_class: Mapping[
+        intermediate.ClassUnion, infer_for_schema.ConstraintsByValue
+    ],
+) -> Optional[infer_for_schema.Constraints]:
+    """Get the constraints for the given property of the class ``cls``."""
+    constraints_by_value = constraints_by_class.get(cls, None)
+
+    if constraints_by_value is None:
+        raise ValueError(
+            f"Class {cls.name!r} is not included in the supplied constraints-by-class."
+        )
+
+    if aas_core_codegen.common.IDENTIFIER_RE.match(property_name) is None:
+        raise ValueError(f"Supplied invalid property name {property_name!r}")
+
+    prop = cls.properties_by_name.get(Identifier(property_name), None)
+    if prop is None:
+        raise ValueError(
+            f"The property {property_name!r} does not exist in class {cls.name!r}"
+        )
+
+    return constraints_by_value.get(
+        intermediate.beneath_optional(prop.type_annotation), None
+    )

--- a/dev/tests/infer_for_schema/test_len_on_properties.py
+++ b/dev/tests/infer_for_schema/test_len_on_properties.py
@@ -2,11 +2,10 @@
 
 import textwrap
 import unittest
-from typing import Optional, MutableMapping
 
 import tests.common
 import tests.infer_for_schema.common
-from aas_core_codegen import infer_for_schema, intermediate
+from aas_core_codegen import infer_for_schema
 
 
 class Test_expected(unittest.TestCase):
@@ -37,20 +36,11 @@ class Test_expected(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
-
-        text = infer_for_schema.dump(constraints_by_props)
-        self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={},
-                  patterns_by_property={},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
-            text,
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
         )
+
+        assert constraints is None
 
     def test_min_value_constant_left(self) -> None:
         source = textwrap.dedent(
@@ -84,21 +74,21 @@ class Test_expected(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
+        )
 
-        text = infer_for_schema.dump(constraints_by_props)
+        text = infer_for_schema.dump(constraints)
+
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={
-                    'some_property': LenConstraint(
-                      min_value=11,
-                      max_value=None)},
-                  patterns_by_property={},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+            """\
+Constraints(
+  len_constraint=LenConstraint(
+    min_value=11,
+    max_value=None),
+  patterns=None,
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 
@@ -134,21 +124,21 @@ class Test_expected(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
+        )
 
-        text = infer_for_schema.dump(constraints_by_props)
+        text = infer_for_schema.dump(constraints)
+
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={
-                    'some_property': LenConstraint(
-                      min_value=11,
-                      max_value=None)},
-                  patterns_by_property={},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+            """\
+Constraints(
+  len_constraint=LenConstraint(
+    min_value=11,
+    max_value=None),
+  patterns=None,
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 
@@ -184,21 +174,21 @@ class Test_expected(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
+        )
 
-        text = infer_for_schema.dump(constraints_by_props)
+        text = infer_for_schema.dump(constraints)
+
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={
-                    'some_property': LenConstraint(
-                      min_value=None,
-                      max_value=9)},
-                  patterns_by_property={},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+            """\
+Constraints(
+  len_constraint=LenConstraint(
+    min_value=None,
+    max_value=9),
+  patterns=None,
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 
@@ -234,21 +224,21 @@ class Test_expected(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
+        )
 
-        text = infer_for_schema.dump(constraints_by_props)
+        text = infer_for_schema.dump(constraints)
+
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={
-                    'some_property': LenConstraint(
-                      min_value=None,
-                      max_value=9)},
-                  patterns_by_property={},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+            """\
+Constraints(
+  len_constraint=LenConstraint(
+    min_value=None,
+    max_value=9),
+  patterns=None,
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 
@@ -286,21 +276,21 @@ class Test_expected(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
+        )
 
-        text = infer_for_schema.dump(constraints_by_props)
+        text = infer_for_schema.dump(constraints)
+
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={
-                    'some_property': LenConstraint(
-                      min_value=None,
-                      max_value=128)},
-                  patterns_by_property={},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+            """\
+Constraints(
+  len_constraint=LenConstraint(
+    min_value=None,
+    max_value=128),
+  patterns=None,
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 
@@ -336,21 +326,21 @@ class Test_expected(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
+        )
 
-        text = infer_for_schema.dump(constraints_by_props)
+        text = infer_for_schema.dump(constraints)
+
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={
-                    'some_property': LenConstraint(
-                      min_value=10,
-                      max_value=10)},
-                  patterns_by_property={},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+            """\
+Constraints(
+  len_constraint=LenConstraint(
+    min_value=10,
+    max_value=10),
+  patterns=None,
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 
@@ -386,21 +376,21 @@ class Test_expected(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
+        )
 
-        text = infer_for_schema.dump(constraints_by_props)
+        text = infer_for_schema.dump(constraints)
+
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={
-                    'some_property': LenConstraint(
-                      min_value=10,
-                      max_value=10)},
-                  patterns_by_property={},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+            """\
+Constraints(
+  len_constraint=LenConstraint(
+    min_value=10,
+    max_value=10),
+  patterns=None,
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 
@@ -438,91 +428,21 @@ class Test_expected(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
-
-        text = infer_for_schema.dump(constraints_by_props)
-        self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={
-                    'some_property': LenConstraint(
-                      min_value=10,
-                      max_value=10)},
-                  patterns_by_property={},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
-            text,
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
         )
 
-    def test_no_inheritance_by_default(self) -> None:
-        source = textwrap.dedent(
+        text = infer_for_schema.dump(constraints)
+
+        self.assertEqual(
             """\
-            @invariant(
-                lambda self: len(self.some_property) > 3,
-                "Some property must be more than 3 characters long."
-            )
-            class Parent:
-                some_property: str
-
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
-
-
-            @invariant(
-                lambda self: len(self.some_property) > 5,
-                "Some property must be more than 5 characters long."
-            )
-            class Something(Parent):
-                def __init__(self, some_property: str) -> None:
-                    Parent.__init__(
-                        self,
-                        some_property=some_property
-                    )
-
-
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
-
-        # NOTE (mristin, 2022-01-02):
-        # We infer only the constraints as specified in the class itself, and
-        # ignore the constraints of the ancestors in *this particular kind of
-        # inference*.
-        #
-        # This is necessary as we want to use these constraints to generate schemas
-        # whereas it is the job of the schema engine to stack the constraints together.
-
-        # fmt: off
-        (
-            _,
-            something_cls,
-            constraints_by_class,
-        ) = (
-            tests.infer_for_schema.common
-            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-                source=source
-            )
-        )
-        # fmt: on
-
-        constraints_by_props = constraints_by_class[something_cls]
-
-        text = infer_for_schema.dump(constraints_by_props)
-        self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={
-                    'some_property': LenConstraint(
-                      min_value=6,
-                      max_value=None)},
-                  patterns_by_property={},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+Constraints(
+  len_constraint=LenConstraint(
+    min_value=10,
+    max_value=10),
+  patterns=None,
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 
@@ -672,18 +592,9 @@ class Test_stacking(unittest.TestCase):
             """
         )
 
-        # NOTE (mristin, 2022-05-18):
-        # This definition here is necessary for mypy.
-        # noinspection PyUnusedLocal
-        constraints_by_class: Optional[
-            MutableMapping[
-                intermediate.ClassUnion, infer_for_schema.ConstraintsByProperty
-            ]
-        ] = None
-
         # fmt: off
         (
-            symbol_table,
+            _,
             something_cls,
             constraints_by_class,
         ) = (
@@ -694,27 +605,21 @@ class Test_stacking(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_class, error = infer_for_schema.merge_constraints_with_ancestors(
-            symbol_table=symbol_table, constraints_by_class=constraints_by_class
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
         )
-        assert error is None, tests.common.most_underlying_messages(error)
-        assert constraints_by_class is not None
 
-        constraints_by_props = constraints_by_class[something_cls]
+        text = infer_for_schema.dump(constraints)
 
-        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={
-                    'some_property': LenConstraint(
-                      min_value=None,
-                      max_value=9)},
-                  patterns_by_property={},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+            """\
+Constraints(
+  len_constraint=LenConstraint(
+    min_value=None,
+    max_value=9),
+  patterns=None,
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 
@@ -745,18 +650,9 @@ class Test_stacking(unittest.TestCase):
             """
         )
 
-        # NOTE (mristin, 2022-05-18):
-        # This definition here is necessary for mypy.
-        # noinspection PyUnusedLocal
-        constraints_by_class: Optional[
-            MutableMapping[
-                intermediate.ClassUnion, infer_for_schema.ConstraintsByProperty
-            ]
-        ] = None
-
         # fmt: off
         (
-            symbol_table,
+            _,
             something_cls,
             constraints_by_class,
         ) = (
@@ -767,27 +663,21 @@ class Test_stacking(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_class, error = infer_for_schema.merge_constraints_with_ancestors(
-            symbol_table=symbol_table, constraints_by_class=constraints_by_class
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
         )
-        assert error is None, tests.common.most_underlying_messages(error)
-        assert constraints_by_class is not None
 
-        constraints_by_props = constraints_by_class[something_cls]
+        text = infer_for_schema.dump(constraints)
 
-        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={
-                    'some_property': LenConstraint(
-                      min_value=4,
-                      max_value=None)},
-                  patterns_by_property={},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+            """\
+Constraints(
+  len_constraint=LenConstraint(
+    min_value=4,
+    max_value=None),
+  patterns=None,
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 
@@ -822,18 +712,9 @@ class Test_stacking(unittest.TestCase):
             """
         )
 
-        # NOTE (mristin, 2022-05-18):
-        # This definition here is necessary for mypy.
-        # noinspection PyUnusedLocal
-        constraints_by_class: Optional[
-            MutableMapping[
-                intermediate.ClassUnion, infer_for_schema.ConstraintsByProperty
-            ]
-        ] = None
-
         # fmt: off
         (
-            symbol_table,
+            _,
             something_cls,
             constraints_by_class,
         ) = (
@@ -844,32 +725,26 @@ class Test_stacking(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_class, error = infer_for_schema.merge_constraints_with_ancestors(
-            symbol_table=symbol_table, constraints_by_class=constraints_by_class
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
         )
-        assert error is None, tests.common.most_underlying_messages(error)
-        assert constraints_by_class is not None
 
-        constraints_by_props = constraints_by_class[something_cls]
+        text = infer_for_schema.dump(constraints)
 
-        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={
-                    'some_property': LenConstraint(
-                      min_value=4,
-                      max_value=9)},
-                  patterns_by_property={},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+            """\
+Constraints(
+  len_constraint=LenConstraint(
+    min_value=4,
+    max_value=9),
+  patterns=None,
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 
     def test_invariant_on_inherited_property(self) -> None:
-        # NOTE (mristin, 2023-02-04):
+        # NOTE (mristin):
         # We encountered a bug when designing V3.0. The schema constraints on
         # the descendant classes where not inferred if an invariant involved properties
         # inherited from the parent class.
@@ -904,18 +779,9 @@ class Test_stacking(unittest.TestCase):
             """
         )
 
-        # NOTE (mristin, 2023-02-04):
-        # This definition here is necessary for mypy.
-        # noinspection PyUnusedLocal
-        constraints_by_class: Optional[
-            MutableMapping[
-                intermediate.ClassUnion, infer_for_schema.ConstraintsByProperty
-            ]
-        ] = None
-
         # fmt: off
         (
-            symbol_table,
+            _,
             something_cls,
             constraints_by_class,
         ) = (
@@ -926,27 +792,21 @@ class Test_stacking(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_class, error = infer_for_schema.merge_constraints_with_ancestors(
-            symbol_table=symbol_table, constraints_by_class=constraints_by_class
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "text", constraints_by_class
         )
-        assert error is None, tests.common.most_underlying_messages(error)
-        assert constraints_by_class is not None
 
-        constraints_by_props = constraints_by_class[something_cls]
+        text = infer_for_schema.dump(constraints)
 
-        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={
-                    'text': LenConstraint(
-                      min_value=None,
-                      max_value=128)},
-                  patterns_by_property={},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+            """\
+Constraints(
+  len_constraint=LenConstraint(
+    min_value=None,
+    max_value=128),
+  patterns=None,
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 

--- a/dev/tests/infer_for_schema/test_len_on_self.py
+++ b/dev/tests/infer_for_schema/test_len_on_self.py
@@ -41,19 +41,11 @@ class Test_expected(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
-        text = infer_for_schema.dump(constraints_by_props)
-        self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={},
-                  patterns_by_property={},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
-            text,
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
         )
+
+        assert constraints is None
 
     def test_min_value_constant_left(self) -> None:
         source = textwrap.dedent(
@@ -91,20 +83,21 @@ class Test_expected(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
-        text = infer_for_schema.dump(constraints_by_props)
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
+        )
+
+        text = infer_for_schema.dump(constraints)
+
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={
-                    'some_property': LenConstraint(
-                      min_value=11,
-                      max_value=None)},
-                  patterns_by_property={},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+            """\
+Constraints(
+  len_constraint=LenConstraint(
+    min_value=11,
+    max_value=None),
+  patterns=None,
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 
@@ -144,20 +137,21 @@ class Test_expected(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
-        text = infer_for_schema.dump(constraints_by_props)
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
+        )
+
+        text = infer_for_schema.dump(constraints)
+
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={
-                    'some_property': LenConstraint(
-                      min_value=11,
-                      max_value=None)},
-                  patterns_by_property={},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+            """\
+Constraints(
+  len_constraint=LenConstraint(
+    min_value=11,
+    max_value=None),
+  patterns=None,
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 
@@ -197,20 +191,21 @@ class Test_expected(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
-        text = infer_for_schema.dump(constraints_by_props)
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
+        )
+
+        text = infer_for_schema.dump(constraints)
+
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={
-                    'some_property': LenConstraint(
-                      min_value=None,
-                      max_value=9)},
-                  patterns_by_property={},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+            """\
+Constraints(
+  len_constraint=LenConstraint(
+    min_value=None,
+    max_value=9),
+  patterns=None,
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 
@@ -250,20 +245,21 @@ class Test_expected(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
-        text = infer_for_schema.dump(constraints_by_props)
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
+        )
+
+        text = infer_for_schema.dump(constraints)
+
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={
-                    'some_property': LenConstraint(
-                      min_value=None,
-                      max_value=9)},
-                  patterns_by_property={},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+            """\
+Constraints(
+  len_constraint=LenConstraint(
+    min_value=None,
+    max_value=9),
+  patterns=None,
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 
@@ -303,20 +299,21 @@ class Test_expected(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
-        text = infer_for_schema.dump(constraints_by_props)
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
+        )
+
+        text = infer_for_schema.dump(constraints)
+
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={
-                    'some_property': LenConstraint(
-                      min_value=10,
-                      max_value=10)},
-                  patterns_by_property={},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+            """\
+Constraints(
+  len_constraint=LenConstraint(
+    min_value=10,
+    max_value=10),
+  patterns=None,
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 
@@ -356,24 +353,25 @@ class Test_expected(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
-        text = infer_for_schema.dump(constraints_by_props)
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
+        )
+
+        text = infer_for_schema.dump(constraints)
+
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={
-                    'some_property': LenConstraint(
-                      min_value=10,
-                      max_value=10)},
-                  patterns_by_property={},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+            """\
+Constraints(
+  len_constraint=LenConstraint(
+    min_value=10,
+    max_value=10),
+  patterns=None,
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 
-    def test_inheritance_between_constrained_primitives_by_default(self) -> None:
+    def test_inheritance_between_constrained_primitives(self) -> None:
         source = textwrap.dedent(
             """\
             @invariant(
@@ -404,10 +402,6 @@ class Test_expected(unittest.TestCase):
             """
         )
 
-        # NOTE (mristin, 2022-05-15):
-        # In contrast to class, we do inherit the constraints among the constrained
-        # primitives as we in-line them later in the schema classes.
-
         # fmt: off
         (
             _,
@@ -421,20 +415,21 @@ class Test_expected(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
-        text = infer_for_schema.dump(constraints_by_props)
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
+        )
+
+        text = infer_for_schema.dump(constraints)
+
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={
-                    'some_property': LenConstraint(
-                      min_value=4,
-                      max_value=5)},
-                  patterns_by_property={},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+            """\
+Constraints(
+  len_constraint=LenConstraint(
+    min_value=4,
+    max_value=5),
+  patterns=None,
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 

--- a/dev/tests/infer_for_schema/test_patterns_on_properties.py
+++ b/dev/tests/infer_for_schema/test_patterns_on_properties.py
@@ -2,11 +2,10 @@
 
 import textwrap
 import unittest
-from typing import Optional, MutableMapping
 
 import tests.common
 import tests.infer_for_schema.common
-from aas_core_codegen import infer_for_schema, intermediate
+from aas_core_codegen import infer_for_schema
 
 
 class Test_expected(unittest.TestCase):
@@ -38,19 +37,11 @@ class Test_expected(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
-        text = infer_for_schema.dump(constraints_by_props)
-        self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={},
-                  patterns_by_property={},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
-            text,
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
         )
+
+        assert constraints is None
 
     def test_single_pattern(self) -> None:
         source = textwrap.dedent(
@@ -90,20 +81,21 @@ class Test_expected(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
-        text = infer_for_schema.dump(constraints_by_props)
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
+        )
+
+        text = infer_for_schema.dump(constraints)
+
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={},
-                  patterns_by_property={
-                    'some_property': [
-                      PatternConstraint(
-                        pattern='^something-[a-zA-Z]+$')]},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+            """\
+Constraints(
+  len_constraint=None,
+  patterns=[
+    PatternConstraint(
+      pattern='^something-[a-zA-Z]+$')],
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 
@@ -152,22 +144,23 @@ class Test_expected(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
-        text = infer_for_schema.dump(constraints_by_props)
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
+        )
+
+        text = infer_for_schema.dump(constraints)
+
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={},
-                  patterns_by_property={
-                    'some_property': [
-                      PatternConstraint(
-                        pattern='^something-[a-zA-Z]+$'),
-                      PatternConstraint(
-                        pattern='^.*acme.*$')]},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+            """\
+Constraints(
+  len_constraint=None,
+  patterns=[
+    PatternConstraint(
+      pattern='^something-[a-zA-Z]+$'),
+    PatternConstraint(
+      pattern='^.*acme.*$')],
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 
@@ -196,11 +189,6 @@ class Test_expected(unittest.TestCase):
             """
         )
 
-        # NOTE (mristin, 2022-01-02):
-        # We infer only the constraints as specified in the class itself, and
-        # ignore the constraints of the ancestors in *this particular kind of
-        # inference*.
-
         # fmt: off
         (
             _,
@@ -214,94 +202,21 @@ class Test_expected(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
-        text = infer_for_schema.dump(constraints_by_props)
-        self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={},
-                  patterns_by_property={
-                    'some_property': [
-                      PatternConstraint(
-                        pattern='^something-[a-zA-Z]+$')]},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
-            text,
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
         )
 
-    def test_no_inheritance_by_default(self) -> None:
-        source = textwrap.dedent(
+        text = infer_for_schema.dump(constraints)
+
+        self.assertEqual(
             """\
-            @verification
-            def matches_something(text: str) -> bool:
-                return match("^something-[a-zA-Z]+$", text) is not None
-
-            @verification
-            def matches_acme(text: str) -> bool:
-                return match("^.*acme.*$", text) is not None
-
-            @invariant(
-                lambda self: matches_something(self.some_property),
-                "Some property must match something."
-            )
-            class Parent:
-                some_property: str
-
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
-
-
-            @invariant(
-                lambda self: matches_acme(self.some_property),
-                "Some property must match acme."
-            )
-            class Something(Parent):
-                def __init__(self, some_property: str) -> None:
-                    Parent.__init__(self, some_property=some_property)
-
-
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
-
-        # NOTE (mristin, 2022-01-02):
-        # We infer only the constraints as specified in the class itself, and
-        # ignore the constraints of the ancestors in *this particular kind of
-        # inference*.
-        #
-        # This is necessary as we want to use these constraints to generate schemas
-        # whereas it is the job of the schema engine to stack the constraints together.
-
-        # fmt: off
-        (
-            _,
-            something_cls,
-            constraints_by_class,
-        ) = (
-            tests.infer_for_schema.common
-            .parse_to_symbol_table_and_something_cls_and_constraints_by_class(
-                source=source
-            )
-        )
-        # fmt: on
-
-        constraints_by_props = constraints_by_class[something_cls]
-        text = infer_for_schema.dump(constraints_by_props)
-        self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={},
-                  patterns_by_property={
-                    'some_property': [
-                      PatternConstraint(
-                        pattern='^.*acme.*$')]},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+Constraints(
+  len_constraint=None,
+  patterns=[
+    PatternConstraint(
+      pattern='^something-[a-zA-Z]+$')],
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 
@@ -332,17 +247,9 @@ class Test_stacking(unittest.TestCase):
             """
         )
 
-        # NOTE (mristin, 2022-05-18):
-        # This definition here is necessary for mypy.
-        constraints_by_class: Optional[
-            MutableMapping[
-                intermediate.ClassUnion, infer_for_schema.ConstraintsByProperty
-            ]
-        ] = None
-
         # fmt: off
         (
-            symbol_table,
+            _,
             something_cls,
             constraints_by_class,
         ) = (
@@ -353,27 +260,21 @@ class Test_stacking(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_class, error = infer_for_schema.merge_constraints_with_ancestors(
-            symbol_table=symbol_table, constraints_by_class=constraints_by_class
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
         )
-        assert error is None, tests.common.most_underlying_messages(error)
-        assert constraints_by_class is not None
 
-        constraints_by_props = constraints_by_class[something_cls]
+        text = infer_for_schema.dump(constraints)
 
-        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={},
-                  patterns_by_property={
-                    'some_property': [
-                      PatternConstraint(
-                        pattern='^something-[a-zA-Z]+$')]},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+            """\
+Constraints(
+  len_constraint=None,
+  patterns=[
+    PatternConstraint(
+      pattern='^something-[a-zA-Z]+$')],
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 
@@ -402,17 +303,9 @@ class Test_stacking(unittest.TestCase):
             """
         )
 
-        # NOTE (mristin, 2022-05-18):
-        # This definition here is necessary for mypy.
-        constraints_by_class: Optional[
-            MutableMapping[
-                intermediate.ClassUnion, infer_for_schema.ConstraintsByProperty
-            ]
-        ] = None
-
         # fmt: off
         (
-            symbol_table,
+            _,
             something_cls,
             constraints_by_class,
         ) = (
@@ -423,27 +316,21 @@ class Test_stacking(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_class, error = infer_for_schema.merge_constraints_with_ancestors(
-            symbol_table=symbol_table, constraints_by_class=constraints_by_class
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
         )
-        assert error is None, tests.common.most_underlying_messages(error)
-        assert constraints_by_class is not None
 
-        constraints_by_props = constraints_by_class[something_cls]
+        text = infer_for_schema.dump(constraints)
 
-        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={},
-                  patterns_by_property={
-                    'some_property': [
-                      PatternConstraint(
-                        pattern='^something-[a-zA-Z]+$')]},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+            """\
+Constraints(
+  len_constraint=None,
+  patterns=[
+    PatternConstraint(
+      pattern='^something-[a-zA-Z]+$')],
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 
@@ -483,17 +370,9 @@ class Test_stacking(unittest.TestCase):
             """
         )
 
-        # NOTE (mristin, 2022-05-18):
-        # This definition here is necessary for mypy.
-        constraints_by_class: Optional[
-            MutableMapping[
-                intermediate.ClassUnion, infer_for_schema.ConstraintsByProperty
-            ]
-        ] = None
-
         # fmt: off
         (
-            symbol_table,
+            _,
             something_cls,
             constraints_by_class,
         ) = (
@@ -504,29 +383,23 @@ class Test_stacking(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_class, error = infer_for_schema.merge_constraints_with_ancestors(
-            symbol_table=symbol_table, constraints_by_class=constraints_by_class
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
         )
-        assert error is None, tests.common.most_underlying_messages(error)
-        assert constraints_by_class is not None
 
-        constraints_by_props = constraints_by_class[something_cls]
+        text = infer_for_schema.dump(constraints)
 
-        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={},
-                  patterns_by_property={
-                    'some_property': [
-                      PatternConstraint(
-                        pattern='^.*acme.*$'),
-                      PatternConstraint(
-                        pattern='^something-[a-zA-Z]+$')]},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+            """\
+Constraints(
+  len_constraint=None,
+  patterns=[
+    PatternConstraint(
+      pattern='^something-[a-zA-Z]+$'),
+    PatternConstraint(
+      pattern='^.*acme.*$')],
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 
@@ -561,17 +434,9 @@ class Test_stacking(unittest.TestCase):
             """
         )
 
-        # NOTE (mristin, 2022-05-18):
-        # This definition here is necessary for mypy.
-        constraints_by_class: Optional[
-            MutableMapping[
-                intermediate.ClassUnion, infer_for_schema.ConstraintsByProperty
-            ]
-        ] = None
-
         # fmt: off
         (
-            symbol_table,
+            _,
             something_cls,
             constraints_by_class,
         ) = (
@@ -582,27 +447,21 @@ class Test_stacking(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_class, error = infer_for_schema.merge_constraints_with_ancestors(
-            symbol_table=symbol_table, constraints_by_class=constraints_by_class
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
         )
-        assert error is None, tests.common.most_underlying_messages(error)
-        assert constraints_by_class is not None
 
-        constraints_by_props = constraints_by_class[something_cls]
+        text = infer_for_schema.dump(constraints)
 
-        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={},
-                  patterns_by_property={
-                    'some_property': [
-                      PatternConstraint(
-                        pattern='^something-[a-zA-Z]+$')]},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+            """\
+Constraints(
+  len_constraint=None,
+  patterns=[
+    PatternConstraint(
+      pattern='^something-[a-zA-Z]+$')],
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 
@@ -636,17 +495,9 @@ class Test_stacking(unittest.TestCase):
             """
         )
 
-        # NOTE (mristin, 2022-05-18):
-        # This definition here is necessary for mypy.
-        constraints_by_class: Optional[
-            MutableMapping[
-                intermediate.ClassUnion, infer_for_schema.ConstraintsByProperty
-            ]
-        ] = None
-
         # fmt: off
         (
-            symbol_table,
+            _,
             something_cls,
             constraints_by_class,
         ) = (
@@ -657,27 +508,21 @@ class Test_stacking(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_class, error = infer_for_schema.merge_constraints_with_ancestors(
-            symbol_table=symbol_table, constraints_by_class=constraints_by_class
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
         )
-        assert error is None, tests.common.most_underlying_messages(error)
-        assert constraints_by_class is not None
 
-        constraints_by_props = constraints_by_class[something_cls]
+        text = infer_for_schema.dump(constraints)
 
-        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={},
-                  patterns_by_property={
-                    'some_property': [
-                      PatternConstraint(
-                        pattern='^something-[a-zA-Z]+$')]},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+            """\
+Constraints(
+  len_constraint=None,
+  patterns=[
+    PatternConstraint(
+      pattern='^something-[a-zA-Z]+$')],
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 

--- a/dev/tests/infer_for_schema/test_patterns_on_self.py
+++ b/dev/tests/infer_for_schema/test_patterns_on_self.py
@@ -41,19 +41,11 @@ class Test_expected(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
-        text = infer_for_schema.dump(constraints_by_props)
-        self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={},
-                  patterns_by_property={},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
-            text,
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
         )
+
+        assert constraints is None
 
     def test_single_pattern(self) -> None:
         source = textwrap.dedent(
@@ -96,20 +88,21 @@ class Test_expected(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
-        text = infer_for_schema.dump(constraints_by_props)
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
+        )
+
+        text = infer_for_schema.dump(constraints)
+
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={},
-                  patterns_by_property={
-                    'some_property': [
-                      PatternConstraint(
-                        pattern='^something-[a-zA-Z]+$')]},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+            """\
+Constraints(
+  len_constraint=None,
+  patterns=[
+    PatternConstraint(
+      pattern='^something-[a-zA-Z]+$')],
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 
@@ -161,26 +154,27 @@ class Test_expected(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
-        text = infer_for_schema.dump(constraints_by_props)
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
+        )
+
+        text = infer_for_schema.dump(constraints)
+
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={},
-                  patterns_by_property={
-                    'some_property': [
-                      PatternConstraint(
-                        pattern='^something-[a-zA-Z]+$'),
-                      PatternConstraint(
-                        pattern='^.*acme.*$')]},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+            """\
+Constraints(
+  len_constraint=None,
+  patterns=[
+    PatternConstraint(
+      pattern='^something-[a-zA-Z]+$'),
+    PatternConstraint(
+      pattern='^.*acme.*$')],
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 
-    def test_inheritance_between_constrained_primitives_by_default(self) -> None:
+    def test_inheritance_between_constrained_primitives_parent_first(self) -> None:
         source = textwrap.dedent(
             """\
             @verification
@@ -217,10 +211,6 @@ class Test_expected(unittest.TestCase):
             """
         )
 
-        # NOTE (mristin, 2022-05-15):
-        # In contrast to classes, we do inherit the constraints among the constrained
-        # primitives as we in-line them later in the schema classes.
-
         # fmt: off
         (
             _,
@@ -234,22 +224,23 @@ class Test_expected(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
-        text = infer_for_schema.dump(constraints_by_props)
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
+        )
+
+        text = infer_for_schema.dump(constraints)
+
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={},
-                  patterns_by_property={
-                    'some_property': [
-                      PatternConstraint(
-                        pattern='^something-[a-zA-Z]+$'),
-                      PatternConstraint(
-                        pattern='^.*acme.*$')]},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
+            """\
+Constraints(
+  len_constraint=None,
+  patterns=[
+    PatternConstraint(
+      pattern='^something-[a-zA-Z]+$'),
+    PatternConstraint(
+      pattern='^.*acme.*$')],
+  set_of_primitives=None,
+  set_of_enumeration_literals=None)""",
             text,
         )
 

--- a/dev/tests/infer_for_schema/test_property_in_set_of_enumeration_literals.py
+++ b/dev/tests/infer_for_schema/test_property_in_set_of_enumeration_literals.py
@@ -3,11 +3,10 @@
 
 import textwrap
 import unittest
-from typing import Optional, MutableMapping
 
 import tests.common
 import tests.infer_for_schema.common
-from aas_core_codegen import infer_for_schema, intermediate
+from aas_core_codegen import infer_for_schema
 
 
 class Test_property_in_set(unittest.TestCase):
@@ -42,20 +41,11 @@ class Test_property_in_set(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
-
-        text = infer_for_schema.dump(constraints_by_props)
-        self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={},
-                  patterns_by_property={},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
-            text,
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
         )
+
+        assert constraints is None
 
     def test_property_in_set(self) -> None:
         source = textwrap.dedent(
@@ -99,21 +89,23 @@ class Test_property_in_set(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
+        )
 
-        text = infer_for_schema.dump(constraints_by_props)
+        text = infer_for_schema.dump(constraints)
+
         self.assertEqual(
             """\
-ConstraintsByProperty(
-  len_constraints_by_property={},
-  patterns_by_property={},
-  set_of_primitives_by_property={},
-  set_of_enumeration_literals_by_property={
-    'some_property': SetOfEnumerationLiteralsConstraint(
-      enumeration='Reference to Enumeration Some_enum',
-      literals=[
-        'Reference to EnumerationLiteral A',
-        'Reference to EnumerationLiteral B'])})""",
+Constraints(
+  len_constraint=None,
+  patterns=None,
+  set_of_primitives=None,
+  set_of_enumeration_literals=SetOfEnumerationLiteralsConstraint(
+    enumeration='Reference to Enumeration Some_enum',
+    literals=[
+      'Reference to EnumerationLiteral A',
+      'Reference to EnumerationLiteral B']))""",
             text,
         )
 
@@ -168,20 +160,22 @@ ConstraintsByProperty(
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
+        )
 
-        text = infer_for_schema.dump(constraints_by_props)
+        text = infer_for_schema.dump(constraints)
+
         self.assertEqual(
             """\
-ConstraintsByProperty(
-  len_constraints_by_property={},
-  patterns_by_property={},
-  set_of_primitives_by_property={},
-  set_of_enumeration_literals_by_property={
-    'some_property': SetOfEnumerationLiteralsConstraint(
-      enumeration='Reference to Enumeration Some_enum',
-      literals=[
-        'Reference to EnumerationLiteral B'])})""",
+Constraints(
+  len_constraint=None,
+  patterns=None,
+  set_of_primitives=None,
+  set_of_enumeration_literals=SetOfEnumerationLiteralsConstraint(
+    enumeration='Reference to Enumeration Some_enum',
+    literals=[
+      'Reference to EnumerationLiteral B']))""",
             text,
         )
 
@@ -229,21 +223,23 @@ ConstraintsByProperty(
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
+        )
 
-        text = infer_for_schema.dump(constraints_by_props)
+        text = infer_for_schema.dump(constraints)
+
         self.assertEqual(
             """\
-ConstraintsByProperty(
-  len_constraints_by_property={},
-  patterns_by_property={},
-  set_of_primitives_by_property={},
-  set_of_enumeration_literals_by_property={
-    'some_property': SetOfEnumerationLiteralsConstraint(
-      enumeration='Reference to Enumeration Some_enum',
-      literals=[
-        'Reference to EnumerationLiteral A',
-        'Reference to EnumerationLiteral B'])})""",
+Constraints(
+  len_constraint=None,
+  patterns=None,
+  set_of_primitives=None,
+  set_of_enumeration_literals=SetOfEnumerationLiteralsConstraint(
+    enumeration='Reference to Enumeration Some_enum',
+    literals=[
+      'Reference to EnumerationLiteral A',
+      'Reference to EnumerationLiteral B']))""",
             text,
         )
 
@@ -300,20 +296,22 @@ ConstraintsByProperty(
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
+        )
 
-        text = infer_for_schema.dump(constraints_by_props)
+        text = infer_for_schema.dump(constraints)
+
         self.assertEqual(
             """\
-ConstraintsByProperty(
-  len_constraints_by_property={},
-  patterns_by_property={},
-  set_of_primitives_by_property={},
-  set_of_enumeration_literals_by_property={
-    'some_property': SetOfEnumerationLiteralsConstraint(
-      enumeration='Reference to Enumeration Some_enum',
-      literals=[
-        'Reference to EnumerationLiteral B'])})""",
+Constraints(
+  len_constraint=None,
+  patterns=None,
+  set_of_primitives=None,
+  set_of_enumeration_literals=SetOfEnumerationLiteralsConstraint(
+    enumeration='Reference to Enumeration Some_enum',
+    literals=[
+      'Reference to EnumerationLiteral B']))""",
             text,
         )
 
@@ -354,16 +352,9 @@ class Test_stacking(unittest.TestCase):
             """
         )
 
-        # noinspection PyUnusedLocal
-        constraints_by_class: Optional[
-            MutableMapping[
-                intermediate.ClassUnion, infer_for_schema.ConstraintsByProperty
-            ]
-        ] = None  # Necessary for mypy
-
         # fmt: off
         (
-            symbol_table,
+            _,
             something_cls,
             constraints_by_class,
         ) = (
@@ -374,27 +365,23 @@ class Test_stacking(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_class, error = infer_for_schema.merge_constraints_with_ancestors(
-            symbol_table=symbol_table, constraints_by_class=constraints_by_class
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
         )
-        assert error is None, tests.common.most_underlying_messages(error)
-        assert constraints_by_class is not None
 
-        constraints_by_props = constraints_by_class[something_cls]
+        text = infer_for_schema.dump(constraints)
 
-        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
             """\
-ConstraintsByProperty(
-  len_constraints_by_property={},
-  patterns_by_property={},
-  set_of_primitives_by_property={},
-  set_of_enumeration_literals_by_property={
-    'some_property': SetOfEnumerationLiteralsConstraint(
-      enumeration='Reference to Enumeration Some_enum',
-      literals=[
-        'Reference to EnumerationLiteral A',
-        'Reference to EnumerationLiteral B'])})""",
+Constraints(
+  len_constraint=None,
+  patterns=None,
+  set_of_primitives=None,
+  set_of_enumeration_literals=SetOfEnumerationLiteralsConstraint(
+    enumeration='Reference to Enumeration Some_enum',
+    literals=[
+      'Reference to EnumerationLiteral A',
+      'Reference to EnumerationLiteral B']))""",
             text,
         )
 
@@ -443,16 +430,9 @@ ConstraintsByProperty(
             """
         )
 
-        # noinspection PyUnusedLocal
-        constraints_by_class: Optional[
-            MutableMapping[
-                intermediate.ClassUnion, infer_for_schema.ConstraintsByProperty
-            ]
-        ] = None  # Necessary for mypy
-
         # fmt: off
         (
-            symbol_table,
+            _,
             something_cls,
             constraints_by_class,
         ) = (
@@ -463,26 +443,22 @@ ConstraintsByProperty(
         )
         # fmt: on
 
-        constraints_by_class, error = infer_for_schema.merge_constraints_with_ancestors(
-            symbol_table=symbol_table, constraints_by_class=constraints_by_class
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
         )
-        assert error is None, tests.common.most_underlying_messages(error)
-        assert constraints_by_class is not None
 
-        constraints_by_props = constraints_by_class[something_cls]
+        text = infer_for_schema.dump(constraints)
 
-        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
             """\
-ConstraintsByProperty(
-  len_constraints_by_property={},
-  patterns_by_property={},
-  set_of_primitives_by_property={},
-  set_of_enumeration_literals_by_property={
-    'some_property': SetOfEnumerationLiteralsConstraint(
-      enumeration='Reference to Enumeration Some_enum',
-      literals=[
-        'Reference to EnumerationLiteral B'])})""",
+Constraints(
+  len_constraint=None,
+  patterns=None,
+  set_of_primitives=None,
+  set_of_enumeration_literals=SetOfEnumerationLiteralsConstraint(
+    enumeration='Reference to Enumeration Some_enum',
+    literals=[
+      'Reference to EnumerationLiteral B']))""",
             text,
         )
 
@@ -552,16 +528,9 @@ ConstraintsByProperty(
             """
         )
 
-        # noinspection PyUnusedLocal
-        constraints_by_class: Optional[
-            MutableMapping[
-                intermediate.ClassUnion, infer_for_schema.ConstraintsByProperty
-            ]
-        ] = None  # Necessary for mypy
-
         # fmt: off
         (
-            symbol_table,
+            _,
             something_cls,
             constraints_by_class,
         ) = (
@@ -572,26 +541,22 @@ ConstraintsByProperty(
         )
         # fmt: on
 
-        constraints_by_class, error = infer_for_schema.merge_constraints_with_ancestors(
-            symbol_table=symbol_table, constraints_by_class=constraints_by_class
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
         )
-        assert error is None, tests.common.most_underlying_messages(error)
-        assert constraints_by_class is not None
 
-        constraints_by_props = constraints_by_class[something_cls]
+        text = infer_for_schema.dump(constraints)
 
-        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
             """\
-ConstraintsByProperty(
-  len_constraints_by_property={},
-  patterns_by_property={},
-  set_of_primitives_by_property={},
-  set_of_enumeration_literals_by_property={
-    'some_property': SetOfEnumerationLiteralsConstraint(
-      enumeration='Reference to Enumeration Some_enum',
-      literals=[
-        'Reference to EnumerationLiteral C'])})""",
+Constraints(
+  len_constraint=None,
+  patterns=None,
+  set_of_primitives=None,
+  set_of_enumeration_literals=SetOfEnumerationLiteralsConstraint(
+    enumeration='Reference to Enumeration Some_enum',
+    literals=[
+      'Reference to EnumerationLiteral C']))""",
             text,
         )
 

--- a/dev/tests/infer_for_schema/test_property_in_set_of_primitives.py
+++ b/dev/tests/infer_for_schema/test_property_in_set_of_primitives.py
@@ -3,11 +3,10 @@
 
 import textwrap
 import unittest
-from typing import Optional, MutableMapping
 
 import tests.common
 import tests.infer_for_schema.common
-from aas_core_codegen import infer_for_schema, intermediate
+from aas_core_codegen import infer_for_schema
 
 
 class Test_property_in_set(unittest.TestCase):
@@ -38,20 +37,11 @@ class Test_property_in_set(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
-
-        text = infer_for_schema.dump(constraints_by_props)
-        self.assertEqual(
-            textwrap.dedent(
-                """\
-                ConstraintsByProperty(
-                  len_constraints_by_property={},
-                  patterns_by_property={},
-                  set_of_primitives_by_property={},
-                  set_of_enumeration_literals_by_property={})"""
-            ),
-            text,
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
         )
+
+        assert constraints is None
 
     def test_property_in_set(self) -> None:
         source = textwrap.dedent(
@@ -88,27 +78,29 @@ class Test_property_in_set(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
+        )
 
-        text = infer_for_schema.dump(constraints_by_props)
+        text = infer_for_schema.dump(constraints)
+
         self.assertEqual(
             """\
-ConstraintsByProperty(
-  len_constraints_by_property={},
-  patterns_by_property={},
-  set_of_primitives_by_property={
-    'some_property': SetOfPrimitivesConstraint(
-      a_type='STR',
-      literals=[
-        PrimitiveSetLiteral(
-          value='A',
-          a_type='STR',
-          parsed=...),
-        PrimitiveSetLiteral(
-          value='B',
-          a_type='STR',
-          parsed=...)])},
-  set_of_enumeration_literals_by_property={})""",
+Constraints(
+  len_constraint=None,
+  patterns=None,
+  set_of_primitives=SetOfPrimitivesConstraint(
+    a_type='STR',
+    literals=[
+      PrimitiveSetLiteral(
+        value='A',
+        a_type='STR',
+        parsed=...),
+      PrimitiveSetLiteral(
+        value='B',
+        a_type='STR',
+        parsed=...)]),
+  set_of_enumeration_literals=None)""",
             text,
         )
 
@@ -151,23 +143,25 @@ ConstraintsByProperty(
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
+        )
 
-        text = infer_for_schema.dump(constraints_by_props)
+        text = infer_for_schema.dump(constraints)
+
         self.assertEqual(
             """\
-ConstraintsByProperty(
-  len_constraints_by_property={},
-  patterns_by_property={},
-  set_of_primitives_by_property={
-    'some_property': SetOfPrimitivesConstraint(
-      a_type='STR',
-      literals=[
-        PrimitiveSetLiteral(
-          value='B',
-          a_type='STR',
-          parsed=...)])},
-  set_of_enumeration_literals_by_property={})""",
+Constraints(
+  len_constraint=None,
+  patterns=None,
+  set_of_primitives=SetOfPrimitivesConstraint(
+    a_type='STR',
+    literals=[
+      PrimitiveSetLiteral(
+        value='B',
+        a_type='STR',
+        parsed=...)]),
+  set_of_enumeration_literals=None)""",
             text,
         )
 
@@ -207,27 +201,29 @@ ConstraintsByProperty(
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
+        )
 
-        text = infer_for_schema.dump(constraints_by_props)
+        text = infer_for_schema.dump(constraints)
+
         self.assertEqual(
             """\
-ConstraintsByProperty(
-  len_constraints_by_property={},
-  patterns_by_property={},
-  set_of_primitives_by_property={
-    'some_property': SetOfPrimitivesConstraint(
-      a_type='STR',
-      literals=[
-        PrimitiveSetLiteral(
-          value='A',
-          a_type='STR',
-          parsed=...),
-        PrimitiveSetLiteral(
-          value='B',
-          a_type='STR',
-          parsed=...)])},
-  set_of_enumeration_literals_by_property={})""",
+Constraints(
+  len_constraint=None,
+  patterns=None,
+  set_of_primitives=SetOfPrimitivesConstraint(
+    a_type='STR',
+    literals=[
+      PrimitiveSetLiteral(
+        value='A',
+        a_type='STR',
+        parsed=...),
+      PrimitiveSetLiteral(
+        value='B',
+        a_type='STR',
+        parsed=...)]),
+  set_of_enumeration_literals=None)""",
             text,
         )
 
@@ -273,23 +269,25 @@ ConstraintsByProperty(
         )
         # fmt: on
 
-        constraints_by_props = constraints_by_class[something_cls]
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
+        )
 
-        text = infer_for_schema.dump(constraints_by_props)
+        text = infer_for_schema.dump(constraints)
+
         self.assertEqual(
             """\
-ConstraintsByProperty(
-  len_constraints_by_property={},
-  patterns_by_property={},
-  set_of_primitives_by_property={
-    'some_property': SetOfPrimitivesConstraint(
-      a_type='STR',
-      literals=[
-        PrimitiveSetLiteral(
-          value='B',
-          a_type='STR',
-          parsed=...)])},
-  set_of_enumeration_literals_by_property={})""",
+Constraints(
+  len_constraint=None,
+  patterns=None,
+  set_of_primitives=SetOfPrimitivesConstraint(
+    a_type='STR',
+    literals=[
+      PrimitiveSetLiteral(
+        value='B',
+        a_type='STR',
+        parsed=...)]),
+  set_of_enumeration_literals=None)""",
             text,
         )
 
@@ -321,16 +319,9 @@ class Test_stacking(unittest.TestCase):
             """
         )
 
-        # noinspection PyUnusedLocal
-        constraints_by_class: Optional[
-            MutableMapping[
-                intermediate.ClassUnion, infer_for_schema.ConstraintsByProperty
-            ]
-        ] = None  # Necessary for mypy
-
         # fmt: off
         (
-            symbol_table,
+            _,
             something_cls,
             constraints_by_class,
         ) = (
@@ -341,33 +332,29 @@ class Test_stacking(unittest.TestCase):
         )
         # fmt: on
 
-        constraints_by_class, error = infer_for_schema.merge_constraints_with_ancestors(
-            symbol_table=symbol_table, constraints_by_class=constraints_by_class
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
         )
-        assert error is None, tests.common.most_underlying_messages(error)
-        assert constraints_by_class is not None
 
-        constraints_by_props = constraints_by_class[something_cls]
+        text = infer_for_schema.dump(constraints)
 
-        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
             """\
-ConstraintsByProperty(
-  len_constraints_by_property={},
-  patterns_by_property={},
-  set_of_primitives_by_property={
-    'some_property': SetOfPrimitivesConstraint(
-      a_type='STR',
-      literals=[
-        PrimitiveSetLiteral(
-          value='A',
-          a_type='STR',
-          parsed=...),
-        PrimitiveSetLiteral(
-          value='B',
-          a_type='STR',
-          parsed=...)])},
-  set_of_enumeration_literals_by_property={})""",
+Constraints(
+  len_constraint=None,
+  patterns=None,
+  set_of_primitives=SetOfPrimitivesConstraint(
+    a_type='STR',
+    literals=[
+      PrimitiveSetLiteral(
+        value='A',
+        a_type='STR',
+        parsed=...),
+      PrimitiveSetLiteral(
+        value='B',
+        a_type='STR',
+        parsed=...)]),
+  set_of_enumeration_literals=None)""",
             text,
         )
 
@@ -405,16 +392,9 @@ ConstraintsByProperty(
             """
         )
 
-        # noinspection PyUnusedLocal
-        constraints_by_class: Optional[
-            MutableMapping[
-                intermediate.ClassUnion, infer_for_schema.ConstraintsByProperty
-            ]
-        ] = None  # Necessary for mypy
-
         # fmt: off
         (
-            symbol_table,
+            _,
             something_cls,
             constraints_by_class,
         ) = (
@@ -425,29 +405,25 @@ ConstraintsByProperty(
         )
         # fmt: on
 
-        constraints_by_class, error = infer_for_schema.merge_constraints_with_ancestors(
-            symbol_table=symbol_table, constraints_by_class=constraints_by_class
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
         )
-        assert error is None, tests.common.most_underlying_messages(error)
-        assert constraints_by_class is not None
 
-        constraints_by_props = constraints_by_class[something_cls]
+        text = infer_for_schema.dump(constraints)
 
-        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
             """\
-ConstraintsByProperty(
-  len_constraints_by_property={},
-  patterns_by_property={},
-  set_of_primitives_by_property={
-    'some_property': SetOfPrimitivesConstraint(
-      a_type='STR',
-      literals=[
-        PrimitiveSetLiteral(
-          value='B',
-          a_type='STR',
-          parsed=...)])},
-  set_of_enumeration_literals_by_property={})""",
+Constraints(
+  len_constraint=None,
+  patterns=None,
+  set_of_primitives=SetOfPrimitivesConstraint(
+    a_type='STR',
+    literals=[
+      PrimitiveSetLiteral(
+        value='B',
+        a_type='STR',
+        parsed=...)]),
+  set_of_enumeration_literals=None)""",
             text,
         )
 
@@ -498,16 +474,9 @@ ConstraintsByProperty(
             """
         )
 
-        # noinspection PyUnusedLocal
-        constraints_by_class: Optional[
-            MutableMapping[
-                intermediate.ClassUnion, infer_for_schema.ConstraintsByProperty
-            ]
-        ] = None  # Necessary for mypy
-
         # fmt: off
         (
-            symbol_table,
+            _,
             something_cls,
             constraints_by_class,
         ) = (
@@ -518,29 +487,25 @@ ConstraintsByProperty(
         )
         # fmt: on
 
-        constraints_by_class, error = infer_for_schema.merge_constraints_with_ancestors(
-            symbol_table=symbol_table, constraints_by_class=constraints_by_class
+        constraints = tests.infer_for_schema.common.select_constraints_of_property(
+            something_cls, "some_property", constraints_by_class
         )
-        assert error is None, tests.common.most_underlying_messages(error)
-        assert constraints_by_class is not None
 
-        constraints_by_props = constraints_by_class[something_cls]
+        text = infer_for_schema.dump(constraints)
 
-        text = infer_for_schema.dump(constraints_by_props)
         self.assertEqual(
             """\
-ConstraintsByProperty(
-  len_constraints_by_property={},
-  patterns_by_property={},
-  set_of_primitives_by_property={
-    'some_property': SetOfPrimitivesConstraint(
-      a_type='STR',
-      literals=[
-        PrimitiveSetLiteral(
-          value='C',
-          a_type='STR',
-          parsed=...)])},
-  set_of_enumeration_literals_by_property={})""",
+Constraints(
+  len_constraint=None,
+  patterns=None,
+  set_of_primitives=SetOfPrimitivesConstraint(
+    a_type='STR',
+    literals=[
+      PrimitiveSetLiteral(
+        value='C',
+        a_type='STR',
+        parsed=...)]),
+  set_of_enumeration_literals=None)""",
             text,
         )
 

--- a/dev/tests/test_main.py
+++ b/dev/tests/test_main.py
@@ -354,6 +354,14 @@ class Test_xsd(_TestCase):
             case_name="list_of_primitives_with_invariants",
         )
 
+    def test_expected_regression_when_len_constraints_on_inherited_property(
+        self,
+    ) -> None:
+        self._run_expected_test(
+            target=aas_core_codegen.main.Target.XSD,
+            case_name="regression_when_len_constraints_on_inherited_property",
+        )
+
 
 class _CaseSpec:
     """Specify a single test."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "docutils==0.22.3",
     "more-itertools==10.8.0",
     "greenery==4.1.0",
+    "typing_extensions>=4.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
So far, we inferred the constraints on the class properties. As we want to support lists of primitives, lists of constrained primitives *etc.*, we need to infer the constraints at each atomic value of a type annotation, not only at the property level.

We adapt the inference in this change to achieve that. It caused only minor changes in the generated code -- since we do not limit ourselves to properties only, and need a more general logic, some of the generated artefacts had to slightly change.