### PR TITLE
Release 0.0.24

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,15 @@
     Please keep this file at 72 line width so that we can copy-paste
     the release logs directly into commit messages.
 
+0.0.24 (2026-05-15)
+===================
+* Improve coverage for TypeScript test data gen (#630)
+* Add support for list of primitives in Python (#625)
+
+In this version we greatly improves the coverage of Xmlization for 
+TypeScript. This way we fixed a blocking issue for the TypeScript SDK 
+generation due to too little coverage.
+
 0.0.23 (2026-05-08)
 ===================
 * Add generation of test code for Java (#599)

--- a/aas_core_codegen/__init__.py
+++ b/aas_core_codegen/__init__.py
@@ -1,6 +1,6 @@
 """Generate implementations and schemas based on an AAS meta-model."""
 
-__version__ = "0.0.23"
+__version__ = "0.0.24"
 __author__ = "Marko Ristin, Nico Braunisch"
 __license__ = "License :: OSI Approved :: MIT License"
 __status__ = "Production/Stable"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "aas-core-codegen"
 # NOTE (mristin):
 # Do not forget to update the CHANGELOG.rst and __init__.py!
-version = "0.0.23"
+version = "0.0.24"
 description = "Generate implementations and schemas based on an AAS meta-model."
 readme = "README.rst"
 authors = [


### PR DESCRIPTION
* Improve coverage for TypeScript test data gen (#630)
* Add support for list of primitives in Python (#625)

In this version we greatly improves the coverage of Xmlization for TypeScript. This way we fixed a blocking issue for the TypeScript SDK generation due to too little coverage.