### PR TITLE
Upgrade mypy to 2.1.0

### DIFF
--- a/aas_core_codegen/cpp/lib/_generate_constants.py
+++ b/aas_core_codegen/cpp/lib/_generate_constants.py
@@ -147,7 +147,7 @@ const std::wstring {constant_name} = (
         )
 
     elif constant.a_type is intermediate.PrimitiveType.BYTEARRAY:
-        assert isinstance(constant.value, bytearray)
+        assert isinstance(constant.value, bytes)
 
         literal, _ = cpp_common.bytes_literal(value=constant.value)
 
@@ -275,7 +275,7 @@ std::unordered_set<
         )
 
         for literal in constant.literals:
-            assert isinstance(literal.value, bytearray)
+            assert isinstance(literal.value, bytes)
             literal_code, _ = cpp_common.bytes_literal(literal.value)
             literal_codes.append(literal_code)
 

--- a/aas_core_codegen/intermediate/_translate.py
+++ b/aas_core_codegen/intermediate/_translate.py
@@ -92,9 +92,9 @@ from aas_core_codegen.intermediate._types import (
     DescriptionOfConstant,
     ConstantUnion,
     ConstantPrimitive,
-    PYTHON_TYPE_TO_PRIMITIVE_TYPE,
     ConstantSetOfPrimitives,
     PRIMITIVE_TYPE_TO_PYTHON_TYPE,
+    PYTHON_CONSTANT_TYPE_TO_PRIMITIVE_TYPE,
     PrimitiveSetLiteral,
     ConstantSetOfEnumerationLiterals,
     Constant,
@@ -1948,7 +1948,7 @@ def _to_constant_primitive(
     parsed: parse.ConstantPrimitive,
 ) -> Tuple[Optional[ConstantPrimitive], Optional[List[Error]]]:
     """Translate the parsed to an intermediate constant primitive."""
-    a_type = PYTHON_TYPE_TO_PRIMITIVE_TYPE.get(type(parsed.value), None)
+    a_type = PYTHON_CONSTANT_TYPE_TO_PRIMITIVE_TYPE.get(type(parsed.value), None)
     if a_type is None:
         return None, [
             Error(

--- a/aas_core_codegen/intermediate/_types.py
+++ b/aas_core_codegen/intermediate/_types.py
@@ -91,6 +91,16 @@ assert (
 )
 # fmt: on
 
+PYTHON_CONSTANT_TYPE_TO_PRIMITIVE_TYPE: Mapping[
+    Union[Type[bool], Type[int], Type[float], Type[str], Type[bytes]], PrimitiveType
+] = {
+    bool: PrimitiveType.BOOL,
+    int: PrimitiveType.INT,
+    float: PrimitiveType.FLOAT,
+    str: PrimitiveType.STR,
+    bytes: PrimitiveType.BYTEARRAY,
+}
+
 
 class TypeAnnotation(DBC):
     """Represent a general type annotation."""
@@ -2004,7 +2014,7 @@ class ConstantPrimitive(Constant):
     """Represent a constant primitive value in the meta-model."""
 
     #: Value of the constant
-    value: Union[bool, int, float, str, bytearray]
+    value: Union[bool, int, float, str, bytes]
 
     #: Type of the constant
     a_type: Final[PrimitiveType]
@@ -2022,7 +2032,7 @@ class ConstantPrimitive(Constant):
     def __init__(
         self,
         name: Identifier,
-        value: Union[bool, int, float, str, bytearray],
+        value: Union[bool, int, float, str, bytes],
         a_type: PrimitiveType,
         description: Optional[DescriptionOfConstant],
         parsed: parse.ConstantPrimitive,

--- a/aas_core_codegen/parse/_translate.py
+++ b/aas_core_codegen/parse/_translate.py
@@ -194,7 +194,7 @@ def _type_annotation(
             return (
                 None,
                 Error(
-                    node.value,
+                    node,
                     f"Expected a string literal "
                     f"if the type annotation is given as a constant, "
                     f"but got: "
@@ -1119,7 +1119,15 @@ def _parse_snapshot(
             ),
         )
 
+    name: str
     if name_node is not None:
+        assert isinstance(name_node, ast.Constant) and isinstance(
+            name_node.value, str
+        ), (
+            "We checked for this above -- "
+            "if name node is set, it must be a string literal."
+        )
+
         name = name_node.value
     elif len(capture_node.args.args) == 1 and name_node is None:
         name = capture_node.args.args[0].arg
@@ -1668,7 +1676,7 @@ def _class_decorator_to_serialization(
                 Error(
                     with_model_type_node,
                     f"Expected the value for ``with_model_type`` parameter "
-                    f"to be a boolean, but got: {with_model_type_node.value}",
+                    f"to be a boolean, but got: {with_model_type_node.value!r}",
                 ),
             )
 
@@ -1921,7 +1929,7 @@ def _classdef_to_enumeration(
                     Error(
                         assign.value,
                         f"Expected a string literal in the enumeration, "
-                        f"but got: {assign.value.value}",
+                        f"but got: {assign.value.value!r}",
                     ),
                 )
 

--- a/aas_core_codegen/parse/_types.py
+++ b/aas_core_codegen/parse/_types.py
@@ -147,12 +147,12 @@ class Constant(DBC):
 class ConstantPrimitive(Constant):
     """Represent a constant value in the meta-model of primitive type."""
 
-    value: Final[Union[bool, int, float, str, bytearray]]
+    value: Final[Union[bool, int, float, str, bytes]]
 
     def __init__(
         self,
         name: Identifier,
-        value: Union[bool, int, float, str, bytearray],
+        value: Union[bool, int, float, str, bytes],
         description: Optional[Description],
         node: ast.AnnAssign,
     ) -> None:

--- a/aas_core_codegen/parse/retree/_types.py
+++ b/aas_core_codegen/parse/retree/_types.py
@@ -116,7 +116,7 @@ class Term(Node):
     @require(
         lambda value, quantifier:
         not (
-                value is Symbol
+                isinstance(value, Symbol)
                 and (
                         value.kind is SymbolKind.START
                         or value.kind is SymbolKind.END

--- a/aas_core_codegen/xsd/main.py
+++ b/aas_core_codegen/xsd/main.py
@@ -926,11 +926,16 @@ def _generate(
             )
         ]
 
-    # NOTE (mristin, 2022-03-30):
+    # NOTE (mristin):
     # We need to use minidom to extract the ``xmlns`` property as ElementTree removes
     # it.
     # noinspection PyUnresolvedReferences
     minidom_doc = xml.dom.minidom.parseString(root_element_as_text)
+
+    assert minidom_doc.documentElement is not None, (
+        "We expect the root element, which is stringified from ET, to be parsed "
+        "successfully."
+    )
 
     if not minidom_doc.documentElement.hasAttribute("xmlns"):
         return None, [

--- a/dev/pyproject.toml
+++ b/dev/pyproject.toml
@@ -10,7 +10,8 @@ requires-python = ">=3.10"
 
 dependencies = [
     "black==22.3.0",
-    "mypy==1.9.0",
+    "mypy==1.19.1; python_version == '3.9'",
+    "mypy==2.1.0; python_version >= '3.10'",
     "pylint==3.3.8",
     "pydocstyle>=2.1.1,<3",
     "coverage>=4.5.1,<5",

--- a/dev/tests/golang/test_common.py
+++ b/dev/tests/golang/test_common.py
@@ -24,25 +24,23 @@ class TestStringLiteral(unittest.TestCase):
 
 class TestBytesLiteral(unittest.TestCase):
     def test_empty(self) -> None:
-        self.assertTupleEqual(
-            ("[...]byte{}", False), golang_common.bytes_literal(bytearray(b""))
-        )
+        self.assertTupleEqual(("[...]byte{}", False), golang_common.bytes_literal(b""))
 
     def test_one(self) -> None:
         self.assertTupleEqual(
             ("[...]byte{0x00}", False),
-            golang_common.bytes_literal(bytearray(b"\x00")),
+            golang_common.bytes_literal(b"\x00"),
         )
 
     def test_eight(self) -> None:
         self.assertTupleEqual(
             ("[...]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}", False),
-            golang_common.bytes_literal(bytearray(b"\x00\x01\x02\x03\x04\x05\x06\x07")),
+            golang_common.bytes_literal(b"\x00\x01\x02\x03\x04\x05\x06\x07"),
         )
 
     def test_nine(self) -> None:
         code, multiline = golang_common.bytes_literal(
-            bytearray(b"\x00\x01\x02\x03\x04\x05\x06\x07\x08")
+            b"\x00\x01\x02\x03\x04\x05\x06\x07\x08"
         )
 
         self.assertEqual(
@@ -57,9 +55,7 @@ class TestBytesLiteral(unittest.TestCase):
 
     def test_sixteen(self) -> None:
         code, multiline = golang_common.bytes_literal(
-            bytearray(
-                b"\x00\x01\x02\x03\x04\x05\x06\x07" b"\x08\x09\x10\x11\x12\x13\x14\x15"
-            )
+            b"\x00\x01\x02\x03\x04\x05\x06\x07" b"\x08\x09\x10\x11\x12\x13\x14\x15"
         )
 
         self.assertEqual(

--- a/dev/tests/python/test_common.py
+++ b/dev/tests/python/test_common.py
@@ -75,19 +75,15 @@ class TestStringLiteral(unittest.TestCase):
 
 class TestBytesLiteral(unittest.TestCase):
     def test_empty(self) -> None:
-        self.assertTupleEqual(
-            ('b""', False), python_common.bytes_literal(bytearray(b""))
-        )
+        self.assertTupleEqual(('b""', False), python_common.bytes_literal(b""))
 
     def test_one(self) -> None:
-        self.assertTupleEqual(
-            ('b"\\x00"', False), python_common.bytes_literal(bytearray(b"\x00"))
-        )
+        self.assertTupleEqual(('b"\\x00"', False), python_common.bytes_literal(b"\x00"))
 
     def test_eight(self) -> None:
         self.assertTupleEqual(
             ('b"\\x00\\x01\\x02\\x03\\x04\\x05\\x06\\x07"', False),
-            python_common.bytes_literal(bytearray(b"\x00\x01\x02\x03\x04\x05\x06\x07")),
+            python_common.bytes_literal(b"\x00\x01\x02\x03\x04\x05\x06\x07"),
         )
 
     def test_nine(self) -> None:
@@ -98,9 +94,7 @@ b"\\x00\\x01\\x02\\x03\\x04\\x05\\x06\\x07"
 b"\\x08"''',
                 True,
             ),
-            python_common.bytes_literal(
-                bytearray(b"\x00\x01\x02\x03\x04\x05\x06\x07\x08")
-            ),
+            python_common.bytes_literal(b"\x00\x01\x02\x03\x04\x05\x06\x07\x08"),
         )
 
     def test_sixteen(self) -> None:
@@ -112,10 +106,7 @@ b"\\x08\\x09\\x10\\x11\\x12\\x13\\x14\\x15"''',
                 True,
             ),
             python_common.bytes_literal(
-                bytearray(
-                    b"\x00\x01\x02\x03\x04\x05\x06\x07"
-                    b"\x08\x09\x10\x11\x12\x13\x14\x15"
-                )
+                b"\x00\x01\x02\x03\x04\x05\x06\x07" b"\x08\x09\x10\x11\x12\x13\x14\x15"
             ),
         )
 

--- a/dev/tests/typescript/test_common.py
+++ b/dev/tests/typescript/test_common.py
@@ -49,26 +49,24 @@ class TestStringLiteral(unittest.TestCase):
 class TestBytesLiteral(unittest.TestCase):
     def test_empty(self) -> None:
         self.assertTupleEqual(
-            ("new Uint8Array()", False), typescript_common.bytes_literal(bytearray(b""))
+            ("new Uint8Array()", False), typescript_common.bytes_literal(b"")
         )
 
     def test_one(self) -> None:
         self.assertTupleEqual(
             ("new Uint8Array([0x00])", False),
-            typescript_common.bytes_literal(bytearray(b"\x00")),
+            typescript_common.bytes_literal(bytes(b"\x00")),
         )
 
     def test_eight(self) -> None:
         self.assertTupleEqual(
             ("new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07])", False),
-            typescript_common.bytes_literal(
-                bytearray(b"\x00\x01\x02\x03\x04\x05\x06\x07")
-            ),
+            typescript_common.bytes_literal(bytes(b"\x00\x01\x02\x03\x04\x05\x06\x07")),
         )
 
     def test_nine(self) -> None:
         code, multiline = typescript_common.bytes_literal(
-            bytearray(b"\x00\x01\x02\x03\x04\x05\x06\x07\x08")
+            bytes(b"\x00\x01\x02\x03\x04\x05\x06\x07\x08")
         )
 
         self.assertEqual(
@@ -85,7 +83,7 @@ new Uint8Array(
 
     def test_sixteen(self) -> None:
         code, multiline = typescript_common.bytes_literal(
-            bytearray(
+            bytes(
                 b"\x00\x01\x02\x03\x04\x05\x06\x07" b"\x08\x09\x10\x11\x12\x13\x14\x15"
             )
         )


### PR DESCRIPTION
We upgrade to the latest version of mypy to be able to use type narrowing on ``x in c`` for when ``x`` is a literal and ``c`` a constant tuple of literals.