### PR TITLE
Test for list of non-optionals in JSON schema

### DIFF
--- a/dev/test_data/main/jsonschema/expected/list_of_classes/expected_output/schema.json
+++ b/dev/test_data/main/jsonschema/expected/list_of_classes/expected_output/schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "DummyForTest",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/Something"
+    }
+  ],
+  "$id": "https://dummy.com",
+  "definitions": {
+    "AbstractItem": {
+      "type": "object",
+      "properties": {
+        "modelType": {
+          "$ref": "#/definitions/ModelType"
+        }
+      },
+      "required": [
+        "modelType"
+      ]
+    },
+    "AbstractItem_choice": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/AnotherItem"
+        },
+        {
+          "$ref": "#/definitions/SomeItem"
+        }
+      ]
+    },
+    "AnotherItem": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/AbstractItem"
+        },
+        {
+          "properties": {
+            "serialNumber": {
+              "type": "integer"
+            },
+            "modelType": {
+              "const": "AnotherItem"
+            }
+          },
+          "required": [
+            "serialNumber"
+          ]
+        }
+      ]
+    },
+    "ModelType": {
+      "type": "string",
+      "enum": [
+        "AnotherItem",
+        "SomeItem"
+      ]
+    },
+    "SomeItem": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/AbstractItem"
+        },
+        {
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "modelType": {
+              "const": "SomeItem"
+            }
+          },
+          "required": [
+            "name"
+          ]
+        }
+      ]
+    },
+    "Something": {
+      "type": "object",
+      "properties": {
+        "someItems": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AbstractItem_choice"
+          }
+        }
+      },
+      "required": [
+        "someItems"
+      ]
+    }
+  }
+}

--- a/dev/test_data/main/jsonschema/expected/list_of_classes/expected_output/stdout.txt
+++ b/dev/test_data/main/jsonschema/expected/list_of_classes/expected_output/stdout.txt
@@ -1,0 +1,1 @@
+Code generated to: <output dir>

--- a/dev/test_data/main/jsonschema/expected/list_of_classes/input/snippets/schema_base.json
+++ b/dev/test_data/main/jsonschema/expected/list_of_classes/input/snippets/schema_base.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "DummyForTest",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/Something"
+    }
+  ]
+}

--- a/dev/test_data/main/jsonschema/expected/list_of_classes/meta_model.py
+++ b/dev/test_data/main/jsonschema/expected/list_of_classes/meta_model.py
@@ -1,0 +1,35 @@
+from enum import Enum
+from typing import List
+
+from icontract import invariant
+
+
+@abstract
+@serialization(with_model_type=True)
+class Abstract_item:
+    pass
+
+
+class Some_item(Abstract_item):
+    name: str
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class Another_item(Abstract_item):
+    serial_number: int
+
+    def __init__(self, serial_number: int) -> None:
+        self.serial_number = serial_number
+
+
+class Something:
+    some_items: List[Abstract_item]
+
+    def __init__(self, some_items: List[Abstract_item]) -> None:
+        self.some_items = some_items
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/dev/test_data/main/jsonschema/expected/list_of_constrained_primitives/expected_output/schema.json
+++ b/dev/test_data/main/jsonschema/expected/list_of_constrained_primitives/expected_output/schema.json
@@ -16,15 +16,16 @@
     "Something": {
       "type": "object",
       "properties": {
-        "someInts": {
+        "someNames": {
           "type": "array",
           "items": {
-            "type": "integer"
+            "type": "string",
+            "minLength": 1
           }
         }
       },
       "required": [
-        "someInts"
+        "someNames"
       ]
     }
   }

--- a/dev/test_data/main/jsonschema/expected/list_of_constrained_primitives/expected_output/stdout.txt
+++ b/dev/test_data/main/jsonschema/expected/list_of_constrained_primitives/expected_output/stdout.txt
@@ -1,0 +1,1 @@
+Code generated to: <output dir>

--- a/dev/test_data/main/jsonschema/expected/list_of_constrained_primitives/input/snippets/schema_base.json
+++ b/dev/test_data/main/jsonschema/expected/list_of_constrained_primitives/input/snippets/schema_base.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "DummyForTest",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/Something"
+    }
+  ]
+}

--- a/dev/test_data/main/jsonschema/expected/list_of_constrained_primitives/meta_model.py
+++ b/dev/test_data/main/jsonschema/expected/list_of_constrained_primitives/meta_model.py
@@ -1,0 +1,19 @@
+from typing import List
+
+from icontract import invariant
+
+
+@invariant(lambda self: len(self) > 0, "Non-empty")
+class Name(str):
+    pass
+
+
+class Something:
+    some_names: List[Name]
+
+    def __init__(self, some_names: List[Name]) -> None:
+        self.some_names = some_names
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/dev/test_data/main/jsonschema/expected/list_of_enums/expected_output/schema.json
+++ b/dev/test_data/main/jsonschema/expected/list_of_enums/expected_output/schema.json
@@ -13,18 +13,25 @@
       "type": "string",
       "enum": []
     },
+    "Result": {
+      "type": "string",
+      "enum": [
+        "fail",
+        "ok"
+      ]
+    },
     "Something": {
       "type": "object",
       "properties": {
-        "someInts": {
+        "someResults": {
           "type": "array",
           "items": {
-            "type": "integer"
+            "$ref": "#/definitions/Result"
           }
         }
       },
       "required": [
-        "someInts"
+        "someResults"
       ]
     }
   }

--- a/dev/test_data/main/jsonschema/expected/list_of_enums/expected_output/stdout.txt
+++ b/dev/test_data/main/jsonschema/expected/list_of_enums/expected_output/stdout.txt
@@ -1,0 +1,1 @@
+Code generated to: <output dir>

--- a/dev/test_data/main/jsonschema/expected/list_of_enums/input/snippets/schema_base.json
+++ b/dev/test_data/main/jsonschema/expected/list_of_enums/input/snippets/schema_base.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "DummyForTest",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/Something"
+    }
+  ]
+}

--- a/dev/test_data/main/jsonschema/expected/list_of_enums/meta_model.py
+++ b/dev/test_data/main/jsonschema/expected/list_of_enums/meta_model.py
@@ -1,0 +1,20 @@
+from enum import Enum
+from typing import List
+
+from icontract import invariant
+
+
+class Result(Enum):
+    Ok = "ok"
+    Fail = "fail"
+
+
+class Something:
+    some_results: List[Result]
+
+    def __init__(self, some_results: List[Result]) -> None:
+        self.some_results = some_results
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/dev/test_data/main/jsonschema/expected/list_of_lists_of_classes/expected_output/schema.json
+++ b/dev/test_data/main/jsonschema/expected/list_of_lists_of_classes/expected_output/schema.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "DummyForTest",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/Something"
+    }
+  ],
+  "$id": "https://dummy.com",
+  "definitions": {
+    "AbstractItem": {
+      "type": "object",
+      "properties": {
+        "modelType": {
+          "$ref": "#/definitions/ModelType"
+        }
+      },
+      "required": [
+        "modelType"
+      ]
+    },
+    "AbstractItem_choice": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/AnotherItem"
+        },
+        {
+          "$ref": "#/definitions/SomeItem"
+        }
+      ]
+    },
+    "AnotherItem": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/AbstractItem"
+        },
+        {
+          "properties": {
+            "serialNumber": {
+              "type": "integer"
+            },
+            "modelType": {
+              "const": "AnotherItem"
+            }
+          },
+          "required": [
+            "serialNumber"
+          ]
+        }
+      ]
+    },
+    "ModelType": {
+      "type": "string",
+      "enum": [
+        "AnotherItem",
+        "SomeItem"
+      ]
+    },
+    "SomeItem": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/AbstractItem"
+        },
+        {
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "modelType": {
+              "const": "SomeItem"
+            }
+          },
+          "required": [
+            "name"
+          ]
+        }
+      ]
+    },
+    "Something": {
+      "type": "object",
+      "properties": {
+        "listOfListsOfItems": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/AbstractItem_choice"
+            }
+          }
+        }
+      },
+      "required": [
+        "listOfListsOfItems"
+      ]
+    }
+  }
+}

--- a/dev/test_data/main/jsonschema/expected/list_of_lists_of_classes/expected_output/stdout.txt
+++ b/dev/test_data/main/jsonschema/expected/list_of_lists_of_classes/expected_output/stdout.txt
@@ -1,0 +1,1 @@
+Code generated to: <output dir>

--- a/dev/test_data/main/jsonschema/expected/list_of_lists_of_classes/input/snippets/schema_base.json
+++ b/dev/test_data/main/jsonschema/expected/list_of_lists_of_classes/input/snippets/schema_base.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "DummyForTest",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/Something"
+    }
+  ]
+}

--- a/dev/test_data/main/jsonschema/expected/list_of_lists_of_classes/meta_model.py
+++ b/dev/test_data/main/jsonschema/expected/list_of_lists_of_classes/meta_model.py
@@ -1,0 +1,35 @@
+from enum import Enum
+from typing import List
+
+from icontract import invariant
+
+
+@abstract
+@serialization(with_model_type=True)
+class Abstract_item:
+    pass
+
+
+class Some_item(Abstract_item):
+    name: str
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class Another_item(Abstract_item):
+    serial_number: int
+
+    def __init__(self, serial_number: int) -> None:
+        self.serial_number = serial_number
+
+
+class Something:
+    list_of_lists_of_items: List[List[Abstract_item]]
+
+    def __init__(self, list_of_lists_of_items: List[List[Abstract_item]]) -> None:
+        self.list_of_lists_of_items = list_of_lists_of_items
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/dev/test_data/main/jsonschema/expected/list_of_lists_of_constrained_primitives/expected_output/schema.json
+++ b/dev/test_data/main/jsonschema/expected/list_of_lists_of_constrained_primitives/expected_output/schema.json
@@ -16,15 +16,19 @@
     "Something": {
       "type": "object",
       "properties": {
-        "someInts": {
+        "listOfListsOfNames": {
           "type": "array",
           "items": {
-            "type": "integer"
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
           }
         }
       },
       "required": [
-        "someInts"
+        "listOfListsOfNames"
       ]
     }
   }

--- a/dev/test_data/main/jsonschema/expected/list_of_lists_of_constrained_primitives/expected_output/stdout.txt
+++ b/dev/test_data/main/jsonschema/expected/list_of_lists_of_constrained_primitives/expected_output/stdout.txt
@@ -1,0 +1,1 @@
+Code generated to: <output dir>

--- a/dev/test_data/main/jsonschema/expected/list_of_lists_of_constrained_primitives/input/snippets/schema_base.json
+++ b/dev/test_data/main/jsonschema/expected/list_of_lists_of_constrained_primitives/input/snippets/schema_base.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "DummyForTest",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/Something"
+    }
+  ]
+}

--- a/dev/test_data/main/jsonschema/expected/list_of_lists_of_constrained_primitives/meta_model.py
+++ b/dev/test_data/main/jsonschema/expected/list_of_lists_of_constrained_primitives/meta_model.py
@@ -1,0 +1,19 @@
+from typing import List
+
+from icontract import invariant
+
+
+@invariant(lambda self: len(self) > 0, "Not empty")
+class Name(str):
+    pass
+
+
+class Something:
+    list_of_lists_of_names: List[List[Name]]
+
+    def __init__(self, list_of_lists_of_names: List[List[Name]]) -> None:
+        self.list_of_lists_of_names = list_of_lists_of_names
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/dev/test_data/main/jsonschema/expected/list_of_lists_of_enums/expected_output/schema.json
+++ b/dev/test_data/main/jsonschema/expected/list_of_lists_of_enums/expected_output/schema.json
@@ -13,18 +13,28 @@
       "type": "string",
       "enum": []
     },
+    "Result": {
+      "type": "string",
+      "enum": [
+        "fail",
+        "ok"
+      ]
+    },
     "Something": {
       "type": "object",
       "properties": {
-        "someInts": {
+        "listOfListsOfResults": {
           "type": "array",
           "items": {
-            "type": "integer"
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Result"
+            }
           }
         }
       },
       "required": [
-        "someInts"
+        "listOfListsOfResults"
       ]
     }
   }

--- a/dev/test_data/main/jsonschema/expected/list_of_lists_of_enums/expected_output/stdout.txt
+++ b/dev/test_data/main/jsonschema/expected/list_of_lists_of_enums/expected_output/stdout.txt
@@ -1,0 +1,1 @@
+Code generated to: <output dir>

--- a/dev/test_data/main/jsonschema/expected/list_of_lists_of_enums/input/snippets/schema_base.json
+++ b/dev/test_data/main/jsonschema/expected/list_of_lists_of_enums/input/snippets/schema_base.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "DummyForTest",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/Something"
+    }
+  ]
+}

--- a/dev/test_data/main/jsonschema/expected/list_of_lists_of_enums/meta_model.py
+++ b/dev/test_data/main/jsonschema/expected/list_of_lists_of_enums/meta_model.py
@@ -1,0 +1,20 @@
+from enum import Enum
+from typing import List
+
+from icontract import invariant
+
+
+class Result(Enum):
+    Ok = "ok"
+    Fail = "fail"
+
+
+class Something:
+    list_of_lists_of_results: List[List[Result]]
+
+    def __init__(self, list_of_lists_of_results: List[List[Result]]) -> None:
+        self.list_of_lists_of_results = list_of_lists_of_results
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/dev/test_data/main/jsonschema/expected/list_of_lists_of_primitives/expected_output/schema.json
+++ b/dev/test_data/main/jsonschema/expected/list_of_lists_of_primitives/expected_output/schema.json
@@ -16,15 +16,18 @@
     "Something": {
       "type": "object",
       "properties": {
-        "someInts": {
+        "listOfListsOfInts": {
           "type": "array",
           "items": {
-            "type": "integer"
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
           }
         }
       },
       "required": [
-        "someInts"
+        "listOfListsOfInts"
       ]
     }
   }

--- a/dev/test_data/main/jsonschema/expected/list_of_lists_of_primitives/expected_output/stdout.txt
+++ b/dev/test_data/main/jsonschema/expected/list_of_lists_of_primitives/expected_output/stdout.txt
@@ -1,0 +1,1 @@
+Code generated to: <output dir>

--- a/dev/test_data/main/jsonschema/expected/list_of_lists_of_primitives/input/snippets/schema_base.json
+++ b/dev/test_data/main/jsonschema/expected/list_of_lists_of_primitives/input/snippets/schema_base.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "DummyForTest",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/Something"
+    }
+  ]
+}

--- a/dev/test_data/main/jsonschema/expected/list_of_lists_of_primitives/meta_model.py
+++ b/dev/test_data/main/jsonschema/expected/list_of_lists_of_primitives/meta_model.py
@@ -1,0 +1,12 @@
+from typing import List
+
+
+class Something:
+    list_of_lists_of_ints: List[List[int]]
+
+    def __init__(self, list_of_lists_of_ints: List[List[int]]) -> None:
+        self.list_of_lists_of_ints = list_of_lists_of_ints
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/dev/test_data/main/jsonschema/expected/list_of_primitives/examples/expected/empty/model.json
+++ b/dev/test_data/main/jsonschema/expected/list_of_primitives/examples/expected/empty/model.json
@@ -1,7 +1,0 @@
-{
-  "someBools": [],
-  "someInts": [],
-  "someFloats": [],
-  "someStrings": [],
-  "someBytes": []
-}

--- a/dev/test_data/main/jsonschema/expected/list_of_primitives/examples/expected/non_empty/model.json
+++ b/dev/test_data/main/jsonschema/expected/list_of_primitives/examples/expected/non_empty/model.json
@@ -1,7 +1,0 @@
-{
-  "someBools": [true, false, true],
-  "someInts": [1, 0, -42, 100],
-  "someFloats": [3.14, -0.5, 2.718],
-  "someStrings": ["hello", "world", "example"],
-  "someBytes": ["SGVsbG8=", "V29ybGQ=", "AQID"]
-}

--- a/dev/test_data/main/jsonschema/expected/list_of_primitives/meta_model.py
+++ b/dev/test_data/main/jsonschema/expected/list_of_primitives/meta_model.py
@@ -1,28 +1,11 @@
 from typing import List
 
-from icontract import DBC
 
-
-class Something(DBC):
-    some_bools: List[bool]
+class Something:
     some_ints: List[int]
-    some_floats: List[float]
-    some_strings: List[str]
-    some_bytes: List[bytearray]
 
-    def __init__(
-            self,
-            some_bools: List[bool],
-            some_ints: List[int],
-            some_floats: List[float],
-            some_strings: List[str],
-            some_bytes: List[bytearray]
-    ) -> None:
-        self.some_bools = some_bools
+    def __init__(self, some_ints: List[int]) -> None:
         self.some_ints = some_ints
-        self.some_floats = some_floats
-        self.some_strings = some_strings
-        self.some_bytes = some_bytes
 
 
 __version__ = "dummy"

--- a/dev/tests/test_main.py
+++ b/dev/tests/test_main.py
@@ -292,6 +292,48 @@ class Test_jsonschema(_TestCase):
             target=aas_core_codegen.main.Target.JSONSCHEMA, case_name="aas_core_meta.v3"
         )
 
+    def test_expected_list_of_classes(self) -> None:
+        self._run_expected_test(
+            target=aas_core_codegen.main.Target.JSONSCHEMA,
+            case_name="list_of_classes",
+        )
+
+    def test_expected_list_of_constrained_primitives(self) -> None:
+        self._run_expected_test(
+            target=aas_core_codegen.main.Target.JSONSCHEMA,
+            case_name="list_of_constrained_primitives",
+        )
+
+    def test_expected_list_of_enums(self) -> None:
+        self._run_expected_test(
+            target=aas_core_codegen.main.Target.JSONSCHEMA,
+            case_name="list_of_enums",
+        )
+
+    def test_expected_list_of_lists_of_classes(self) -> None:
+        self._run_expected_test(
+            target=aas_core_codegen.main.Target.JSONSCHEMA,
+            case_name="list_of_lists_of_classes",
+        )
+
+    def test_expected_list_of_lists_of_constrained_primitives(self) -> None:
+        self._run_expected_test(
+            target=aas_core_codegen.main.Target.JSONSCHEMA,
+            case_name="list_of_lists_of_constrained_primitives",
+        )
+
+    def test_expected_list_of_lists_of_enums(self) -> None:
+        self._run_expected_test(
+            target=aas_core_codegen.main.Target.JSONSCHEMA,
+            case_name="list_of_lists_of_enums",
+        )
+
+    def test_expected_list_of_lists_of_primitives(self) -> None:
+        self._run_expected_test(
+            target=aas_core_codegen.main.Target.JSONSCHEMA,
+            case_name="list_of_lists_of_primitives",
+        )
+
     def test_expected_list_of_primitives(self) -> None:
         self._run_expected_test(
             target=aas_core_codegen.main.Target.JSONSCHEMA,


### PR DESCRIPTION
We explicitly test that JSON schema generator supports not only lists of classes and primitives, but also lists of constrained primitives, lists of lists *etc.* At the moment, we do not support lists of optionals, as they can not be represented in XML.