### PR TITLE
Remove support for Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@master

--- a/dev/pyproject.toml
+++ b/dev/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "aas-core-codegen-dev"
 version = "0.0.1"
 description = "Develop aas-core-codegen."
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 
 dependencies = [
     "black==22.3.0",
@@ -31,10 +31,6 @@ packages = [
     "continuous_integration",
     "live_tests"
 ]
-
-[tool.black]
-line-length = 88
-target-version = ["py38"]
 
 # NOTE (mristin):
 # We put the configuration of mypy and pylint in separate files as it is a nightmare

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,11 @@ keywords = ["asset administration shell", "code generation", "industry 4.0", "in
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "asttokens>=2.0.8,<3",
     # NOTE (mristin):


### PR DESCRIPTION
Python 3.9 is not supported by mypy and many other tools anymore, so we remove its support as well.