### PR TITLE
Release 0.0.25

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,15 @@
     Please keep this file at 72 line width so that we can copy-paste
     the release logs directly into commit messages.
 
+0.0.25 (2026-05-19)
+===================
+* Increase TypeScript SDK Code Coverage (#632)
+
+The previous release, 0.0.24, did not provide sufficient code coverage
+for the TypeScript SDK, but that was revealed only once we already
+released 0.0.24 and ran the continuous integration of the TypeScript
+SDK.
+
 0.0.24 (2026-05-15)
 ===================
 * Improve coverage for TypeScript test data gen (#630)

--- a/aas_core_codegen/__init__.py
+++ b/aas_core_codegen/__init__.py
@@ -1,6 +1,6 @@
 """Generate implementations and schemas based on an AAS meta-model."""
 
-__version__ = "0.0.24"
+__version__ = "0.0.25"
 __author__ = "Marko Ristin, Nico Braunisch"
 __license__ = "License :: OSI Approved :: MIT License"
 __status__ = "Production/Stable"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "aas-core-codegen"
 # NOTE (mristin):
 # Do not forget to update the CHANGELOG.rst and __init__.py!
-version = "0.0.24"
+version = "0.0.25"
 description = "Generate implementations and schemas based on an AAS meta-model."
 readme = "README.rst"
 authors = [


### PR DESCRIPTION
* Increase TypeScript SDK Code Coverage (#632)

The previous release, 0.0.24, did not provide sufficient code coverage for the TypeScript SDK, but that was revealed only once we already released 0.0.24 and ran the continuous integration of the TypeScript SDK.