### PR TITLE
Add support for lists of non-optionals in XSD

### DIFF
--- a/aas_core_codegen/xsd/main.py
+++ b/aas_core_codegen/xsd/main.py
@@ -5,7 +5,7 @@ import re
 # noinspection PyUnresolvedReferences
 import xml.dom.minidom
 import xml.etree.ElementTree as ET
-from typing import TextIO, MutableMapping, Optional, Tuple, List, Any, Mapping
+from typing import TextIO, MutableMapping, Optional, Tuple, List, Any, Mapping, Final
 
 import greenery
 from icontract import ensure, require
@@ -177,425 +177,416 @@ def _translate_pattern(pattern: str) -> Tuple[Optional[str], Optional[str]]:
     return "".join(parts), None
 
 
-def _generate_xs_restriction(
-    base_type: intermediate.PrimitiveType,
-    constraints: Optional[infer_for_schema.Constraints],
-) -> Tuple[Optional[ET.Element], Optional[str]]:
-    """
-    Generate the ``xs:restriction`` for the given primitive.
+class _SimpleTypeRestriction:
+    """Model the restrictions applied on a simple type."""
 
-    Return the restriction element (if any length or pattern constraints), or
-    an error.
-    """
-    if constraints is None:
-        return None, None
+    pattern: Final[Optional[str]]
 
-    if constraints.len_constraint is None and (
-        constraints.patterns is None or (len(constraints.patterns) == 0)
-    ):
-        return None, None
+    min_length: Final[Optional[int]]
+    max_length: Final[Optional[int]]
 
-    restriction = ET.Element("xs:restriction", {"base": _PRIMITIVE_MAP[base_type]})
-
-    # NOTE (mristin):
-    # We skip the general XML character pattern. It makes greenery
-    # unbearably slow since it instantiates *each* character in
-    # the character range. Since XML engines can not deal with the special
-    # characters any ways, there is no need to include this constraint in
-    # the XSD pattern restrictions.
-    patterns_relevant_for_xsd: Optional[List[infer_for_schema.PatternConstraint]] = None
-
-    if constraints.patterns is not None:
-        patterns_relevant_for_xsd = [
-            pattern_constraint
-            for pattern_constraint in constraints.patterns
-            if pattern_constraint.pattern
-            != (
-                "^[\\x09\\x0A\\x0D\\x20-\\uD7FF\\uE000-\\uFFFD"
-                "\\U00010000-\\U0010FFFF]*$"
-            )
-        ]
-
-    if patterns_relevant_for_xsd is not None and len(patterns_relevant_for_xsd) > 0:
-        translated_pattern: Optional[str]
-
-        if len(patterns_relevant_for_xsd) == 1:
-            translated_pattern, error = _translate_pattern(
-                patterns_relevant_for_xsd[0].pattern
-            )
-            if error is not None:
-                return None, error
-        else:
-            # NOTE (mristin, 2023-02-27):
-            # The module ``greenery`` is not annotated with types at the moment.
-            merger = None  # type: Optional[Any]
-            for pattern_constraint in patterns_relevant_for_xsd:
-                # NOTE (mristin, 2023-02-27):
-                # Greenery expects the characters to be in Unicode and not escaped.
-                translated_for_greenery = _undo_escaping_backslash_x_u_and_U_in_pattern(
-                    pattern_constraint.pattern
-                )
-
-                try:
-                    parsed = greenery.parse(translated_for_greenery)
-                except Exception as exception:
-                    if translated_for_greenery == pattern_constraint.pattern:
-                        return None, (
-                            f"The greenery failed to parse "
-                            f"the pattern {translated_for_greenery!r}: {exception}"
-                        )
-                    else:
-                        return None, (
-                            f"The greenery failed to parse "
-                            f"the pattern {translated_for_greenery!r} "
-                            f"(which was originally {pattern_constraint.pattern!r}): "
-                            f"{exception}"
-                        )
-
-                if merger is None:
-                    merger = parsed
-                else:
-                    merger = merger & parsed
-
-            assert merger is not None
-
-            translated_pattern, error = _translate_pattern(str(merger))
-            if error is not None:
-                return None, error
-
-        assert translated_pattern is not None
-
-        pattern = ET.Element(
-            "xs:pattern",
-            {"value": translated_pattern},
-        )
-
-        restriction.append(pattern)
-
-    if constraints.len_constraint is not None:
-        if constraints.len_constraint.min_value is not None:
-            min_length = ET.Element(
-                "xs:minLength", {"value": str(constraints.len_constraint.min_value)}
-            )
-            restriction.append(min_length)
-
-        if constraints.len_constraint.max_value is not None:
-            max_length = ET.Element(
-                "xs:maxLength", {"value": str(constraints.len_constraint.max_value)}
-            )
-            restriction.append(max_length)
-
-    return restriction, None
-
-
-@ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
-def _generate_xs_element_for_a_primitive_property(
-    prop: intermediate.Property, constraints: Optional[infer_for_schema.Constraints]
-) -> Tuple[Optional[ET.Element], Optional[Error]]:
-    """
-    Generate the ``xs:element`` for a primitive property.
-
-    A primitive property is a property whose type is either a primitive or
-    a constrained primitive. The reason why we take these two together is that we
-    in-line the constraints for the constrained primitives.
-
-    We do not define the constrained primitives separately in the schema in order to
-    avoid the confusion during comparisons between the XSD and the meta-model in
-    the book.
-    """
-    type_anno = intermediate.beneath_optional(prop.type_annotation)
-
-    if (
-        isinstance(type_anno, intermediate.OurTypeAnnotation)
-        and type_anno.our_type.name == "Value_data_type"
-    ):
-        # NOTE (mristin, 2022-11-10):
-        # Please see :py:const:`_EXPLANATION_ABOUT_WHY_WE_EXPECT_VALUE_DATA_TYPE`
-        # for the explanation why we hard-wire the ``Value_data_type`` here
-        return (
-            ET.Element(
-                "xs:element",
-                {
-                    "name": naming.xml_property(prop.name),
-                    "type": "valueDataType",
-                },
-            ),
-            None,
-        )
-
-    # NOTE (mristin):
-    # Specify the type of the ``type_anno`` here with assert instead of specifying it
-    # in the pre-condition to help mypy a bit.
-
-    base_type = intermediate.try_primitive_type(type_anno)
-
-    assert (
-        base_type is not None
-    ), f"Expected a primitive or a constrained primitive, but got: {type_anno}"
-
-    xs_restriction, error = _generate_xs_restriction(
-        base_type=base_type, constraints=constraints
+    @require(
+        lambda pattern, min_length, max_length: (pattern is not None)
+        or (min_length is not None)
+        or (max_length is not None),
+        "At least one constraint defined",
     )
-    if error is not None:
-        return None, Error(
-            prop.parsed.node,
-            f"Failed to generate the restriction for property {prop.name}: {error}",
-        )
-    # NOTE (mristin, 2022-06-18):
-    # xs_restriction may be None here if there are no constraints.
+    def __init__(
+        self,
+        pattern: Optional[str] = None,
+        min_length: Optional[int] = None,
+        max_length: Optional[int] = None,
+    ) -> None:
+        self.pattern = pattern
+        self.min_length = min_length
+        self.max_length = max_length
 
-    xs_element: ET.Element
 
-    if xs_restriction is None:
-        xs_element = ET.Element(
-            "xs:element",
-            {
-                "name": naming.xml_property(prop.name),
-                "type": _PRIMITIVE_MAP[base_type],
-            },
-        )
-    else:
-        xs_simple_type = ET.Element("xs:simpleType")
-        xs_simple_type.append(xs_restriction)
+class _SimpleType:
+    """
+    Model a simple type in XSD.
 
-        xs_element = ET.Element("xs:element", {"name": naming.xml_property(prop.name)})
-        xs_element.append(xs_simple_type)
+    This is meant to be represented either with ``<xs:simpleType>``, if there are
+    restrictions, or as an attribute ``type="..."`` in the containing element, when
+    there are no restrictions.
+    """
 
-    return xs_element, None
+    tajp: Final[str]
+    restriction: Final[Optional[_SimpleTypeRestriction]]
+
+    def __init__(
+        self, tajp: str, restriction: Optional[_SimpleTypeRestriction]
+    ) -> None:
+        self.tajp = tajp
+        self.restriction = restriction
 
 
 @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
-def _generate_xs_element_for_a_list_property(
-    prop: intermediate.Property, constraints: Optional[infer_for_schema.Constraints]
-) -> Tuple[Optional[ET.Element], Optional[Error]]:
-    """Generate the ``xs:element`` for a list property."""
-    type_anno = intermediate.beneath_optional(prop.type_annotation)
+def _translate_to_simple_type(
+    primitive_type: intermediate.PrimitiveType,
+    constraints: Optional[infer_for_schema.Constraints],
+) -> Tuple[Optional[_SimpleType], Optional[str]]:
+    restriction: Optional[_SimpleTypeRestriction] = None
 
-    # NOTE (mristin):
-    # Specify the ``type_anno`` here with assert instead of specifying it
-    # in the pre-condition to help mypy a bit.
-    assert isinstance(type_anno, intermediate.ListTypeAnnotation)
+    min_length: Optional[int] = None
+    max_length: Optional[int] = None
+    pattern: Optional[str] = None
 
-    min_occurs = "0"
-    max_occurs = "unbounded"
     if constraints is not None:
         if constraints.len_constraint is not None:
-            if constraints.len_constraint.min_value is not None:
-                min_occurs = str(constraints.len_constraint.min_value)
+            min_length = constraints.len_constraint.min_value
+            max_length = constraints.len_constraint.max_value
 
-            if constraints.len_constraint.max_value is not None:
-                max_occurs = str(constraints.len_constraint.max_value)
-
-    xs_element: ET.Element
-
-    if isinstance(type_anno.items, intermediate.PrimitiveTypeAnnotation):
-        xs_element_inner = ET.Element(
-            "xs:element",
-            {
-                # NOTE (mristin):
-                # We simply pick ``v`` as there is currently no specification for
-                # the list of primitives in XML.
-                "name": "v",
-                "type": _PRIMITIVE_MAP[type_anno.items.a_type],
-                "minOccurs": min_occurs,
-                "maxOccurs": max_occurs,
-            },
-        )
-        xs_sequence = ET.Element("xs:sequence")
-        xs_sequence.append(xs_element_inner)
-
-        xs_complex_type = ET.Element("xs:complexType")
-        xs_complex_type.append(xs_sequence)
-
-        xs_element = ET.Element("xs:element", {"name": naming.xml_property(prop.name)})
-        xs_element.append(xs_complex_type)
-
-    elif isinstance(type_anno.items, intermediate.OurTypeAnnotation):
-        # NOTE (mristin):
-        # We need to nest the elements in the tag element to separate them in the
-        # sequence.
-
-        our_type = type_anno.items.our_type
-
-        if isinstance(our_type, intermediate.Enumeration):
-            return None, Error(
-                prop.parsed.node,
-                f"We do not know how to specify the list of enumerations "
-                f"for the property {prop.name!r} of {prop.specified_for.name!r} "
-                f"in the XSD with the type: {type_anno}",
-            )
-
-        elif isinstance(our_type, intermediate.ConstrainedPrimitive):
-            return None, Error(
-                prop.parsed.node,
-                f"We do not know how to specify the list of constrained primitives "
-                f"for the property {prop.name!r} of {prop.specified_for.name!r} "
-                f"in the XSD with the type: {type_anno}",
-            )
-
-        elif isinstance(
-            our_type, (intermediate.AbstractClass, intermediate.ConcreteClass)
-        ):
+        if constraints.patterns is not None:
             # NOTE (mristin):
-            # We need to check for the concrete descendants. If there are no concrete
-            # descendants, there is no choice group either. Notably, this not only
-            # applies to concrete classes, but there is no choice group for the abstract
-            # classes without descendants either.
-            if len(our_type.concrete_descendants) > 0:
-                choice_group_name = xsd_naming.choice_group_name(our_type.name)
-                xs_group = ET.Element(
-                    "xs:group",
-                    {
-                        "ref": choice_group_name,
-                        "minOccurs": min_occurs,
-                        "maxOccurs": max_occurs,
-                    },
+            # We skip the general XML character pattern. It makes greenery
+            # unbearably slow since it instantiates *each* character in
+            # the character range. Since XML engines can not deal with the special
+            # characters any ways, there is no need to include this constraint in
+            # the XSD pattern restrictions.
+            patterns_relevant_for_xsd = [
+                pattern_constraint
+                for pattern_constraint in constraints.patterns
+                if pattern_constraint.pattern
+                != (
+                    "^[\\x09\\x0A\\x0D\\x20-\\uD7FF\\uE000-\\uFFFD"
+                    "\\U00010000-\\U0010FFFF]*$"
                 )
+            ]
 
-                xs_sequence = ET.Element("xs:sequence")
-                xs_sequence.append(xs_group)
+            if len(patterns_relevant_for_xsd) > 0:
+                translated_pattern: Optional[str]
 
-                xs_complex_type = ET.Element("xs:complexType")
-                xs_complex_type.append(xs_sequence)
-
-                xs_element = ET.Element(
-                    "xs:element", {"name": naming.xml_property(prop.name)}
-                )
-                xs_element.append(xs_complex_type)
-            else:
-                xs_element_inner = ET.Element(
-                    "xs:element",
-                    {
-                        "name": naming.xml_class_name(our_type.name),
-                        "type": xsd_naming.type_name(our_type.name),
-                        "minOccurs": min_occurs,
-                        "maxOccurs": max_occurs,
-                    },
-                )
-                xs_sequence = ET.Element("xs:sequence")
-                xs_sequence.append(xs_element_inner)
-
-                xs_complex_type = ET.Element("xs:complexType")
-                xs_complex_type.append(xs_sequence)
-
-                xs_element = ET.Element(
-                    "xs:element", {"name": naming.xml_property(prop.name)}
-                )
-                xs_element.append(xs_complex_type)
-
-        elif isinstance(our_type, intermediate.ConstrainedPrimitive):
-            return None, Error(
-                prop.parsed.node,
-                f"We do not know how to specify the list of constrained primitives "
-                f"for the property {prop.name!r} of {prop.specified_for.name!r} "
-                f"in the XSD with the type: {type_anno}",
-            )
-        else:
-            assert_never(our_type)
-    else:
-        return None, Error(
-            prop.parsed.node,
-            f"We do not know how to specify the list "
-            f"for the property {prop.name!r} of {prop.specified_for.name!r} "
-            f"in the XSD with the type: {type_anno}. "
-            f"If you need this feature, please contact the developers.",
-        )
-
-    return xs_element, None
-
-
-@ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
-def _generate_xs_element_for_a_property(
-    prop: intermediate.Property, constraints: Optional[infer_for_schema.Constraints]
-) -> Tuple[Optional[ET.Element], Optional[Error]]:
-    """Generate the definition of an ``xs:element`` for a property."""
-    type_anno = intermediate.beneath_optional(prop.type_annotation)
-
-    xs_element: Optional[ET.Element]
-
-    if isinstance(type_anno, intermediate.PrimitiveTypeAnnotation):
-        xs_element, error = _generate_xs_element_for_a_primitive_property(
-            prop=prop, constraints=constraints
-        )
-        if error is not None:
-            return None, error
-        assert xs_element is not None
-
-    elif isinstance(type_anno, intermediate.OurTypeAnnotation):
-        our_type = type_anno.our_type
-
-        if isinstance(our_type, intermediate.Enumeration):
-            xs_element = ET.Element(
-                "xs:element",
-                {
-                    "name": naming.xml_property(prop.name),
-                    "type": xsd_naming.type_name(our_type.name),
-                },
-            )
-
-        elif isinstance(our_type, intermediate.ConstrainedPrimitive):
-            xs_element, error = _generate_xs_element_for_a_primitive_property(
-                prop=prop, constraints=constraints
-            )
-            if error is not None:
-                return None, error
-            assert xs_element is not None
-
-        elif isinstance(
-            our_type, (intermediate.AbstractClass, intermediate.ConcreteClass)
-        ):
-            # NOTE (mristin, 2022-05-26):
-            # We generate choices only if there are at least one concrete descendant.
-            # Otherwise, the choice is not generated. Hence, we need to reference
-            # a choice only if there is actually one.
-            #
-            # This is especially necessary for abstract classes with no descendants
-            # which we still want to include in the schema. We simply generate an empty
-            # element in the schema for such abstract classes without descendants.
-            if len(our_type.concrete_descendants) > 0:
-                xs_sequence = ET.Element("xs:sequence")
-                xs_sequence.append(
-                    ET.Element(
-                        "xs:group", {"ref": xsd_naming.choice_group_name(our_type.name)}
+                if len(patterns_relevant_for_xsd) == 1:
+                    translated_pattern, error = _translate_pattern(
+                        patterns_relevant_for_xsd[0].pattern
                     )
-                )
+                    if error is not None:
+                        return None, error
+                else:
+                    # NOTE (mristin, 2023-02-27):
+                    # The module ``greenery`` is not annotated with types at the moment.
+                    merger = None  # type: Optional[Any]
+                    for pattern_constraint in patterns_relevant_for_xsd:
+                        # NOTE (mristin, 2023-02-27):
+                        # Greenery expects the characters to be in Unicode and not escaped.
+                        translated_for_greenery = (
+                            _undo_escaping_backslash_x_u_and_U_in_pattern(
+                                pattern_constraint.pattern
+                            )
+                        )
 
-                xs_complex_type = ET.Element("xs:complexType")
-                xs_complex_type.append(xs_sequence)
+                        try:
+                            parsed = greenery.parse(translated_for_greenery)
+                        except Exception as exception:
+                            if translated_for_greenery == pattern_constraint.pattern:
+                                return None, (
+                                    f"The greenery failed to parse "
+                                    f"the pattern {translated_for_greenery!r}: "
+                                    f"{exception}"
+                                )
+                            else:
+                                return None, (
+                                    f"The greenery failed to parse "
+                                    f"the pattern {translated_for_greenery!r} "
+                                    f"(which was originally "
+                                    f"{pattern_constraint.pattern!r}): {exception}"
+                                )
 
-                xs_element = ET.Element(
-                    "xs:element", {"name": naming.xml_property(prop.name)}
-                )
-                xs_element.append(xs_complex_type)
-            else:
-                xs_element = ET.Element(
-                    "xs:element",
-                    {
-                        "name": naming.xml_property(prop.name),
-                        "type": xsd_naming.type_name(our_type.name),
-                    },
-                )
-        else:
-            assert_never(type_anno.our_type)
+                        if merger is None:
+                            merger = parsed
+                        else:
+                            merger = merger & parsed
 
-    elif isinstance(type_anno, intermediate.ListTypeAnnotation):
-        xs_element, error = _generate_xs_element_for_a_list_property(
-            prop=prop, constraints=constraints
+                    assert merger is not None
+
+                    translated_pattern, error = _translate_pattern(str(merger))
+                    if error is not None:
+                        return None, error
+
+                assert translated_pattern is not None
+                pattern = translated_pattern
+
+    if (min_length is not None) or (max_length is not None) or (pattern is not None):
+        restriction = _SimpleTypeRestriction(
+            min_length=min_length, max_length=max_length, pattern=pattern
         )
-        if error is not None:
-            return None, error
 
-        assert xs_element is not None
+    return (
+        _SimpleType(tajp=_PRIMITIVE_MAP[primitive_type], restriction=restriction),
+        None,
+    )
+
+
+class _TypeElementOrTypeIdentifier:
+    """
+    Represent a rendering of a type annotation.
+
+    A type annotation can either be represented as a ``type`` attribute of an element,
+    or as a proper ``xs:simpleType`` or ``xs:complexType`` element.
+
+    For example:
+
+    .. code-block:: xml
+
+        <xs:element name="something" type="xs:string" />
+
+    or:
+
+    .. code-block:: xml
+
+        <xs:element name="someLanguage">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:minLength value="1" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:element>
+    """
+
+    tajp: Final[Optional[str]]
+
+    element: Final[Optional[ET.Element]]
+
+    @require(lambda tajp, element: (tajp is not None) ^ (element is not None))
+    def __init__(
+        self, tajp: Optional[str] = None, element: Optional[ET.Element] = None
+    ) -> None:
+        self.tajp = tajp
+        self.element = element
+
+
+def _value_to_type_element_or_type_identifier(
+    type_annotation: intermediate.TypeAnnotationExceptOptional,
+    constraints_by_value: infer_for_schema.ConstraintsByValue,
+) -> Tuple[Optional[_TypeElementOrTypeIdentifier], Optional[str]]:
+    """
+    Translate the given type annotation to XSD.
+
+    Return the either type element or type identifier, or an error, if any.
+    """
+    if isinstance(type_annotation, intermediate.OurTypeAnnotation):
+        if type_annotation.our_type.name == "Value_data_type":
+            # NOTE (mristin, 2022-11-10):
+            # Please see :py:const:`_EXPLANATION_ABOUT_WHY_WE_EXPECT_VALUE_DATA_TYPE`
+            # for the explanation why we hard-wire the ``Value_data_type`` here.
+            return _TypeElementOrTypeIdentifier(tajp="valueDataType"), None
+
+    primitive_type = intermediate.try_primitive_type(type_annotation)
+
+    if primitive_type is not None:
+        simple_type, simple_type_error = _translate_to_simple_type(
+            primitive_type=primitive_type,
+            constraints=constraints_by_value.get(type_annotation, None),
+        )
+        if simple_type_error is not None:
+            return None, (
+                f"Failed to translate the type annotation {type_annotation} "
+                f"to xs:simpleType: {simple_type_error}"
+            )
+
+        assert simple_type is not None
+
+        if simple_type.restriction is None:
+            return _TypeElementOrTypeIdentifier(tajp=simple_type.tajp), None
+        else:
+            xs_simple_type = ET.Element("xs:simpleType")
+
+            xs_restriction = ET.SubElement(
+                xs_simple_type, "xs:restriction", {"base": simple_type.tajp}
+            )
+
+            # NOTE (mristin):
+            # We define the pattern first for the legacy reasons -- already published
+            # XSD schemas defined the pattern first, so we want to keep the diffs
+            # minimal even though it intuitively makes more sense to start with
+            # length.
+
+            if simple_type.restriction.pattern is not None:
+                ET.SubElement(
+                    xs_restriction,
+                    "xs:pattern",
+                    {"value": simple_type.restriction.pattern},
+                )
+
+            if simple_type.restriction is not None:
+                if simple_type.restriction.min_length is not None:
+                    ET.SubElement(
+                        xs_restriction,
+                        "xs:minLength",
+                        {"value": str(simple_type.restriction.min_length)},
+                    )
+
+                if simple_type.restriction.max_length is not None:
+                    ET.SubElement(
+                        xs_restriction,
+                        "xs:maxLength",
+                        {"value": str(simple_type.restriction.max_length)},
+                    )
+
+            return _TypeElementOrTypeIdentifier(element=xs_simple_type), None
     else:
-        assert_never(type_anno)
+        if isinstance(type_annotation, intermediate.PrimitiveTypeAnnotation):
+            raise AssertionError("This execution path must have been handled before.")
 
-    assert xs_element is not None
+        elif isinstance(type_annotation, intermediate.OurTypeAnnotation):
+            our_type = type_annotation.our_type
 
-    if isinstance(prop.type_annotation, intermediate.OptionalTypeAnnotation):
-        xs_element.attrib["minOccurs"] = "0"
-        xs_element.attrib["maxOccurs"] = "1"
+            if isinstance(our_type, intermediate.Enumeration):
+                return (
+                    _TypeElementOrTypeIdentifier(
+                        tajp=xsd_naming.type_name(our_type.name)
+                    ),
+                    None,
+                )
 
-    return xs_element, None
+            elif isinstance(our_type, intermediate.ConstrainedPrimitive):
+                raise AssertionError(
+                    "This execution path must have been handled before."
+                )
+
+            elif isinstance(
+                our_type, (intermediate.AbstractClass, intermediate.ConcreteClass)
+            ):
+                # NOTE (mristin):
+                # We generate choices only if there are at least one concrete descendant.
+                # Otherwise, the choice is not generated. Hence, we need to reference
+                # a choice only if there is actually one.
+                #
+                # This is especially necessary for abstract classes with no descendants
+                # which we still want to include in the schema. We simply generate an empty
+                # element in the schema for such abstract classes without descendants.
+
+                if len(our_type.concrete_descendants) > 0:
+                    xs_complex_type = ET.Element("xs:complexType")
+                    xs_sequence = ET.SubElement(xs_complex_type, "xs:sequence")
+
+                    ET.SubElement(
+                        xs_sequence,
+                        "xs:group",
+                        {"ref": xsd_naming.choice_group_name(our_type.name)},
+                    )
+
+                    return (
+                        _TypeElementOrTypeIdentifier(
+                            element=xs_complex_type,
+                        ),
+                        None,
+                    )
+
+                else:
+                    return (
+                        _TypeElementOrTypeIdentifier(
+                            tajp=xsd_naming.type_name(our_type.name)
+                        ),
+                        None,
+                    )
+            else:
+                # noinspection PyTypeChecker
+                assert_never(our_type)
+
+        elif isinstance(type_annotation, intermediate.ListTypeAnnotation):
+            assert not isinstance(
+                type_annotation.items, intermediate.OptionalTypeAnnotation
+            ), (
+                "(mristin, 2026-05-08): Only lists of non-optionals are supported "
+                "at the moment. If you see this, please contact the developers."
+            )
+
+            xs_complex_type = ET.Element("xs:complexType")
+            xs_sequence = ET.SubElement(xs_complex_type, "xs:sequence")
+
+            item_element: ET.Element
+
+            if isinstance(
+                type_annotation.items, intermediate.OurTypeAnnotation
+            ) and isinstance(
+                type_annotation.items.our_type,
+                (intermediate.AbstractClass, intermediate.ConcreteClass),
+            ):
+                # NOTE (mristin):
+                # All the other cases introduce ``<v>`` element to capture the items,
+                # but lists of classes use the name of the class, so we have to handle
+                # it here differently.
+
+                # NOTE (mristin):
+                # We generate choices only if there are at least one concrete descendant.
+                # Otherwise, the choice is not generated. Hence, we need to reference
+                # a choice only if there is actually one.
+                #
+                # This is especially necessary for abstract classes with no descendants
+                # which we still want to include in the schema. We simply generate an empty
+                # element in the schema for such abstract classes without descendants.
+
+                if len(type_annotation.items.our_type.concrete_descendants) > 0:
+                    item_element = ET.Element(
+                        "xs:group",
+                        {
+                            "ref": xsd_naming.choice_group_name(
+                                type_annotation.items.our_type.name
+                            )
+                        },
+                    )
+                else:
+                    item_element = ET.Element(
+                        "xs:element",
+                        {
+                            "name": naming.xml_class_name(
+                                type_annotation.items.our_type.name
+                            ),
+                            "type": xsd_naming.type_name(
+                                type_annotation.items.our_type.name
+                            ),
+                        },
+                    )
+            else:
+                (
+                    items_type_element_or_identifier,
+                    translation_error,
+                ) = _value_to_type_element_or_type_identifier(
+                    type_annotation=type_annotation.items,
+                    constraints_by_value=constraints_by_value,
+                )
+
+                if translation_error is not None:
+                    return None, (
+                        f"Failed to translate the type annotation {type_annotation} to "
+                        f"a type element or a type identifier: {translation_error}"
+                    )
+
+                assert items_type_element_or_identifier is not None
+
+                item_element = ET.Element("xs:element", {"name": "v"})
+
+                if items_type_element_or_identifier.tajp is not None:
+                    item_element.attrib["type"] = items_type_element_or_identifier.tajp
+
+                else:
+                    assert items_type_element_or_identifier.element is not None
+
+                    item_element.append(items_type_element_or_identifier.element)
+
+            xs_sequence.append(item_element)
+
+            min_occurs = "0"
+            max_occurs = "unbounded"
+
+            constraints = constraints_by_value.get(type_annotation, None)
+            if constraints is not None and constraints.len_constraint is not None:
+                if constraints.len_constraint.min_value is not None:
+                    min_occurs = str(constraints.len_constraint.min_value)
+
+                if constraints.len_constraint.max_value is not None:
+                    max_occurs = str(constraints.len_constraint.max_value)
+
+            item_element.attrib["minOccurs"] = min_occurs
+            item_element.attrib["maxOccurs"] = max_occurs
+
+            return _TypeElementOrTypeIdentifier(element=xs_complex_type), None
+
+        else:
+            # noinspection PyTypeChecker
+            assert_never(type_annotation)
 
 
 @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
@@ -632,16 +623,43 @@ def _define_properties(
 
         type_anno = intermediate.beneath_optional(prop.type_annotation)
 
-        constraints = constraints_by_value.get(type_anno, None)
+        xs_element = ET.Element("xs:element", {"name": naming.xml_property(prop.name)})
 
-        xs_element, error = _generate_xs_element_for_a_property(
-            prop=prop, constraints=constraints
+        # fmt: off
+        (
+            type_element_or_identifier,
+            type_error
+        ) = _value_to_type_element_or_type_identifier(
+            type_annotation=type_anno,
+            constraints_by_value=constraints_by_value
         )
-        if error is not None:
-            errors.append(error)
+        # fmt: on
+
+        if type_error is not None:
+            errors.append(
+                Error(
+                    prop.parsed.node,
+                    f"Failed to translate the type annotation, "
+                    f"{type_anno}, of the property {prop.name} "
+                    f"to XSD: {type_error}",
+                )
+            )
+            continue
+
+        assert type_element_or_identifier is not None
+
+        if type_element_or_identifier.tajp is not None:
+            xs_element.attrib["type"] = type_element_or_identifier.tajp
         else:
-            assert xs_element is not None
-            sequence.append(xs_element)
+            assert type_element_or_identifier.element is not None
+
+            xs_element.append(type_element_or_identifier.element)
+
+        if isinstance(prop.type_annotation, intermediate.OptionalTypeAnnotation):
+            xs_element.attrib["minOccurs"] = "0"
+            xs_element.attrib["maxOccurs"] = "1"
+
+        sequence.append(xs_element)
 
     if len(errors) > 0:
         return None, errors
@@ -1122,6 +1140,7 @@ def _generate(
                     choice_group = _generate_choice_group(cls=our_type)
                     elements.append(choice_group)
             else:
+                # noinspection PyTypeChecker
                 assert_never(our_type)
 
         assert elements is not None

--- a/dev/test_data/main/xsd/expected/list_of_classes/examples/expected/empty/model.xml
+++ b/dev/test_data/main/xsd/expected/list_of_classes/examples/expected/empty/model.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<something xmlns="https://dummy.com">
+    <someItems/>
+    <listOfParentlessAndChildless/>
+</something>

--- a/dev/test_data/main/xsd/expected/list_of_classes/examples/expected/non_empty/model.xml
+++ b/dev/test_data/main/xsd/expected/list_of_classes/examples/expected/non_empty/model.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<something xmlns="https://dummy.com">
+    <someItems>
+        <someItem>
+            <name>Item One</name>
+        </someItem>
+        <anotherItem>
+            <serialNumber>1001</serialNumber>
+        </anotherItem>
+    </someItems>
+
+    <listOfParentlessAndChildless>
+        <parentlessAndChildless>
+            <identifier>ID-001</identifier>
+        </parentlessAndChildless>
+        <parentlessAndChildless>
+            <identifier>ID-002</identifier>
+        </parentlessAndChildless>
+    </listOfParentlessAndChildless>
+</something>

--- a/dev/test_data/main/xsd/expected/list_of_classes/expected_output/schema.xsd
+++ b/dev/test_data/main/xsd/expected/list_of_classes/expected_output/schema.xsd
@@ -1,0 +1,76 @@
+<?xml version="1.0" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="https://dummy.com" elementFormDefault="qualified" targetNamespace="https://dummy.com">
+  <xs:group name="abstractItem">
+    <xs:sequence/>
+  </xs:group>
+  <xs:group name="abstractItem_choice">
+    <xs:choice>
+      <xs:element name="anotherItem" type="anotherItem_t"/>
+      <xs:element name="someItem" type="someItem_t"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="anotherItem">
+    <xs:sequence>
+      <xs:group ref="abstractItem"/>
+      <xs:element name="serialNumber" type="xs:long"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="parentlessAndChildless">
+    <xs:sequence>
+      <xs:element name="identifier" type="xs:string"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="someItem">
+    <xs:sequence>
+      <xs:group ref="abstractItem"/>
+      <xs:element name="name" type="xs:string"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="something">
+    <xs:sequence>
+      <xs:element name="someItems">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="abstractItem_choice" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="listOfParentlessAndChildless">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="parentlessAndChildless" type="parentlessAndChildless_t" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="valueDataType">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+  <xs:complexType name="abstractItem_t">
+    <xs:sequence>
+      <xs:group ref="abstractItem"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="anotherItem_t">
+    <xs:sequence>
+      <xs:group ref="anotherItem"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="parentlessAndChildless_t">
+    <xs:sequence>
+      <xs:group ref="parentlessAndChildless"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="someItem_t">
+    <xs:sequence>
+      <xs:group ref="someItem"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="something_t">
+    <xs:sequence>
+      <xs:group ref="something"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="something" type="something_t"/>
+</xs:schema>

--- a/dev/test_data/main/xsd/expected/list_of_classes/expected_output/stdout.txt
+++ b/dev/test_data/main/xsd/expected/list_of_classes/expected_output/stdout.txt
@@ -1,0 +1,1 @@
+Code generated to: <output dir>

--- a/dev/test_data/main/xsd/expected/list_of_classes/input/snippets/root_element.xml
+++ b/dev/test_data/main/xsd/expected/list_of_classes/input/snippets/root_element.xml
@@ -1,0 +1,8 @@
+<xs:schema
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns="https://dummy.com"
+        elementFormDefault="qualified"
+        targetNamespace="https://dummy.com"
+>
+    <xs:element name="something" type="something_t" />
+</xs:schema>

--- a/dev/test_data/main/xsd/expected/list_of_classes/meta_model.py
+++ b/dev/test_data/main/xsd/expected/list_of_classes/meta_model.py
@@ -1,0 +1,57 @@
+from enum import Enum
+from typing import List
+
+from icontract import invariant
+
+
+# NOTE (mristin):
+# The XSD generator expects the constrained primitive Value data type to be defined
+# since we had to hard-wire it. If we remove that hard-wiring, we can also remove
+# this definition as well.
+
+class Value_data_type(str, DBC):
+    pass
+
+
+@abstract
+@serialization(with_model_type=True)
+class Abstract_item:
+    pass
+
+
+class Some_item(Abstract_item):
+    name: str
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class Another_item(Abstract_item):
+    serial_number: int
+
+    def __init__(self, serial_number: int) -> None:
+        self.serial_number = serial_number
+
+
+class Parentless_and_childless:
+    identifier: str
+
+    def __init__(self, identifier: str) -> None:
+        self.identifier = identifier
+
+
+class Something:
+    some_items: List[Abstract_item]
+    list_of_parentless_and_childless: List[Parentless_and_childless]
+
+    def __init__(
+            self,
+            some_items: List[Abstract_item],
+            list_of_parentless_and_childless: List[Parentless_and_childless]
+    ) -> None:
+        self.some_items = some_items
+        self.list_of_parentless_and_childless = list_of_parentless_and_childless
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/dev/test_data/main/xsd/expected/list_of_classes_with_invariants/examples/expected/simple/model.xml
+++ b/dev/test_data/main/xsd/expected/list_of_classes_with_invariants/examples/expected/simple/model.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<something xmlns="https://dummy.com">
+    <someItems>
+        <someItem>
+            <name>Widget</name>
+        </someItem>
+
+        <anotherItem>
+            <serialNumber>1001</serialNumber>
+        </anotherItem>
+
+        <someItem>
+            <name>Gadget</name>
+        </someItem>
+    </someItems>
+
+    <listOfParentlessAndChildless>
+        <parentlessAndChildless>
+            <identifier>ID-001</identifier>
+        </parentlessAndChildless>
+
+        <parentlessAndChildless>
+            <identifier>ID-002</identifier>
+        </parentlessAndChildless>
+
+        <parentlessAndChildless>
+            <identifier>ID-003</identifier>
+        </parentlessAndChildless>
+    </listOfParentlessAndChildless>
+</something>

--- a/dev/test_data/main/xsd/expected/list_of_classes_with_invariants/expected_output/schema.xsd
+++ b/dev/test_data/main/xsd/expected/list_of_classes_with_invariants/expected_output/schema.xsd
@@ -1,0 +1,76 @@
+<?xml version="1.0" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="https://dummy.com" elementFormDefault="qualified" targetNamespace="https://dummy.com">
+  <xs:group name="abstractItem">
+    <xs:sequence/>
+  </xs:group>
+  <xs:group name="abstractItem_choice">
+    <xs:choice>
+      <xs:element name="anotherItem" type="anotherItem_t"/>
+      <xs:element name="someItem" type="someItem_t"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="anotherItem">
+    <xs:sequence>
+      <xs:group ref="abstractItem"/>
+      <xs:element name="serialNumber" type="xs:long"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="parentlessAndChildless">
+    <xs:sequence>
+      <xs:element name="identifier" type="xs:string"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="someItem">
+    <xs:sequence>
+      <xs:group ref="abstractItem"/>
+      <xs:element name="name" type="xs:string"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="something">
+    <xs:sequence>
+      <xs:element name="someItems">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:group ref="abstractItem_choice" minOccurs="2" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="listOfParentlessAndChildless">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="parentlessAndChildless" type="parentlessAndChildless_t" minOccurs="3" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="valueDataType">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+  <xs:complexType name="abstractItem_t">
+    <xs:sequence>
+      <xs:group ref="abstractItem"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="anotherItem_t">
+    <xs:sequence>
+      <xs:group ref="anotherItem"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="parentlessAndChildless_t">
+    <xs:sequence>
+      <xs:group ref="parentlessAndChildless"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="someItem_t">
+    <xs:sequence>
+      <xs:group ref="someItem"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="something_t">
+    <xs:sequence>
+      <xs:group ref="something"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="something" type="something_t"/>
+</xs:schema>

--- a/dev/test_data/main/xsd/expected/list_of_classes_with_invariants/expected_output/stdout.txt
+++ b/dev/test_data/main/xsd/expected/list_of_classes_with_invariants/expected_output/stdout.txt
@@ -1,0 +1,1 @@
+Code generated to: <output dir>

--- a/dev/test_data/main/xsd/expected/list_of_classes_with_invariants/input/snippets/root_element.xml
+++ b/dev/test_data/main/xsd/expected/list_of_classes_with_invariants/input/snippets/root_element.xml
@@ -1,0 +1,8 @@
+<xs:schema
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns="https://dummy.com"
+        elementFormDefault="qualified"
+        targetNamespace="https://dummy.com"
+>
+    <xs:element name="something" type="something_t" />
+</xs:schema>

--- a/dev/test_data/main/xsd/expected/list_of_classes_with_invariants/meta_model.py
+++ b/dev/test_data/main/xsd/expected/list_of_classes_with_invariants/meta_model.py
@@ -1,0 +1,64 @@
+from enum import Enum
+from typing import List
+
+from icontract import invariant
+
+
+# NOTE (mristin):
+# The XSD generator expects the constrained primitive Value data type to be defined
+# since we had to hard-wire it. If we remove that hard-wiring, we can also remove
+# this definition as well.
+
+class Value_data_type(str, DBC):
+    pass
+
+
+@abstract
+@serialization(with_model_type=True)
+class Abstract_item:
+    pass
+
+
+class Some_item(Abstract_item):
+    name: str
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class Another_item(Abstract_item):
+    serial_number: int
+
+    def __init__(self, serial_number: int) -> None:
+        self.serial_number = serial_number
+
+
+class Parentless_and_childless:
+    identifier: str
+
+    def __init__(self, identifier: str) -> None:
+        self.identifier = identifier
+
+
+@invariant(
+    lambda self: len(self.some_items) >= 2, "At least 2 elements"
+)
+@invariant(
+    lambda self: len(self.list_of_parentless_and_childless) >= 3,
+    "At least 3 elements"
+)
+class Something:
+    some_items: List[Abstract_item]
+    list_of_parentless_and_childless: List[Parentless_and_childless]
+
+    def __init__(
+            self,
+            some_items: List[Abstract_item],
+            list_of_parentless_and_childless: List[Parentless_and_childless]
+    ) -> None:
+        self.some_items = some_items
+        self.list_of_parentless_and_childless = list_of_parentless_and_childless
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/dev/test_data/main/xsd/expected/list_of_constrained_primitives/examples/expected/empty/model.xml
+++ b/dev/test_data/main/xsd/expected/list_of_constrained_primitives/examples/expected/empty/model.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<something xmlns="https://dummy.com">
+  <someNames/>
+</something>

--- a/dev/test_data/main/xsd/expected/list_of_constrained_primitives/examples/expected/non_empty/model.xml
+++ b/dev/test_data/main/xsd/expected/list_of_constrained_primitives/examples/expected/non_empty/model.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<something xmlns="https://dummy.com">
+  <someNames>
+    <v>Alice</v>
+    <v>Bob</v>
+  </someNames>
+</something>

--- a/dev/test_data/main/xsd/expected/list_of_constrained_primitives/expected_output/schema.xsd
+++ b/dev/test_data/main/xsd/expected/list_of_constrained_primitives/expected_output/schema.xsd
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="https://dummy.com" elementFormDefault="qualified" targetNamespace="https://dummy.com">
+  <xs:group name="something">
+    <xs:sequence>
+      <xs:element name="someNames">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="v" minOccurs="0" maxOccurs="unbounded">
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:minLength value="1"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="valueDataType">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+  <xs:complexType name="something_t">
+    <xs:sequence>
+      <xs:group ref="something"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="something" type="something_t"/>
+</xs:schema>

--- a/dev/test_data/main/xsd/expected/list_of_constrained_primitives/expected_output/stdout.txt
+++ b/dev/test_data/main/xsd/expected/list_of_constrained_primitives/expected_output/stdout.txt
@@ -1,0 +1,1 @@
+Code generated to: <output dir>

--- a/dev/test_data/main/xsd/expected/list_of_constrained_primitives/input/snippets/root_element.xml
+++ b/dev/test_data/main/xsd/expected/list_of_constrained_primitives/input/snippets/root_element.xml
@@ -1,0 +1,8 @@
+<xs:schema
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns="https://dummy.com"
+        elementFormDefault="qualified"
+        targetNamespace="https://dummy.com"
+>
+    <xs:element name="something" type="something_t" />
+</xs:schema>

--- a/dev/test_data/main/xsd/expected/list_of_constrained_primitives/meta_model.py
+++ b/dev/test_data/main/xsd/expected/list_of_constrained_primitives/meta_model.py
@@ -1,0 +1,28 @@
+from typing import List
+
+from icontract import invariant
+
+# NOTE (mristin):
+# The XSD generator expects the constrained primitive Value data type to be defined
+# since we had to hard-wire it. If we remove that hard-wiring, we can also remove
+# this definition as well.
+
+class Value_data_type(str, DBC):
+    pass
+
+
+
+@invariant(lambda self: len(self) > 0, "Non-empty")
+class Name(str):
+    pass
+
+
+class Something:
+    some_names: List[Name]
+
+    def __init__(self, some_names: List[Name]) -> None:
+        self.some_names = some_names
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/dev/test_data/main/xsd/expected/list_of_enums/examples/expected/empty/model.xml
+++ b/dev/test_data/main/xsd/expected/list_of_enums/examples/expected/empty/model.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<something xmlns="https://dummy.com">
+    <someResults/>
+</something>

--- a/dev/test_data/main/xsd/expected/list_of_enums/examples/expected/non_empty/model.xml
+++ b/dev/test_data/main/xsd/expected/list_of_enums/examples/expected/non_empty/model.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<something xmlns="https://dummy.com">
+    <someResults>
+        <v>ok</v>
+        <v>fail</v>
+        <v>ok</v>
+        <v>fail</v>
+    </someResults>
+</something>

--- a/dev/test_data/main/xsd/expected/list_of_enums/expected_output/schema.xsd
+++ b/dev/test_data/main/xsd/expected/list_of_enums/expected_output/schema.xsd
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="https://dummy.com" elementFormDefault="qualified" targetNamespace="https://dummy.com">
+  <xs:group name="something">
+    <xs:sequence>
+      <xs:element name="someResults">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="v" type="result_t" minOccurs="0" maxOccurs="unbounded"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="result_t">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="ok"/>
+      <xs:enumeration value="fail"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="valueDataType">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+  <xs:complexType name="something_t">
+    <xs:sequence>
+      <xs:group ref="something"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="something" type="something_t"/>
+</xs:schema>

--- a/dev/test_data/main/xsd/expected/list_of_enums/expected_output/stdout.txt
+++ b/dev/test_data/main/xsd/expected/list_of_enums/expected_output/stdout.txt
@@ -1,0 +1,1 @@
+Code generated to: <output dir>

--- a/dev/test_data/main/xsd/expected/list_of_enums/input/snippets/root_element.xml
+++ b/dev/test_data/main/xsd/expected/list_of_enums/input/snippets/root_element.xml
@@ -1,0 +1,8 @@
+<xs:schema
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns="https://dummy.com"
+        elementFormDefault="qualified"
+        targetNamespace="https://dummy.com"
+>
+    <xs:element name="something" type="something_t" />
+</xs:schema>

--- a/dev/test_data/main/xsd/expected/list_of_enums/meta_model.py
+++ b/dev/test_data/main/xsd/expected/list_of_enums/meta_model.py
@@ -1,0 +1,29 @@
+from enum import Enum
+from typing import List
+
+from icontract import invariant
+
+
+# NOTE (mristin):
+# The XSD generator expects the constrained primitive Value data type to be defined
+# since we had to hard-wire it. If we remove that hard-wiring, we can also remove
+# this definition as well.
+
+class Value_data_type(str, DBC):
+    pass
+
+
+class Result(Enum):
+    Ok = "ok"
+    Fail = "fail"
+
+
+class Something:
+    some_results: List[Result]
+
+    def __init__(self, some_results: List[Result]) -> None:
+        self.some_results = some_results
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/dev/test_data/main/xsd/expected/list_of_lists_of_classes/examples/expected/empty/model.xml
+++ b/dev/test_data/main/xsd/expected/list_of_lists_of_classes/examples/expected/empty/model.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<something xmlns="https://dummy.com">
+    <listOfListsOfItems/>
+</something>

--- a/dev/test_data/main/xsd/expected/list_of_lists_of_classes/examples/expected/non_empty/model.xml
+++ b/dev/test_data/main/xsd/expected/list_of_lists_of_classes/examples/expected/non_empty/model.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<something xmlns="https://dummy.com">
+    <listOfListsOfItems>
+        <v>
+            <someItem>
+                <name>First Item</name>
+            </someItem>
+            <anotherItem>
+                <serialNumber>1001</serialNumber>
+            </anotherItem>
+        </v>
+
+        <v>
+            <anotherItem>
+                <serialNumber>2002</serialNumber>
+            </anotherItem>
+        </v>
+
+        <v>
+            <someItem>
+                <name>Third Item</name>
+            </someItem>
+        </v>
+    </listOfListsOfItems>
+</something>

--- a/dev/test_data/main/xsd/expected/list_of_lists_of_classes/expected_output/schema.xsd
+++ b/dev/test_data/main/xsd/expected/list_of_lists_of_classes/expected_output/schema.xsd
@@ -1,0 +1,65 @@
+<?xml version="1.0" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="https://dummy.com" elementFormDefault="qualified" targetNamespace="https://dummy.com">
+  <xs:group name="abstractItem">
+    <xs:sequence/>
+  </xs:group>
+  <xs:group name="abstractItem_choice">
+    <xs:choice>
+      <xs:element name="anotherItem" type="anotherItem_t"/>
+      <xs:element name="someItem" type="someItem_t"/>
+    </xs:choice>
+  </xs:group>
+  <xs:group name="anotherItem">
+    <xs:sequence>
+      <xs:group ref="abstractItem"/>
+      <xs:element name="serialNumber" type="xs:long"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="someItem">
+    <xs:sequence>
+      <xs:group ref="abstractItem"/>
+      <xs:element name="name" type="xs:string"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:group name="something">
+    <xs:sequence>
+      <xs:element name="listOfListsOfItems">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="v" minOccurs="0" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:group ref="abstractItem_choice" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="valueDataType">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+  <xs:complexType name="abstractItem_t">
+    <xs:sequence>
+      <xs:group ref="abstractItem"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="anotherItem_t">
+    <xs:sequence>
+      <xs:group ref="anotherItem"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="someItem_t">
+    <xs:sequence>
+      <xs:group ref="someItem"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="something_t">
+    <xs:sequence>
+      <xs:group ref="something"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="something" type="something_t"/>
+</xs:schema>

--- a/dev/test_data/main/xsd/expected/list_of_lists_of_classes/expected_output/stdout.txt
+++ b/dev/test_data/main/xsd/expected/list_of_lists_of_classes/expected_output/stdout.txt
@@ -1,0 +1,1 @@
+Code generated to: <output dir>

--- a/dev/test_data/main/xsd/expected/list_of_lists_of_classes/input/snippets/root_element.xml
+++ b/dev/test_data/main/xsd/expected/list_of_lists_of_classes/input/snippets/root_element.xml
@@ -1,0 +1,8 @@
+<xs:schema
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns="https://dummy.com"
+        elementFormDefault="qualified"
+        targetNamespace="https://dummy.com"
+>
+    <xs:element name="something" type="something_t" />
+</xs:schema>

--- a/dev/test_data/main/xsd/expected/list_of_lists_of_classes/meta_model.py
+++ b/dev/test_data/main/xsd/expected/list_of_lists_of_classes/meta_model.py
@@ -1,0 +1,44 @@
+from enum import Enum
+from typing import List
+
+from icontract import invariant
+
+
+# NOTE (mristin):
+# The XSD generator expects the constrained primitive Value data type to be defined
+# since we had to hard-wire it. If we remove that hard-wiring, we can also remove
+# this definition as well.
+
+class Value_data_type(str, DBC):
+    pass
+
+
+@abstract
+@serialization(with_model_type=True)
+class Abstract_item:
+    pass
+
+
+class Some_item(Abstract_item):
+    name: str
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class Another_item(Abstract_item):
+    serial_number: int
+
+    def __init__(self, serial_number: int) -> None:
+        self.serial_number = serial_number
+
+
+class Something:
+    list_of_lists_of_items: List[List[Abstract_item]]
+
+    def __init__(self, list_of_lists_of_items: List[List[Abstract_item]]) -> None:
+        self.list_of_lists_of_items = list_of_lists_of_items
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/dev/test_data/main/xsd/expected/list_of_lists_of_constrained_primitives/examples/empty/model.xml
+++ b/dev/test_data/main/xsd/expected/list_of_lists_of_constrained_primitives/examples/empty/model.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<something xmlns="https://dummy.com">
+    <listOfListsOfNames/>
+</something>

--- a/dev/test_data/main/xsd/expected/list_of_lists_of_constrained_primitives/examples/list_of_empty_lists/model.xml
+++ b/dev/test_data/main/xsd/expected/list_of_lists_of_constrained_primitives/examples/list_of_empty_lists/model.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<something xmlns="https://dummy.com">
+    <listOfListsOfNames>
+        <v/>
+        <v/>
+        <v/>
+        <v/>
+    </listOfListsOfNames>
+</something>

--- a/dev/test_data/main/xsd/expected/list_of_lists_of_constrained_primitives/examples/non_empty/model.xml
+++ b/dev/test_data/main/xsd/expected/list_of_lists_of_constrained_primitives/examples/non_empty/model.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<something xmlns="https://dummy.com">
+    <listOfListsOfNames>
+        <v>
+            <v>Alice</v>
+            <v>Bob</v>
+        </v>
+        <v>
+            <v>Charlie</v>
+        </v>
+        <v>
+            <v>Dave</v>
+            <v>Eve</v>
+            <v>Frank</v>
+        </v>
+        <v>
+            <v>Grace</v>
+            <v>Heidi</v>
+        </v>
+    </listOfListsOfNames>
+</something>

--- a/dev/test_data/main/xsd/expected/list_of_lists_of_constrained_primitives/expected_output/schema.xsd
+++ b/dev/test_data/main/xsd/expected/list_of_lists_of_constrained_primitives/expected_output/schema.xsd
@@ -1,0 +1,35 @@
+<?xml version="1.0" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="https://dummy.com" elementFormDefault="qualified" targetNamespace="https://dummy.com">
+  <xs:group name="something">
+    <xs:sequence>
+      <xs:element name="listOfListsOfNames">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="v" minOccurs="0" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="v" minOccurs="0" maxOccurs="unbounded">
+                    <xs:simpleType>
+                      <xs:restriction base="xs:string">
+                        <xs:minLength value="1"/>
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:element>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="valueDataType">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+  <xs:complexType name="something_t">
+    <xs:sequence>
+      <xs:group ref="something"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="something" type="something_t"/>
+</xs:schema>

--- a/dev/test_data/main/xsd/expected/list_of_lists_of_constrained_primitives/expected_output/stdout.txt
+++ b/dev/test_data/main/xsd/expected/list_of_lists_of_constrained_primitives/expected_output/stdout.txt
@@ -1,0 +1,1 @@
+Code generated to: <output dir>

--- a/dev/test_data/main/xsd/expected/list_of_lists_of_constrained_primitives/input/snippets/root_element.xml
+++ b/dev/test_data/main/xsd/expected/list_of_lists_of_constrained_primitives/input/snippets/root_element.xml
@@ -1,0 +1,8 @@
+<xs:schema
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns="https://dummy.com"
+        elementFormDefault="qualified"
+        targetNamespace="https://dummy.com"
+>
+    <xs:element name="something" type="something_t" />
+</xs:schema>

--- a/dev/test_data/main/xsd/expected/list_of_lists_of_constrained_primitives/meta_model.py
+++ b/dev/test_data/main/xsd/expected/list_of_lists_of_constrained_primitives/meta_model.py
@@ -1,0 +1,28 @@
+from typing import List
+
+from icontract import invariant
+
+
+# NOTE (mristin):
+# The XSD generator expects the constrained primitive Value data type to be defined
+# since we had to hard-wire it. If we remove that hard-wiring, we can also remove
+# this definition as well.
+
+class Value_data_type(str, DBC):
+    pass
+
+
+@invariant(lambda self: len(self) > 0, "Not empty")
+class Name(str):
+    pass
+
+
+class Something:
+    list_of_lists_of_names: List[List[Name]]
+
+    def __init__(self, list_of_lists_of_names: List[List[Name]]) -> None:
+        self.list_of_lists_of_names = list_of_lists_of_names
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/dev/test_data/main/xsd/expected/list_of_lists_of_enums/examples/empty/model.xml
+++ b/dev/test_data/main/xsd/expected/list_of_lists_of_enums/examples/empty/model.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<something xmlns="https://dummy.com">
+    <listOfListsOfResults/>
+</something>

--- a/dev/test_data/main/xsd/expected/list_of_lists_of_enums/examples/list_of_empty_lists/model.xml
+++ b/dev/test_data/main/xsd/expected/list_of_lists_of_enums/examples/list_of_empty_lists/model.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<something xmlns="https://dummy.com">
+    <listOfListsOfResults>
+        <v/>
+        <v/>
+        <v/>
+        <v/>
+    </listOfListsOfResults>
+</something>

--- a/dev/test_data/main/xsd/expected/list_of_lists_of_enums/examples/non_empty/model.xml
+++ b/dev/test_data/main/xsd/expected/list_of_lists_of_enums/examples/non_empty/model.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<something xmlns="https://dummy.com">
+    <listOfListsOfResults>
+        <v>
+            <v>ok</v>
+            <v>fail</v>
+        </v>
+        <v>
+            <v>ok</v>
+        </v>
+        <v>
+            <v>fail</v>
+            <v>fail</v>
+        </v>
+        <v>
+            <v>ok</v>
+            <v>ok</v>
+            <v>fail</v>
+        </v>
+    </listOfListsOfResults>
+</something>

--- a/dev/test_data/main/xsd/expected/list_of_lists_of_enums/expected_output/schema.xsd
+++ b/dev/test_data/main/xsd/expected/list_of_lists_of_enums/expected_output/schema.xsd
@@ -1,0 +1,35 @@
+<?xml version="1.0" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="https://dummy.com" elementFormDefault="qualified" targetNamespace="https://dummy.com">
+  <xs:group name="something">
+    <xs:sequence>
+      <xs:element name="listOfListsOfResults">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="v" minOccurs="0" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="v" type="result_t" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="result_t">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="ok"/>
+      <xs:enumeration value="fail"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="valueDataType">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+  <xs:complexType name="something_t">
+    <xs:sequence>
+      <xs:group ref="something"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="something" type="something_t"/>
+</xs:schema>

--- a/dev/test_data/main/xsd/expected/list_of_lists_of_enums/expected_output/stdout.txt
+++ b/dev/test_data/main/xsd/expected/list_of_lists_of_enums/expected_output/stdout.txt
@@ -1,0 +1,1 @@
+Code generated to: <output dir>

--- a/dev/test_data/main/xsd/expected/list_of_lists_of_enums/input/snippets/root_element.xml
+++ b/dev/test_data/main/xsd/expected/list_of_lists_of_enums/input/snippets/root_element.xml
@@ -1,0 +1,8 @@
+<xs:schema
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns="https://dummy.com"
+        elementFormDefault="qualified"
+        targetNamespace="https://dummy.com"
+>
+    <xs:element name="something" type="something_t" />
+</xs:schema>

--- a/dev/test_data/main/xsd/expected/list_of_lists_of_enums/meta_model.py
+++ b/dev/test_data/main/xsd/expected/list_of_lists_of_enums/meta_model.py
@@ -1,0 +1,29 @@
+from enum import Enum
+from typing import List
+
+from icontract import invariant
+
+
+# NOTE (mristin):
+# The XSD generator expects the constrained primitive Value data type to be defined
+# since we had to hard-wire it. If we remove that hard-wiring, we can also remove
+# this definition as well.
+
+class Value_data_type(str, DBC):
+    pass
+
+
+class Result(Enum):
+    Ok = "ok"
+    Fail = "fail"
+
+
+class Something:
+    list_of_lists_of_results: List[List[Result]]
+
+    def __init__(self, list_of_lists_of_results: List[List[Result]]) -> None:
+        self.list_of_lists_of_results = list_of_lists_of_results
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/dev/test_data/main/xsd/expected/list_of_lists_of_primitives/examples/empty/model.xml
+++ b/dev/test_data/main/xsd/expected/list_of_lists_of_primitives/examples/empty/model.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<something xmlns="https://dummy.com">
+    <listOfListsOfInts/>
+</something>

--- a/dev/test_data/main/xsd/expected/list_of_lists_of_primitives/examples/list_of_empty_lists/model.xml
+++ b/dev/test_data/main/xsd/expected/list_of_lists_of_primitives/examples/list_of_empty_lists/model.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<something xmlns="https://dummy.com">
+    <listOfListsOfInts>
+        <v/>
+        <v/>
+        <v/>
+        <v/>
+    </listOfListsOfInts>
+</something>

--- a/dev/test_data/main/xsd/expected/list_of_lists_of_primitives/examples/non_empty/model.xml
+++ b/dev/test_data/main/xsd/expected/list_of_lists_of_primitives/examples/non_empty/model.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<something xmlns="https://dummy.com">
+    <listOfListsOfInts>
+        <v>
+            <v>1</v>
+            <v>2</v>
+        </v>
+        <v>
+            <v>42</v>
+        </v>
+        <v>
+            <v>-7</v>
+            <v>0</v>
+            <v>999999999</v>
+        </v>
+        <v>
+            <v>123</v>
+            <v>456</v>
+        </v>
+    </listOfListsOfInts>
+</something>

--- a/dev/test_data/main/xsd/expected/list_of_lists_of_primitives/expected_output/schema.xsd
+++ b/dev/test_data/main/xsd/expected/list_of_lists_of_primitives/expected_output/schema.xsd
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="https://dummy.com" elementFormDefault="qualified" targetNamespace="https://dummy.com">
+  <xs:group name="something">
+    <xs:sequence>
+      <xs:element name="listOfListsOfInts">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="v" minOccurs="0" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:sequence>
+                  <xs:element name="v" type="xs:long" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+  <xs:simpleType name="valueDataType">
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+  <xs:complexType name="something_t">
+    <xs:sequence>
+      <xs:group ref="something"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name="something" type="something_t"/>
+</xs:schema>

--- a/dev/test_data/main/xsd/expected/list_of_lists_of_primitives/expected_output/stdout.txt
+++ b/dev/test_data/main/xsd/expected/list_of_lists_of_primitives/expected_output/stdout.txt
@@ -1,0 +1,1 @@
+Code generated to: <output dir>

--- a/dev/test_data/main/xsd/expected/list_of_lists_of_primitives/input/snippets/root_element.xml
+++ b/dev/test_data/main/xsd/expected/list_of_lists_of_primitives/input/snippets/root_element.xml
@@ -1,0 +1,8 @@
+<xs:schema
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns="https://dummy.com"
+        elementFormDefault="qualified"
+        targetNamespace="https://dummy.com"
+>
+    <xs:element name="something" type="something_t" />
+</xs:schema>

--- a/dev/test_data/main/xsd/expected/list_of_lists_of_primitives/meta_model.py
+++ b/dev/test_data/main/xsd/expected/list_of_lists_of_primitives/meta_model.py
@@ -1,0 +1,21 @@
+from typing import List
+
+
+# NOTE (mristin):
+# The XSD generator expects the constrained primitive Value data type to be defined
+# since we had to hard-wire it. If we remove that hard-wiring, we can also remove
+# this definition as well.
+
+class Value_data_type(str, DBC):
+    pass
+
+
+class Something:
+    list_of_lists_of_ints: List[List[int]]
+
+    def __init__(self, list_of_lists_of_ints: List[List[int]]) -> None:
+        self.list_of_lists_of_ints = list_of_lists_of_ints
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"

--- a/dev/tests/test_main.py
+++ b/dev/tests/test_main.py
@@ -391,6 +391,52 @@ class Test_xsd(_TestCase):
             target=aas_core_codegen.main.Target.XSD, case_name="aas_core_meta.v3"
         )
 
+    def test_expected_list_of_classes(self) -> None:
+        self._run_expected_test(
+            target=aas_core_codegen.main.Target.XSD, case_name="list_of_classes"
+        )
+
+    def test_expected_list_of_classes_with_invariants(self) -> None:
+        self._run_expected_test(
+            target=aas_core_codegen.main.Target.XSD,
+            case_name="list_of_classes_with_invariants",
+        )
+
+    def test_expected_list_of_constrained_primitives(self) -> None:
+        self._run_expected_test(
+            target=aas_core_codegen.main.Target.XSD,
+            case_name="list_of_constrained_primitives",
+        )
+
+    def test_expected_list_of_enums(self) -> None:
+        self._run_expected_test(
+            target=aas_core_codegen.main.Target.XSD, case_name="list_of_enums"
+        )
+
+    def test_expected_list_of_lists_of_classes(self) -> None:
+        self._run_expected_test(
+            target=aas_core_codegen.main.Target.XSD,
+            case_name="list_of_lists_of_classes",
+        )
+
+    def test_expected_list_of_lists_of_constrained_primitives(self) -> None:
+        self._run_expected_test(
+            target=aas_core_codegen.main.Target.XSD,
+            case_name="list_of_lists_of_constrained_primitives",
+        )
+
+    def test_expected_list_of_lists_of_enums(self) -> None:
+        self._run_expected_test(
+            target=aas_core_codegen.main.Target.XSD,
+            case_name="list_of_lists_of_enums",
+        )
+
+    def test_expected_list_of_lists_of_primitives(self) -> None:
+        self._run_expected_test(
+            target=aas_core_codegen.main.Target.XSD,
+            case_name="list_of_lists_of_primitives",
+        )
+
     def test_expected_list_of_primitives(self) -> None:
         self._run_expected_test(
             target=aas_core_codegen.main.Target.XSD, case_name="list_of_primitives"


### PR DESCRIPTION
We add the support for list of non-optionals in the generator for XSD schemas. That is, with this change, we support lists of constrained primitives, lists of lists *etc.*