### PR TITLE
Unify XML serialization of doubles

### DIFF
--- a/aas_core_codegen/cpp/lib/_generate_xmlization.py
+++ b/aas_core_codegen/cpp/lib/_generate_xmlization.py
@@ -3997,8 +3997,13 @@ void SelfClosingWriter::SerializeDouble(
 {I}}} else if(std::isnan(value)) {{
 {II}WriteStringWithoutEscapingNorFlushing("NaN");
 {I}}} else {{
+{II}// NOTE (mristin):
+{II}// We have to use a stream to avoid trailing zeros. std::to_string always
+{II}// outputs trailing zeros up to a certain number of decimal places (usually 6).
+{II}std::ostringstream oss;
+{II}oss << value;
 {II}WriteStringWithoutEscapingNorFlushing(
-{III}std::to_string(value)
+{III}oss.str()
 {II});
 {I}}}
 }}"""

--- a/dev/test_data/live_tests/cpp/test_data/primitive_types/Xml/Expected/something/maximal.xml
+++ b/dev/test_data/live_tests/cpp/test_data/primitive_types/Xml/Expected/something/maximal.xml
@@ -1,1 +1,1 @@
-<something xmlns="https://dummy.com"><someBool>true</someBool><someInt>1234</someInt><someFloat>34.230000</someFloat><someString>hello world</someString><someBytes>SGVsbG8gV29ybGQ=</someBytes></something>
+<something xmlns="https://dummy.com"><someBool>true</someBool><someInt>1234</someInt><someFloat>34.23</someFloat><someString>hello world</someString><someBytes>SGVsbG8gV29ybGQ=</someBytes></something>

--- a/dev/test_data/live_tests/cpp/test_data/primitive_types/Xml/Expected/something/minimal.xml
+++ b/dev/test_data/live_tests/cpp/test_data/primitive_types/Xml/Expected/something/minimal.xml
@@ -1,1 +1,1 @@
-<something xmlns="https://dummy.com"><someBool>true</someBool><someInt>1234</someInt><someFloat>34.230000</someFloat><someString>hello world</someString><someBytes>SGVsbG8gV29ybGQ=</someBytes></something>
+<something xmlns="https://dummy.com"><someBool>true</someBool><someInt>1234</someInt><someFloat>34.23</someFloat><someString>hello world</someString><someBytes>SGVsbG8gV29ybGQ=</someBytes></something>

--- a/dev/test_data/live_tests/csharp/test_data/constrained_primitives/Xml/Expected/something/minimal.xml
+++ b/dev/test_data/live_tests/csharp/test_data/constrained_primitives/Xml/Expected/something/minimal.xml
@@ -1,1 +1,1 @@
-<something xmlns="https://dummy.com"><someBool>true</someBool><someInt>1234</someInt><someFloat>34.230000</someFloat><someString>hello world</someString><someBytes>SGVsbG8gV29ybGQ=</someBytes></something>
+<something xmlns="https://dummy.com"><someBool>true</someBool><someInt>1234</someInt><someFloat>34.23</someFloat><someString>hello world</someString><someBytes>SGVsbG8gV29ybGQ=</someBytes></something>

--- a/dev/test_data/live_tests/csharp/test_data/constrained_primitives/Xml/Unexpected/Invalid/ConstrainViolated/something/some_bool_violated.xml
+++ b/dev/test_data/live_tests/csharp/test_data/constrained_primitives/Xml/Unexpected/Invalid/ConstrainViolated/something/some_bool_violated.xml
@@ -1,1 +1,1 @@
-<something xmlns="https://dummy.com"><someBool>false</someBool><someInt>1234</someInt><someFloat>34.230000</someFloat><someString>hello world</someString><someBytes>SGVsbG8gV29ybGQ=</someBytes></something>
+<something xmlns="https://dummy.com"><someBool>false</someBool><someInt>1234</someInt><someFloat>34.23</someFloat><someString>hello world</someString><someBytes>SGVsbG8gV29ybGQ=</someBytes></something>

--- a/dev/test_data/live_tests/csharp/test_data/primitive_types/Xml/Expected/something/maximal.xml
+++ b/dev/test_data/live_tests/csharp/test_data/primitive_types/Xml/Expected/something/maximal.xml
@@ -1,1 +1,1 @@
-<something xmlns="https://dummy.com"><someBool>true</someBool><someInt>1234</someInt><someFloat>34.230000</someFloat><someString>hello world</someString><someBytes>SGVsbG8gV29ybGQ=</someBytes></something>
+<something xmlns="https://dummy.com"><someBool>true</someBool><someInt>1234</someInt><someFloat>34.23</someFloat><someString>hello world</someString><someBytes>SGVsbG8gV29ybGQ=</someBytes></something>

--- a/dev/test_data/live_tests/csharp/test_data/primitive_types/Xml/Expected/something/minimal.xml
+++ b/dev/test_data/live_tests/csharp/test_data/primitive_types/Xml/Expected/something/minimal.xml
@@ -1,1 +1,1 @@
-<something xmlns="https://dummy.com"><someBool>true</someBool><someInt>1234</someInt><someFloat>34.230000</someFloat><someString>hello world</someString><someBytes>SGVsbG8gV29ybGQ=</someBytes></something>
+<something xmlns="https://dummy.com"><someBool>true</someBool><someInt>1234</someInt><someFloat>34.23</someFloat><someString>hello world</someString><someBytes>SGVsbG8gV29ybGQ=</someBytes></something>

--- a/dev/test_data/live_tests/golang/test_data/constrained_primitives/Xml/Expected/something/minimal.xml
+++ b/dev/test_data/live_tests/golang/test_data/constrained_primitives/Xml/Expected/something/minimal.xml
@@ -1,1 +1,1 @@
-<something xmlns="https://dummy.com"><someBool>true</someBool><someInt>1234</someInt><someFloat>34.230000</someFloat><someString>hello world</someString><someBytes>SGVsbG8gV29ybGQ=</someBytes></something>
+<something xmlns="https://dummy.com"><someBool>true</someBool><someInt>1234</someInt><someFloat>34.23</someFloat><someString>hello world</someString><someBytes>SGVsbG8gV29ybGQ=</someBytes></something>

--- a/dev/test_data/live_tests/golang/test_data/constrained_primitives/Xml/Unexpected/Invalid/ConstrainViolated/something/some_bool_violated.xml
+++ b/dev/test_data/live_tests/golang/test_data/constrained_primitives/Xml/Unexpected/Invalid/ConstrainViolated/something/some_bool_violated.xml
@@ -1,1 +1,1 @@
-<something xmlns="https://dummy.com"><someBool>false</someBool><someInt>1234</someInt><someFloat>34.230000</someFloat><someString>hello world</someString><someBytes>SGVsbG8gV29ybGQ=</someBytes></something>
+<something xmlns="https://dummy.com"><someBool>false</someBool><someInt>1234</someInt><someFloat>34.23</someFloat><someString>hello world</someString><someBytes>SGVsbG8gV29ybGQ=</someBytes></something>

--- a/dev/test_data/live_tests/golang/test_data/primitive_types/Xml/Expected/something/minimal.xml
+++ b/dev/test_data/live_tests/golang/test_data/primitive_types/Xml/Expected/something/minimal.xml
@@ -1,1 +1,1 @@
-<something xmlns="https://dummy.com"><someBool>true</someBool><someInt>1234</someInt><someFloat>34.230000</someFloat><someString>hello world</someString><someBytes>SGVsbG8gV29ybGQ=</someBytes></something>
+<something xmlns="https://dummy.com"><someBool>true</someBool><someInt>1234</someInt><someFloat>34.23</someFloat><someString>hello world</someString><someBytes>SGVsbG8gV29ybGQ=</someBytes></something>

--- a/dev/test_data/live_tests/typescript/test_data/constrained_primitives/Xml/Expected/something/minimal.xml
+++ b/dev/test_data/live_tests/typescript/test_data/constrained_primitives/Xml/Expected/something/minimal.xml
@@ -1,1 +1,1 @@
-<something xmlns="https://dummy.com"><someBool>true</someBool><someInt>1234</someInt><someFloat>34.230000</someFloat><someString>hello world</someString><someBytes>SGVsbG8gV29ybGQ=</someBytes></something>
+<something xmlns="https://dummy.com"><someBool>true</someBool><someInt>1234</someInt><someFloat>34.23</someFloat><someString>hello world</someString><someBytes>SGVsbG8gV29ybGQ=</someBytes></something>

--- a/dev/test_data/live_tests/typescript/test_data/constrained_primitives/Xml/Unexpected/Invalid/ConstrainViolated/something/some_bool_violated.xml
+++ b/dev/test_data/live_tests/typescript/test_data/constrained_primitives/Xml/Unexpected/Invalid/ConstrainViolated/something/some_bool_violated.xml
@@ -1,1 +1,1 @@
-<something xmlns="https://dummy.com"><someBool>false</someBool><someInt>1234</someInt><someFloat>34.230000</someFloat><someString>hello world</someString><someBytes>SGVsbG8gV29ybGQ=</someBytes></something>
+<something xmlns="https://dummy.com"><someBool>false</someBool><someInt>1234</someInt><someFloat>34.23</someFloat><someString>hello world</someString><someBytes>SGVsbG8gV29ybGQ=</someBytes></something>

--- a/dev/test_data/live_tests/typescript/test_data/primitive_types/Xml/Expected/something/minimal.xml
+++ b/dev/test_data/live_tests/typescript/test_data/primitive_types/Xml/Expected/something/minimal.xml
@@ -1,1 +1,1 @@
-<something xmlns="https://dummy.com"><someBool>true</someBool><someInt>1234</someInt><someFloat>34.230000</someFloat><someString>hello world</someString><someBytes>SGVsbG8gV29ybGQ=</someBytes></something>
+<something xmlns="https://dummy.com"><someBool>true</someBool><someInt>1234</someInt><someFloat>34.23</someFloat><someString>hello world</someString><someBytes>SGVsbG8gV29ybGQ=</someBytes></something>

--- a/dev/test_data/main/cpp/expected/aas_core_meta.v3/expected_output/src/xmlization.cpp
+++ b/dev/test_data/main/cpp/expected/aas_core_meta.v3/expected_output/src/xmlization.cpp
@@ -36707,8 +36707,13 @@ void SelfClosingWriter::SerializeDouble(
   } else if(std::isnan(value)) {
     WriteStringWithoutEscapingNorFlushing("NaN");
   } else {
+    // NOTE (mristin):
+    // We have to use a stream to avoid trailing zeros. std::to_string always
+    // outputs trailing zeros up to a certain number of decimal places (usually 6).
+    std::ostringstream oss;
+    oss << value;
     WriteStringWithoutEscapingNorFlushing(
-      std::to_string(value)
+      oss.str()
     );
   }
 }

--- a/dev/test_data/main/cpp/expected/primitive_types/expected_output/src/xmlization.cpp
+++ b/dev/test_data/main/cpp/expected/primitive_types/expected_output/src/xmlization.cpp
@@ -3147,8 +3147,13 @@ void SelfClosingWriter::SerializeDouble(
   } else if(std::isnan(value)) {
     WriteStringWithoutEscapingNorFlushing("NaN");
   } else {
+    // NOTE (mristin):
+    // We have to use a stream to avoid trailing zeros. std::to_string always
+    // outputs trailing zeros up to a certain number of decimal places (usually 6).
+    std::ostringstream oss;
+    oss << value;
     WriteStringWithoutEscapingNorFlushing(
-      std::to_string(value)
+      oss.str()
     );
   }
 }


### PR DESCRIPTION
We had slight discrepancy between C++ and other generated SDKs: the C++ SDK serialized doubles in XML with trailing zeros. We change the C++ XML serialization to match the output of the other SDKs.

This also allows us to have the unified test data across different languages. In one of the future changes, we plan to unify the live tests to re-use the test data.