### PR TITLE
Fix Python tests for test data

### DIFF
--- a/aas_core_codegen/python/tests/_generate_common.py
+++ b/aas_core_codegen/python/tests/_generate_common.py
@@ -55,7 +55,7 @@ import {qualified_module_name}.types as aas_types"""
         ),
         Stripped(
             """\
-_REPO_ROOT = pathlib.Path(os.path.realpath(__file__)).parent.parent"""
+_REPO_ROOT = pathlib.Path(os.path.realpath(__file__)).parent.parent.parent"""
         ),
         Stripped(
             '''\

--- a/aas_core_codegen/python/tests/_generate_test_descend_and_pass_through_visitor.py
+++ b/aas_core_codegen/python/tests/_generate_test_descend_and_pass_through_visitor.py
@@ -51,6 +51,7 @@ import {qualified_module_name}.types as aas_types"""
         ),
         Stripped(
             """\
+import tests.common
 import tests.common_xmlization"""
         ),
         Stripped(

--- a/aas_core_codegen/python/tests/_generate_test_for_over_x_or_empty.py
+++ b/aas_core_codegen/python/tests/_generate_test_for_over_x_or_empty.py
@@ -133,6 +133,7 @@ import {qualified_module_name}.types as aas_types"""
         ),
         Stripped(
             """\
+import tests.common
 import tests.common_xmlization"""
         ),
     ]

--- a/aas_core_codegen/python/tests/_generate_test_for_x_or_default.py
+++ b/aas_core_codegen/python/tests/_generate_test_for_x_or_default.py
@@ -127,6 +127,7 @@ import {qualified_module_name}.types as aas_types"""
         ),
         Stripped(
             """\
+import tests.common
 import tests.common_xmlization"""
         ),
     ]

--- a/aas_core_codegen/python/tests/_generate_test_jsonization_of_classes_with_descendants.py
+++ b/aas_core_codegen/python/tests/_generate_test_jsonization_of_classes_with_descendants.py
@@ -124,6 +124,7 @@ import {qualified_module_name}.jsonization as aas_jsonization"""
         ),
         Stripped(
             """\
+import tests.common
 import tests.common_jsonization"""
         ),
         _generate_test_case(symbol_table=symbol_table),

--- a/aas_core_codegen/python/tests/_generate_test_jsonization_of_concrete_classes.py
+++ b/aas_core_codegen/python/tests/_generate_test_jsonization_of_concrete_classes.py
@@ -105,6 +105,7 @@ import {qualified_module_name}.jsonization as aas_jsonization"""
         ),
         Stripped(
             """\
+import tests.common
 import tests.common_jsonization"""
         ),
         _generate_test_case(symbol_table=symbol_table),

--- a/aas_core_codegen/python/tests/_generate_test_xmlization_of_classes_with_descendants.py
+++ b/aas_core_codegen/python/tests/_generate_test_xmlization_of_classes_with_descendants.py
@@ -149,6 +149,7 @@ import {qualified_module_name}.xmlization as aas_xmlization"""
         ),
         Stripped(
             """\
+import tests.common
 import tests.common_xmlization"""
         ),
         _generate_test_case(symbol_table=symbol_table),

--- a/aas_core_codegen/python/tests/_generate_test_xmlization_of_concrete_classes.py
+++ b/aas_core_codegen/python/tests/_generate_test_xmlization_of_concrete_classes.py
@@ -151,6 +151,7 @@ import {qualified_module_name}.xmlization as aas_xmlization"""
         ),
         Stripped(
             """\
+import tests.common
 import tests.common_xmlization"""
         ),
         _generate_test_case(symbol_table=symbol_table),

--- a/dev/live_tests/live_test_python.py
+++ b/dev/live_tests/live_test_python.py
@@ -288,16 +288,27 @@ disable=too-few-public-methods,len-as-condition,duplicate-code,no-else-raise,no-
                 # well.
                 env.pop("PYTHONPATH", None)
 
-                env_var_test_data_dir = f"{env_var_prefix}_TEST_DATA_DIR"
                 env_var_test_record_mode = f"{env_var_prefix}_TESTS_RECORD_MODE"
-
-                env[env_var_test_data_dir] = str(project_dir / "test_data")
                 env[env_var_test_record_mode] = "1"
 
                 print(
                     f"Running "
-                    f"{env_var_test_data_dir}"
-                    f"={env.get(env_var_test_data_dir)} "
+                    f"{env_var_test_record_mode}"
+                    f"={env.get(env_var_test_record_mode)} "
+                    f"{live_tests_common.escape_and_join_command(cmd)} "
+                    f"in {project_dir}"
+                )
+                subprocess.check_call(cmd, cwd=project_dir, env=env)
+
+                # NOTE (mristin):
+                # Parts of the Python tests were accessing tests.common which was not
+                # properly imported. We only run mypy on the library, but not on tests,
+                # so that bug remained uncovered in the live tests. We now re-run
+                # the tests against the recorded traces to avoid the regression.
+
+                env[env_var_test_record_mode] = "0"
+                print(
+                    f"Running the tests again without re-recording with "
                     f"{env_var_test_record_mode}"
                     f"={env.get(env_var_test_record_mode)} "
                     f"{live_tests_common.escape_and_join_command(cmd)} "

--- a/dev/test_data/live_tests/python/test_data/primitive_types/Xml/Expected/something/minimal.xml
+++ b/dev/test_data/live_tests/python/test_data/primitive_types/Xml/Expected/something/minimal.xml
@@ -1,1 +1,1 @@
-<something xmlns="https://dummy.com"><someBool>true</someBool><someInt>1234</someInt><someFloat>34.230000</someFloat><someString>hello world</someString><someBytes>SGVsbG8gV29ybGQ=</someBytes></something>
+<something xmlns="https://dummy.com"><someBool>true</someBool><someInt>1234</someInt><someFloat>34.23</someFloat><someString>hello world</someString><someBytes>SGVsbG8gV29ybGQ=</someBytes></something>

--- a/dev/test_data/main/python/expected/aas_core_meta.v3/expected_output/dev/tests/common.py
+++ b/dev/test_data/main/python/expected/aas_core_meta.v3/expected_output/dev/tests/common.py
@@ -20,7 +20,7 @@ import aas_core3.common as aas_common
 import aas_core3.types as aas_types
 
 
-_REPO_ROOT = pathlib.Path(os.path.realpath(__file__)).parent.parent
+_REPO_ROOT = pathlib.Path(os.path.realpath(__file__)).parent.parent.parent
 
 
 #: Path to the directory which contains input and golden files

--- a/dev/test_data/main/python/expected/aas_core_meta.v3/expected_output/dev/tests/test_descend_and_pass_through_visitor.py
+++ b/dev/test_data/main/python/expected/aas_core_meta.v3/expected_output/dev/tests/test_descend_and_pass_through_visitor.py
@@ -21,6 +21,7 @@ import unittest
 import aas_core3.types as aas_types
 
 
+import tests.common
 import tests.common_xmlization
 
 

--- a/dev/test_data/main/python/expected/aas_core_meta.v3/expected_output/dev/tests/test_for_over_X_or_empty.py
+++ b/dev/test_data/main/python/expected/aas_core_meta.v3/expected_output/dev/tests/test_for_over_X_or_empty.py
@@ -15,6 +15,7 @@ import unittest
 import aas_core3.types as aas_types
 
 
+import tests.common
 import tests.common_xmlization
 
 

--- a/dev/test_data/main/python/expected/aas_core_meta.v3/expected_output/dev/tests/test_for_x_or_default.py
+++ b/dev/test_data/main/python/expected/aas_core_meta.v3/expected_output/dev/tests/test_for_x_or_default.py
@@ -15,6 +15,7 @@ import unittest
 import aas_core3.types as aas_types
 
 
+import tests.common
 import tests.common_xmlization
 
 

--- a/dev/test_data/main/python/expected/aas_core_meta.v3/expected_output/dev/tests/test_jsonization_of_classes_with_descendants.py
+++ b/dev/test_data/main/python/expected/aas_core_meta.v3/expected_output/dev/tests/test_jsonization_of_classes_with_descendants.py
@@ -15,6 +15,7 @@ import unittest
 import aas_core3.jsonization as aas_jsonization
 
 
+import tests.common
 import tests.common_jsonization
 
 

--- a/dev/test_data/main/python/expected/aas_core_meta.v3/expected_output/dev/tests/test_jsonization_of_concrete_classes.py
+++ b/dev/test_data/main/python/expected/aas_core_meta.v3/expected_output/dev/tests/test_jsonization_of_concrete_classes.py
@@ -15,6 +15,7 @@ import unittest
 import aas_core3.jsonization as aas_jsonization
 
 
+import tests.common
 import tests.common_jsonization
 
 

--- a/dev/test_data/main/python/expected/aas_core_meta.v3/expected_output/dev/tests/test_xmlization_of_classes_with_descendants.py
+++ b/dev/test_data/main/python/expected/aas_core_meta.v3/expected_output/dev/tests/test_xmlization_of_classes_with_descendants.py
@@ -18,6 +18,7 @@ import xml.etree.ElementTree as ET
 import aas_core3.xmlization as aas_xmlization
 
 
+import tests.common
 import tests.common_xmlization
 
 

--- a/dev/test_data/main/python/expected/aas_core_meta.v3/expected_output/dev/tests/test_xmlization_of_concrete_classes.py
+++ b/dev/test_data/main/python/expected/aas_core_meta.v3/expected_output/dev/tests/test_xmlization_of_concrete_classes.py
@@ -18,6 +18,7 @@ import xml.etree.ElementTree as ET
 import aas_core3.xmlization as aas_xmlization
 
 
+import tests.common
 import tests.common_xmlization
 
 

--- a/dev/test_data/main/python/expected/primitive_types/expected_output/dev/tests/common.py
+++ b/dev/test_data/main/python/expected/primitive_types/expected_output/dev/tests/common.py
@@ -20,7 +20,7 @@ import dummy.common as aas_common
 import dummy.types as aas_types
 
 
-_REPO_ROOT = pathlib.Path(os.path.realpath(__file__)).parent.parent
+_REPO_ROOT = pathlib.Path(os.path.realpath(__file__)).parent.parent.parent
 
 
 #: Path to the directory which contains input and golden files

--- a/dev/test_data/main/python/expected/primitive_types/expected_output/dev/tests/test_descend_and_pass_through_visitor.py
+++ b/dev/test_data/main/python/expected/primitive_types/expected_output/dev/tests/test_descend_and_pass_through_visitor.py
@@ -21,6 +21,7 @@ import unittest
 import dummy.types as aas_types
 
 
+import tests.common
 import tests.common_xmlization
 
 

--- a/dev/test_data/main/python/expected/primitive_types/expected_output/dev/tests/test_for_over_X_or_empty.py
+++ b/dev/test_data/main/python/expected/primitive_types/expected_output/dev/tests/test_for_over_X_or_empty.py
@@ -15,6 +15,7 @@ import unittest
 import dummy.types as aas_types
 
 
+import tests.common
 import tests.common_xmlization
 
 

--- a/dev/test_data/main/python/expected/primitive_types/expected_output/dev/tests/test_for_x_or_default.py
+++ b/dev/test_data/main/python/expected/primitive_types/expected_output/dev/tests/test_for_x_or_default.py
@@ -15,6 +15,7 @@ import unittest
 import dummy.types as aas_types
 
 
+import tests.common
 import tests.common_xmlization
 
 

--- a/dev/test_data/main/python/expected/primitive_types/expected_output/dev/tests/test_jsonization_of_classes_with_descendants.py
+++ b/dev/test_data/main/python/expected/primitive_types/expected_output/dev/tests/test_jsonization_of_classes_with_descendants.py
@@ -15,6 +15,7 @@ import unittest
 import dummy.jsonization as aas_jsonization
 
 
+import tests.common
 import tests.common_jsonization
 
 

--- a/dev/test_data/main/python/expected/primitive_types/expected_output/dev/tests/test_jsonization_of_concrete_classes.py
+++ b/dev/test_data/main/python/expected/primitive_types/expected_output/dev/tests/test_jsonization_of_concrete_classes.py
@@ -15,6 +15,7 @@ import unittest
 import dummy.jsonization as aas_jsonization
 
 
+import tests.common
 import tests.common_jsonization
 
 

--- a/dev/test_data/main/python/expected/primitive_types/expected_output/dev/tests/test_xmlization_of_classes_with_descendants.py
+++ b/dev/test_data/main/python/expected/primitive_types/expected_output/dev/tests/test_xmlization_of_classes_with_descendants.py
@@ -18,6 +18,7 @@ import xml.etree.ElementTree as ET
 import dummy.xmlization as aas_xmlization
 
 
+import tests.common
 import tests.common_xmlization
 
 

--- a/dev/test_data/main/python/expected/primitive_types/expected_output/dev/tests/test_xmlization_of_concrete_classes.py
+++ b/dev/test_data/main/python/expected/primitive_types/expected_output/dev/tests/test_xmlization_of_concrete_classes.py
@@ -18,6 +18,7 @@ import xml.etree.ElementTree as ET
 import dummy.xmlization as aas_xmlization
 
 
+import tests.common
 import tests.common_xmlization
 
 


### PR DESCRIPTION
We fix the generator for Python tests which was missing a couple of import statements. The omission was not revelead until we ran the tests again *without* re-recording -- the re-recording in the tests masked the issue as they did not access the modules which were not properly imported.

Moreover, the test data pointed in the generated test code was wrong, so basically generated unit tests were running against empty data.